### PR TITLE
[Event Hubs Processor] Restore Project Reference

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -27,10 +27,8 @@
             the 5.7.x line is released for GA.
 
     <PackageReference Include="Azure.Messaging.EventHubs" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" />
     -->
-    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.7.0-beta.4" />
-
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" />
     <!-- END TEMP -->
 
     <PackageReference Include="Azure.Storage.Blobs" />


### PR DESCRIPTION
# Summary 

The focus of these changes is to restore the project reference to the Event Hubs core package until the 5.7.x line is released for GA.