### PR TITLE
Added Value (variant) Type

### DIFF
--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
@@ -9,6 +9,111 @@ namespace Azure
         public virtual System.BinaryData? Data { get { throw null; } set { } }
         public virtual bool IsReadOnly { get { throw null; } }
     }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct Value
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public Value(System.ArraySegment<byte> segment) { throw null; }
+        public Value(System.ArraySegment<char> segment) { throw null; }
+        public Value(bool value) { throw null; }
+        public Value(byte value) { throw null; }
+        public Value(char value) { throw null; }
+        public Value(System.DateTime value) { throw null; }
+        public Value(System.DateTimeOffset value) { throw null; }
+        public Value(double value) { throw null; }
+        public Value(short value) { throw null; }
+        public Value(int value) { throw null; }
+        public Value(long value) { throw null; }
+        public Value(bool? value) { throw null; }
+        public Value(byte? value) { throw null; }
+        public Value(char? value) { throw null; }
+        public Value(System.DateTimeOffset? value) { throw null; }
+        public Value(System.DateTime? value) { throw null; }
+        public Value(double? value) { throw null; }
+        public Value(short? value) { throw null; }
+        public Value(int? value) { throw null; }
+        public Value(long? value) { throw null; }
+        public Value(sbyte? value) { throw null; }
+        public Value(float? value) { throw null; }
+        public Value(ushort? value) { throw null; }
+        public Value(uint? value) { throw null; }
+        public Value(ulong? value) { throw null; }
+        public Value(object? value) { throw null; }
+        public Value(sbyte value) { throw null; }
+        public Value(float value) { throw null; }
+        public Value(ushort value) { throw null; }
+        public Value(uint value) { throw null; }
+        public Value(ulong value) { throw null; }
+        public System.Type? Type { get { throw null; } }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public T As<T>() { throw null; }
+        public static Azure.Value Create<T>(T value) { throw null; }
+        public static explicit operator System.ArraySegment<byte> (in Azure.Value value) { throw null; }
+        public static explicit operator System.ArraySegment<char> (in Azure.Value value) { throw null; }
+        public static explicit operator bool (in Azure.Value value) { throw null; }
+        public static explicit operator byte (in Azure.Value value) { throw null; }
+        public static explicit operator char (in Azure.Value value) { throw null; }
+        public static explicit operator System.DateTime (in Azure.Value value) { throw null; }
+        public static explicit operator System.DateTimeOffset (in Azure.Value value) { throw null; }
+        public static explicit operator decimal (in Azure.Value value) { throw null; }
+        public static explicit operator double (in Azure.Value value) { throw null; }
+        public static explicit operator short (in Azure.Value value) { throw null; }
+        public static explicit operator int (in Azure.Value value) { throw null; }
+        public static explicit operator long (in Azure.Value value) { throw null; }
+        public static explicit operator bool? (in Azure.Value value) { throw null; }
+        public static explicit operator byte? (in Azure.Value value) { throw null; }
+        public static explicit operator char? (in Azure.Value value) { throw null; }
+        public static explicit operator System.DateTimeOffset? (in Azure.Value value) { throw null; }
+        public static explicit operator System.DateTime? (in Azure.Value value) { throw null; }
+        public static explicit operator decimal? (in Azure.Value value) { throw null; }
+        public static explicit operator double? (in Azure.Value value) { throw null; }
+        public static explicit operator short? (in Azure.Value value) { throw null; }
+        public static explicit operator int? (in Azure.Value value) { throw null; }
+        public static explicit operator long? (in Azure.Value value) { throw null; }
+        public static explicit operator sbyte? (in Azure.Value value) { throw null; }
+        public static explicit operator float? (in Azure.Value value) { throw null; }
+        public static explicit operator ushort? (in Azure.Value value) { throw null; }
+        public static explicit operator uint? (in Azure.Value value) { throw null; }
+        public static explicit operator ulong? (in Azure.Value value) { throw null; }
+        public static explicit operator sbyte (in Azure.Value value) { throw null; }
+        public static explicit operator float (in Azure.Value value) { throw null; }
+        public static explicit operator ushort (in Azure.Value value) { throw null; }
+        public static explicit operator uint (in Azure.Value value) { throw null; }
+        public static explicit operator ulong (in Azure.Value value) { throw null; }
+        public static implicit operator Azure.Value (System.ArraySegment<byte> value) { throw null; }
+        public static implicit operator Azure.Value (System.ArraySegment<char> value) { throw null; }
+        public static implicit operator Azure.Value (bool value) { throw null; }
+        public static implicit operator Azure.Value (byte value) { throw null; }
+        public static implicit operator Azure.Value (char value) { throw null; }
+        public static implicit operator Azure.Value (System.DateTime value) { throw null; }
+        public static implicit operator Azure.Value (System.DateTimeOffset value) { throw null; }
+        public static implicit operator Azure.Value (decimal value) { throw null; }
+        public static implicit operator Azure.Value (double value) { throw null; }
+        public static implicit operator Azure.Value (short value) { throw null; }
+        public static implicit operator Azure.Value (int value) { throw null; }
+        public static implicit operator Azure.Value (long value) { throw null; }
+        public static implicit operator Azure.Value (bool? value) { throw null; }
+        public static implicit operator Azure.Value (byte? value) { throw null; }
+        public static implicit operator Azure.Value (char? value) { throw null; }
+        public static implicit operator Azure.Value (System.DateTimeOffset? value) { throw null; }
+        public static implicit operator Azure.Value (System.DateTime? value) { throw null; }
+        public static implicit operator Azure.Value (decimal? value) { throw null; }
+        public static implicit operator Azure.Value (double? value) { throw null; }
+        public static implicit operator Azure.Value (short? value) { throw null; }
+        public static implicit operator Azure.Value (int? value) { throw null; }
+        public static implicit operator Azure.Value (long? value) { throw null; }
+        public static implicit operator Azure.Value (sbyte? value) { throw null; }
+        public static implicit operator Azure.Value (float? value) { throw null; }
+        public static implicit operator Azure.Value (ushort? value) { throw null; }
+        public static implicit operator Azure.Value (uint? value) { throw null; }
+        public static implicit operator Azure.Value (ulong? value) { throw null; }
+        public static implicit operator Azure.Value (sbyte value) { throw null; }
+        public static implicit operator Azure.Value (float value) { throw null; }
+        public static implicit operator Azure.Value (ushort value) { throw null; }
+        public static implicit operator Azure.Value (uint value) { throw null; }
+        public static implicit operator Azure.Value (ulong value) { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public bool TryGetValue<T>(out T value) { throw null; }
+    }
 }
 namespace Azure.Core
 {

--- a/sdk/core/Azure.Core.Experimental/src/Variant/Value.DateTimeOffsetFlag.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Variant/Value.DateTimeOffsetFlag.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure {
+    public readonly partial struct Value
+    {
+        private sealed class DateTimeOffsetFlag : TypeFlag<DateTimeOffset>
+        {
+            public static DateTimeOffsetFlag Instance { get; } = new();
+
+            public override DateTimeOffset To(in Value value)
+                => new(new DateTime(value._union.Ticks, DateTimeKind.Utc));
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/src/Variant/Value.NullableTemplate.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Variant/Value.NullableTemplate.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.InteropServices;
+
+namespace Azure {
+    public readonly partial struct Value
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly struct NullableTemplate<T> where T : unmanaged
+        {
+            public readonly bool _hasValue;
+            public readonly T _value;
+
+            public NullableTemplate(T value)
+            {
+                _value = value;
+                _hasValue = true;
+            }
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/src/Variant/Value.PackedDateTimeOffset.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Variant/Value.PackedDateTimeOffset.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+
+namespace Azure {
+    public readonly partial struct Value
+    {
+        private readonly struct PackedDateTimeOffset
+        {
+            // HHHHHMMT TTT...
+            //
+            // HHHHH   - hour bits 1-31
+            // MM      - minutes flag
+            // T       - ticks bit
+            //            00 - :00
+            //            01 - :15
+            //            10 - :30
+            //            11 - :45
+
+            // Base local tick time 1800 [DateTime(1800, 1, 1).Ticks]
+            private const ulong BaseTicks = 567709344000000000;
+            private const ulong MaxTicks = BaseTicks + TickMask;
+
+            // Hours go from -14 to 14. We add 14 to get our number to store.
+            private const int HourOffset = 14;
+
+            private const ulong TickMask    = 0b00000001_11111111_11111111_11111111__11111111_11111111_11111111_11111111;
+            private const ulong MinuteMask  = 0b00000110_00000000_00000000_00000000__00000000_00000000_00000000_00000000;
+            private const ulong HourMask    = 0b11111000_00000000_00000000_00000000__00000000_00000000_00000000_00000000;
+
+            private const int MinuteShift = 57;
+            private const int HourShift = 59;
+
+            private readonly ulong _data;
+
+            private PackedDateTimeOffset(ulong data) => _data = data;
+
+            public static bool TryCreate(DateTimeOffset dateTime, TimeSpan offset, out PackedDateTimeOffset packed)
+            {
+                bool result = false;
+                packed = default;
+
+                ulong ticks = (ulong)dateTime.Ticks;
+                if (ticks > BaseTicks && ticks < MaxTicks)
+                {
+                    ulong data = default;
+                    int minutes = offset.Minutes;
+                    if (minutes % 15 == 0)
+                    {
+                        data = (ulong)(minutes / 15) << MinuteShift;
+                        int hours = offset.Hours + HourOffset;
+
+                        // Only valid offset hours are -14 to 14
+                        Debug.Assert(hours >= 0 && hours <= 28);
+                        data |= (ulong)hours << HourShift;
+                        data |= ticks - BaseTicks;
+                        packed = new(data);
+                        result = true;
+                    }
+                }
+
+                return result;
+            }
+
+            public DateTimeOffset Extract()
+            {
+                TimeSpan offset = new(
+                    (int)(((_data & HourMask) >> HourShift) - HourOffset),
+                    (int)((_data & MinuteMask) >> MinuteShift),
+                    0);
+                return new((long)((_data & TickMask) + BaseTicks), offset);
+            }
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/src/Variant/Value.PackedDateTimeOffsetFlag.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Variant/Value.PackedDateTimeOffsetFlag.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure {
+    public readonly partial struct Value
+    {
+        private sealed class PackedDateTimeOffsetFlag : TypeFlag<DateTimeOffset>
+        {
+            public static PackedDateTimeOffsetFlag Instance { get; } = new();
+
+            public override DateTimeOffset To(in Value value)
+                => value._union.PackedDateTimeOffset.Extract();
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/src/Variant/Value.StraightCastFlag.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Variant/Value.StraightCastFlag.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+
+namespace Azure {
+    public readonly partial struct Value
+    {
+        private sealed class StraightCastFlag<T> : TypeFlag<T>
+        {
+            public static StraightCastFlag<T> Instance { get; } = new();
+
+            public override T To(in Value value)
+                => Unsafe.As<Union, T>(ref Unsafe.AsRef(value._union));
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/src/Variant/Value.TypeFlag.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Variant/Value.TypeFlag.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Azure {
+    public readonly partial struct Value
+    {
+        private abstract class TypeFlag
+        {
+            public abstract Type Type
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get;
+            }
+
+            public abstract object ToObject(in Value value);
+        }
+
+        private abstract class TypeFlag<T> : TypeFlag
+        {
+            public sealed override Type Type
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => typeof(T);
+            }
+
+            public override object ToObject(in Value value) => To(value)!;
+            public abstract T To(in Value value);
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/src/Variant/Value.TypeFlags.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Variant/Value.TypeFlags.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure {
+    public readonly partial struct Value
+    {
+        private static class TypeFlags
+        {
+            internal static readonly StraightCastFlag<bool> Boolean                 = StraightCastFlag<bool>.Instance;
+            internal static readonly StraightCastFlag<char> Char                    = StraightCastFlag<char>.Instance;
+            internal static readonly StraightCastFlag<byte> Byte                    = StraightCastFlag<byte>.Instance;
+            internal static readonly StraightCastFlag<sbyte> SByte                  = StraightCastFlag<sbyte>.Instance;
+            internal static readonly StraightCastFlag<short> Int16                  = StraightCastFlag<short>.Instance;
+            internal static readonly StraightCastFlag<ushort> UInt16                = StraightCastFlag<ushort>.Instance;
+            internal static readonly StraightCastFlag<int> Int32                    = StraightCastFlag<int>.Instance;
+            internal static readonly StraightCastFlag<uint> UInt32                  = StraightCastFlag<uint>.Instance;
+            internal static readonly StraightCastFlag<long> Int64                   = StraightCastFlag<long>.Instance;
+            internal static readonly StraightCastFlag<ulong> UInt64                 = StraightCastFlag<ulong>.Instance;
+            internal static readonly StraightCastFlag<float> Single                 = StraightCastFlag<float>.Instance;
+            internal static readonly StraightCastFlag<double> Double                = StraightCastFlag<double>.Instance;
+            internal static readonly StraightCastFlag<DateTime> DateTime            = StraightCastFlag<DateTime>.Instance;
+            internal static readonly DateTimeOffsetFlag DateTimeOffset              = DateTimeOffsetFlag.Instance;
+            internal static readonly PackedDateTimeOffsetFlag PackedDateTimeOffset  = PackedDateTimeOffsetFlag.Instance;
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/src/Variant/Value.Union.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Variant/Value.Union.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Azure {
+    public readonly partial struct Value
+    {
+        [StructLayout(LayoutKind.Explicit, CharSet = CharSet.Unicode)]
+        private struct Union
+        {
+            [FieldOffset(0)] public byte Byte;
+            [FieldOffset(0)] public sbyte SByte;
+            [FieldOffset(0)] public char Char;
+            [FieldOffset(0)] public bool Boolean;
+            [FieldOffset(0)] public short Int16;
+            [FieldOffset(0)] public ushort UInt16;
+            [FieldOffset(0)] public int Int32;
+            [FieldOffset(0)] public uint UInt32;
+            [FieldOffset(0)] public long Int64;
+            [FieldOffset(0)] public long Ticks;
+            [FieldOffset(0)] public ulong UInt64;
+            [FieldOffset(0)] public float Single;                   // 4 bytes
+            [FieldOffset(0)] public double Double;                  // 8 bytes
+            [FieldOffset(0)] public DateTime DateTime;              // 8 bytes  (ulong)
+            [FieldOffset(0)] public PackedDateTimeOffset PackedDateTimeOffset;
+            [FieldOffset(0)] public (int Offset, int Count) Segment;
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/src/Variant/Value.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Variant/Value.cs
@@ -8,7 +8,7 @@ using System.Runtime.CompilerServices;
 
 namespace Azure {
     /// <summary>
-    /// Used to store primitive values without boxing, and other intstances.
+    /// Used to store primitive values without boxing, and other instances.
     /// </summary>
     public readonly partial struct Value
     {
@@ -112,7 +112,7 @@ namespace Azure {
         /// <param name="value"></param>
         public static implicit operator Value(byte value) => new(value);
         /// <summary>
-        /// Casts valure to byte, if possible.
+        /// Casts value to byte, if possible.
         /// </summary>
         /// <param name="value"></param>
         public static explicit operator byte(in Value value) => value.As<byte>();

--- a/sdk/core/Azure.Core.Experimental/src/Variant/Value.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Variant/Value.cs
@@ -1,0 +1,1347 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Azure {
+    /// <summary>
+    /// Used to store primitive values without boxing, and other intstances.
+    /// </summary>
+    public readonly partial struct Value
+    {
+        private readonly Union _union;
+        private readonly object? _object;
+
+        /// <summary>
+        /// Creates instance.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(object? value)
+        {
+            _object = value;
+            _union = default;
+        }
+
+        /// <summary>
+        /// Type of the instance stored in this value.
+        /// </summary>
+        public readonly Type? Type
+        {
+            get
+            {
+                Type? type;
+                if (_object is null)
+                {
+                    type = null;
+                }
+                else if (_object is TypeFlag typeFlag)
+                {
+                    type = typeFlag.Type;
+                }
+                else
+                {
+                    type = _object.GetType();
+
+                    if (_union.UInt64 != 0 && type.IsArray)
+                    {
+                        // We have an ArraySegment
+                        if (type == typeof(byte[]))
+                        {
+                            type = typeof(ArraySegment<byte>);
+                        }
+                        else if (type == typeof(char[]))
+                        {
+                            type = typeof(ArraySegment<char>);
+                        }
+                        else
+                        {
+                            ThrowInvalidOperation();
+                        }
+                    }
+                }
+
+                return type;
+            }
+        }
+
+        [DoesNotReturn]
+        private static void ThrowInvalidCast() => throw new InvalidCastException();
+
+        [DoesNotReturn]
+        private static void ThrowArgumentNull(string paramName) => throw new ArgumentNullException(paramName);
+
+        [DoesNotReturn]
+        private static void ThrowInvalidOperation() => throw new InvalidOperationException();
+
+        #region Byte
+        /// <summary>
+        /// Stores byte in this value.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(byte value)
+        {
+            this = default;
+            _object = TypeFlags.Byte;
+            _union.Byte = value;
+        }
+
+        /// <summary>
+        /// Stores nullable byte in this value.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(byte? value)
+        {
+            this = default;
+            if (value.HasValue)
+            {
+                _object = TypeFlags.Byte;
+                _union.Byte = value.Value;
+            }
+            else
+            {
+                _object = null;
+            }
+        }
+
+        /// <summary>
+        /// Casts byte to value.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(byte value) => new(value);
+        /// <summary>
+        /// Casts valure to byte, if possible.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator byte(in Value value) => value.As<byte>();
+        /// <summary>
+        /// Casts nullable byte to value.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(byte? value) => new(value);
+        /// <summary>
+        /// Casts value to nullable byte, if possible.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator byte?(in Value value) => value.As<byte?>();
+        #endregion
+
+        #region SByte
+        /// <summary>
+        /// Stores sbyte in this value.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(sbyte value)
+        {
+            this = default;
+            _object = TypeFlags.SByte;
+            _union.SByte = value;
+        }
+
+        /// <summary>
+        /// Stores nullable sbyte in this value.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(sbyte? value)
+        {
+            this = default;
+            if (value.HasValue)
+            {
+                _object = TypeFlags.SByte;
+                _union.SByte = value.Value;
+            }
+            else
+            {
+                _object = null;
+            }
+        }
+
+        /// <summary>
+        /// Casts sbyte to value.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(sbyte value) => new(value);
+        /// <summary>
+        /// Casts value to sbyte, if possible.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator sbyte(in Value value) => value.As<sbyte>();
+        /// <summary>
+        /// Casts nullable sbyte to value.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(sbyte? value) => new(value);
+        /// <summary>
+        /// Casts value to nullable sbyte, if possible.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator sbyte?(in Value value) => value.As<sbyte?>();
+        #endregion
+
+        #region Boolean
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(bool value)
+        {
+            this = default;
+            _object = TypeFlags.Boolean;
+            _union.Boolean = value;
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(bool? value)
+        {
+            this = default;
+            if (value.HasValue)
+            {
+                _object = TypeFlags.Boolean;
+                _union.Boolean = value.Value;
+            }
+            else
+            {
+                _object = null;
+            }
+        }
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(bool value) => new(value);
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator bool(in Value value) => value.As<bool>();
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(bool? value) => new(value);
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator bool?(in Value value) => value.As<bool?>();
+        #endregion
+
+        #region Char
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(char value)
+        {
+            this = default;
+            _object = TypeFlags.Char;
+            _union.Char = value;
+        }
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(char? value)
+        {
+            this = default;
+            if (value.HasValue)
+            {
+                _object = TypeFlags.Char;
+                _union.Char = value.Value;
+            }
+            else
+            {
+                _object = null;
+            }
+        }
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(char value) => new(value);
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator char(in Value value) => value.As<char>();
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(char? value) => new(value);
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator char?(in Value value) => value.As<char?>();
+        #endregion
+
+        #region Int16
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(short value)
+        {
+            this = default;
+            _object = TypeFlags.Int16;
+            _union.Int16 = value;
+        }
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(short? value)
+        {
+            this = default;
+            if (value.HasValue)
+            {
+                _object = TypeFlags.Int16;
+                _union.Int16 = value.Value;
+            }
+            else
+            {
+                _object = null;
+            }
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(short value) => new(value);
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator short(in Value value) => value.As<short>();
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(short? value) => new(value);
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator short?(in Value value) => value.As<short?>();
+        #endregion
+
+        #region Int32
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(int value)
+        {
+            this = default;
+            _object = TypeFlags.Int32;
+            _union.Int32 = value;
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(int? value)
+        {
+            this = default;
+            if (value.HasValue)
+            {
+                _object = TypeFlags.Int32;
+                _union.Int32 = value.Value;
+            }
+            else
+            {
+                _object = null;
+            }
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(int value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator int(in Value value) => value.As<int>();
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(int? value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator int?(in Value value) => value.As<int?>();
+        #endregion
+
+        #region Int64
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(long value)
+        {
+            this = default;
+            _object = TypeFlags.Int64;
+            _union.Int64 = value;
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(long? value)
+        {
+            this = default;
+            if (value.HasValue)
+            {
+                _object = TypeFlags.Int64;
+                _union.Int64 = value.Value;
+            }
+            else
+            {
+                _object = null;
+            }
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(long value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator long(in Value value) => value.As<long>();
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(long? value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator long?(in Value value) => value.As<long?>();
+        #endregion
+
+        #region UInt16
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(ushort value)
+        {
+            this = default;
+            _object = TypeFlags.UInt16;
+            _union.UInt16 = value;
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(ushort? value)
+        {
+            this = default;
+            if (value.HasValue)
+            {
+                _object = TypeFlags.UInt16;
+                _union.UInt16 = value.Value;
+            }
+            else
+            {
+                _object = null;
+            }
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(ushort value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator ushort(in Value value) => value.As<ushort>();
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(ushort? value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator ushort?(in Value value) => value.As<ushort?>();
+        #endregion
+
+        #region UInt32
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(uint value)
+        {
+            this = default;
+            _object = TypeFlags.UInt32;
+            _union.UInt32 = value;
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(uint? value)
+        {
+            this = default;
+            if (value.HasValue)
+            {
+                _object = TypeFlags.UInt32;
+                _union.UInt32 = value.Value;
+            }
+            else
+            {
+                _object = null;
+            }
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(uint value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator uint(in Value value) => value.As<uint>();
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(uint? value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator uint?(in Value value) => value.As<uint?>();
+        #endregion
+
+        #region UInt64
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(ulong value)
+        {
+            this = default;
+            _object = TypeFlags.UInt64;
+            _union.UInt64 = value;
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(ulong? value)
+        {
+            this = default;
+            if (value.HasValue)
+            {
+                _object = TypeFlags.UInt64;
+                _union.UInt64 = value.Value;
+            }
+            else
+            {
+                _object = null;
+            }
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(ulong value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator ulong(in Value value) => value.As<ulong>();
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(ulong? value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator ulong?(in Value value) => value.As<ulong?>();
+        #endregion
+
+        #region Single
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(float value)
+        {
+            this = default;
+            _object = TypeFlags.Single;
+            _union.Single = value;
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(float? value)
+        {
+            this = default;
+            if (value.HasValue)
+            {
+                _object = TypeFlags.Single;
+                _union.Single = value.Value;
+            }
+            else
+            {
+                _object = null;
+            }
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(float value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator float(in Value value) => value.As<float>();
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(float? value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator float?(in Value value) => value.As<float?>();
+        #endregion
+
+        #region Double
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(double value)
+        {
+            this = default;
+            _object = TypeFlags.Double;
+            _union.Double = value;
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(double? value)
+        {
+            this = default;
+            if (value.HasValue)
+            {
+                _object = TypeFlags.Double;
+                _union.Double = value.Value;
+            }
+            else
+            {
+                _object = null;
+            }
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(double value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator double(in Value value) => value.As<double>();
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(double? value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator double?(in Value value) => value.As<double?>();
+        #endregion
+
+        #region DateTimeOffset
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(DateTimeOffset value)
+        {
+            this = default;
+            TimeSpan offset = value.Offset;
+            if (offset.Ticks == 0)
+            {
+                // This is a UTC time
+                _union.Ticks = value.Ticks;
+                _object = TypeFlags.DateTimeOffset;
+            }
+            else if (PackedDateTimeOffset.TryCreate(value, offset, out var packed))
+            {
+                _union.PackedDateTimeOffset = packed;
+                _object = TypeFlags.PackedDateTimeOffset;
+            }
+            else
+            {
+                _object = value;
+            }
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(DateTimeOffset? value)
+        {
+            this = default;
+            if (!value.HasValue)
+            {
+                _object = null;
+            }
+            else
+            {
+                this = new(value.Value);
+            }
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(DateTimeOffset value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator DateTimeOffset(in Value value) => value.As<DateTimeOffset>();
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(DateTimeOffset? value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator DateTimeOffset?(in Value value) => value.As<DateTimeOffset?>();
+        #endregion
+
+        #region DateTime
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(DateTime value)
+        {
+            this = default;
+
+            _union.DateTime = value;
+            _object = TypeFlags.DateTime;
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public Value(DateTime? value)
+        {
+            this = default;
+            if (value.HasValue)
+            {
+                _object = TypeFlags.DateTime;
+                _union.DateTime = value.Value;
+            }
+            else
+            {
+                _object = value;
+            }
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(DateTime value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator DateTime(in Value value) => value.As<DateTime>();
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(DateTime? value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator DateTime?(in Value value) => value.As<DateTime?>();
+        #endregion
+
+        #region ArraySegment
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="segment"></param>
+        public Value(ArraySegment<byte> segment)
+        {
+            this = default;
+            byte[]? array = segment.Array;
+            if (array is null)
+            {
+                ThrowArgumentNull(nameof(segment));
+            }
+
+            _object = array;
+            if (segment.Offset == 0 && segment.Count == 0)
+            {
+                _union.UInt64 = ulong.MaxValue;
+            }
+            else
+            {
+                _union.Segment = (segment.Offset, segment.Count);
+            }
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(ArraySegment<byte> value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator ArraySegment<byte>(in Value value) => value.As<ArraySegment<byte>>();
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="segment"></param>
+        public Value(ArraySegment<char> segment)
+        {
+            this = default;
+            char[]? array = segment.Array;
+            if (array is null)
+            {
+                ThrowArgumentNull(nameof(segment));
+            }
+
+            _object = array;
+            if (segment.Offset == 0 && segment.Count == 0)
+            {
+                _union.UInt64 = ulong.MaxValue;
+            }
+            else
+            {
+                _union.Segment = (segment.Offset, segment.Count);
+            }
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(ArraySegment<char> value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator ArraySegment<char>(in Value value) => value.As<ArraySegment<char>>();
+        #endregion
+
+        #region Decimal
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(decimal value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator decimal(in Value value) => value.As<decimal>();
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Value(decimal? value) => value.HasValue ? new(value.Value) : new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator decimal?(in Value value) => value.As<decimal?>();
+        #endregion
+
+        #region T
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static Value Create<T>(T value)
+        {
+            // Explicit cast for types we don't box
+            if (typeof(T) == typeof(bool)) return new(Unsafe.As<T, bool>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(byte)) return new(Unsafe.As<T, byte>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(sbyte)) return new(Unsafe.As<T, sbyte>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(char)) return new(Unsafe.As<T, char>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(short)) return new(Unsafe.As<T, short>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(int)) return new(Unsafe.As<T, int>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(long)) return new(Unsafe.As<T, long>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(ushort)) return new(Unsafe.As<T, ushort>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(uint)) return new(Unsafe.As<T, uint>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(ulong)) return new(Unsafe.As<T, ulong>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(float)) return new(Unsafe.As<T, float>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(double)) return new(Unsafe.As<T, double>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(DateTime)) return new(Unsafe.As<T, DateTime>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(DateTimeOffset)) return new(Unsafe.As<T, DateTimeOffset>(ref Unsafe.AsRef(value)));
+
+            if (typeof(T) == typeof(bool?)) return new(Unsafe.As<T, bool?>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(byte?)) return new(Unsafe.As<T, byte?>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(sbyte?)) return new(Unsafe.As<T, sbyte?>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(char?)) return new(Unsafe.As<T, char?>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(short?)) return new(Unsafe.As<T, short?>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(int?)) return new(Unsafe.As<T, int?>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(long?)) return new(Unsafe.As<T, long?>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(ushort?)) return new(Unsafe.As<T, ushort?>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(uint?)) return new(Unsafe.As<T, uint?>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(ulong?)) return new(Unsafe.As<T, ulong?>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(float?)) return new(Unsafe.As<T, float?>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(double?)) return new(Unsafe.As<T, double?>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(DateTime?)) return new(Unsafe.As<T, DateTime?>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(DateTimeOffset?)) return new(Unsafe.As<T, DateTimeOffset?>(ref Unsafe.AsRef(value)));
+
+            if (typeof(T) == typeof(ArraySegment<byte>)) return new(Unsafe.As<T, ArraySegment<byte>>(ref Unsafe.AsRef(value)));
+            if (typeof(T) == typeof(ArraySegment<char>)) return new(Unsafe.As<T, ArraySegment<char>>(ref Unsafe.AsRef(value)));
+
+            if (typeof(T).IsEnum)
+            {
+                Debug.Assert(Unsafe.SizeOf<T>() <= sizeof(ulong));
+                return new Value(StraightCastFlag<T>.Instance, Unsafe.As<T, ulong>(ref value));
+            }
+
+            return new Value(value);
+        }
+
+        private Value(object o, ulong u)
+        {
+            _union = default;
+            _object = o;
+            _union.UInt64 = u;
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly bool TryGetValue<T>(out T value)
+        {
+            bool success;
+
+            // Checking the type gets all of the non-relevant compares elided by the JIT
+            if (_object is not null && ((typeof(T) == typeof(bool) && _object == TypeFlags.Boolean)
+                || (typeof(T) == typeof(byte) && _object == TypeFlags.Byte)
+                || (typeof(T) == typeof(char) && _object == TypeFlags.Char)
+                || (typeof(T) == typeof(double) && _object == TypeFlags.Double)
+                || (typeof(T) == typeof(short) && _object == TypeFlags.Int16)
+                || (typeof(T) == typeof(int) && _object == TypeFlags.Int32)
+                || (typeof(T) == typeof(long) && _object == TypeFlags.Int64)
+                || (typeof(T) == typeof(sbyte) && _object == TypeFlags.SByte)
+                || (typeof(T) == typeof(float) && _object == TypeFlags.Single)
+                || (typeof(T) == typeof(ushort) && _object == TypeFlags.UInt16)
+                || (typeof(T) == typeof(uint) && _object == TypeFlags.UInt32)
+                || (typeof(T) == typeof(ulong) && _object == TypeFlags.UInt64)))
+            {
+                value = CastTo<T>();
+                success = true;
+            }
+            else if (typeof(T) == typeof(DateTime) && _object == TypeFlags.DateTime)
+            {
+                value = Unsafe.As<DateTime, T>(ref Unsafe.AsRef(_union.DateTime));
+                success = true;
+            }
+            else if (typeof(T) == typeof(DateTimeOffset) && _object == TypeFlags.DateTimeOffset)
+            {
+                value = Unsafe.As<DateTimeOffset, T>(ref Unsafe.AsRef(new DateTimeOffset(_union.Ticks, TimeSpan.Zero)));
+                success = true;
+            }
+            else if (typeof(T) == typeof(DateTimeOffset) && _object == TypeFlags.PackedDateTimeOffset)
+            {
+                value = Unsafe.As<DateTimeOffset, T>(ref Unsafe.AsRef(_union.PackedDateTimeOffset.Extract()));
+                success = true;
+            }
+            else if (typeof(T).IsValueType)
+            {
+                success = TryGetValueSlow(out value);
+            }
+            else
+            {
+                success = TryGetObjectSlow(out value);
+            }
+
+            return success;
+        }
+
+        private readonly bool TryGetValueSlow<T>(out T value)
+        {
+            // Single return has a significant performance benefit.
+
+            bool result = false;
+
+            if (_object is null)
+            {
+                // A null is stored, it can only be assigned to a reference type or nullable.
+                value = default!;
+                result = Nullable.GetUnderlyingType(typeof(T)) is not null;
+            }
+            else if (typeof(T).IsEnum && _object is TypeFlag<T> typeFlag)
+            {
+                value = typeFlag.To(in this);
+                result = true;
+            }
+            else if (_object is T t)
+            {
+                value = t;
+                result = true;
+            }
+            else if (typeof(T) == typeof(ArraySegment<byte>))
+            {
+                ulong bits = _union.UInt64;
+                if (bits != 0 && _object is byte[] byteArray)
+                {
+                    ArraySegment<byte> segment = bits != ulong.MaxValue
+                        ? new(byteArray, _union.Segment.Offset, _union.Segment.Count)
+                        : new(byteArray, 0, 0);
+                    value = Unsafe.As<ArraySegment<byte>, T>(ref segment);
+                    result = true;
+                }
+                else
+                {
+                    value = default!;
+                }
+            }
+            else if (typeof(T) == typeof(ArraySegment<char>))
+            {
+                ulong bits = _union.UInt64;
+                if (bits != 0 && _object is char[] charArray)
+                {
+                    ArraySegment<char> segment = bits != ulong.MaxValue
+                        ? new(charArray, _union.Segment.Offset, _union.Segment.Count)
+                        : new(charArray, 0, 0);
+                    value = Unsafe.As<ArraySegment<char>, T>(ref segment);
+                    result = true;
+                }
+                else
+                {
+                    value = default!;
+                }
+            }
+            else if (typeof(T) == typeof(int?) && _object == TypeFlags.Int32)
+            {
+                value = Unsafe.As<int?, T>(ref Unsafe.AsRef((int?)_union.Int32));
+                result = true;
+            }
+            else if (typeof(T) == typeof(long?) && _object == TypeFlags.Int64)
+            {
+                value = Unsafe.As<long?, T>(ref Unsafe.AsRef((long?)_union.Int64));
+                result = true;
+            }
+            else if (typeof(T) == typeof(bool?) && _object == TypeFlags.Boolean)
+            {
+                value = Unsafe.As<bool?, T>(ref Unsafe.AsRef((bool?)_union.Boolean));
+                result = true;
+            }
+            else if (typeof(T) == typeof(float?) && _object == TypeFlags.Single)
+            {
+                value = Unsafe.As<float?, T>(ref Unsafe.AsRef((float?)_union.Single));
+                result = true;
+            }
+            else if (typeof(T) == typeof(double?) && _object == TypeFlags.Double)
+            {
+                value = Unsafe.As<double?, T>(ref Unsafe.AsRef((double?)_union.Double));
+                result = true;
+            }
+            else if (typeof(T) == typeof(uint?) && _object == TypeFlags.UInt32)
+            {
+                value = Unsafe.As<uint?, T>(ref Unsafe.AsRef((uint?)_union.UInt32));
+                result = true;
+            }
+            else if (typeof(T) == typeof(ulong?) && _object == TypeFlags.UInt64)
+            {
+                value = Unsafe.As<ulong?, T>(ref Unsafe.AsRef((ulong?)_union.UInt64));
+                result = true;
+            }
+            else if (typeof(T) == typeof(char?) && _object == TypeFlags.Char)
+            {
+                value = Unsafe.As<char?, T>(ref Unsafe.AsRef((char?)_union.Char));
+                result = true;
+            }
+            else if (typeof(T) == typeof(short?) && _object == TypeFlags.Int16)
+            {
+                value = Unsafe.As<short?, T>(ref Unsafe.AsRef((short?)_union.Int16));
+                result = true;
+            }
+            else if (typeof(T) == typeof(ushort?) && _object == TypeFlags.UInt16)
+            {
+                value = Unsafe.As<ushort?, T>(ref Unsafe.AsRef((ushort?)_union.UInt16));
+                result = true;
+            }
+            else if (typeof(T) == typeof(byte?) && _object == TypeFlags.Byte)
+            {
+                value = Unsafe.As<byte?, T>(ref Unsafe.AsRef((byte?)_union.Byte));
+                result = true;
+            }
+            else if (typeof(T) == typeof(sbyte?) && _object == TypeFlags.SByte)
+            {
+                value = Unsafe.As<sbyte?, T>(ref Unsafe.AsRef((sbyte?)_union.SByte));
+                result = true;
+            }
+            else if (typeof(T) == typeof(DateTime?) && _object == TypeFlags.DateTime)
+            {
+                value = Unsafe.As<DateTime?, T>(ref Unsafe.AsRef((DateTime?)_union.DateTime));
+                result = true;
+            }
+            else if (typeof(T) == typeof(DateTimeOffset?) && _object == TypeFlags.DateTimeOffset)
+            {
+                value = Unsafe.As<DateTimeOffset?, T>(ref Unsafe.AsRef((DateTimeOffset?)new DateTimeOffset(_union.Ticks, TimeSpan.Zero)));
+                result = true;
+            }
+            else if (typeof(T) == typeof(DateTimeOffset?) && _object == TypeFlags.PackedDateTimeOffset)
+            {
+                value = Unsafe.As<DateTimeOffset?, T>(ref Unsafe.AsRef((DateTimeOffset?)_union.PackedDateTimeOffset.Extract()));
+                result = true;
+            }
+            else if (Nullable.GetUnderlyingType(typeof(T)) is Type underlyingType
+                && underlyingType.IsEnum
+                && _object is TypeFlag underlyingTypeFlag
+                && underlyingTypeFlag.Type == underlyingType)
+            {
+                // Asked for a nullable enum and we've got that type.
+
+                // We've got multiple layouts, depending on the size of the enum backing field. We can't use the
+                // nullable itself (e.g. default(T)) as a template as it gets treated specially by the runtime.
+
+                int size = Unsafe.SizeOf<T>();
+
+                switch (size)
+                {
+                    case (2):
+                        value = Unsafe.As<NullableTemplate<byte>, T>(ref Unsafe.AsRef(new NullableTemplate<byte>(_union.Byte)));
+                        result = true;
+                        break;
+                    case (4):
+                        value = Unsafe.As<NullableTemplate<ushort>, T>(ref Unsafe.AsRef(new NullableTemplate<ushort>(_union.UInt16)));
+                        result = true;
+                        break;
+                    case (8):
+                        value = Unsafe.As<NullableTemplate<uint>, T>(ref Unsafe.AsRef(new NullableTemplate<uint>(_union.UInt32)));
+                        result = true;
+                        break;
+                    case (16):
+                        value = Unsafe.As<NullableTemplate<ulong>, T>(ref Unsafe.AsRef(new NullableTemplate<ulong>(_union.UInt64)));
+                        result = true;
+                        break;
+                    default:
+                        ThrowInvalidOperation();
+                        value = default!;
+                        result = false;
+                        break;
+                }
+            }
+            else
+            {
+                value = default!;
+                result = false;
+            }
+
+            return result;
+        }
+
+        private readonly bool TryGetObjectSlow<T>(out T value)
+        {
+            // Single return has a significant performance benefit.
+
+            bool result = false;
+
+            if (_object is null)
+            {
+                value = default!;
+            }
+            else if (typeof(T) == typeof(char[]))
+            {
+                if (_union.UInt64 == 0 && _object is char[])
+                {
+                    value = (T)_object;
+                    result = true;
+                }
+                else
+                {
+                    // Don't allow "implicit" cast to array if we stored a segment.
+                    value = default!;
+                    result = false;
+                }
+            }
+            else if (typeof(T) == typeof(byte[]))
+            {
+                if (_union.UInt64 == 0 && _object is byte[])
+                {
+                    value = (T)_object;
+                    result = true;
+                }
+                else
+                {
+                    // Don't allow "implicit" cast to array if we stored a segment.
+                    value = default!;
+                    result = false;
+                }
+            }
+            else if (typeof(T) == typeof(object))
+            {
+                // This case must also come before the _object is T case to make sure we don't leak our flags.
+                if (_object is TypeFlag flag)
+                {
+                    value = (T)flag.ToObject(this);
+                    result = true;
+                }
+                else if (_union.UInt64 != 0 && _object is char[] chars)
+                {
+                    value = _union.UInt64 != ulong.MaxValue
+                        ? (T)(object)new ArraySegment<char>(chars, _union.Segment.Offset, _union.Segment.Count)
+                        : (T)(object)new ArraySegment<char>(chars, 0, 0);
+                    result = true;
+                }
+                else if (_union.UInt64 != 0 && _object is byte[] bytes)
+                {
+                    value = _union.UInt64 != ulong.MaxValue
+                        ? (T)(object)new ArraySegment<byte>(bytes, _union.Segment.Offset, _union.Segment.Count)
+                        : (T)(object)new ArraySegment<byte>(bytes, 0, 0);
+                    result = true;
+                }
+                else
+                {
+                    value = (T)_object;
+                    result = true;
+                }
+            }
+            else if (_object is T t)
+            {
+                value = t;
+                result = true;
+            }
+            else
+            {
+                value = default!;
+                result = false;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly T As<T>()
+        {
+            if (!TryGetValue<T>(out T value))
+            {
+                ThrowInvalidCast();
+            }
+
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private readonly T CastTo<T>()
+        {
+            Debug.Assert(typeof(T).IsPrimitive);
+            T value = Unsafe.As<Union, T>(ref Unsafe.AsRef(_union));
+            return value;
+        }
+        #endregion
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/Creation.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/Creation.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+
+namespace Azure
+{
+    public class Creation
+    {
+        [Test]
+        public void CreateIsAllocationFree()
+        {
+            var watch = MemoryWatch.Create;
+
+            Value.Create((byte)default);
+            watch.Validate();
+            Value.Create((sbyte)default);
+            watch.Validate();
+            Value.Create((char)default);
+            watch.Validate();
+            Value.Create((double)default);
+            watch.Validate();
+            Value.Create((short)default);
+            watch.Validate();
+            Value.Create((int)default);
+            watch.Validate();
+            Value.Create((long)default);
+            watch.Validate();
+            Value.Create((ushort)default);
+            watch.Validate();
+            Value.Create((uint)default);
+            watch.Validate();
+            Value.Create((ulong)default);
+            watch.Validate();
+            Value.Create((float)default);
+            watch.Validate();
+            Value.Create((double)default);
+            watch.Validate();
+
+            Value.Create((bool?)default);
+            watch.Validate();
+            Value.Create((byte?)default);
+            watch.Validate();
+            Value.Create((sbyte?)default);
+            watch.Validate();
+            Value.Create((char?)default);
+            watch.Validate();
+            Value.Create((double?)default);
+            watch.Validate();
+            Value.Create((short?)default);
+            watch.Validate();
+            Value.Create((int?)default);
+            watch.Validate();
+            Value.Create((long?)default);
+            watch.Validate();
+            Value.Create((ushort?)default);
+            watch.Validate();
+            Value.Create((uint?)default);
+            watch.Validate();
+            Value.Create((ulong?)default);
+            watch.Validate();
+            Value.Create((float?)default);
+            watch.Validate();
+            Value.Create((double?)default);
+            watch.Validate();
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/Creation.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/Creation.cs
@@ -10,8 +10,10 @@ namespace Azure
         [Test]
         public void CreateIsAllocationFree()
         {
-            var watch = MemoryWatch.Create;
+            var watch = MemoryWatch.Create();
 
+            Value.Create((bool)default);
+            watch.Validate();
             Value.Create((byte)default);
             watch.Validate();
             Value.Create((sbyte)default);

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/MemoryWatch.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/MemoryWatch.cs
@@ -11,7 +11,7 @@ namespace Azure
         private static bool s_jit;
         private long _allocations;
 
-        public static void JIT()
+        private static void JIT()
         {
             if (s_jit)
             {
@@ -35,6 +35,10 @@ namespace Azure
             Value.Create((double)default).As<double>();
             Value.Create((DateTime)default).As<DateTime>();
             Value.Create((DateTimeOffset)default).As<DateTimeOffset>();
+            Value.Create(new byte[1]).As<byte[]>();
+            Value.Create(new char[1]).As<char[]>();
+            Value.Create(new ArraySegment<byte>(new byte[1])).As<ArraySegment<byte>>();
+            Value.Create(new ArraySegment<char>(new char[1])).As<ArraySegment<char>>();
 
             Value.Create((bool?)default).As<bool?>();
             Value.Create((byte?)default).As<byte?>();
@@ -72,15 +76,12 @@ namespace Azure
             s_jit = true;
         }
 
-        public MemoryWatch(long allocations) => _allocations = allocations;
+        private MemoryWatch(long allocations) => _allocations = allocations;
 
-        public static MemoryWatch Create
+        public static MemoryWatch Create()
         {
-            get
-            {
-                JIT();
-                return new(GetAllocatedBytesPortable());
-            }
+            JIT();
+            return new(GetAllocatedBytesPortable());
         }
 
         public void Dispose() => Validate();
@@ -94,7 +95,7 @@ namespace Azure
             _allocations = GetAllocatedBytesPortable();
         }
 
-        public static long GetAllocatedBytesPortable()
+        private static long GetAllocatedBytesPortable()
         {
 #if NET6_0
             return GC.GetAllocatedBytesForCurrentThread();

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/MemoryWatch.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/MemoryWatch.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using NUnit.Framework;
+
+namespace Azure
+{
+    public ref struct MemoryWatch
+    {
+        private static bool s_jit;
+        private long _allocations;
+
+        public static void JIT()
+        {
+            if (s_jit)
+            {
+                return;
+            }
+
+            // JITing allocates, so make sure we've got all of our <T> methods created.
+
+            Value.Create((bool)default).As<bool>();
+            Value.Create((byte)default).As<byte>();
+            Value.Create((sbyte)default).As<sbyte>();
+            Value.Create((char)default).As<char>();
+            Value.Create((double)default).As<double>();
+            Value.Create((short)default).As<short>();
+            Value.Create((int)default).As<int>();
+            Value.Create((long)default).As<long>();
+            Value.Create((ushort)default).As<ushort>();
+            Value.Create((uint)default).As<uint>();
+            Value.Create((ulong)default).As<ulong>();
+            Value.Create((float)default).As<float>();
+            Value.Create((double)default).As<double>();
+            Value.Create((DateTime)default).As<DateTime>();
+            Value.Create((DateTimeOffset)default).As<DateTimeOffset>();
+
+            Value.Create((bool?)default).As<bool?>();
+            Value.Create((byte?)default).As<byte?>();
+            Value.Create((sbyte?)default).As<sbyte?>();
+            Value.Create((char?)default).As<char?>();
+            Value.Create((double?)default).As<double?>();
+            Value.Create((short?)default).As<short?>();
+            Value.Create((int?)default).As<int?>();
+            Value.Create((long?)default).As<long?>();
+            Value.Create((ushort?)default).As<ushort?>();
+            Value.Create((uint?)default).As<uint?>();
+            Value.Create((ulong?)default).As<ulong?>();
+            Value.Create((float?)default).As<float?>();
+            Value.Create((double?)default).As<double?>();
+            Value.Create((DateTime?)default).As<DateTime?>();
+            Value.Create((DateTimeOffset?)default).As<DateTimeOffset?>();
+
+            Value value = default;
+            value.TryGetValue(out bool _);
+            value.TryGetValue(out byte _);
+            value.TryGetValue(out sbyte _);
+            value.TryGetValue(out char _);
+            value.TryGetValue(out double _);
+            value.TryGetValue(out short _);
+            value.TryGetValue(out int _);
+            value.TryGetValue(out long _);
+            value.TryGetValue(out ushort _);
+            value.TryGetValue(out uint _);
+            value.TryGetValue(out ulong _);
+            value.TryGetValue(out float _);
+            value.TryGetValue(out double _);
+            value.TryGetValue(out DateTime _);
+            value.TryGetValue(out DateTimeOffset _);
+
+            s_jit = true;
+        }
+
+        public MemoryWatch(long allocations) => _allocations = allocations;
+
+        public static MemoryWatch Create
+        {
+            get
+            {
+                JIT();
+                return new(GetAllocatedBytesPortable());
+            }
+        }
+
+        public void Dispose() => Validate();
+
+        public void Validate()
+        {
+            var allocated = GetAllocatedBytesPortable();
+            Assert.AreEqual(0, allocated - _allocations);
+
+            // Assert.AreEqual allocates
+            _allocations = GetAllocatedBytesPortable();
+        }
+
+        public static long GetAllocatedBytesPortable()
+        {
+#if NET6_0
+            return GC.GetAllocatedBytesForCurrentThread();
+#else
+            return 0;
+#endif
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringArrays.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringArrays.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using NUnit.Framework;
+
+namespace Azure
+{
+    public class StoringArrays
+    {
+        [Test]
+        public void ByteArray()
+        {
+            byte[] b = new byte[10];
+            Value value;
+
+            value = Value.Create(b);
+            Assert.AreEqual(typeof(byte[]), value.Type);
+            Assert.AreSame(b, value.As<byte[]>());
+            Assert.AreEqual(b, (byte[])value.As<object>());
+
+            Assert.Throws<InvalidCastException>(() => value.As<ArraySegment<byte>>());
+        }
+
+        [Test]
+        public void CharArray()
+        {
+            char[] b = new char[10];
+            Value value;
+
+            value = Value.Create(b);
+            Assert.AreEqual(typeof(char[]), value.Type);
+            Assert.AreSame(b, value.As<char[]>());
+            Assert.AreEqual(b, (char[])value.As<object>());
+
+            Assert.Throws<InvalidCastException>(() => value.As<ArraySegment<char>>());
+        }
+
+        [Test]
+        public void ByteSegment()
+        {
+            byte[] b = new byte[10];
+            Value value;
+
+            ArraySegment<byte> segment = new(b);
+            value = Value.Create(segment);
+            Assert.AreEqual(typeof(ArraySegment<byte>), value.Type);
+            Assert.AreEqual(segment, value.As<ArraySegment<byte>>());
+            Assert.AreEqual(segment, (ArraySegment<byte>)value.As<object>());
+            Assert.Throws<InvalidCastException>(() => value.As<byte[]>());
+
+            segment = new(b, 0, 0);
+            value = Value.Create(segment);
+            Assert.AreEqual(typeof(ArraySegment<byte>), value.Type);
+            Assert.AreEqual(segment, value.As<ArraySegment<byte>>());
+            Assert.AreEqual(segment, (ArraySegment<byte>)value.As<object>());
+            Assert.Throws<InvalidCastException>(() => value.As<byte[]>());
+
+            segment = new(b, 1, 1);
+            value = Value.Create(segment);
+            Assert.AreEqual(typeof(ArraySegment<byte>), value.Type);
+            Assert.AreEqual(segment, value.As<ArraySegment<byte>>());
+            Assert.AreEqual(segment, (ArraySegment<byte>)value.As<object>());
+            Assert.Throws<InvalidCastException>(() => value.As<byte[]>());
+        }
+
+        [Test]
+        public void CharSegment()
+        {
+            char[] b = new char[10];
+            Value value;
+
+            ArraySegment<char> segment = new(b);
+            value = Value.Create(segment);
+            Assert.AreEqual(typeof(ArraySegment<char>), value.Type);
+            Assert.AreEqual(segment, value.As<ArraySegment<char>>());
+            Assert.AreEqual(segment, (ArraySegment<char>)value.As<object>());
+            Assert.Throws<InvalidCastException>(() => value.As<char[]>());
+
+            segment = new(b, 0, 0);
+            value = Value.Create(segment);
+            Assert.AreEqual(typeof(ArraySegment<char>), value.Type);
+            Assert.AreEqual(segment, value.As<ArraySegment<char>>());
+            Assert.AreEqual(segment, (ArraySegment<char>)value.As<object>());
+            Assert.Throws<InvalidCastException>(() => value.As<char[]>());
+
+            segment = new(b, 1, 1);
+            value = Value.Create(segment);
+            Assert.AreEqual(typeof(ArraySegment<char>), value.Type);
+            Assert.AreEqual(segment, value.As<ArraySegment<char>>());
+            Assert.AreEqual(segment, (ArraySegment<char>)value.As<object>());
+            Assert.Throws<InvalidCastException>(() => value.As<char[]>());
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringArrays.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringArrays.cs
@@ -12,9 +12,11 @@ namespace Azure
         public void ByteArray()
         {
             byte[] b = new byte[10];
-            Value value;
 
-            value = Value.Create(b);
+            var watch = MemoryWatch.Create();
+            Value value = Value.Create(b);
+            watch.Validate();
+
             Assert.AreEqual(typeof(byte[]), value.Type);
             Assert.AreSame(b, value.As<byte[]>());
             Assert.AreEqual(b, (byte[])value.As<object>());
@@ -26,9 +28,11 @@ namespace Azure
         public void CharArray()
         {
             char[] b = new char[10];
-            Value value;
 
-            value = Value.Create(b);
+            var watch = MemoryWatch.Create();
+            Value value = Value.Create(b);
+            watch.Validate();
+
             Assert.AreEqual(typeof(char[]), value.Type);
             Assert.AreSame(b, value.As<char[]>());
             Assert.AreEqual(b, (char[])value.As<object>());
@@ -40,10 +44,12 @@ namespace Azure
         public void ByteSegment()
         {
             byte[] b = new byte[10];
-            Value value;
-
             ArraySegment<byte> segment = new(b);
-            value = Value.Create(segment);
+
+            var watch = MemoryWatch.Create();
+            Value value = Value.Create(segment);
+            watch.Validate();
+
             Assert.AreEqual(typeof(ArraySegment<byte>), value.Type);
             Assert.AreEqual(segment, value.As<ArraySegment<byte>>());
             Assert.AreEqual(segment, (ArraySegment<byte>)value.As<object>());
@@ -68,10 +74,12 @@ namespace Azure
         public void CharSegment()
         {
             char[] b = new char[10];
-            Value value;
-
             ArraySegment<char> segment = new(b);
-            value = Value.Create(segment);
+
+            var watch = MemoryWatch.Create();
+            Value value = Value.Create(segment);
+            watch.Validate();
+
             Assert.AreEqual(typeof(ArraySegment<char>), value.Type);
             Assert.AreEqual(segment, value.As<ArraySegment<char>>());
             Assert.AreEqual(segment, (ArraySegment<char>)value.As<object>());

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringBoolean.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringBoolean.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
 
 namespace Azure
 {
@@ -9,18 +8,18 @@ namespace Azure
     {
         [TestCase(true)]
         [TestCase(false)]
-        public void BooleanImplicit(bool @bool)
+        public void BooleanImplicit(bool testValue)
         {
             Value value;
             using (MemoryWatch.Create)
             {
-                value = @bool;
+                value = testValue;
             }
 
-            Assert.AreEqual(@bool, value.As<bool>());
+            Assert.AreEqual(testValue, value.As<bool>());
             Assert.AreEqual(typeof(bool), value.Type);
 
-            bool? source = @bool;
+            bool? source = testValue;
             using (MemoryWatch.Create)
             {
                 value = source;
@@ -31,18 +30,18 @@ namespace Azure
 
         [TestCase(true)]
         [TestCase(false)]
-        public void BooleanCreate(bool @bool)
+        public void BooleanCreate(bool testValue)
         {
             Value value;
             using (MemoryWatch.Create)
             {
-                value = Value.Create(@bool);
+                value = Value.Create(testValue);
             }
 
-            Assert.AreEqual(@bool, value.As<bool>());
+            Assert.AreEqual(testValue, value.As<bool>());
             Assert.AreEqual(typeof(bool), value.Type);
 
-            bool? source = @bool;
+            bool? source = testValue;
 
             using (MemoryWatch.Create)
             {
@@ -55,7 +54,7 @@ namespace Azure
 
         [TestCase(true)]
         [TestCase(false)]
-        public void BooleanInOut(bool @bool)
+        public void BooleanInOut(bool testValue)
         {
             Value value;
             bool success;
@@ -63,22 +62,22 @@ namespace Azure
 
             using (MemoryWatch.Create)
             {
-                value = new(@bool);
+                value = new(testValue);
                 success = value.TryGetValue(out result);
             }
 
             Assert.True(success);
-            Assert.AreEqual(@bool, result);
+            Assert.AreEqual(testValue, result);
 
-            Assert.AreEqual(@bool, value.As<bool>());
-            Assert.AreEqual(@bool, (bool)value);
+            Assert.AreEqual(testValue, value.As<bool>());
+            Assert.AreEqual(testValue, (bool)value);
         }
 
         [TestCase(true)]
         [TestCase(false)]
-        public void NullableBooleanInBooleanOut(bool? @bool)
+        public void NullableBooleanInBooleanOut(bool? testValue)
         {
-            bool? source = @bool;
+            bool? source = testValue;
             Value value;
             bool success;
             bool result;
@@ -90,49 +89,49 @@ namespace Azure
             }
 
             Assert.True(success);
-            Assert.AreEqual(@bool, result);
+            Assert.AreEqual(testValue, result);
 
-            Assert.AreEqual(@bool, value.As<bool>());
+            Assert.AreEqual(testValue, value.As<bool>());
 
-            Assert.AreEqual(@bool, (bool)value);
+            Assert.AreEqual(testValue, (bool)value);
         }
 
         [TestCase(true)]
         [TestCase(false)]
-        public void BooleanInNullableBooleanOut(bool @bool)
+        public void BooleanInNullableBooleanOut(bool testValue)
         {
-            bool source = @bool;
+            bool source = testValue;
             Value value = new(source);
             bool success = value.TryGetValue(out bool? result);
             Assert.True(success);
-            Assert.AreEqual(@bool, result);
+            Assert.AreEqual(testValue, result);
 
-            Assert.AreEqual(@bool, (bool?)value);
+            Assert.AreEqual(testValue, (bool?)value);
         }
 
         [TestCase(true)]
         [TestCase(false)]
-        public void BoxedBoolean(bool @bool)
+        public void BoxedBoolean(bool testValue)
         {
-            bool i = @bool;
+            bool i = testValue;
             object o = i;
             Value value = new(o);
 
             Assert.AreEqual(typeof(bool), value.Type);
             Assert.True(value.TryGetValue(out bool result));
-            Assert.AreEqual(@bool, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out bool? nullableResult));
-            Assert.AreEqual(@bool, nullableResult!.Value);
+            Assert.AreEqual(testValue, nullableResult!.Value);
 
-            bool? n = @bool;
+            bool? n = testValue;
             o = n;
             value = new(o);
 
             Assert.AreEqual(typeof(bool), value.Type);
             Assert.True(value.TryGetValue(out result));
-            Assert.AreEqual(@bool, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out nullableResult));
-            Assert.AreEqual(@bool, nullableResult!.Value);
+            Assert.AreEqual(testValue, nullableResult!.Value);
         }
 
         [Test]
@@ -153,18 +152,18 @@ namespace Azure
 
         [TestCase(true)]
         [TestCase(false)]
-        public void OutAsObject(bool @bool)
+        public void OutAsObject(bool testValue)
         {
-            Value value = new(@bool);
+            Value value = new(testValue);
             object o = value.As<object>();
             Assert.AreEqual(typeof(bool), o.GetType());
-            Assert.AreEqual(@bool, (bool)o);
+            Assert.AreEqual(testValue, (bool)o);
 
-            bool? n = @bool;
+            bool? n = testValue;
             value = new(n);
             o = value.As<object>();
             Assert.AreEqual(typeof(bool), o.GetType());
-            Assert.AreEqual(@bool, (bool)o);
+            Assert.AreEqual(testValue, (bool)o);
         }
     }
 }

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringBoolean.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringBoolean.cs
@@ -1,0 +1,170 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+
+namespace Azure
+{
+    public class StoringBoolean
+    {
+        [TestCase(true)]
+        [TestCase(false)]
+        public void BooleanImplicit(bool @bool)
+        {
+            Value value;
+            using (MemoryWatch.Create)
+            {
+                value = @bool;
+            }
+
+            Assert.AreEqual(@bool, value.As<bool>());
+            Assert.AreEqual(typeof(bool), value.Type);
+
+            bool? source = @bool;
+            using (MemoryWatch.Create)
+            {
+                value = source;
+            }
+            Assert.AreEqual(source, value.As<bool?>());
+            Assert.AreEqual(typeof(bool), value.Type);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void BooleanCreate(bool @bool)
+        {
+            Value value;
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(@bool);
+            }
+
+            Assert.AreEqual(@bool, value.As<bool>());
+            Assert.AreEqual(typeof(bool), value.Type);
+
+            bool? source = @bool;
+
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(source);
+            }
+
+            Assert.AreEqual(source, value.As<bool?>());
+            Assert.AreEqual(typeof(bool), value.Type);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void BooleanInOut(bool @bool)
+        {
+            Value value;
+            bool success;
+            bool result;
+
+            using (MemoryWatch.Create)
+            {
+                value = new(@bool);
+                success = value.TryGetValue(out result);
+            }
+
+            Assert.True(success);
+            Assert.AreEqual(@bool, result);
+
+            Assert.AreEqual(@bool, value.As<bool>());
+            Assert.AreEqual(@bool, (bool)value);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void NullableBooleanInBooleanOut(bool? @bool)
+        {
+            bool? source = @bool;
+            Value value;
+            bool success;
+            bool result;
+
+            using (MemoryWatch.Create)
+            {
+                value = new(source);
+                success = value.TryGetValue(out result);
+            }
+
+            Assert.True(success);
+            Assert.AreEqual(@bool, result);
+
+            Assert.AreEqual(@bool, value.As<bool>());
+
+            Assert.AreEqual(@bool, (bool)value);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void BooleanInNullableBooleanOut(bool @bool)
+        {
+            bool source = @bool;
+            Value value = new(source);
+            bool success = value.TryGetValue(out bool? result);
+            Assert.True(success);
+            Assert.AreEqual(@bool, result);
+
+            Assert.AreEqual(@bool, (bool?)value);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void BoxedBoolean(bool @bool)
+        {
+            bool i = @bool;
+            object o = i;
+            Value value = new(o);
+
+            Assert.AreEqual(typeof(bool), value.Type);
+            Assert.True(value.TryGetValue(out bool result));
+            Assert.AreEqual(@bool, result);
+            Assert.True(value.TryGetValue(out bool? nullableResult));
+            Assert.AreEqual(@bool, nullableResult!.Value);
+
+            bool? n = @bool;
+            o = n;
+            value = new(o);
+
+            Assert.AreEqual(typeof(bool), value.Type);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(@bool, result);
+            Assert.True(value.TryGetValue(out nullableResult));
+            Assert.AreEqual(@bool, nullableResult!.Value);
+        }
+
+        [Test]
+        public void NullBoolean()
+        {
+            bool? source = null;
+            Value value;
+
+            using (MemoryWatch.Create)
+            {
+                value = source;
+            }
+
+            Assert.Null(value.Type);
+            Assert.AreEqual(source, value.As<bool?>());
+            Assert.False(value.As<bool?>().HasValue);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void OutAsObject(bool @bool)
+        {
+            Value value = new(@bool);
+            object o = value.As<object>();
+            Assert.AreEqual(typeof(bool), o.GetType());
+            Assert.AreEqual(@bool, (bool)o);
+
+            bool? n = @bool;
+            value = new(n);
+            o = value.As<object>();
+            Assert.AreEqual(typeof(bool), o.GetType());
+            Assert.AreEqual(@bool, (bool)o);
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringBoolean.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringBoolean.cs
@@ -11,7 +11,7 @@ namespace Azure
         public void BooleanImplicit(bool testValue)
         {
             Value value;
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = testValue;
             }
@@ -20,7 +20,7 @@ namespace Azure
             Assert.AreEqual(typeof(bool), value.Type);
 
             bool? source = testValue;
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = source;
             }
@@ -33,7 +33,7 @@ namespace Azure
         public void BooleanCreate(bool testValue)
         {
             Value value;
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(testValue);
             }
@@ -43,7 +43,7 @@ namespace Azure
 
             bool? source = testValue;
 
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(source);
             }
@@ -60,7 +60,7 @@ namespace Azure
             bool success;
             bool result;
 
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = new(testValue);
                 success = value.TryGetValue(out result);
@@ -82,7 +82,7 @@ namespace Azure
             bool success;
             bool result;
 
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = new(source);
                 success = value.TryGetValue(out result);
@@ -140,7 +140,7 @@ namespace Azure
             bool? source = null;
             Value value;
 
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = source;
             }

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringByte.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringByte.cs
@@ -27,7 +27,7 @@ namespace Azure
         public void ByteCreate(byte testValue)
         {
             Value value;
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(testValue);
             }
@@ -37,7 +37,7 @@ namespace Azure
 
             byte? source = testValue;
 
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(source);
             }

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringByte.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringByte.cs
@@ -9,13 +9,13 @@ namespace Azure
         [TestCase(42)]
         [TestCase(byte.MinValue)]
         [TestCase(byte.MaxValue)]
-        public void ByteImplicit(byte @byte)
+        public void ByteImplicit(byte testValue)
         {
-            Value value = @byte;
-            Assert.AreEqual(@byte, value.As<byte>());
+            Value value = testValue;
+            Assert.AreEqual(testValue, value.As<byte>());
             Assert.AreEqual(typeof(byte), value.Type);
 
-            byte? source = @byte;
+            byte? source = testValue;
             value = source;
             Assert.AreEqual(source, value.As<byte?>());
             Assert.AreEqual(typeof(byte), value.Type);
@@ -24,18 +24,18 @@ namespace Azure
         [TestCase(42)]
         [TestCase(byte.MinValue)]
         [TestCase(byte.MaxValue)]
-        public void ByteCreate(byte @byte)
+        public void ByteCreate(byte testValue)
         {
             Value value;
             using (MemoryWatch.Create)
             {
-                value = Value.Create(@byte);
+                value = Value.Create(testValue);
             }
 
-            Assert.AreEqual(@byte, value.As<byte>());
+            Assert.AreEqual(testValue, value.As<byte>());
             Assert.AreEqual(typeof(byte), value.Type);
 
-            byte? source = @byte;
+            byte? source = testValue;
 
             using (MemoryWatch.Create)
             {
@@ -49,72 +49,72 @@ namespace Azure
         [TestCase(42)]
         [TestCase(byte.MinValue)]
         [TestCase(byte.MaxValue)]
-        public void ByteInOut(byte @byte)
+        public void ByteInOut(byte testValue)
         {
-            Value value = new(@byte);
+            Value value = new(testValue);
             bool success = value.TryGetValue(out byte result);
             Assert.True(success);
-            Assert.AreEqual(@byte, result);
+            Assert.AreEqual(testValue, result);
 
-            Assert.AreEqual(@byte, value.As<byte>());
-            Assert.AreEqual(@byte, (byte)value);
+            Assert.AreEqual(testValue, value.As<byte>());
+            Assert.AreEqual(testValue, (byte)value);
         }
 
         [TestCase(42)]
         [TestCase(byte.MinValue)]
         [TestCase(byte.MaxValue)]
-        public void NullableByteInByteOut(byte? @byte)
+        public void NullableByteInByteOut(byte? testValue)
         {
-            byte? source = @byte;
+            byte? source = testValue;
             Value value = new(source);
 
             bool success = value.TryGetValue(out byte result);
             Assert.True(success);
-            Assert.AreEqual(@byte, result);
+            Assert.AreEqual(testValue, result);
 
-            Assert.AreEqual(@byte, value.As<byte>());
+            Assert.AreEqual(testValue, value.As<byte>());
 
-            Assert.AreEqual(@byte, (byte)value);
+            Assert.AreEqual(testValue, (byte)value);
         }
 
         [TestCase(42)]
         [TestCase(byte.MinValue)]
         [TestCase(byte.MaxValue)]
-        public void ByteInNullableByteOut(byte @byte)
+        public void ByteInNullableByteOut(byte testValue)
         {
-            byte source = @byte;
+            byte source = testValue;
             Value value = new(source);
             bool success = value.TryGetValue(out byte? result);
             Assert.True(success);
-            Assert.AreEqual(@byte, result);
+            Assert.AreEqual(testValue, result);
 
-            Assert.AreEqual(@byte, (byte?)value);
+            Assert.AreEqual(testValue, (byte?)value);
         }
 
         [TestCase(42)]
         [TestCase(byte.MinValue)]
         [TestCase(byte.MaxValue)]
-        public void BoxedByte(byte @byte)
+        public void BoxedByte(byte testValue)
         {
-            byte i = @byte;
+            byte i = testValue;
             object o = i;
             Value value = new(o);
 
             Assert.AreEqual(typeof(byte), value.Type);
             Assert.True(value.TryGetValue(out byte result));
-            Assert.AreEqual(@byte, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out byte? nullableResult));
-            Assert.AreEqual(@byte, nullableResult!.Value);
+            Assert.AreEqual(testValue, nullableResult!.Value);
 
-            byte? n = @byte;
+            byte? n = testValue;
             o = n;
             value = new(o);
 
             Assert.AreEqual(typeof(byte), value.Type);
             Assert.True(value.TryGetValue(out result));
-            Assert.AreEqual(@byte, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out nullableResult));
-            Assert.AreEqual(@byte, nullableResult!.Value);
+            Assert.AreEqual(testValue, nullableResult!.Value);
         }
 
         [Test]
@@ -130,18 +130,18 @@ namespace Azure
         [TestCase(42)]
         [TestCase(byte.MinValue)]
         [TestCase(byte.MaxValue)]
-        public void OutAsObject(byte @byte)
+        public void OutAsObject(byte testValue)
         {
-            Value value = new(@byte);
+            Value value = new(testValue);
             object o = value.As<object>();
             Assert.AreEqual(typeof(byte), o.GetType());
-            Assert.AreEqual(@byte, (byte)o);
+            Assert.AreEqual(testValue, (byte)o);
 
-            byte? n = @byte;
+            byte? n = testValue;
             value = new(n);
             o = value.As<object>();
             Assert.AreEqual(typeof(byte), o.GetType());
-            Assert.AreEqual(@byte, (byte)o);
+            Assert.AreEqual(testValue, (byte)o);
         }
     }
 }

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringByte.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringByte.cs
@@ -1,0 +1,147 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using NUnit.Framework;
+
+namespace Azure
+{
+    public class StoringByte
+    {
+        [TestCase(42)]
+        [TestCase(byte.MinValue)]
+        [TestCase(byte.MaxValue)]
+        public void ByteImplicit(byte @byte)
+        {
+            Value value = @byte;
+            Assert.AreEqual(@byte, value.As<byte>());
+            Assert.AreEqual(typeof(byte), value.Type);
+
+            byte? source = @byte;
+            value = source;
+            Assert.AreEqual(source, value.As<byte?>());
+            Assert.AreEqual(typeof(byte), value.Type);
+        }
+
+        [TestCase(42)]
+        [TestCase(byte.MinValue)]
+        [TestCase(byte.MaxValue)]
+        public void ByteCreate(byte @byte)
+        {
+            Value value;
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(@byte);
+            }
+
+            Assert.AreEqual(@byte, value.As<byte>());
+            Assert.AreEqual(typeof(byte), value.Type);
+
+            byte? source = @byte;
+
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(source);
+            }
+
+            Assert.AreEqual(source, value.As<byte?>());
+            Assert.AreEqual(typeof(byte), value.Type);
+        }
+
+        [TestCase(42)]
+        [TestCase(byte.MinValue)]
+        [TestCase(byte.MaxValue)]
+        public void ByteInOut(byte @byte)
+        {
+            Value value = new(@byte);
+            bool success = value.TryGetValue(out byte result);
+            Assert.True(success);
+            Assert.AreEqual(@byte, result);
+
+            Assert.AreEqual(@byte, value.As<byte>());
+            Assert.AreEqual(@byte, (byte)value);
+        }
+
+        [TestCase(42)]
+        [TestCase(byte.MinValue)]
+        [TestCase(byte.MaxValue)]
+        public void NullableByteInByteOut(byte? @byte)
+        {
+            byte? source = @byte;
+            Value value = new(source);
+
+            bool success = value.TryGetValue(out byte result);
+            Assert.True(success);
+            Assert.AreEqual(@byte, result);
+
+            Assert.AreEqual(@byte, value.As<byte>());
+
+            Assert.AreEqual(@byte, (byte)value);
+        }
+
+        [TestCase(42)]
+        [TestCase(byte.MinValue)]
+        [TestCase(byte.MaxValue)]
+        public void ByteInNullableByteOut(byte @byte)
+        {
+            byte source = @byte;
+            Value value = new(source);
+            bool success = value.TryGetValue(out byte? result);
+            Assert.True(success);
+            Assert.AreEqual(@byte, result);
+
+            Assert.AreEqual(@byte, (byte?)value);
+        }
+
+        [TestCase(42)]
+        [TestCase(byte.MinValue)]
+        [TestCase(byte.MaxValue)]
+        public void BoxedByte(byte @byte)
+        {
+            byte i = @byte;
+            object o = i;
+            Value value = new(o);
+
+            Assert.AreEqual(typeof(byte), value.Type);
+            Assert.True(value.TryGetValue(out byte result));
+            Assert.AreEqual(@byte, result);
+            Assert.True(value.TryGetValue(out byte? nullableResult));
+            Assert.AreEqual(@byte, nullableResult!.Value);
+
+            byte? n = @byte;
+            o = n;
+            value = new(o);
+
+            Assert.AreEqual(typeof(byte), value.Type);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(@byte, result);
+            Assert.True(value.TryGetValue(out nullableResult));
+            Assert.AreEqual(@byte, nullableResult!.Value);
+        }
+
+        [Test]
+        public void NullByte()
+        {
+            byte? source = null;
+            Value value = source;
+            Assert.Null(value.Type);
+            Assert.AreEqual(source, value.As<byte?>());
+            Assert.False(value.As<byte?>().HasValue);
+        }
+
+        [TestCase(42)]
+        [TestCase(byte.MinValue)]
+        [TestCase(byte.MaxValue)]
+        public void OutAsObject(byte @byte)
+        {
+            Value value = new(@byte);
+            object o = value.As<object>();
+            Assert.AreEqual(typeof(byte), o.GetType());
+            Assert.AreEqual(@byte, (byte)o);
+
+            byte? n = @byte;
+            value = new(n);
+            o = value.As<object>();
+            Assert.AreEqual(typeof(byte), o.GetType());
+            Assert.AreEqual(@byte, (byte)o);
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringChar.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringChar.cs
@@ -1,0 +1,147 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using NUnit.Framework;
+
+namespace Azure
+{
+    public class StoringChar
+    {
+        [TestCase('!')]
+        [TestCase(char.MaxValue)]
+        [TestCase(char.MinValue)]
+        public void CharImplicit(char @char)
+        {
+            Value value = @char;
+            Assert.AreEqual(@char, value.As<char>());
+            Assert.AreEqual(typeof(char), value.Type);
+
+            char? source = @char;
+            value = source;
+            Assert.AreEqual(source, value.As<char?>());
+            Assert.AreEqual(typeof(char), value.Type);
+        }
+
+        [TestCase('!')]
+        [TestCase(char.MaxValue)]
+        [TestCase(char.MinValue)]
+        public void CharCreate(char @char)
+        {
+            Value value;
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(@char);
+            }
+
+            Assert.AreEqual(@char, value.As<char>());
+            Assert.AreEqual(typeof(char), value.Type);
+
+            char? source = @char;
+
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(source);
+            }
+
+            Assert.AreEqual(source, value.As<char?>());
+            Assert.AreEqual(typeof(char), value.Type);
+        }
+
+        [TestCase('!')]
+        [TestCase(char.MaxValue)]
+        [TestCase(char.MinValue)]
+        public void CharInOut(char @char)
+        {
+            Value value = new(@char);
+            bool success = value.TryGetValue(out char result);
+            Assert.True(success);
+            Assert.AreEqual(@char, result);
+
+            Assert.AreEqual(@char, value.As<char>());
+            Assert.AreEqual(@char, (char)value);
+        }
+
+        [TestCase('!')]
+        [TestCase(char.MaxValue)]
+        [TestCase(char.MinValue)]
+        public void NullableCharInCharOut(char? @char)
+        {
+            char? source = @char;
+            Value value = new(source);
+
+            bool success = value.TryGetValue(out char result);
+            Assert.True(success);
+            Assert.AreEqual(@char, result);
+
+            Assert.AreEqual(@char, value.As<char>());
+
+            Assert.AreEqual(@char, (char)value);
+        }
+
+        [TestCase('!')]
+        [TestCase(char.MaxValue)]
+        [TestCase(char.MinValue)]
+        public void CharInNullableCharOut(char @char)
+        {
+            char source = @char;
+            Value value = new(source);
+            bool success = value.TryGetValue(out char? result);
+            Assert.True(success);
+            Assert.AreEqual(@char, result);
+
+            Assert.AreEqual(@char, (char?)value);
+        }
+
+        [TestCase('!')]
+        [TestCase(char.MaxValue)]
+        [TestCase(char.MinValue)]
+        public void BoxedChar(char @char)
+        {
+            char i = @char;
+            object o = i;
+            Value value = new(o);
+
+            Assert.AreEqual(typeof(char), value.Type);
+            Assert.True(value.TryGetValue(out char result));
+            Assert.AreEqual(@char, result);
+            Assert.True(value.TryGetValue(out char? nullableResult));
+            Assert.AreEqual(@char, nullableResult!.Value);
+
+            char? n = @char;
+            o = n;
+            value = new(o);
+
+            Assert.AreEqual(typeof(char), value.Type);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(@char, result);
+            Assert.True(value.TryGetValue(out nullableResult));
+            Assert.AreEqual(@char, nullableResult!.Value);
+        }
+
+        [Test]
+        public void NullChar()
+        {
+            char? source = null;
+            Value value = source;
+            Assert.Null(value.Type);
+            Assert.AreEqual(source, value.As<char?>());
+            Assert.False(value.As<char?>().HasValue);
+        }
+
+        [TestCase('!')]
+        [TestCase(char.MaxValue)]
+        [TestCase(char.MinValue)]
+        public void OutAsObject(char @char)
+        {
+            Value value = new(@char);
+            object o = value.As<object>();
+            Assert.AreEqual(typeof(char), o.GetType());
+            Assert.AreEqual(@char, (char)o);
+
+            char? n = @char;
+            value = new(n);
+            o = value.As<object>();
+            Assert.AreEqual(typeof(char), o.GetType());
+            Assert.AreEqual(@char, (char)o);
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringChar.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringChar.cs
@@ -27,7 +27,7 @@ namespace Azure
         public void CharCreate(char testValue)
         {
             Value value;
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(testValue);
             }
@@ -37,7 +37,7 @@ namespace Azure
 
             char? source = testValue;
 
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(source);
             }

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringChar.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringChar.cs
@@ -9,13 +9,13 @@ namespace Azure
         [TestCase('!')]
         [TestCase(char.MaxValue)]
         [TestCase(char.MinValue)]
-        public void CharImplicit(char @char)
+        public void CharImplicit(char testValue)
         {
-            Value value = @char;
-            Assert.AreEqual(@char, value.As<char>());
+            Value value = testValue;
+            Assert.AreEqual(testValue, value.As<char>());
             Assert.AreEqual(typeof(char), value.Type);
 
-            char? source = @char;
+            char? source = testValue;
             value = source;
             Assert.AreEqual(source, value.As<char?>());
             Assert.AreEqual(typeof(char), value.Type);
@@ -24,18 +24,18 @@ namespace Azure
         [TestCase('!')]
         [TestCase(char.MaxValue)]
         [TestCase(char.MinValue)]
-        public void CharCreate(char @char)
+        public void CharCreate(char testValue)
         {
             Value value;
             using (MemoryWatch.Create)
             {
-                value = Value.Create(@char);
+                value = Value.Create(testValue);
             }
 
-            Assert.AreEqual(@char, value.As<char>());
+            Assert.AreEqual(testValue, value.As<char>());
             Assert.AreEqual(typeof(char), value.Type);
 
-            char? source = @char;
+            char? source = testValue;
 
             using (MemoryWatch.Create)
             {
@@ -49,72 +49,72 @@ namespace Azure
         [TestCase('!')]
         [TestCase(char.MaxValue)]
         [TestCase(char.MinValue)]
-        public void CharInOut(char @char)
+        public void CharInOut(char testValue)
         {
-            Value value = new(@char);
+            Value value = new(testValue);
             bool success = value.TryGetValue(out char result);
             Assert.True(success);
-            Assert.AreEqual(@char, result);
+            Assert.AreEqual(testValue, result);
 
-            Assert.AreEqual(@char, value.As<char>());
-            Assert.AreEqual(@char, (char)value);
+            Assert.AreEqual(testValue, value.As<char>());
+            Assert.AreEqual(testValue, (char)value);
         }
 
         [TestCase('!')]
         [TestCase(char.MaxValue)]
         [TestCase(char.MinValue)]
-        public void NullableCharInCharOut(char? @char)
+        public void NullableCharInCharOut(char? testValue)
         {
-            char? source = @char;
+            char? source = testValue;
             Value value = new(source);
 
             bool success = value.TryGetValue(out char result);
             Assert.True(success);
-            Assert.AreEqual(@char, result);
+            Assert.AreEqual(testValue, result);
 
-            Assert.AreEqual(@char, value.As<char>());
+            Assert.AreEqual(testValue, value.As<char>());
 
-            Assert.AreEqual(@char, (char)value);
+            Assert.AreEqual(testValue, (char)value);
         }
 
         [TestCase('!')]
         [TestCase(char.MaxValue)]
         [TestCase(char.MinValue)]
-        public void CharInNullableCharOut(char @char)
+        public void CharInNullableCharOut(char testValue)
         {
-            char source = @char;
+            char source = testValue;
             Value value = new(source);
             bool success = value.TryGetValue(out char? result);
             Assert.True(success);
-            Assert.AreEqual(@char, result);
+            Assert.AreEqual(testValue, result);
 
-            Assert.AreEqual(@char, (char?)value);
+            Assert.AreEqual(testValue, (char?)value);
         }
 
         [TestCase('!')]
         [TestCase(char.MaxValue)]
         [TestCase(char.MinValue)]
-        public void BoxedChar(char @char)
+        public void BoxedChar(char testValue)
         {
-            char i = @char;
+            char i = testValue;
             object o = i;
             Value value = new(o);
 
             Assert.AreEqual(typeof(char), value.Type);
             Assert.True(value.TryGetValue(out char result));
-            Assert.AreEqual(@char, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out char? nullableResult));
-            Assert.AreEqual(@char, nullableResult!.Value);
+            Assert.AreEqual(testValue, nullableResult!.Value);
 
-            char? n = @char;
+            char? n = testValue;
             o = n;
             value = new(o);
 
             Assert.AreEqual(typeof(char), value.Type);
             Assert.True(value.TryGetValue(out result));
-            Assert.AreEqual(@char, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out nullableResult));
-            Assert.AreEqual(@char, nullableResult!.Value);
+            Assert.AreEqual(testValue, nullableResult!.Value);
         }
 
         [Test]
@@ -130,18 +130,18 @@ namespace Azure
         [TestCase('!')]
         [TestCase(char.MaxValue)]
         [TestCase(char.MinValue)]
-        public void OutAsObject(char @char)
+        public void OutAsObject(char testValue)
         {
-            Value value = new(@char);
+            Value value = new(testValue);
             object o = value.As<object>();
             Assert.AreEqual(typeof(char), o.GetType());
-            Assert.AreEqual(@char, (char)o);
+            Assert.AreEqual(testValue, (char)o);
 
-            char? n = @char;
+            char? n = testValue;
             value = new(n);
             o = value.As<object>();
             Assert.AreEqual(typeof(char), o.GetType());
-            Assert.AreEqual(@char, (char)o);
+            Assert.AreEqual(testValue, (char)o);
         }
     }
 }

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringDateTime.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringDateTime.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using NUnit.Framework;
+
+namespace Azure
+{
+    public class StoringDateTime
+    {
+        public static DateTime[] DateTimeData => new[]
+        {
+            DateTime.Now,
+            DateTime.UtcNow,
+            DateTime.MaxValue,
+            DateTime.MinValue
+        };
+
+        [Test]
+        public void DateTimeImplicit([ValueSource("DateTimeData")] DateTime testValue)
+        {
+            Value value = testValue;
+            Assert.AreEqual(testValue, value.As<DateTime>());
+            Assert.AreEqual(typeof(DateTime), value.Type);
+
+            DateTime? source = testValue;
+            value = source;
+            Assert.AreEqual(source, value.As<DateTime?>());
+            Assert.AreEqual(typeof(DateTime), value.Type);
+        }
+
+        [Test]
+        public void DateTimeInOut([ValueSource("DateTimeData")] DateTime testValue)
+        {
+            Value value = new(testValue);
+            bool success = value.TryGetValue(out DateTime result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, value.As<DateTime>());
+            Assert.AreEqual(testValue, (DateTime)value);
+        }
+
+        [Test]
+        public void NullableDateTimeInDateTimeOut([ValueSource("DateTimeData")] DateTime? testValue)
+        {
+            DateTime? source = testValue;
+            Value value = new(source);
+
+            bool success = value.TryGetValue(out DateTime result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, value.As<DateTime>());
+
+            Assert.AreEqual(testValue, (DateTime)value);
+        }
+
+        [Test]
+        public void DateTimeInNullableDateTimeOut([ValueSource("DateTimeData")] DateTime testValue)
+        {
+            DateTime source = testValue;
+            Value value = new(source);
+            bool success = value.TryGetValue(out DateTime? result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, (DateTime?)value);
+        }
+
+        [Test]
+        public void NullDateTime()
+        {
+            DateTime? source = null;
+            Value value = source;
+            Assert.Null(value.Type);
+            Assert.AreEqual(source, value.As<DateTime?>());
+            Assert.False(value.As<DateTime?>().HasValue);
+        }
+
+        [Test]
+        public void OutAsObject([ValueSource("DateTimeData")] DateTime testValue)
+        {
+            Value value = new(testValue);
+            object o = value.As<object>();
+            Assert.AreEqual(typeof(DateTime), o.GetType());
+            Assert.AreEqual(testValue, (DateTime)o);
+
+            DateTime? n = testValue;
+            value = new(n);
+            o = value.As<object>();
+            Assert.AreEqual(typeof(DateTime), o.GetType());
+            Assert.AreEqual(testValue, (DateTime)o);
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringDateTimeOffset.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringDateTimeOffset.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using NUnit.Framework;
+
+namespace Azure
+{
+    public class StoringDateTimeOffset
+    {
+        public static DateTimeOffset[] DateTimeOffsetData => new[]
+        {
+            DateTimeOffset.Now,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.MaxValue,
+            DateTimeOffset.MinValue
+        };
+
+        [Test]
+        public void DateTimeOffsetImplicit([ValueSource("DateTimeOffsetData")] DateTimeOffset testValue)
+        {
+            Value value = testValue;
+            Assert.AreEqual(testValue, value.As<DateTimeOffset>());
+            Assert.AreEqual(typeof(DateTimeOffset), value.Type);
+
+            DateTimeOffset? source = testValue;
+            value = source;
+            Assert.AreEqual(source, value.As<DateTimeOffset?>());
+            Assert.AreEqual(typeof(DateTimeOffset), value.Type);
+        }
+
+        [Test]
+        public void DateTimeOffsetInOut([ValueSource("DateTimeOffsetData")] DateTimeOffset testValue)
+        {
+            Value value = new(testValue);
+            bool success = value.TryGetValue(out DateTimeOffset result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, value.As<DateTimeOffset>());
+            Assert.AreEqual(testValue, (DateTimeOffset)value);
+        }
+
+        [Test]
+        public void NullableDateTimeOffsetInDateTimeOffsetOut([ValueSource("DateTimeOffsetData")] DateTimeOffset? testValue)
+        {
+            DateTimeOffset? source = testValue;
+            Value value = new(source);
+
+            bool success = value.TryGetValue(out DateTimeOffset result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, value.As<DateTimeOffset>());
+
+            Assert.AreEqual(testValue, (DateTimeOffset)value);
+        }
+
+        [Test]
+        public void DateTimeOffsetInNullableDateTimeOffsetOut([ValueSource("DateTimeOffsetData")] DateTimeOffset testValue)
+        {
+            DateTimeOffset source = testValue;
+            Value value = new(source);
+            bool success = value.TryGetValue(out DateTimeOffset? result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, (DateTimeOffset?)value);
+        }
+
+        [Test]
+        public void NullDateTimeOffset()
+        {
+            DateTimeOffset? source = null;
+            Value value = source;
+            Assert.Null(value.Type);
+            Assert.AreEqual(source, value.As<DateTimeOffset?>());
+            Assert.False(value.As<DateTimeOffset?>().HasValue);
+        }
+
+        [Test]
+        public void OutAsObject([ValueSource("DateTimeOffsetData")] DateTimeOffset testValue)
+        {
+            Value value = new(testValue);
+            object o = value.As<object>();
+            Assert.AreEqual(typeof(DateTimeOffset), o.GetType());
+            Assert.AreEqual(testValue, (DateTimeOffset)o);
+
+            DateTimeOffset? n = testValue;
+            value = new(n);
+            o = value.As<object>();
+            Assert.AreEqual(typeof(DateTimeOffset), o.GetType());
+            Assert.AreEqual(testValue, (DateTimeOffset)o);
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringDecimal.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringDecimal.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+
+namespace Azure
+{
+    public class StoringDecimal
+    {
+        public static decimal[] DecimalData => new[]
+        {
+            42,
+            decimal.MaxValue,
+            decimal.MinValue
+        };
+
+        [Test]
+        public void DecimalImplicit()
+        {
+            Value value = (decimal)42.0;
+            Assert.AreEqual((decimal)42.0, value.As<decimal>());
+            Assert.AreEqual(typeof(decimal), value.Type);
+
+            decimal? source = (decimal?)42.0;
+            value = source;
+            Assert.AreEqual(source, value.As<decimal?>());
+            Assert.AreEqual(typeof(decimal), value.Type);
+        }
+
+        [Test]
+        public void DecimalInOut([ValueSource("DecimalData")] decimal testValue)
+        {
+            Value value = new(testValue);
+            bool success = value.TryGetValue(out decimal result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, value.As<decimal>());
+            Assert.AreEqual(testValue, (decimal)value);
+        }
+
+        [Test]
+        public void NullableDecimalInDecimalOut([ValueSource("DecimalData")] decimal? testValue)
+        {
+            decimal? source = testValue;
+            Value value = new(source);
+
+            bool success = value.TryGetValue(out decimal result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, value.As<decimal>());
+
+            Assert.AreEqual(testValue, (decimal)value);
+        }
+
+        [Test]
+        public void DecimalInNullableDecimalOut([ValueSource("DecimalData")] decimal testValue)
+        {
+            decimal source = testValue;
+            Value value = new(source);
+            bool success = value.TryGetValue(out decimal? result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, (decimal?)value);
+        }
+
+        [Test]
+        public void NullDecimal()
+        {
+            decimal? source = null;
+            Value value = source;
+            Assert.Null(value.Type);
+            Assert.AreEqual(source, value.As<decimal?>());
+            Assert.False(value.As<decimal?>().HasValue);
+        }
+
+        [Test]
+        public void OutAsObject([ValueSource("DecimalData")] decimal testValue)
+        {
+            Value value = new(testValue);
+            object o = value.As<object>();
+            Assert.AreEqual(typeof(decimal), o.GetType());
+            Assert.AreEqual(testValue, (decimal)o);
+
+            decimal? n = testValue;
+            value = new(n);
+            o = value.As<object>();
+            Assert.AreEqual(typeof(decimal), o.GetType());
+            Assert.AreEqual(testValue, (decimal)o);
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringDouble.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringDouble.cs
@@ -35,7 +35,7 @@ namespace Azure
         public void DoubleCreate([ValueSource("DoubleData")] double testValue)
         {
             Value value;
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(testValue);
             }
@@ -45,7 +45,7 @@ namespace Azure
 
             double? source = testValue;
 
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(source);
             }

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringDouble.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringDouble.cs
@@ -1,0 +1,145 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+
+namespace Azure
+{
+    public class StoringDouble
+    {
+        public static double[] DoubleData => new[]
+        {
+            0d,
+            42d,
+            double.MaxValue,
+            double.MinValue,
+            double.NaN,
+            double.NegativeInfinity,
+            double.PositiveInfinity
+        };
+
+        [Test]
+        public void DoubleImplicit([ValueSource("DoubleData")] double testValue)
+        {
+            Value value = testValue;
+            Assert.AreEqual(testValue, value.As<double>());
+            Assert.AreEqual(typeof(double), value.Type);
+
+            double? source = testValue;
+            value = source;
+            Assert.AreEqual(source, value.As<double?>());
+            Assert.AreEqual(typeof(double), value.Type);
+        }
+
+        [Test]
+        public void DoubleCreate([ValueSource("DoubleData")] double testValue)
+        {
+            Value value;
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(testValue);
+            }
+
+            Assert.AreEqual(testValue, value.As<double>());
+            Assert.AreEqual(typeof(double), value.Type);
+
+            double? source = testValue;
+
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(source);
+            }
+
+            Assert.AreEqual(source, value.As<double?>());
+            Assert.AreEqual(typeof(double), value.Type);
+        }
+
+        [Test]
+        public void DoubleInOut([ValueSource("DoubleData")] double testValue)
+        {
+            Value value = new(testValue);
+            bool success = value.TryGetValue(out double result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, value.As<double>());
+            Assert.AreEqual(testValue, (double)value);
+        }
+
+        [Test]
+        public void NullableDoubleInDoubleOut([ValueSource("DoubleData")] double? testValue)
+        {
+            double? source = testValue;
+            Value value = new(source);
+
+            bool success = value.TryGetValue(out double result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, value.As<double>());
+
+            Assert.AreEqual(testValue, (double)value);
+        }
+
+        [Test]
+        public void DoubleInNullableDoubleOut([ValueSource("DoubleData")] double testValue)
+        {
+            double source = testValue;
+            Value value = new(source);
+            bool success = value.TryGetValue(out double? result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, (double)value);
+        }
+
+        [Test]
+        public void BoxedDouble([ValueSource("DoubleData")] double testValue)
+        {
+            double i = testValue;
+            object o = i;
+            Value value = new(o);
+
+            Assert.AreEqual(typeof(double), value.Type);
+            Assert.True(value.TryGetValue(out double result));
+            Assert.AreEqual(testValue, result);
+            Assert.True(value.TryGetValue(out double? nullableResult));
+            Assert.AreEqual(testValue, nullableResult!.Value);
+
+            double? n = testValue;
+            o = n;
+            value = new(o);
+
+            Assert.AreEqual(typeof(double), value.Type);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(testValue, result);
+            Assert.True(value.TryGetValue(out nullableResult));
+            Assert.AreEqual(testValue, nullableResult!.Value);
+        }
+
+        [Test]
+        public void NullDouble()
+        {
+            double? source = null;
+            Value value = source;
+            Assert.Null(value.Type);
+            Assert.AreEqual(source, value.As<double?>());
+            Assert.False(value.As<double?>().HasValue);
+        }
+
+        [Test]
+        public void OutAsObject([ValueSource("DoubleData")] double testValue)
+        {
+            Value value = new(testValue);
+            object o = value.As<object>();
+            Assert.AreEqual(typeof(double), o.GetType());
+            Assert.AreEqual(testValue, (double)o);
+
+            double? n = testValue;
+            value = new(n);
+            o = value.As<object>();
+            Assert.AreEqual(typeof(double), o.GetType());
+            Assert.AreEqual(testValue, (double)o);
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringEnum.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringEnum.cs
@@ -64,86 +64,86 @@ namespace Azure
 
         [TestCase(ByteEnum.MinValue)]
         [TestCase(ByteEnum.MaxValue)]
-        public void ByteSize(ByteEnum @enum)
+        public void ByteSize(ByteEnum testValue)
         {
-            Value value = Value.Create(@enum);
+            Value value = Value.Create(testValue);
             Assert.True(value.TryGetValue(out ByteEnum result));
-            Assert.AreEqual(@enum, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out ByteEnum? nullResult));
-            Assert.AreEqual(@enum, nullResult!.Value);
-            value = Value.Create((ByteEnum?)@enum);
+            Assert.AreEqual(testValue, nullResult!.Value);
+            value = Value.Create((ByteEnum?)testValue);
             Assert.True(value.TryGetValue(out result));
-            Assert.AreEqual(@enum, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out nullResult));
-            Assert.AreEqual(@enum, nullResult!.Value);
+            Assert.AreEqual(testValue, nullResult!.Value);
 
             // Create boxed
-            value = new(@enum);
+            value = new(testValue);
             Assert.True(value.TryGetValue(out result));
-            Assert.AreEqual(@enum, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out nullResult));
-            Assert.AreEqual(@enum, nullResult!.Value);
-            value = new((ByteEnum?)@enum);
+            Assert.AreEqual(testValue, nullResult!.Value);
+            value = new((ByteEnum?)testValue);
             Assert.True(value.TryGetValue(out result));
-            Assert.AreEqual(@enum, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out nullResult));
-            Assert.AreEqual(@enum, nullResult!.Value);
+            Assert.AreEqual(testValue, nullResult!.Value);
         }
 
         [TestCase(ShortEnum.MinValue)]
         [TestCase(ShortEnum.MaxValue)]
-        public void ShortSize(ShortEnum @enum)
+        public void ShortSize(ShortEnum testValue)
         {
-            Value value = Value.Create(@enum);
+            Value value = Value.Create(testValue);
             Assert.True(value.TryGetValue(out ShortEnum result));
-            Assert.AreEqual(@enum, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out ShortEnum? nullResult));
-            Assert.AreEqual(@enum, nullResult!.Value);
-            value = Value.Create((ShortEnum?)@enum);
+            Assert.AreEqual(testValue, nullResult!.Value);
+            value = Value.Create((ShortEnum?)testValue);
             Assert.True(value.TryGetValue(out result));
-            Assert.AreEqual(@enum, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out nullResult));
-            Assert.AreEqual(@enum, nullResult!.Value);
+            Assert.AreEqual(testValue, nullResult!.Value);
 
             // Create boxed
-            value = new(@enum);
+            value = new(testValue);
             Assert.True(value.TryGetValue(out result));
-            Assert.AreEqual(@enum, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out nullResult));
-            Assert.AreEqual(@enum, nullResult!.Value);
-            value = new((ShortEnum?)@enum);
+            Assert.AreEqual(testValue, nullResult!.Value);
+            value = new((ShortEnum?)testValue);
             Assert.True(value.TryGetValue(out result));
-            Assert.AreEqual(@enum, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out nullResult));
-            Assert.AreEqual(@enum, nullResult!.Value);
+            Assert.AreEqual(testValue, nullResult!.Value);
         }
 
         [TestCase(LongEnum.MinValue)]
         [TestCase(LongEnum.MaxValue)]
-        public void LongSize(LongEnum @enum)
+        public void LongSize(LongEnum testValue)
         {
-            Value value = Value.Create(@enum);
+            Value value = Value.Create(testValue);
             Assert.True(value.TryGetValue(out LongEnum result));
-            Assert.AreEqual(@enum, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out LongEnum? nullResult));
-            Assert.AreEqual(@enum, nullResult!.Value);
-            value = Value.Create((LongEnum?)@enum);
+            Assert.AreEqual(testValue, nullResult!.Value);
+            value = Value.Create((LongEnum?)testValue);
             Assert.True(value.TryGetValue(out result));
-            Assert.AreEqual(@enum, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out nullResult));
-            Assert.AreEqual(@enum, nullResult!.Value);
+            Assert.AreEqual(testValue, nullResult!.Value);
 
             // Create boxed
-            value = new(@enum);
+            value = new(testValue);
             Assert.True(value.TryGetValue(out result));
-            Assert.AreEqual(@enum, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out nullResult));
-            Assert.AreEqual(@enum, nullResult!.Value);
-            value = new((LongEnum?)@enum);
+            Assert.AreEqual(testValue, nullResult!.Value);
+            value = new((LongEnum?)testValue);
             Assert.True(value.TryGetValue(out result));
-            Assert.AreEqual(@enum, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out nullResult));
-            Assert.AreEqual(@enum, nullResult!.Value);
+            Assert.AreEqual(testValue, nullResult!.Value);
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringEnum.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringEnum.cs
@@ -1,0 +1,174 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.CompilerServices;
+using NUnit.Framework;
+
+namespace Azure
+{
+    public class StoringEnum
+    {
+        [Test]
+        public void BasicFunctionality()
+        {
+            InitType();
+            DayOfWeek day = DayOfWeek.Monday;
+
+            MemoryWatch watch = MemoryWatch.Create;
+            Value value = Value.Create(day);
+            DayOfWeek outDay = value.As<DayOfWeek>();
+            watch.Validate();
+
+            Assert.AreEqual(day, outDay);
+            Assert.AreEqual(typeof(DayOfWeek), value.Type);
+        }
+
+        [Test]
+        public void NullableEnum()
+        {
+            DayOfWeek? day = DayOfWeek.Monday;
+
+            Value value = Value.Create(day);
+            DayOfWeek outDay = value.As<DayOfWeek>();
+
+            Assert.AreEqual(day.Value, outDay);
+            Assert.AreEqual(typeof(DayOfWeek), value.Type);
+        }
+
+        [Test]
+        public void ToFromNullableEnum()
+        {
+            DayOfWeek day = DayOfWeek.Monday;
+            Value value = Value.Create(day);
+            Assert.True(value.TryGetValue(out DayOfWeek? nullDay));
+            Assert.AreEqual(day, nullDay);
+
+            value = Value.Create((DayOfWeek?)day);
+            Assert.True(value.TryGetValue(out DayOfWeek outDay));
+            Assert.AreEqual(day, outDay);
+        }
+
+        [Test]
+        public void BoxedEnum()
+        {
+            DayOfWeek day = DayOfWeek.Monday;
+            Value value = new(day);
+            Assert.True(value.TryGetValue(out DayOfWeek? nullDay));
+            Assert.AreEqual(day, nullDay);
+
+            value = new((DayOfWeek?)day);
+            Assert.True(value.TryGetValue(out DayOfWeek outDay));
+            Assert.AreEqual(day, outDay);
+        }
+
+        [TestCase(ByteEnum.MinValue)]
+        [TestCase(ByteEnum.MaxValue)]
+        public void ByteSize(ByteEnum @enum)
+        {
+            Value value = Value.Create(@enum);
+            Assert.True(value.TryGetValue(out ByteEnum result));
+            Assert.AreEqual(@enum, result);
+            Assert.True(value.TryGetValue(out ByteEnum? nullResult));
+            Assert.AreEqual(@enum, nullResult!.Value);
+            value = Value.Create((ByteEnum?)@enum);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(@enum, result);
+            Assert.True(value.TryGetValue(out nullResult));
+            Assert.AreEqual(@enum, nullResult!.Value);
+
+            // Create boxed
+            value = new(@enum);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(@enum, result);
+            Assert.True(value.TryGetValue(out nullResult));
+            Assert.AreEqual(@enum, nullResult!.Value);
+            value = new((ByteEnum?)@enum);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(@enum, result);
+            Assert.True(value.TryGetValue(out nullResult));
+            Assert.AreEqual(@enum, nullResult!.Value);
+        }
+
+        [TestCase(ShortEnum.MinValue)]
+        [TestCase(ShortEnum.MaxValue)]
+        public void ShortSize(ShortEnum @enum)
+        {
+            Value value = Value.Create(@enum);
+            Assert.True(value.TryGetValue(out ShortEnum result));
+            Assert.AreEqual(@enum, result);
+            Assert.True(value.TryGetValue(out ShortEnum? nullResult));
+            Assert.AreEqual(@enum, nullResult!.Value);
+            value = Value.Create((ShortEnum?)@enum);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(@enum, result);
+            Assert.True(value.TryGetValue(out nullResult));
+            Assert.AreEqual(@enum, nullResult!.Value);
+
+            // Create boxed
+            value = new(@enum);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(@enum, result);
+            Assert.True(value.TryGetValue(out nullResult));
+            Assert.AreEqual(@enum, nullResult!.Value);
+            value = new((ShortEnum?)@enum);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(@enum, result);
+            Assert.True(value.TryGetValue(out nullResult));
+            Assert.AreEqual(@enum, nullResult!.Value);
+        }
+
+        [TestCase(LongEnum.MinValue)]
+        [TestCase(LongEnum.MaxValue)]
+        public void LongSize(LongEnum @enum)
+        {
+            Value value = Value.Create(@enum);
+            Assert.True(value.TryGetValue(out LongEnum result));
+            Assert.AreEqual(@enum, result);
+            Assert.True(value.TryGetValue(out LongEnum? nullResult));
+            Assert.AreEqual(@enum, nullResult!.Value);
+            value = Value.Create((LongEnum?)@enum);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(@enum, result);
+            Assert.True(value.TryGetValue(out nullResult));
+            Assert.AreEqual(@enum, nullResult!.Value);
+
+            // Create boxed
+            value = new(@enum);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(@enum, result);
+            Assert.True(value.TryGetValue(out nullResult));
+            Assert.AreEqual(@enum, nullResult!.Value);
+            value = new((LongEnum?)@enum);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(@enum, result);
+            Assert.True(value.TryGetValue(out nullResult));
+            Assert.AreEqual(@enum, nullResult!.Value);
+        }
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        internal DayOfWeek InitType()
+        {
+            DayOfWeek day = DayOfWeek.Monday;
+            return Value.Create(day).As<DayOfWeek>();
+        }
+
+        public enum ByteEnum : byte
+        {
+            MinValue = byte.MinValue,
+            MaxValue = byte.MaxValue
+        }
+
+        public enum ShortEnum : short
+        {
+            MinValue = short.MinValue,
+            MaxValue = short.MaxValue
+        }
+
+        public enum LongEnum : long
+        {
+            MinValue = long.MinValue,
+            MaxValue = long.MaxValue
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringEnum.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringEnum.cs
@@ -15,10 +15,13 @@ namespace Azure
             InitType();
             DayOfWeek day = DayOfWeek.Monday;
 
-            MemoryWatch watch = MemoryWatch.Create;
-            Value value = Value.Create(day);
-            DayOfWeek outDay = value.As<DayOfWeek>();
-            watch.Validate();
+            Value value;
+            DayOfWeek outDay;
+            using (MemoryWatch watch = MemoryWatch.Create())
+            {
+                value = Value.Create(day);
+                outDay = value.As<DayOfWeek>();
+            }
 
             Assert.AreEqual(day, outDay);
             Assert.AreEqual(typeof(DayOfWeek), value.Type);

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringFloat.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringFloat.cs
@@ -1,0 +1,145 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+
+namespace Azure
+{
+    public class StoringFloat
+    {
+        public static float[] FloatData => new[]
+        {
+            0f,
+            42f,
+            float.MaxValue,
+            float.MinValue,
+            float.NaN,
+            float.NegativeInfinity,
+            float.PositiveInfinity
+        };
+
+        [Test]
+        public void FloatImplicit([ValueSource("FloatData")] float testValue)
+        {
+            Value value = testValue;
+            Assert.AreEqual(testValue, value.As<float>());
+            Assert.AreEqual(typeof(float), value.Type);
+
+            float? source = testValue;
+            value = source;
+            Assert.AreEqual(source, value.As<float?>());
+            Assert.AreEqual(typeof(float), value.Type);
+        }
+
+        [Test]
+        public void FloatCreate([ValueSource("FloatData")] float testValue)
+        {
+            Value value;
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(testValue);
+            }
+
+            Assert.AreEqual(testValue, value.As<float>());
+            Assert.AreEqual(typeof(float), value.Type);
+
+            float? source = testValue;
+
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(source);
+            }
+
+            Assert.AreEqual(source, value.As<float?>());
+            Assert.AreEqual(typeof(float), value.Type);
+        }
+
+        [Test]
+        public void FloatInOut([ValueSource("FloatData")] float testValue)
+        {
+            Value value = new(testValue);
+            bool success = value.TryGetValue(out float result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, value.As<float>());
+            Assert.AreEqual(testValue, (float)value);
+        }
+
+        [Test]
+        public void NullableFloatInFloatOut([ValueSource("FloatData")] float? testValue)
+        {
+            float? source = testValue;
+            Value value = new(source);
+
+            bool success = value.TryGetValue(out float result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, value.As<float>());
+
+            Assert.AreEqual(testValue, (float)value);
+        }
+
+        [Test]
+        public void FloatInNullableFloatOut([ValueSource("FloatData")] float testValue)
+        {
+            float source = testValue;
+            Value value = new(source);
+            bool success = value.TryGetValue(out float? result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, (float?)value);
+        }
+
+        [Test]
+        public void BoxedFloat([ValueSource("FloatData")] float testValue)
+        {
+            float i = testValue;
+            object o = i;
+            Value value = new(o);
+
+            Assert.AreEqual(typeof(float), value.Type);
+            Assert.True(value.TryGetValue(out float result));
+            Assert.AreEqual(testValue, result);
+            Assert.True(value.TryGetValue(out float? nullableResult));
+            Assert.AreEqual(testValue, nullableResult!.Value);
+
+            float? n = testValue;
+            o = n;
+            value = new(o);
+
+            Assert.AreEqual(typeof(float), value.Type);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(testValue, result);
+            Assert.True(value.TryGetValue(out nullableResult));
+            Assert.AreEqual(testValue, nullableResult!.Value);
+        }
+
+        [Test]
+        public void NullFloat()
+        {
+            float? source = null;
+            Value value = source;
+            Assert.Null(value.Type);
+            Assert.AreEqual(source, value.As<float?>());
+            Assert.False(value.As<float?>().HasValue);
+        }
+
+        [Test]
+        public void OutAsObject([ValueSource("FloatData")] float testValue)
+        {
+            Value value = new(testValue);
+            object o = value.As<object>();
+            Assert.AreEqual(typeof(float), o.GetType());
+            Assert.AreEqual(testValue, (float)o);
+
+            float? n = testValue;
+            value = new(n);
+            o = value.As<object>();
+            Assert.AreEqual(typeof(float), o.GetType());
+            Assert.AreEqual(testValue, (float)o);
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringFloat.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringFloat.cs
@@ -35,7 +35,7 @@ namespace Azure
         public void FloatCreate([ValueSource("FloatData")] float testValue)
         {
             Value value;
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(testValue);
             }
@@ -45,7 +45,7 @@ namespace Azure
 
             float? source = testValue;
 
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(source);
             }

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringInt.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringInt.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+
+namespace Azure
+{
+    public class StoringInt
+    {
+        public static int[] Int32Data => new[]
+        {
+            0,
+            42,
+            int.MaxValue ,
+            int.MinValue
+        };
+
+        [Test]
+        public void IntImplicit([ValueSource("Int32Data")] int testValue)
+        {
+            Value value = testValue;
+            Assert.AreEqual(testValue, value.As<int>());
+            Assert.AreEqual(typeof(int), value.Type);
+
+            int? source = testValue;
+            value = source;
+            Assert.AreEqual(source, value.As<int?>());
+            Assert.AreEqual(typeof(int), value.Type);
+        }
+
+        [Test]
+        public void IntCreate([ValueSource("Int32Data")] int testValue)
+        {
+            Value value;
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(testValue);
+            }
+
+            Assert.AreEqual(testValue, value.As<int>());
+            Assert.AreEqual(typeof(int), value.Type);
+
+            int? source = testValue;
+
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(source);
+            }
+
+            Assert.AreEqual(source, value.As<int?>());
+            Assert.AreEqual(typeof(int), value.Type);
+        }
+
+        [Test]
+        public void IntInOut([ValueSource("Int32Data")] int testValue)
+        {
+            Value value = new(testValue);
+            bool success = value.TryGetValue(out int result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, value.As<int>());
+            Assert.AreEqual(testValue, (int)value);
+        }
+
+        [Test]
+        public void NullableIntInIntOut([ValueSource("Int32Data")] int? testValue)
+        {
+            int? source = testValue;
+            Value value = new(source);
+
+            bool success = value.TryGetValue(out int result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, value.As<int>());
+
+            Assert.AreEqual(testValue, (int)value);
+        }
+
+        [Test]
+        public void IntInNullableIntOut([ValueSource("Int32Data")] int testValue)
+        {
+            int source = testValue;
+            Value value = new(source);
+            Assert.True(value.TryGetValue(out int? result));
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, (int?)value);
+        }
+
+        [Test]
+        public void BoxedInt([ValueSource("Int32Data")] int testValue)
+        {
+            int i = testValue;
+            object o = i;
+            Value value = new(o);
+
+            Assert.AreEqual(typeof(int), value.Type);
+            Assert.True(value.TryGetValue(out int result));
+            Assert.AreEqual(testValue, result);
+            Assert.True(value.TryGetValue(out int? nullableResult));
+            Assert.AreEqual(testValue, nullableResult!.Value);
+
+            int? n = testValue;
+            o = n;
+            value = new(o);
+
+            Assert.AreEqual(typeof(int), value.Type);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(testValue, result);
+            Assert.True(value.TryGetValue(out nullableResult));
+            Assert.AreEqual(testValue, nullableResult!.Value);
+        }
+
+        [Test]
+        public void NullInt()
+        {
+            int? source = null;
+            Value value = source;
+            Assert.Null(value.Type);
+            Assert.AreEqual(source, value.As<int?>());
+            Assert.False(value.As<int?>().HasValue);
+        }
+
+        [Test]
+        public void OutAsObject([ValueSource("Int32Data")] int testValue)
+        {
+            Value value = new(testValue);
+            object o = value.As<object>();
+            Assert.AreEqual(typeof(int), o.GetType());
+            Assert.AreEqual(testValue, (int)o);
+
+            int? n = testValue;
+            value = new(n);
+            o = value.As<object>();
+            Assert.AreEqual(typeof(int), o.GetType());
+            Assert.AreEqual(testValue, (int)o);
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringInt.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringInt.cs
@@ -32,7 +32,7 @@ namespace Azure
         public void IntCreate([ValueSource("Int32Data")] int testValue)
         {
             Value value;
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(testValue);
             }
@@ -42,7 +42,7 @@ namespace Azure
 
             int? source = testValue;
 
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(source);
             }

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringInt.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringInt.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 
 namespace Azure
 {
-    public class StoringInt
+    public class StoringInt32
     {
         public static int[] Int32Data => new[]
         {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringInt.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringInt.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 
 namespace Azure
 {
-    public class StoringInt32
+    public class StoringInt
     {
         public static int[] Int32Data => new[]
         {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringLong.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringLong.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+
+namespace Azure
+{
+    public class StoringLong
+    {
+        public static long[] LongData => new[]
+        {
+            0,
+            42,
+            long.MaxValue,
+            long.MinValue
+        };
+
+        [Test]
+        public void LongImplicit([ValueSource("LongData")] long testValue)
+        {
+            Value value = testValue;
+            Assert.AreEqual(testValue, value.As<long>());
+            Assert.AreEqual(typeof(long), value.Type);
+
+            long? source = testValue;
+            value = source;
+            Assert.AreEqual(source, value.As<long>());
+            Assert.AreEqual(typeof(long), value.Type);
+        }
+
+        [Test]
+        public void LongCreate([ValueSource("LongData")] long testValue)
+        {
+            Value value;
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(testValue);
+            }
+
+            Assert.AreEqual(testValue, value.As<long>());
+            Assert.AreEqual(typeof(long), value.Type);
+
+            long? source = testValue;
+
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(source);
+            }
+
+            Assert.AreEqual(source, value.As<long?>());
+            Assert.AreEqual(typeof(long), value.Type);
+        }
+
+        [Test]
+        public void LongInOut([ValueSource("LongData")] long testValue)
+        {
+            Value value = new(testValue);
+            bool success = value.TryGetValue(out long result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, value.As<long>());
+            Assert.AreEqual(testValue, (long)value);
+        }
+
+        [Test]
+        public void NullableLongInLongOut([ValueSource("LongData")] long? testValue)
+        {
+            long? source = testValue;
+            Value value = new(source);
+
+            bool success = value.TryGetValue(out long result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, value.As<long>());
+
+            Assert.AreEqual(testValue, (long)value);
+        }
+
+        [Test]
+        public void LongInNullableLongOut([ValueSource("LongData")] long testValue)
+        {
+            long source = testValue;
+            Value value = new(source);
+            bool success = value.TryGetValue(out long? result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, (long?)value);
+        }
+
+        [Test]
+        public void BoxedLong([ValueSource("LongData")] long testValue)
+        {
+            long i = testValue;
+            object o = i;
+            Value value = new(o);
+
+            Assert.AreEqual(typeof(long), value.Type);
+            Assert.True(value.TryGetValue(out long result));
+            Assert.AreEqual(testValue, result);
+            Assert.True(value.TryGetValue(out long? nullableResult));
+            Assert.AreEqual(testValue, nullableResult!.Value);
+
+            long? n = testValue;
+            o = n;
+            value = new(o);
+
+            Assert.AreEqual(typeof(long), value.Type);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(testValue, result);
+            Assert.True(value.TryGetValue(out nullableResult));
+            Assert.AreEqual(testValue, nullableResult!.Value);
+        }
+
+        [Test]
+        public void NullLong()
+        {
+            long? source = null;
+            Value value = source;
+            Assert.Null(value.Type);
+            Assert.AreEqual(source, value.As<long?>());
+            Assert.False(value.As<long?>().HasValue);
+        }
+
+        [Test]
+        public void OutAsObject([ValueSource("LongData")] long testValue)
+        {
+            Value value = new(testValue);
+            object o = value.As<object>();
+            Assert.AreEqual(typeof(long), o.GetType());
+            Assert.AreEqual(testValue, (long)o);
+
+            long? n = testValue;
+            value = new(n);
+            o = value.As<object>();
+            Assert.AreEqual(typeof(long), o.GetType());
+            Assert.AreEqual(testValue, (long)o);
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringLong.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringLong.cs
@@ -32,7 +32,7 @@ namespace Azure
         public void LongCreate([ValueSource("LongData")] long testValue)
         {
             Value value;
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(testValue);
             }
@@ -42,7 +42,7 @@ namespace Azure
 
             long? source = testValue;
 
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(source);
             }

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringNull.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringNull.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using NUnit.Framework;
+
+namespace Azure
+{
+    public class StoringNull
+    {
+        [Test]
+        public void GetIntFromStoredNull()
+        {
+            Value nullValue = new((object)null);
+            Assert.Throws<InvalidCastException>(() => _ = nullValue.As<int>());
+
+            Value nullFastValue = new((object)null);
+            Assert.Throws<InvalidCastException>(() => _ = nullFastValue.As<int>());
+
+            bool success = nullFastValue.TryGetValue(out int result);
+            Assert.False(success);
+
+            Assert.AreEqual(default(int), result);
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringObject.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringObject.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using NUnit.Framework;
+
+namespace Azure
+{
+    public class StoringObject
+    {
+        [Test]
+        public void BasicStorage()
+        {
+            A a = new();
+            Value value = new(a);
+            Assert.AreEqual(typeof(A), value.Type);
+            Assert.AreSame(a, value.As<A>());
+
+            bool success = value.TryGetValue(out B result);
+            Assert.False(success);
+            Assert.Null(result);
+        }
+
+        [Test]
+        public void DerivedRetrieval()
+        {
+            B b = new();
+            Value value = new(b);
+            Assert.AreEqual(typeof(B), value.Type);
+            Assert.AreSame(b, value.As<A>());
+            Assert.AreSame(b, value.As<B>());
+
+            bool success = value.TryGetValue(out C result);
+            Assert.False(success);
+            Assert.Null(result);
+
+            Assert.Throws<InvalidCastException>(() => value.As<C>());
+
+            A a = new B();
+            value = new(a);
+            Assert.AreEqual(typeof(B), value.Type);
+        }
+
+        [Test]
+        public void AsInterface()
+        {
+            I a = new A();
+            Value value = new(a);
+            Assert.AreEqual(typeof(A), value.Type);
+
+            Assert.AreSame(a, value.As<A>());
+            Assert.AreSame(a, value.As<I>());
+        }
+
+        private class A : I { }
+        private class B : A, I { }
+        private class C : B, I { }
+
+        private interface I
+        {
+            string ToString();
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringSByte.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringSByte.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+
+namespace Azure
+{
+    public class StoringSByte
+    {
+        [TestCase(0)]
+        [TestCase(42)]
+        [TestCase(sbyte.MinValue)]
+        [TestCase(sbyte.MaxValue)]
+        public void SByteImplicit(sbyte @sbyte)
+        {
+            Value value = @sbyte;
+            Assert.AreEqual(@sbyte, value.As<sbyte>());
+            Assert.AreEqual(typeof(sbyte), value.Type);
+
+            sbyte? source = @sbyte;
+            value = source;
+            Assert.AreEqual(source, value.As<sbyte?>());
+            Assert.AreEqual(typeof(sbyte), value.Type);
+        }
+
+        [TestCase(0)]
+        [TestCase(42)]
+        [TestCase(sbyte.MinValue)]
+        [TestCase(sbyte.MaxValue)]
+        public void SByteCreate(sbyte @sbyte)
+        {
+            Value value;
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(@sbyte);
+            }
+
+            Assert.AreEqual(@sbyte, value.As<sbyte>());
+            Assert.AreEqual(typeof(sbyte), value.Type);
+
+            sbyte? source = @sbyte;
+
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(source);
+            }
+
+            Assert.AreEqual(source, value.As<sbyte?>());
+            Assert.AreEqual(typeof(sbyte), value.Type);
+        }
+
+        [TestCase(0)]
+        [TestCase(42)]
+        [TestCase(sbyte.MinValue)]
+        [TestCase(sbyte.MaxValue)]
+        public void SByteInOut(sbyte @sbyte)
+        {
+            Value value = new(@sbyte);
+            bool success = value.TryGetValue(out sbyte result);
+            Assert.True(success);
+            Assert.AreEqual(@sbyte, result);
+
+            Assert.AreEqual(@sbyte, value.As<sbyte>());
+            Assert.AreEqual(@sbyte, (sbyte)value);
+        }
+
+        [TestCase(0)]
+        [TestCase(42)]
+        [TestCase(sbyte.MinValue)]
+        [TestCase(sbyte.MaxValue)]
+        public void NullableSByteInSByteOut(sbyte? @sbyte)
+        {
+            sbyte? source = @sbyte;
+            Value value = new(source);
+
+            bool success = value.TryGetValue(out sbyte result);
+            Assert.True(success);
+            Assert.AreEqual(@sbyte, result);
+
+            Assert.AreEqual(@sbyte, value.As<sbyte>());
+
+            Assert.AreEqual(@sbyte, (sbyte)value);
+        }
+
+        [TestCase(0)]
+        [TestCase(42)]
+        [TestCase(sbyte.MinValue)]
+        [TestCase(sbyte.MaxValue)]
+        public void SByteInNullableSByteOut(sbyte @sbyte)
+        {
+            sbyte source = @sbyte;
+            Value value = new(source);
+            bool success = value.TryGetValue(out sbyte? result);
+            Assert.True(success);
+            Assert.AreEqual(@sbyte, result);
+
+            Assert.AreEqual(@sbyte, (sbyte?)value);
+        }
+
+        [Test]
+        public void NullSByte()
+        {
+            sbyte? source = null;
+            Value value = source;
+            Assert.Null(value.Type);
+            Assert.AreEqual(source, value.As<sbyte?>());
+            Assert.False(value.As<sbyte?>().HasValue);
+        }
+
+        [TestCase(0)]
+        [TestCase(42)]
+        [TestCase(sbyte.MinValue)]
+        [TestCase(sbyte.MaxValue)]
+        public void OutAsObject(sbyte @sbyte)
+        {
+            Value value = new(@sbyte);
+            object o = value.As<object>();
+            Assert.AreEqual(typeof(sbyte), o.GetType());
+            Assert.AreEqual(@sbyte, (sbyte)o);
+
+            sbyte? n = @sbyte;
+            value = new(n);
+            o = value.As<object>();
+            Assert.AreEqual(typeof(sbyte), o.GetType());
+            Assert.AreEqual(@sbyte, (sbyte)o);
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringSByte.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringSByte.cs
@@ -11,13 +11,13 @@ namespace Azure
         [TestCase(42)]
         [TestCase(sbyte.MinValue)]
         [TestCase(sbyte.MaxValue)]
-        public void SByteImplicit(sbyte @sbyte)
+        public void SByteImplicit(sbyte testValue)
         {
-            Value value = @sbyte;
-            Assert.AreEqual(@sbyte, value.As<sbyte>());
+            Value value = testValue;
+            Assert.AreEqual(testValue, value.As<sbyte>());
             Assert.AreEqual(typeof(sbyte), value.Type);
 
-            sbyte? source = @sbyte;
+            sbyte? source = testValue;
             value = source;
             Assert.AreEqual(source, value.As<sbyte?>());
             Assert.AreEqual(typeof(sbyte), value.Type);
@@ -27,18 +27,18 @@ namespace Azure
         [TestCase(42)]
         [TestCase(sbyte.MinValue)]
         [TestCase(sbyte.MaxValue)]
-        public void SByteCreate(sbyte @sbyte)
+        public void SByteCreate(sbyte testValue)
         {
             Value value;
             using (MemoryWatch.Create)
             {
-                value = Value.Create(@sbyte);
+                value = Value.Create(testValue);
             }
 
-            Assert.AreEqual(@sbyte, value.As<sbyte>());
+            Assert.AreEqual(testValue, value.As<sbyte>());
             Assert.AreEqual(typeof(sbyte), value.Type);
 
-            sbyte? source = @sbyte;
+            sbyte? source = testValue;
 
             using (MemoryWatch.Create)
             {
@@ -53,48 +53,48 @@ namespace Azure
         [TestCase(42)]
         [TestCase(sbyte.MinValue)]
         [TestCase(sbyte.MaxValue)]
-        public void SByteInOut(sbyte @sbyte)
+        public void SByteInOut(sbyte testValue)
         {
-            Value value = new(@sbyte);
+            Value value = new(testValue);
             bool success = value.TryGetValue(out sbyte result);
             Assert.True(success);
-            Assert.AreEqual(@sbyte, result);
+            Assert.AreEqual(testValue, result);
 
-            Assert.AreEqual(@sbyte, value.As<sbyte>());
-            Assert.AreEqual(@sbyte, (sbyte)value);
+            Assert.AreEqual(testValue, value.As<sbyte>());
+            Assert.AreEqual(testValue, (sbyte)value);
         }
 
         [TestCase(0)]
         [TestCase(42)]
         [TestCase(sbyte.MinValue)]
         [TestCase(sbyte.MaxValue)]
-        public void NullableSByteInSByteOut(sbyte? @sbyte)
+        public void NullableSByteInSByteOut(sbyte? testValue)
         {
-            sbyte? source = @sbyte;
+            sbyte? source = testValue;
             Value value = new(source);
 
             bool success = value.TryGetValue(out sbyte result);
             Assert.True(success);
-            Assert.AreEqual(@sbyte, result);
+            Assert.AreEqual(testValue, result);
 
-            Assert.AreEqual(@sbyte, value.As<sbyte>());
+            Assert.AreEqual(testValue, value.As<sbyte>());
 
-            Assert.AreEqual(@sbyte, (sbyte)value);
+            Assert.AreEqual(testValue, (sbyte)value);
         }
 
         [TestCase(0)]
         [TestCase(42)]
         [TestCase(sbyte.MinValue)]
         [TestCase(sbyte.MaxValue)]
-        public void SByteInNullableSByteOut(sbyte @sbyte)
+        public void SByteInNullableSByteOut(sbyte testValue)
         {
-            sbyte source = @sbyte;
+            sbyte source = testValue;
             Value value = new(source);
             bool success = value.TryGetValue(out sbyte? result);
             Assert.True(success);
-            Assert.AreEqual(@sbyte, result);
+            Assert.AreEqual(testValue, result);
 
-            Assert.AreEqual(@sbyte, (sbyte?)value);
+            Assert.AreEqual(testValue, (sbyte?)value);
         }
 
         [Test]
@@ -111,18 +111,18 @@ namespace Azure
         [TestCase(42)]
         [TestCase(sbyte.MinValue)]
         [TestCase(sbyte.MaxValue)]
-        public void OutAsObject(sbyte @sbyte)
+        public void OutAsObject(sbyte testValue)
         {
-            Value value = new(@sbyte);
+            Value value = new(testValue);
             object o = value.As<object>();
             Assert.AreEqual(typeof(sbyte), o.GetType());
-            Assert.AreEqual(@sbyte, (sbyte)o);
+            Assert.AreEqual(testValue, (sbyte)o);
 
-            sbyte? n = @sbyte;
+            sbyte? n = testValue;
             value = new(n);
             o = value.As<object>();
             Assert.AreEqual(typeof(sbyte), o.GetType());
-            Assert.AreEqual(@sbyte, (sbyte)o);
+            Assert.AreEqual(testValue, (sbyte)o);
         }
     }
 }

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringSByte.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringSByte.cs
@@ -30,7 +30,7 @@ namespace Azure
         public void SByteCreate(sbyte testValue)
         {
             Value value;
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(testValue);
             }
@@ -40,7 +40,7 @@ namespace Azure
 
             sbyte? source = testValue;
 
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(source);
             }

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringShort.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringShort.cs
@@ -32,7 +32,7 @@ namespace Azure
         public void ShortCreate([ValueSource("ShortData")] short testValue)
         {
             Value value;
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(testValue);
             }
@@ -42,7 +42,7 @@ namespace Azure
 
             short? source = testValue;
 
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(source);
             }

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringShort.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringShort.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+
+namespace Azure
+{
+    public class StoringShort
+    {
+        public static short[] ShortData => new short[]
+        {
+            0,
+            42,
+            short.MaxValue,
+            short.MinValue
+        };
+
+        [Test]
+        public void ShortImplicit([ValueSource("ShortData")] short testValue)
+        {
+            Value value = testValue;
+            Assert.AreEqual(testValue, value.As<short>());
+            Assert.AreEqual(typeof(short), value.Type);
+
+            short? source = testValue;
+            value = source;
+            Assert.AreEqual(source, value.As<short?>());
+            Assert.AreEqual(typeof(short), value.Type);
+        }
+
+        [Test]
+        public void ShortCreate([ValueSource("ShortData")] short testValue)
+        {
+            Value value;
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(testValue);
+            }
+
+            Assert.AreEqual(testValue, value.As<short>());
+            Assert.AreEqual(typeof(short), value.Type);
+
+            short? source = testValue;
+
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(source);
+            }
+
+            Assert.AreEqual(source, value.As<short?>());
+            Assert.AreEqual(typeof(short), value.Type);
+        }
+
+        [Test]
+        public void ShortInOut([ValueSource("ShortData")] short testValue)
+        {
+            Value value = new(testValue);
+            bool success = value.TryGetValue(out short result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, value.As<short>());
+            Assert.AreEqual(testValue, (short)value);
+        }
+
+        [Test]
+        public void NullableShortInShortOut([ValueSource("ShortData")] short? testValue)
+        {
+            short? source = testValue;
+            Value value = new(source);
+
+            bool success = value.TryGetValue(out short result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, value.As<short>());
+
+            Assert.AreEqual(testValue, (short)value);
+        }
+
+        [Test]
+        public void ShortInNullableShortOut([ValueSource("ShortData")] short testValue)
+        {
+            short source = testValue;
+            Value value = new(source);
+            bool success = value.TryGetValue(out short? result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, (short?)value);
+        }
+
+        [Test]
+        public void BoxedShort([ValueSource("ShortData")] short testValue)
+        {
+            short i = testValue;
+            object o = i;
+            Value value = new(o);
+
+            Assert.AreEqual(typeof(short), value.Type);
+            Assert.True(value.TryGetValue(out short result));
+            Assert.AreEqual(testValue, result);
+            Assert.True(value.TryGetValue(out short? nullableResult));
+            Assert.AreEqual(testValue, nullableResult!.Value);
+
+            short? n = testValue;
+            o = n;
+            value = new(o);
+
+            Assert.AreEqual(typeof(short), value.Type);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(testValue, result);
+            Assert.True(value.TryGetValue(out nullableResult));
+            Assert.AreEqual(testValue, nullableResult!.Value);
+        }
+
+        [Test]
+        public void NullShort()
+        {
+            short? source = null;
+            Value value = source;
+            Assert.Null(value.Type);
+            Assert.AreEqual(source, value.As<short?>());
+            Assert.False(value.As<short?>().HasValue);
+        }
+
+        [Test]
+        public void OutAsObject([ValueSource("ShortData")] short testValue)
+        {
+            Value value = new(testValue);
+            object o = value.As<object>();
+            Assert.AreEqual(typeof(short), o.GetType());
+            Assert.AreEqual(testValue, (short)o);
+
+            short? n = testValue;
+            value = new(n);
+            o = value.As<object>();
+            Assert.AreEqual(typeof(short), o.GetType());
+            Assert.AreEqual(testValue, (short)o);
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUInt.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUInt.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+
+namespace Azure
+{
+    public class StoringUInt
+    {
+        public static uint[] UInt32Data => new uint[]
+        {
+            42,
+            uint.MaxValue,
+            uint.MinValue
+        };
+
+        [Test]
+        public void UIntImplicit([ValueSource("UInt32Data")] uint testValue)
+        {
+            Value value = testValue;
+            Assert.AreEqual(testValue, value.As<uint>());
+            Assert.AreEqual(typeof(uint), value.Type);
+
+            uint? source = testValue;
+            value = source;
+            Assert.AreEqual(source, value.As<uint?>());
+            Assert.AreEqual(typeof(uint), value.Type);
+        }
+
+        [Test]
+        public void UIntCreate([ValueSource("UInt32Data")] uint testValue)
+        {
+            Value value;
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(testValue);
+            }
+
+            Assert.AreEqual(testValue, value.As<uint>());
+            Assert.AreEqual(typeof(uint), value.Type);
+
+            uint? source = testValue;
+
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(source);
+            }
+
+            Assert.AreEqual(source, value.As<uint?>());
+            Assert.AreEqual(typeof(uint), value.Type);
+        }
+
+        [Test]
+        public void UIntInOut([ValueSource("UInt32Data")] uint testValue)
+        {
+            Value value = new(testValue);
+            bool success = value.TryGetValue(out uint result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, value.As<uint>());
+            Assert.AreEqual(testValue, (uint)value);
+        }
+
+        [Test]
+        public void NullableUIntInUIntOut([ValueSource("UInt32Data")] uint? testValue)
+        {
+            uint? source = testValue;
+            Value value = new(source);
+
+            bool success = value.TryGetValue(out uint result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, value.As<uint>());
+
+            Assert.AreEqual(testValue, (uint)value);
+        }
+
+        [Test]
+        public void UIntInNullableUIntOut([ValueSource("UInt32Data")] uint testValue)
+        {
+            uint source = testValue;
+            Value value = new(source);
+            bool success = value.TryGetValue(out uint? result);
+            Assert.True(success);
+            Assert.AreEqual(testValue, result);
+
+            Assert.AreEqual(testValue, (uint?)value);
+        }
+
+        [Test]
+        public void BoxedUInt([ValueSource("UInt32Data")] uint testValue)
+        {
+            uint i = testValue;
+            object o = i;
+            Value value = new(o);
+
+            Assert.AreEqual(typeof(uint), value.Type);
+            Assert.True(value.TryGetValue(out uint result));
+            Assert.AreEqual(testValue, result);
+            Assert.True(value.TryGetValue(out uint? nullableResult));
+            Assert.AreEqual(testValue, nullableResult!.Value);
+
+            uint? n = testValue;
+            o = n;
+            value = new(o);
+
+            Assert.AreEqual(typeof(uint), value.Type);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(testValue, result);
+            Assert.True(value.TryGetValue(out nullableResult));
+            Assert.AreEqual(testValue, nullableResult!.Value);
+        }
+
+        [Test]
+        public void NullUInt()
+        {
+            uint? source = null;
+            Value value = source;
+            Assert.Null(value.Type);
+            Assert.AreEqual(source, value.As<uint?>());
+            Assert.False(value.As<uint?>().HasValue);
+        }
+
+        [Test]
+        public void OutAsObject([ValueSource("UInt32Data")] uint testValue)
+        {
+            Value value = new(testValue);
+            object o = value.As<object>();
+            Assert.AreEqual(typeof(uint), o.GetType());
+            Assert.AreEqual(testValue, (uint)o);
+
+            uint? n = testValue;
+            value = new(n);
+            o = value.As<object>();
+            Assert.AreEqual(typeof(uint), o.GetType());
+            Assert.AreEqual(testValue, (uint)o);
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUInt.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUInt.cs
@@ -31,7 +31,7 @@ namespace Azure
         public void UIntCreate([ValueSource("UInt32Data")] uint testValue)
         {
             Value value;
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(testValue);
             }
@@ -41,7 +41,7 @@ namespace Azure
 
             uint? source = testValue;
 
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(source);
             }

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUShort.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUShort.cs
@@ -28,7 +28,7 @@ namespace Azure
         public void UShortCreate(ushort testValue)
         {
             Value value;
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(testValue);
             }
@@ -38,7 +38,7 @@ namespace Azure
 
             ushort? source = testValue;
 
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(source);
             }

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUShort.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUShort.cs
@@ -10,13 +10,13 @@ namespace Azure
         [TestCase((ushort)42)]
         [TestCase(ushort.MinValue)]
         [TestCase(ushort.MaxValue)]
-        public void UShortImplicit(ushort @ushort)
+        public void UShortImplicit(ushort testValue)
         {
-            Value value = @ushort;
-            Assert.AreEqual(@ushort, value.As<ushort>());
+            Value value = testValue;
+            Assert.AreEqual(testValue, value.As<ushort>());
             Assert.AreEqual(typeof(ushort), value.Type);
 
-            ushort? source = @ushort;
+            ushort? source = testValue;
             value = source;
             Assert.AreEqual(source, value.As<ushort?>());
             Assert.AreEqual(typeof(ushort), value.Type);
@@ -25,18 +25,18 @@ namespace Azure
         [TestCase((ushort)42)]
         [TestCase(ushort.MinValue)]
         [TestCase(ushort.MaxValue)]
-        public void UShortCreate(ushort @ushort)
+        public void UShortCreate(ushort testValue)
         {
             Value value;
             using (MemoryWatch.Create)
             {
-                value = Value.Create(@ushort);
+                value = Value.Create(testValue);
             }
 
-            Assert.AreEqual(@ushort, value.As<ushort>());
+            Assert.AreEqual(testValue, value.As<ushort>());
             Assert.AreEqual(typeof(ushort), value.Type);
 
-            ushort? source = @ushort;
+            ushort? source = testValue;
 
             using (MemoryWatch.Create)
             {
@@ -50,72 +50,72 @@ namespace Azure
         [TestCase((ushort)42)]
         [TestCase(ushort.MinValue)]
         [TestCase(ushort.MaxValue)]
-        public void UShortInOut(ushort @ushort)
+        public void UShortInOut(ushort testValue)
         {
-            Value value = new(@ushort);
+            Value value = new(testValue);
             bool success = value.TryGetValue(out ushort result);
             Assert.True(success);
-            Assert.AreEqual(@ushort, result);
+            Assert.AreEqual(testValue, result);
 
-            Assert.AreEqual(@ushort, value.As<ushort>());
-            Assert.AreEqual(@ushort, (ushort)value);
+            Assert.AreEqual(testValue, value.As<ushort>());
+            Assert.AreEqual(testValue, (ushort)value);
         }
 
         [TestCase((ushort)42)]
         [TestCase(ushort.MinValue)]
         [TestCase(ushort.MaxValue)]
-        public void NullableUShortInUShortOut(ushort? @ushort)
+        public void NullableUShortInUShortOut(ushort? testValue)
         {
-            ushort? source = @ushort;
+            ushort? source = testValue;
             Value value = new(source);
 
             bool success = value.TryGetValue(out ushort result);
             Assert.True(success);
-            Assert.AreEqual(@ushort, result);
+            Assert.AreEqual(testValue, result);
 
-            Assert.AreEqual(@ushort, value.As<ushort>());
+            Assert.AreEqual(testValue, value.As<ushort>());
 
-            Assert.AreEqual(@ushort, (ushort)value);
+            Assert.AreEqual(testValue, (ushort)value);
         }
 
         [TestCase((ushort)42)]
         [TestCase(ushort.MinValue)]
         [TestCase(ushort.MaxValue)]
-        public void UShortInNullableUShortOut(ushort @ushort)
+        public void UShortInNullableUShortOut(ushort testValue)
         {
-            ushort source = @ushort;
+            ushort source = testValue;
             Value value = new(source);
             bool success = value.TryGetValue(out ushort? result);
             Assert.True(success);
-            Assert.AreEqual(@ushort, result);
+            Assert.AreEqual(testValue, result);
 
-            Assert.AreEqual(@ushort, (ushort?)value);
+            Assert.AreEqual(testValue, (ushort?)value);
         }
 
         [TestCase((ushort)42)]
         [TestCase(ushort.MinValue)]
         [TestCase(ushort.MaxValue)]
-        public void BoxedUShort(ushort @ushort)
+        public void BoxedUShort(ushort testValue)
         {
-            ushort i = @ushort;
+            ushort i = testValue;
             object o = i;
             Value value = new(o);
 
             Assert.AreEqual(typeof(ushort), value.Type);
             Assert.True(value.TryGetValue(out ushort result));
-            Assert.AreEqual(@ushort, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out ushort? nullableResult));
-            Assert.AreEqual(@ushort, nullableResult!.Value);
+            Assert.AreEqual(testValue, nullableResult!.Value);
 
-            ushort? n = @ushort;
+            ushort? n = testValue;
             o = n;
             value = new(o);
 
             Assert.AreEqual(typeof(ushort), value.Type);
             Assert.True(value.TryGetValue(out result));
-            Assert.AreEqual(@ushort, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out nullableResult));
-            Assert.AreEqual(@ushort, nullableResult!.Value);
+            Assert.AreEqual(testValue, nullableResult!.Value);
         }
 
         [Test]
@@ -131,18 +131,18 @@ namespace Azure
         [TestCase((ushort)42)]
         [TestCase(ushort.MinValue)]
         [TestCase(ushort.MaxValue)]
-        public void OutAsObject(ushort @ushort)
+        public void OutAsObject(ushort testValue)
         {
-            Value value = new(@ushort);
+            Value value = new(testValue);
             object o = value.As<object>();
             Assert.AreEqual(typeof(ushort), o.GetType());
-            Assert.AreEqual(@ushort, (ushort)o);
+            Assert.AreEqual(testValue, (ushort)o);
 
-            ushort? n = @ushort;
+            ushort? n = testValue;
             value = new(n);
             o = value.As<object>();
             Assert.AreEqual(typeof(ushort), o.GetType());
-            Assert.AreEqual(@ushort, (ushort)o);
+            Assert.AreEqual(testValue, (ushort)o);
         }
     }
 }

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUShort.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUShort.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+
+namespace Azure
+{
+    public class StoringUShort
+    {
+        [TestCase((ushort)42)]
+        [TestCase(ushort.MinValue)]
+        [TestCase(ushort.MaxValue)]
+        public void UShortImplicit(ushort @ushort)
+        {
+            Value value = @ushort;
+            Assert.AreEqual(@ushort, value.As<ushort>());
+            Assert.AreEqual(typeof(ushort), value.Type);
+
+            ushort? source = @ushort;
+            value = source;
+            Assert.AreEqual(source, value.As<ushort?>());
+            Assert.AreEqual(typeof(ushort), value.Type);
+        }
+
+        [TestCase((ushort)42)]
+        [TestCase(ushort.MinValue)]
+        [TestCase(ushort.MaxValue)]
+        public void UShortCreate(ushort @ushort)
+        {
+            Value value;
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(@ushort);
+            }
+
+            Assert.AreEqual(@ushort, value.As<ushort>());
+            Assert.AreEqual(typeof(ushort), value.Type);
+
+            ushort? source = @ushort;
+
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(source);
+            }
+
+            Assert.AreEqual(source, value.As<ushort?>());
+            Assert.AreEqual(typeof(ushort), value.Type);
+        }
+
+        [TestCase((ushort)42)]
+        [TestCase(ushort.MinValue)]
+        [TestCase(ushort.MaxValue)]
+        public void UShortInOut(ushort @ushort)
+        {
+            Value value = new(@ushort);
+            bool success = value.TryGetValue(out ushort result);
+            Assert.True(success);
+            Assert.AreEqual(@ushort, result);
+
+            Assert.AreEqual(@ushort, value.As<ushort>());
+            Assert.AreEqual(@ushort, (ushort)value);
+        }
+
+        [TestCase((ushort)42)]
+        [TestCase(ushort.MinValue)]
+        [TestCase(ushort.MaxValue)]
+        public void NullableUShortInUShortOut(ushort? @ushort)
+        {
+            ushort? source = @ushort;
+            Value value = new(source);
+
+            bool success = value.TryGetValue(out ushort result);
+            Assert.True(success);
+            Assert.AreEqual(@ushort, result);
+
+            Assert.AreEqual(@ushort, value.As<ushort>());
+
+            Assert.AreEqual(@ushort, (ushort)value);
+        }
+
+        [TestCase((ushort)42)]
+        [TestCase(ushort.MinValue)]
+        [TestCase(ushort.MaxValue)]
+        public void UShortInNullableUShortOut(ushort @ushort)
+        {
+            ushort source = @ushort;
+            Value value = new(source);
+            bool success = value.TryGetValue(out ushort? result);
+            Assert.True(success);
+            Assert.AreEqual(@ushort, result);
+
+            Assert.AreEqual(@ushort, (ushort?)value);
+        }
+
+        [TestCase((ushort)42)]
+        [TestCase(ushort.MinValue)]
+        [TestCase(ushort.MaxValue)]
+        public void BoxedUShort(ushort @ushort)
+        {
+            ushort i = @ushort;
+            object o = i;
+            Value value = new(o);
+
+            Assert.AreEqual(typeof(ushort), value.Type);
+            Assert.True(value.TryGetValue(out ushort result));
+            Assert.AreEqual(@ushort, result);
+            Assert.True(value.TryGetValue(out ushort? nullableResult));
+            Assert.AreEqual(@ushort, nullableResult!.Value);
+
+            ushort? n = @ushort;
+            o = n;
+            value = new(o);
+
+            Assert.AreEqual(typeof(ushort), value.Type);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(@ushort, result);
+            Assert.True(value.TryGetValue(out nullableResult));
+            Assert.AreEqual(@ushort, nullableResult!.Value);
+        }
+
+        [Test]
+        public void NullUShort()
+        {
+            ushort? source = null;
+            Value value = source;
+            Assert.Null(value.Type);
+            Assert.AreEqual(source, value.As<ushort?>());
+            Assert.False(value.As<ushort?>().HasValue);
+        }
+
+        [TestCase((ushort)42)]
+        [TestCase(ushort.MinValue)]
+        [TestCase(ushort.MaxValue)]
+        public void OutAsObject(ushort @ushort)
+        {
+            Value value = new(@ushort);
+            object o = value.As<object>();
+            Assert.AreEqual(typeof(ushort), o.GetType());
+            Assert.AreEqual(@ushort, (ushort)o);
+
+            ushort? n = @ushort;
+            value = new(n);
+            o = value.As<object>();
+            Assert.AreEqual(typeof(ushort), o.GetType());
+            Assert.AreEqual(@ushort, (ushort)o);
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUlong.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUlong.cs
@@ -10,13 +10,13 @@ namespace Azure
         [TestCase(42ul)]
         [TestCase(ulong.MinValue)]
         [TestCase(ulong.MaxValue)]
-        public void ULongImplicit(ulong @ulong)
+        public void ULongImplicit(ulong testValue)
         {
-            Value value = @ulong;
-            Assert.AreEqual(@ulong, value.As<ulong>());
+            Value value = testValue;
+            Assert.AreEqual(testValue, value.As<ulong>());
             Assert.AreEqual(typeof(ulong), value.Type);
 
-            ulong? source = @ulong;
+            ulong? source = testValue;
             value = source;
             Assert.AreEqual(source, value.As<ulong?>());
             Assert.AreEqual(typeof(ulong), value.Type);
@@ -25,18 +25,18 @@ namespace Azure
         [TestCase(42ul)]
         [TestCase(ulong.MinValue)]
         [TestCase(ulong.MaxValue)]
-        public void ULongCreate(ulong @ulong)
+        public void ULongCreate(ulong testValue)
         {
             Value value;
             using (MemoryWatch.Create)
             {
-                value = Value.Create(@ulong);
+                value = Value.Create(testValue);
             }
 
-            Assert.AreEqual(@ulong, value.As<ulong>());
+            Assert.AreEqual(testValue, value.As<ulong>());
             Assert.AreEqual(typeof(ulong), value.Type);
 
-            ulong? source = @ulong;
+            ulong? source = testValue;
 
             using (MemoryWatch.Create)
             {
@@ -50,72 +50,72 @@ namespace Azure
         [TestCase(42ul)]
         [TestCase(ulong.MinValue)]
         [TestCase(ulong.MaxValue)]
-        public void ULongInOut(ulong @ulong)
+        public void ULongInOut(ulong testValue)
         {
-            Value value = new(@ulong);
+            Value value = new(testValue);
             bool success = value.TryGetValue(out ulong result);
             Assert.True(success);
-            Assert.AreEqual(@ulong, result);
+            Assert.AreEqual(testValue, result);
 
-            Assert.AreEqual(@ulong, value.As<ulong>());
-            Assert.AreEqual(@ulong, (ulong)value);
+            Assert.AreEqual(testValue, value.As<ulong>());
+            Assert.AreEqual(testValue, (ulong)value);
         }
 
         [TestCase(42ul)]
         [TestCase(ulong.MinValue)]
         [TestCase(ulong.MaxValue)]
-        public void NullableULongInULongOut(ulong? @ulong)
+        public void NullableULongInULongOut(ulong? testValue)
         {
-            ulong? source = @ulong;
+            ulong? source = testValue;
             Value value = new(source);
 
             bool success = value.TryGetValue(out ulong result);
             Assert.True(success);
-            Assert.AreEqual(@ulong, result);
+            Assert.AreEqual(testValue, result);
 
-            Assert.AreEqual(@ulong, value.As<ulong>());
+            Assert.AreEqual(testValue, value.As<ulong>());
 
-            Assert.AreEqual(@ulong, (ulong)value);
+            Assert.AreEqual(testValue, (ulong)value);
         }
 
         [TestCase(42ul)]
         [TestCase(ulong.MinValue)]
         [TestCase(ulong.MaxValue)]
-        public void ULongInNullableULongOut(ulong @ulong)
+        public void ULongInNullableULongOut(ulong testValue)
         {
-            ulong source = @ulong;
+            ulong source = testValue;
             Value value = new(source);
             bool success = value.TryGetValue(out ulong? result);
             Assert.True(success);
-            Assert.AreEqual(@ulong, result);
+            Assert.AreEqual(testValue, result);
 
-            Assert.AreEqual(@ulong, (ulong?)value);
+            Assert.AreEqual(testValue, (ulong?)value);
         }
 
         [TestCase(42ul)]
         [TestCase(ulong.MinValue)]
         [TestCase(ulong.MaxValue)]
-        public void BoxedULong(ulong @ulong)
+        public void BoxedULong(ulong testValue)
         {
-            ulong i = @ulong;
+            ulong i = testValue;
             object o = i;
             Value value = new(o);
 
             Assert.AreEqual(typeof(ulong), value.Type);
             Assert.True(value.TryGetValue(out ulong result));
-            Assert.AreEqual(@ulong, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out ulong? nullableResult));
-            Assert.AreEqual(@ulong, nullableResult!.Value);
+            Assert.AreEqual(testValue, nullableResult!.Value);
 
-            ulong? n = @ulong;
+            ulong? n = testValue;
             o = n;
             value = new(o);
 
             Assert.AreEqual(typeof(ulong), value.Type);
             Assert.True(value.TryGetValue(out result));
-            Assert.AreEqual(@ulong, result);
+            Assert.AreEqual(testValue, result);
             Assert.True(value.TryGetValue(out nullableResult));
-            Assert.AreEqual(@ulong, nullableResult!.Value);
+            Assert.AreEqual(testValue, nullableResult!.Value);
         }
 
         [Test]
@@ -131,18 +131,18 @@ namespace Azure
         [TestCase(42ul)]
         [TestCase(ulong.MinValue)]
         [TestCase(ulong.MaxValue)]
-        public void OutAsObject(ulong @ulong)
+        public void OutAsObject(ulong testValue)
         {
-            Value value = new(@ulong);
+            Value value = new(testValue);
             object o = value.As<object>();
             Assert.AreEqual(typeof(ulong), o.GetType());
-            Assert.AreEqual(@ulong, (ulong)o);
+            Assert.AreEqual(testValue, (ulong)o);
 
-            ulong? n = @ulong;
+            ulong? n = testValue;
             value = new(n);
             o = value.As<object>();
             Assert.AreEqual(typeof(ulong), o.GetType());
-            Assert.AreEqual(@ulong, (ulong)o);
+            Assert.AreEqual(testValue, (ulong)o);
         }
     }
 }

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUlong.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUlong.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+
+namespace Azure
+{
+    public class StoringULong
+    {
+        [TestCase(42ul)]
+        [TestCase(ulong.MinValue)]
+        [TestCase(ulong.MaxValue)]
+        public void ULongImplicit(ulong @ulong)
+        {
+            Value value = @ulong;
+            Assert.AreEqual(@ulong, value.As<ulong>());
+            Assert.AreEqual(typeof(ulong), value.Type);
+
+            ulong? source = @ulong;
+            value = source;
+            Assert.AreEqual(source, value.As<ulong?>());
+            Assert.AreEqual(typeof(ulong), value.Type);
+        }
+
+        [TestCase(42ul)]
+        [TestCase(ulong.MinValue)]
+        [TestCase(ulong.MaxValue)]
+        public void ULongCreate(ulong @ulong)
+        {
+            Value value;
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(@ulong);
+            }
+
+            Assert.AreEqual(@ulong, value.As<ulong>());
+            Assert.AreEqual(typeof(ulong), value.Type);
+
+            ulong? source = @ulong;
+
+            using (MemoryWatch.Create)
+            {
+                value = Value.Create(source);
+            }
+
+            Assert.AreEqual(source, value.As<ulong?>());
+            Assert.AreEqual(typeof(ulong), value.Type);
+        }
+
+        [TestCase(42ul)]
+        [TestCase(ulong.MinValue)]
+        [TestCase(ulong.MaxValue)]
+        public void ULongInOut(ulong @ulong)
+        {
+            Value value = new(@ulong);
+            bool success = value.TryGetValue(out ulong result);
+            Assert.True(success);
+            Assert.AreEqual(@ulong, result);
+
+            Assert.AreEqual(@ulong, value.As<ulong>());
+            Assert.AreEqual(@ulong, (ulong)value);
+        }
+
+        [TestCase(42ul)]
+        [TestCase(ulong.MinValue)]
+        [TestCase(ulong.MaxValue)]
+        public void NullableULongInULongOut(ulong? @ulong)
+        {
+            ulong? source = @ulong;
+            Value value = new(source);
+
+            bool success = value.TryGetValue(out ulong result);
+            Assert.True(success);
+            Assert.AreEqual(@ulong, result);
+
+            Assert.AreEqual(@ulong, value.As<ulong>());
+
+            Assert.AreEqual(@ulong, (ulong)value);
+        }
+
+        [TestCase(42ul)]
+        [TestCase(ulong.MinValue)]
+        [TestCase(ulong.MaxValue)]
+        public void ULongInNullableULongOut(ulong @ulong)
+        {
+            ulong source = @ulong;
+            Value value = new(source);
+            bool success = value.TryGetValue(out ulong? result);
+            Assert.True(success);
+            Assert.AreEqual(@ulong, result);
+
+            Assert.AreEqual(@ulong, (ulong?)value);
+        }
+
+        [TestCase(42ul)]
+        [TestCase(ulong.MinValue)]
+        [TestCase(ulong.MaxValue)]
+        public void BoxedULong(ulong @ulong)
+        {
+            ulong i = @ulong;
+            object o = i;
+            Value value = new(o);
+
+            Assert.AreEqual(typeof(ulong), value.Type);
+            Assert.True(value.TryGetValue(out ulong result));
+            Assert.AreEqual(@ulong, result);
+            Assert.True(value.TryGetValue(out ulong? nullableResult));
+            Assert.AreEqual(@ulong, nullableResult!.Value);
+
+            ulong? n = @ulong;
+            o = n;
+            value = new(o);
+
+            Assert.AreEqual(typeof(ulong), value.Type);
+            Assert.True(value.TryGetValue(out result));
+            Assert.AreEqual(@ulong, result);
+            Assert.True(value.TryGetValue(out nullableResult));
+            Assert.AreEqual(@ulong, nullableResult!.Value);
+        }
+
+        [Test]
+        public void NullULong()
+        {
+            ulong? source = null;
+            Value value = source;
+            Assert.Null(value.Type);
+            Assert.AreEqual(source, value.As<ulong?>());
+            Assert.False(value.As<ulong?>().HasValue);
+        }
+
+        [TestCase(42ul)]
+        [TestCase(ulong.MinValue)]
+        [TestCase(ulong.MaxValue)]
+        public void OutAsObject(ulong @ulong)
+        {
+            Value value = new(@ulong);
+            object o = value.As<object>();
+            Assert.AreEqual(typeof(ulong), o.GetType());
+            Assert.AreEqual(@ulong, (ulong)o);
+
+            ulong? n = @ulong;
+            value = new(n);
+            o = value.As<object>();
+            Assert.AreEqual(typeof(ulong), o.GetType());
+            Assert.AreEqual(@ulong, (ulong)o);
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUlong.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUlong.cs
@@ -28,7 +28,7 @@ namespace Azure
         public void ULongCreate(ulong testValue)
         {
             Value value;
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(testValue);
             }
@@ -38,7 +38,7 @@ namespace Azure
 
             ulong? source = testValue;
 
-            using (MemoryWatch.Create)
+            using (MemoryWatch.Create())
             {
                 value = Value.Create(source);
             }


### PR DESCRIPTION
From time to time we run into cases where we want to store a heterogenous collection of values. This type allows to store such values while minimizing boxing. The type was developed by @JeremyKuhne. The original idea was that this type ends up in the BCL, but the idea was rejected. 

Here is an example of a very similar type in a track2 library: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/Models/TimeSeriesValue.cs