### PR TITLE
[Event Hubs Processor] Release Prep

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Experimental/src/Azure.Messaging.EventHubs.Experimental.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Experimental/src/Azure.Messaging.EventHubs.Experimental.csproj
@@ -12,14 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--
-        TEMP: Package reference is needed until the CheckpointStore is included in a release.
-
-    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.7.0-beta.3" /> Remove override when the v5.7.0 line is released for GA
-    -->
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" />
-    <!-- END TEMP -->
-
+    <PackageReference Include="Azure.Messaging.EventHubs" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.Reflection.TypeExtensions" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Experimental/tests/Azure.Messaging.EventHubs.Experimental.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Experimental/tests/Azure.Messaging.EventHubs.Experimental.Tests.csproj
@@ -18,6 +18,14 @@
     <PackageReference Include="Polly" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
     <PackageReference Include="System.ValueTuple" />
+
+    <!--
+        TEMP:
+            Project reference is needed until the CheckpointStore is included in a release.  Revert when
+            the 5.7.x line is released for GA; allow the dependency to flow in transitively.
+    -->
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" />
+    <!-- END TEMP -->
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.7.0-beta.4 (Unreleased)
+## 5.7.0-beta.4 (2022-03-11)
 
 ### Acknowledgments
 
@@ -8,15 +8,9 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 - Daniel Marbach _([GitHub](https://github.com/danielmarbach))_
 
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
 ### Other Changes
 
-- Remove allocations from Event Source logging by introducing `WriteEvent` overloads to handle cases that would otherwise result in boxing to `object[]` via params array.  _(A community contribution, courtesy of [danielmarbach](https://github.com/danielmarbach))_
+- Removed allocations from Event Source logging by introducing `WriteEvent` overloads to handle cases that would otherwise result in boxing to `object[]` via params array.  _(A community contribution, courtesy of [danielmarbach](https://github.com/danielmarbach))_
 
 - Enhanced README documentation to call attention to the need for the Azure Storage container used with the processor to exist, and highlight that it will not be implicitly created.
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Azure.Messaging.EventHubs" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" />
     -->
-    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.7.1-beta.4" />
+    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.7.0-beta.4" />
 
     <!-- END TEMP -->
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -22,11 +22,15 @@
     <!-- END TEMP -->
 
     <!--
-        TEMP: Package reference is needed until the CheckpointStore is included in a release.
+        TEMP:
+            Project reference is needed until the CheckpointStore is included in a release.  Revert when
+            the 5.7.x line is released for GA.
 
-    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.7.0-beta.3" /> Remove override when the v5.7.0 line is released for GA
-    -->
+    <PackageReference Include="Azure.Messaging.EventHubs" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" />
+    -->
+    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.7.1-beta.4" />
+
     <!-- END TEMP -->
 
     <PackageReference Include="Azure.Storage.Blobs" />

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
@@ -13,7 +13,9 @@
 
   <ItemGroup>
     <!--
-        TEMP: Package reference is needed until the CheckpointStore is included in a release.
+        TEMP:
+            Project reference is needed until the CheckpointStore is included in a release.  Revert when
+            the 5.7.x line is released for GA.
 
     <PackageReference Include="Azure.Messaging.EventHubs" />
     -->


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare the Event Hubs processor library for the March milestone beta release.