### PR TITLE
Azure Monitor Exporter - Exporter refactor

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -14,6 +14,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     internal class AzureMonitorLogExporter : BaseExporter<LogRecord>
     {
         private readonly ITransmitter _transmitter;
+        private readonly string _instrumentationKey;
         private readonly ResourceParser _resourceParser;
 
         public AzureMonitorLogExporter(AzureMonitorExporterOptions options) : this(new AzureMonitorTransmitter(options))
@@ -23,6 +24,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         internal AzureMonitorLogExporter(ITransmitter transmitter)
         {
             _transmitter = transmitter;
+            _instrumentationKey = transmitter.InstrumentationKey;
             _resourceParser = new ResourceParser();
         }
 
@@ -40,8 +42,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     _resourceParser.UpdateRoleNameAndInstance(resource);
                 }
 
-                var instrumentationKey = _transmitter.InstrumentationKey;
-                var telemetryItems = LogsHelper.OtelToAzureMonitorLogs(batch, _resourceParser.RoleName, _resourceParser.RoleInstance, instrumentationKey);
+                var telemetryItems = LogsHelper.OtelToAzureMonitorLogs(batch, _resourceParser.RoleName, _resourceParser.RoleInstance, _instrumentationKey);
 
                 // TODO: Handle return value, it can be converted as metrics.
                 // TODO: Validate CancellationToken and async pattern here.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -34,7 +34,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
             try
             {
-                if (_resourceParser.RoleName == _resourceParser.RoleInstance == default)
+                if (_resourceParser.RoleName is null && _resourceParser.RoleInstance is null)
                 {
                     var resource = ParentProvider.GetResource();
                     _resourceParser.UpdateRoleNameAndInstance(resource);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -40,7 +40,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     _resourceParser.UpdateRoleNameAndInstance(resource);
                 }
 
-                var instrumentationKey = (_transmitter as AzureMonitorTransmitter).InstrumentationKey;
+                var instrumentationKey = _transmitter.InstrumentationKey;
                 var telemetryItems = LogsHelper.OtelToAzureMonitorLogs(batch, _resourceParser.RoleName, _resourceParser.RoleInstance, instrumentationKey);
 
                 // TODO: Handle return value, it can be converted as metrics.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
@@ -41,7 +41,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     _resourceParser.UpdateRoleNameAndInstance(resource);
                 }
 
-                var instrumentationKey = (_transmitter as AzureMonitorTransmitter).InstrumentationKey;
+                var instrumentationKey = _transmitter.InstrumentationKey;
                 var telemetryItems = MetricHelper.OtelToAzureMonitorMetrics(batch, _resourceParser.RoleName, _resourceParser.RoleInstance, instrumentationKey);
 
                 // TODO: Handle return value, it can be converted as metrics.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
@@ -15,6 +15,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     internal class AzureMonitorMetricExporter : BaseExporter<Metric>
     {
         private readonly ITransmitter _transmitter;
+        private readonly string _instrumentationKey;
         private readonly ResourceParser _resourceParser;
 
         public AzureMonitorMetricExporter(AzureMonitorExporterOptions options) : this(new AzureMonitorTransmitter(options))
@@ -24,6 +25,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         internal AzureMonitorMetricExporter(ITransmitter transmitter)
         {
             _transmitter = transmitter;
+            _instrumentationKey = transmitter.InstrumentationKey;
             _resourceParser = new ResourceParser();
         }
 
@@ -41,8 +43,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     _resourceParser.UpdateRoleNameAndInstance(resource);
                 }
 
-                var instrumentationKey = _transmitter.InstrumentationKey;
-                var telemetryItems = MetricHelper.OtelToAzureMonitorMetrics(batch, _resourceParser.RoleName, _resourceParser.RoleInstance, instrumentationKey);
+                var telemetryItems = MetricHelper.OtelToAzureMonitorMetrics(batch, _resourceParser.RoleName, _resourceParser.RoleInstance, _instrumentationKey);
 
                 // TODO: Handle return value, it can be converted as metrics.
                 // TODO: Validate CancellationToken and async pattern here.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
@@ -35,7 +35,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
             try
             {
-                if (_resourceParser.RoleName == _resourceParser.RoleInstance == default)
+                if (_resourceParser.RoleName is null && _resourceParser.RoleInstance is null)
                 {
                     var resource = ParentProvider.GetResource();
                     _resourceParser.UpdateRoleNameAndInstance(resource);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
@@ -14,6 +14,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     public class AzureMonitorTraceExporter : BaseExporter<Activity>
     {
         private readonly ITransmitter _transmitter;
+        private readonly string _instrumentationKey;
         private readonly ResourceParser _resourceParser;
         private readonly StorageTransmissionEvaluator _storageTransmissionEvaluator;
         private readonly Stopwatch _stopwatch;
@@ -26,6 +27,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         internal AzureMonitorTraceExporter(ITransmitter transmitter)
         {
             _transmitter = transmitter;
+            _instrumentationKey = transmitter.InstrumentationKey;
             _resourceParser = new ResourceParser();
 
             // Todo: Add check if offline storage is enabled by user via options
@@ -54,8 +56,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     _resourceParser.UpdateRoleNameAndInstance(resource);
                 }
 
-                var instrumentationKey = _transmitter.InstrumentationKey;
-                var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, _resourceParser.RoleName, _resourceParser.RoleInstance, instrumentationKey);
+                var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, _resourceParser.RoleName, _resourceParser.RoleInstance, _instrumentationKey);
 
                 // TODO: Handle return value, it can be converted as metrics.
                 // TODO: Validate CancellationToken and async pattern here.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
@@ -54,7 +54,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     _resourceParser.UpdateRoleNameAndInstance(resource);
                 }
 
-                var instrumentationKey = (_transmitter as AzureMonitorTransmitter).InstrumentationKey;
+                var instrumentationKey = _transmitter.InstrumentationKey;
                 var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, _resourceParser.RoleName, _resourceParser.RoleInstance, instrumentationKey);
 
                 // TODO: Handle return value, it can be converted as metrics.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/ITransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/ITransmitter.cs
@@ -17,5 +17,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         /// </summary>
         ValueTask<ExportResult> TrackAsync(IEnumerable<TelemetryItem> telemetryItems, bool async, CancellationToken cancellationToken);
         ValueTask TransmitFromStorage(long maxFileToTransmit, bool aysnc, CancellationToken cancellationToken);
+        string InstrumentationKey { get; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/ResourceParser.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/ResourceParser.cs
@@ -15,11 +15,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
         internal void UpdateRoleNameAndInstance(Resource resource)
         {
-            if (RoleName != null || RoleInstance != null)
-            {
-                return;
-            }
-
             if (resource == null)
             {
                 return;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorTraceExporterTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorTraceExporterTests.cs
@@ -63,14 +63,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // instrumentationKey: AzureMonitorTraceExporter.AzureMonitorTransmitter.instrumentationKey
             // endpoint: AzureMonitorTraceExporter.AzureMonitorTransmitter.ServiceRestClient.endpoint
 
-            ikey = typeof(AzureMonitorTraceExporter)
-                .GetField("_instrumentationKey", BindingFlags.Instance | BindingFlags.NonPublic)
-                .GetValue(exporter)
-                .ToString();
-
             var transmitter = typeof(AzureMonitorTraceExporter)
                 .GetField("_transmitter", BindingFlags.Instance | BindingFlags.NonPublic)
                 .GetValue(exporter);
+
+            ikey = (transmitter as AzureMonitorTransmitter).InstrumentationKey;
 
             var serviceRestClient = typeof(AzureMonitorTransmitter)
                 .GetField("_applicationInsightsRestClient", BindingFlags.Instance | BindingFlags.NonPublic)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorTraceExporterTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorTraceExporterTests.cs
@@ -63,11 +63,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // instrumentationKey: AzureMonitorTraceExporter.AzureMonitorTransmitter.instrumentationKey
             // endpoint: AzureMonitorTraceExporter.AzureMonitorTransmitter.ServiceRestClient.endpoint
 
+            ikey = typeof(AzureMonitorTraceExporter)
+                .GetField("_instrumentationKey", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(exporter)
+                .ToString();
+
             var transmitter = typeof(AzureMonitorTraceExporter)
                 .GetField("_transmitter", BindingFlags.Instance | BindingFlags.NonPublic)
                 .GetValue(exporter);
-
-            ikey = (transmitter as AzureMonitorTransmitter).InstrumentationKey;
 
             var serviceRestClient = typeof(AzureMonitorTransmitter)
                 .GetField("_applicationInsightsRestClient", BindingFlags.Instance | BindingFlags.NonPublic)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceParserTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceParserTests.cs
@@ -32,20 +32,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         }
 
         [Fact]
-        public void RoleNameAndInstanceIsAssignedOnce()
-        {
-            var resource1 = CreateTestResource(serviceName: "my-service1", serviceInstance: "my-instance1");
-            var resource2 = CreateTestResource(serviceName: "my-service2", serviceInstance: "my-instance2");
-
-            var resourceParser = new ResourceParser();
-            resourceParser.UpdateRoleNameAndInstance(resource1);
-            resourceParser.UpdateRoleNameAndInstance(resource2);
-
-            Assert.Equal("my-service1", resourceParser.RoleName);
-            Assert.Equal("my-instance1", resourceParser.RoleInstance);
-        }
-
-        [Fact]
         public void ServiceNameFromResource()
         {
             var resource = CreateTestResource(serviceName: "my-service");

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/TelemetryItemTests.cs
@@ -98,12 +98,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests
             using var activitySource = new ActivitySource(ActivitySourceName);
 
             var mockTransmitter = new MockTransmitter();
-            var processor = new BatchActivityExportProcessor(new AzureMonitorTraceExporter(
-                options: new AzureMonitorExporterOptions
-                {
-                    ConnectionString = EmptyConnectionString,
-                },
-                transmitter: mockTransmitter));
+            var processor = new BatchActivityExportProcessor(new AzureMonitorTraceExporter(mockTransmitter));
 
             using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
@@ -125,12 +120,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests
         {
             // SETUP
             var mockTransmitter = new MockTransmitter();
-            var processor = new BatchLogRecordExportProcessor(new AzureMonitorLogExporter(
-                options: new AzureMonitorExporterOptions
-                {
-                    ConnectionString = EmptyConnectionString,
-                },
-                transmitter: mockTransmitter));
+            var processor = new BatchLogRecordExportProcessor(new AzureMonitorLogExporter(mockTransmitter));
 
             var serviceCollection = new ServiceCollection().AddLogging(builder =>
             {
@@ -166,18 +156,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests
 
             var mockTransmitter = new MockTransmitter();
 
-            var azureMonitorExporterOptions = new AzureMonitorExporterOptions
-            {
-                ConnectionString = EmptyConnectionString,
-            };
+            var processor1 = new BatchActivityExportProcessor(new AzureMonitorTraceExporter(mockTransmitter));
 
-            var processor1 = new BatchActivityExportProcessor(new AzureMonitorTraceExporter(
-                options: azureMonitorExporterOptions,
-                transmitter: mockTransmitter));
-
-            var processor2 = new BatchLogRecordExportProcessor(new AzureMonitorLogExporter(
-                options: azureMonitorExporterOptions,
-                transmitter: mockTransmitter));
+            var processor2 = new BatchLogRecordExportProcessor(new AzureMonitorLogExporter(mockTransmitter));
 
             using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/TestFramework/MockTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/TestFramework/MockTransmitter.cs
@@ -16,6 +16,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.TestFramework
     {
         public ConcurrentBag<TelemetryItem> TelemetryItems = new ConcurrentBag<TelemetryItem>();
 
+        public string InstrumentationKey => "00000000-0000-0000-0000-000000000000";
+
         public ValueTask<ExportResult> TrackAsync(IEnumerable<TelemetryItem> telemetryItems, bool async, CancellationToken cancellationToken)
         {
             foreach (var telemetryItem in telemetryItems)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/TestFramework/OpenTelemetryWebApplicationFactory.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/TestFramework/OpenTelemetryWebApplicationFactory.cs
@@ -30,12 +30,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.TestFramework
 
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
-            this.ActivityProcessor = new BatchActivityExportProcessor(new AzureMonitorTraceExporter(
-                options: new AzureMonitorExporterOptions
-                {
-                    ConnectionString = EmptyConnectionString,
-                },
-                transmitter: this.Transmitter));
+            this.ActivityProcessor = new BatchActivityExportProcessor(new AzureMonitorTraceExporter(this.Transmitter));
 
             builder.ConfigureServices(services => services.AddOpenTelemetryTracing((builder) => builder
                         .AddAspNetCoreInstrumentation()


### PR DESCRIPTION
- Modified the code to read the resource only if `RoleName` or `RoleInstance` is not set
- Moved all options to transmitter to avoid duplicate code in all exporters.