### PR TITLE
[Storage][Webjobs] Throw a timeout exception if blob/logs scan hanged.

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 5.0.1
+- Throw a timeout exception if blob/logs scan hanged.
+
 ## 5.0.0 (2021-10-26)
 - General availability of Microsoft.Azure.WebJobs.Extensions.Storage.Blobs 5.0.0.
 - Fixed bug where internal message format of blob trigger didn't interop with previous major versions of the extension.

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/ScanBlobScanLogHybridPollingStrategy.Logger.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/ScanBlobScanLogHybridPollingStrategy.Logger.cs
@@ -26,6 +26,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                 LoggerMessage.Define<string>(LogLevel.Debug, new EventId(3, nameof(ContainerDoesNotExist)),
                     "Container '{containerName}' does not exist.");
 
+            private static readonly Action<ILogger<BlobListener>, TimeSpan, Exception> _timeout =
+                LoggerMessage.Define<TimeSpan>(LogLevel.Error, new EventId(4, nameof(ContainerDoesNotExist)),
+                    "Logs and container scan operation reached timeout '{timeout}'.");
+
             public static void InitializedScanInfo(ILogger<BlobListener> logger, string container, DateTime latestScanInfo) =>
                 _initializedScanInfo(logger, container, latestScanInfo.ToString(Constants.DateTimeFormatString, CultureInfo.InvariantCulture), null);
 
@@ -34,6 +38,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
 
             public static void ContainerDoesNotExist(ILogger<BlobListener> logger, string container) =>
                 _containerDoesNotExist(logger, container, null);
+
+            public static void Timeout(ILogger<BlobListener> logger, TimeSpan timeout) =>
+                _timeout(logger, timeout, null);
         }
     }
 }


### PR DESCRIPTION
We had a few incidents when blob/log scan hanged. There were no errors in the logs and other triggers were executed without issues. After function host restart new blobs are picked up. 
The change adds a log if blob/log scan hanged as well as recovery as the function host will be restarted on unhandled exception.The timeout value is relatively long(10 minutes) to avoid false positives.
