### PR TITLE
Delete useless checks

### DIFF
--- a/sdk/signalr/Microsoft.Azure.Management.SignalR/src/Generated/Models/SignalRFeature.cs
+++ b/sdk/signalr/Microsoft.Azure.Management.SignalR/src/Generated/Models/SignalRFeature.cs
@@ -124,16 +124,13 @@ namespace Microsoft.Azure.Management.SignalR.Models
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "Value");
             }
-            if (Value != null)
+            if (Value.Length > 128)
             {
-                if (Value.Length > 128)
-                {
-                    throw new ValidationException(ValidationRules.MaxLength, "Value", 128);
-                }
-                if (Value.Length < 1)
-                {
-                    throw new ValidationException(ValidationRules.MinLength, "Value", 1);
-                }
+                throw new ValidationException(ValidationRules.MaxLength, "Value", 128);
+            }
+            if (Value.Length < 1)
+            {
+                throw new ValidationException(ValidationRules.MinLength, "Value", 1);
             }
         }
     }

--- a/sdk/signalr/Microsoft.Azure.Management.SignalR/src/Generated/SignalRManagementClient.cs
+++ b/sdk/signalr/Microsoft.Azure.Management.SignalR/src/Generated/SignalRManagementClient.cs
@@ -208,10 +208,7 @@ namespace Microsoft.Azure.Management.SignalR
                 throw new System.ArgumentNullException("credentials");
             }
             Credentials = credentials;
-            if (Credentials != null)
-            {
-                Credentials.InitializeServiceClient(this);
-            }
+            Credentials.InitializeServiceClient(this);
         }
 
         /// <summary>
@@ -235,10 +232,7 @@ namespace Microsoft.Azure.Management.SignalR
                 throw new System.ArgumentNullException("credentials");
             }
             Credentials = credentials;
-            if (Credentials != null)
-            {
-                Credentials.InitializeServiceClient(this);
-            }
+            Credentials.InitializeServiceClient(this);
         }
 
         /// <summary>
@@ -263,10 +257,7 @@ namespace Microsoft.Azure.Management.SignalR
                 throw new System.ArgumentNullException("credentials");
             }
             Credentials = credentials;
-            if (Credentials != null)
-            {
-                Credentials.InitializeServiceClient(this);
-            }
+            Credentials.InitializeServiceClient(this);
         }
 
         /// <summary>
@@ -296,10 +287,7 @@ namespace Microsoft.Azure.Management.SignalR
             }
             BaseUri = baseUri;
             Credentials = credentials;
-            if (Credentials != null)
-            {
-                Credentials.InitializeServiceClient(this);
-            }
+            Credentials.InitializeServiceClient(this);
         }
 
         /// <summary>
@@ -332,10 +320,7 @@ namespace Microsoft.Azure.Management.SignalR
             }
             BaseUri = baseUri;
             Credentials = credentials;
-            if (Credentials != null)
-            {
-                Credentials.InitializeServiceClient(this);
-            }
+            Credentials.InitializeServiceClient(this);
         }
 
         /// <summary>


### PR DESCRIPTION
I hope my changes make more readable code :)
* 16aa7a45c12f0c8167be9a277b2eccbf3f468bc0 This expression always be true, because we already have above this code null check, for example [here](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/signalr/Microsoft.Azure.Management.SignalR/src/Generated/SignalRManagementClient.cs#L206).
* 620e5affcdf10e6c6a257fca15176fd32359c13b This expression always be true, because [here](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/signalr/Microsoft.Azure.Management.SignalR/src/Generated/Models/SignalRFeature.cs#L123) we have already have check.