### PR TITLE
Azure Monitor Exporter - Enable persistent storage for logs and metrics

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -16,6 +16,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         private readonly ITransmitter _transmitter;
         private readonly string _instrumentationKey;
         private readonly ResourceParser _resourceParser;
+        private readonly AzureMonitorPersistentStorage _persistentStorage;
 
         public AzureMonitorLogExporter(AzureMonitorExporterOptions options) : this(new AzureMonitorTransmitter(options))
         {
@@ -26,11 +27,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             _transmitter = transmitter;
             _instrumentationKey = transmitter.InstrumentationKey;
             _resourceParser = new ResourceParser();
+
+            // TODO: Add check if offline storage is enabled by user via options
+            // If disabled do not initialize AzureMonitorPersistentStorage
+            _persistentStorage = new AzureMonitorPersistentStorage(transmitter);
         }
 
         /// <inheritdoc/>
         public override ExportResult Export(in Batch<LogRecord> batch)
         {
+            _persistentStorage?.StartExporterTimer();
+
             // Prevent Azure Monitor's HTTP operations from being instrumented.
             using var scope = SuppressInstrumentationScope.Begin();
 
@@ -43,10 +50,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 }
 
                 var telemetryItems = LogsHelper.OtelToAzureMonitorLogs(batch, _resourceParser.RoleName, _resourceParser.RoleInstance, _instrumentationKey);
-
-                // TODO: Handle return value, it can be converted as metrics.
-                // TODO: Validate CancellationToken and async pattern here.
                 var exportResult = _transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
+                _persistentStorage?.StopExporterTimerAndTransmitFromStorage();
 
                 return exportResult;
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorPersistentStorage.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorPersistentStorage.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using System.Threading;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter
+{
+    internal class AzureMonitorPersistentStorage
+    {
+        private const int StorageTransmissionEvaluatorSampleSize = 10;
+        private readonly Stopwatch _stopwatch;
+        private readonly StorageTransmissionEvaluator _storageTransmissionEvaluator;
+        private readonly ITransmitter _transmitter;
+        private long _exportStartTimeInMilliseconds;
+
+        public AzureMonitorPersistentStorage(ITransmitter transmitter)
+        {
+            _transmitter = transmitter;
+            _stopwatch = Stopwatch.StartNew();
+            _storageTransmissionEvaluator = new StorageTransmissionEvaluator(StorageTransmissionEvaluatorSampleSize);
+        }
+
+        internal void StartExporterTimer()
+        {
+            // Get export start time
+            _exportStartTimeInMilliseconds = _stopwatch.ElapsedMilliseconds;
+
+            // Add export time interval to data sample
+            _storageTransmissionEvaluator.AddExportIntervalToDataSample(_exportStartTimeInMilliseconds);
+        }
+
+        internal void StopExporterTimerAndTransmitFromStorage()
+        {
+            // Get export end time
+            long exportEndTimeInMilliseconds = _stopwatch.ElapsedMilliseconds;
+
+            // Calculate duration and add it to data sample
+            long currentBatchExportDurationInMilliseconds = exportEndTimeInMilliseconds - _exportStartTimeInMilliseconds;
+            _storageTransmissionEvaluator.AddExportDurationToDataSample(currentBatchExportDurationInMilliseconds);
+
+            // Get max number of files we can transmit in this export and start transmitting
+            long maxFilesToTransmit = _storageTransmissionEvaluator.GetMaxFilesToTransmitFromStorage();
+            _transmitter.TransmitFromStorage(maxFilesToTransmit, false, CancellationToken.None);
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
@@ -16,9 +16,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         private readonly ITransmitter _transmitter;
         private readonly string _instrumentationKey;
         private readonly ResourceParser _resourceParser;
-        private readonly StorageTransmissionEvaluator _storageTransmissionEvaluator;
-        private readonly Stopwatch _stopwatch;
-        private const int StorageTransmissionEvaluatorSampleSize = 10;
+        private readonly AzureMonitorPersistentStorage _persistentStorage;
 
         public AzureMonitorTraceExporter(AzureMonitorExporterOptions options) : this(new AzureMonitorTransmitter(options))
         {
@@ -30,20 +28,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             _instrumentationKey = transmitter.InstrumentationKey;
             _resourceParser = new ResourceParser();
 
-            // Todo: Add check if offline storage is enabled by user via options
-            _stopwatch = Stopwatch.StartNew();
-
-            _storageTransmissionEvaluator = new StorageTransmissionEvaluator(StorageTransmissionEvaluatorSampleSize);
+            // TODO: Add check if offline storage is enabled by user via options
+            // If disabled do not initialize AzureMonitorPersistentStorage
+            _persistentStorage = new AzureMonitorPersistentStorage(transmitter);
         }
 
         /// <inheritdoc/>
         public override ExportResult Export(in Batch<Activity> batch)
         {
-            // Get export start time
-            long exportStartTimeInMilliseconds = _stopwatch.ElapsedMilliseconds;
-
-            // Add export time interval to data sample
-            _storageTransmissionEvaluator.AddExportIntervalToDataSample(exportStartTimeInMilliseconds);
+            _persistentStorage?.StartExporterTimer();
 
             // Prevent Azure Monitor's HTTP operations from being instrumented.
             using var scope = SuppressInstrumentationScope.Begin();
@@ -57,21 +50,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 }
 
                 var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, _resourceParser.RoleName, _resourceParser.RoleInstance, _instrumentationKey);
-
-                // TODO: Handle return value, it can be converted as metrics.
-                // TODO: Validate CancellationToken and async pattern here.
                 var exportResult = _transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
-
-                // Get export end time
-                long exportEndTimeInMilliseconds = _stopwatch.ElapsedMilliseconds;
-
-                // Calculate duration and add it to data sample
-                long currentBatchExportDurationInMilliseconds = exportEndTimeInMilliseconds - exportStartTimeInMilliseconds;
-                _storageTransmissionEvaluator.AddExportDurationToDataSample(currentBatchExportDurationInMilliseconds);
-
-                // Get max number of files we can transmit in this export and start transmitting
-                long maxFilesToTransmit = _storageTransmissionEvaluator.GetMaxFilesToTransmitFromStorage();
-                _transmitter.TransmitFromStorage(maxFilesToTransmit, false, CancellationToken.None);
+                _persistentStorage?.StopExporterTimerAndTransmitFromStorage();
 
                 return exportResult;
             }


### PR DESCRIPTION
- Moved the logic for `TransmitFromStorage` from trace exporter to common class `AzureMonitorPersistentStorage`
- Enabled persistent storage for logs and metrics exporter