### PR TITLE
Check ExpiresOn date in live tests

### DIFF
--- a/sdk/communication/Azure.Communication.NetworkTraversal/tests/CommunicationRelayClient/CommunicationRelayClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.NetworkTraversal/tests/CommunicationRelayClient/CommunicationRelayClientLiveTests.cs
@@ -7,6 +7,7 @@ using Azure.Communication.Tests;
 using Azure.Communication.Identity;
 using NUnit.Framework;
 using System.Text.Json;
+using Azure.Core.TestFramework;
 
 namespace Azure.Communication.NetworkTraversal.Tests
 {
@@ -156,7 +157,14 @@ namespace Azure.Communication.NetworkTraversal.Tests
 
             Assert.IsNotNull(turnCredentialsResponse.Value);
             Assert.IsNotNull(turnCredentialsResponse.Value.ExpiresOn);
-            Assert.IsTrue(currentTime<=turnCredentialsResponse.Value.ExpiresOn);
+
+            // We only check if we are actually hitting an endpoint.
+            // If we compare them when running from playback, the expiresOn value will be the one that was previously recorded so it will always fail.
+            if (Mode != RecordedTestMode.Playback)
+            {
+                Assert.IsTrue(currentTime <= turnCredentialsResponse.Value.ExpiresOn);
+            }
+
             Assert.IsNotNull(turnCredentialsResponse.Value.IceServers);
 
             foreach (CommunicationIceServer serverCredential in turnCredentialsResponse.Value.IceServers)
@@ -194,7 +202,14 @@ namespace Azure.Communication.NetworkTraversal.Tests
 
             Assert.IsNotNull(turnCredentialsResponse.Value);
             Assert.IsNotNull(turnCredentialsResponse.Value.ExpiresOn);
-            Assert.IsTrue(currentTime <= turnCredentialsResponse.Value.ExpiresOn);
+
+            // We only check if we are actually hitting an endpoint.
+            // If we compare them when running from playback, the expiresOn value will be the one that was previously recorded so it will always fail.
+            if (Mode != RecordedTestMode.Playback)
+            {
+                Assert.IsTrue(currentTime <= turnCredentialsResponse.Value.ExpiresOn);
+            }
+
             Assert.IsNotNull(turnCredentialsResponse.Value.IceServers);
 
             foreach (CommunicationIceServer serverCredential in turnCredentialsResponse.Value.IceServers)


### PR DESCRIPTION
Only check ExpiresOn date/time of credential when actually hitting a real endpoint. Playback mode skip check, since it would fail since the ExpiresOn date is gotten from the recordings

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
