### PR TITLE
[Search] Add missing property when cloning `SearchOptions`

### DIFF
--- a/sdk/search/Azure.Search.Documents/src/Options/SearchOptions.cs
+++ b/sdk/search/Azure.Search.Documents/src/Options/SearchOptions.cs
@@ -310,10 +310,33 @@ namespace Azure.Search.Documents
             Debug.Assert(source != null);
             Debug.Assert(destination != null);
 
-            foreach (System.Reflection.PropertyInfo propertyInfo in typeof(SearchOptions).GetProperties())
-            {
-                propertyInfo.SetValue(destination, propertyInfo.GetValue(source));
-            }
+            destination.Facets = source.Facets;
+            destination.Filter = source.Filter;
+            destination.HighlightFields = source.HighlightFields;
+            destination.HighlightPostTag = source.HighlightPostTag;
+            destination.HighlightPreTag = source.HighlightPreTag;
+            destination.IncludeTotalCount = source.IncludeTotalCount;
+            destination.MinimumCoverage = source.MinimumCoverage;
+            destination.OrderBy = source.OrderBy;
+            destination.QueryAnswer = source.QueryAnswer;
+            destination.QueryAnswerCount = source.QueryAnswerCount;
+            destination.QueryCaption = source.QueryCaption;
+            destination.QueryCaptionHighlightEnabled = source.QueryCaptionHighlightEnabled;
+            destination.QueryLanguage = source.QueryLanguage;
+            destination.QuerySpeller = source.QuerySpeller;
+            destination.QueryType = source.QueryType;
+            destination.ScoringParameters = source.ScoringParameters;
+            destination.ScoringProfile = source.ScoringProfile;
+            destination.ScoringStatistics = source.ScoringStatistics;
+            destination.SearchFields = source.SearchFields;
+            destination.SearchMode = source.SearchMode;
+            destination.SearchText = source.SearchText;
+            destination.Select = source.Select;
+            destination.SemanticConfigurationName = source.SemanticConfigurationName;
+            destination.SemanticFields = source.SemanticFields;
+            destination.SessionId = source.SessionId;
+            destination.Size = source.Size;
+            destination.Skip = source.Skip;
         }
 
         /// <summary>

--- a/sdk/search/Azure.Search.Documents/src/Options/SearchOptions.cs
+++ b/sdk/search/Azure.Search.Documents/src/Options/SearchOptions.cs
@@ -310,32 +310,11 @@ namespace Azure.Search.Documents
             Debug.Assert(source != null);
             Debug.Assert(destination != null);
 
-            destination.Facets = source.Facets;
-            destination.Filter = source.Filter;
-            destination.HighlightFields = source.HighlightFields;
-            destination.HighlightPostTag = source.HighlightPostTag;
-            destination.HighlightPreTag = source.HighlightPreTag;
-            destination.IncludeTotalCount = source.IncludeTotalCount;
-            destination.MinimumCoverage = source.MinimumCoverage;
-            destination.OrderBy = source.OrderBy;
-            destination.QueryAnswer = source.QueryAnswer;
-            destination.QueryAnswerCount = source.QueryAnswerCount;
-            destination.QueryCaption = source.QueryCaption;
-            destination.QueryCaptionHighlightEnabled = source.QueryCaptionHighlightEnabled;
-            destination.QueryLanguage = source.QueryLanguage;
-            destination.QuerySpeller = source.QuerySpeller;
-            destination.QueryType = source.QueryType;
-            destination.ScoringParameters = source.ScoringParameters;
-            destination.ScoringProfile = source.ScoringProfile;
-            destination.ScoringStatistics = source.ScoringStatistics;
-            destination.SearchFields = source.SearchFields;
-            destination.SearchMode = source.SearchMode;
-            destination.SearchText = source.SearchText;
-            destination.Select = source.Select;
-            destination.SemanticConfigurationName = source.SemanticConfigurationName;
-            destination.SemanticFields = source.SemanticFields;
-            destination.Size = source.Size;
-            destination.Skip = source.Skip;
+            foreach (System.Reflection.PropertyInfo sourcePropertyInfo in source.GetType().GetProperties())
+            {
+                System.Reflection.PropertyInfo destinationPropertyInfo = destination.GetType().GetProperty(sourcePropertyInfo.Name);
+                destinationPropertyInfo.SetValue(destination, sourcePropertyInfo.GetValue(source));
+            }
         }
 
         /// <summary>

--- a/sdk/search/Azure.Search.Documents/src/Options/SearchOptions.cs
+++ b/sdk/search/Azure.Search.Documents/src/Options/SearchOptions.cs
@@ -310,10 +310,9 @@ namespace Azure.Search.Documents
             Debug.Assert(source != null);
             Debug.Assert(destination != null);
 
-            foreach (System.Reflection.PropertyInfo sourcePropertyInfo in source.GetType().GetProperties())
+            foreach (System.Reflection.PropertyInfo propertyInfo in typeof(SearchOptions).GetProperties())
             {
-                System.Reflection.PropertyInfo destinationPropertyInfo = destination.GetType().GetProperty(sourcePropertyInfo.Name);
-                destinationPropertyInfo.SetValue(destination, sourcePropertyInfo.GetValue(source));
+                propertyInfo.SetValue(destination, propertyInfo.GetValue(source));
             }
         }
 

--- a/sdk/search/Azure.Search.Documents/tests/DocumentOperations/SearchTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/DocumentOperations/SearchTests.cs
@@ -1029,17 +1029,19 @@ namespace Azure.Search.Documents.Tests
             source.QueryCaptionHighlightEnabled = false;
             // source.QueryType = null;
             source.Select = null;
+            source.SessionId = "SessionId";
             source.Size = 100;
             source.Skip = null;
 
             SearchOptions clonedSearchOptions = source.Clone();
 
             CollectionAssert.AreEquivalent(source.Facets, clonedSearchOptions.Facets); // A non-null collection with multiple items
-            Assert.AreEqual(source.Filter, clonedSearchOptions.Filter); // String value
+            Assert.AreEqual(source.Filter, clonedSearchOptions.Filter); // A string value
             Assert.IsNull(clonedSearchOptions.IncludeTotalCount); // An unset bool? value
             Assert.AreEqual(source.QueryCaptionHighlightEnabled, clonedSearchOptions.QueryCaptionHighlightEnabled); // A bool? value
             Assert.IsNull(source.QueryType); // An unset enum? value
             Assert.IsNull(clonedSearchOptions.Select); // A `null` collection
+            Assert.AreEqual(source.SessionId, clonedSearchOptions.SessionId); // A string value
             Assert.AreEqual(source.Size, clonedSearchOptions.Size); // An int? value
             Assert.IsNull(clonedSearchOptions.Skip); // An int? value set as `null`
         }

--- a/sdk/search/Azure.Search.Documents/tests/DocumentOperations/SearchTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/DocumentOperations/SearchTests.cs
@@ -1018,6 +1018,32 @@ namespace Azure.Search.Documents.Tests
                 ids);
         }
 
+        [Test]
+        public void SearchOptionsCanBeCopied()
+        {
+            SearchOptions source = new();
+
+            source.Facets = new List<string> { "facet1", "facet2" };
+            source.Filter = "searchFilter";
+            // source.IncludeTotalCount = null;
+            source.QueryCaptionHighlightEnabled = false;
+            // source.QueryType = null;
+            source.Select = null;
+            source.Size = 100;
+            source.Skip = null;
+
+            SearchOptions clonedSearchOptions = source.Clone();
+
+            CollectionAssert.AreEquivalent(source.Facets, clonedSearchOptions.Facets); // A non-null collection with multiple items
+            Assert.AreEqual(source.Filter, clonedSearchOptions.Filter); // String value
+            Assert.IsNull(clonedSearchOptions.IncludeTotalCount); // An unset bool? value
+            Assert.AreEqual(source.QueryCaptionHighlightEnabled, clonedSearchOptions.QueryCaptionHighlightEnabled); // A bool? value
+            Assert.IsNull(source.QueryType); // An unset enum? value
+            Assert.IsNull(clonedSearchOptions.Select); // A `null` collection
+            Assert.AreEqual(source.Size, clonedSearchOptions.Size); // An int? value
+            Assert.IsNull(clonedSearchOptions.Skip); // An int? value set as `null`
+        }
+
         /* TODO: Enable these Track 1 tests when we have support for index creation
         protected void TestCanSearchWithDateTimeInStaticModel()
         {


### PR DESCRIPTION
Copy all properties using reflection to alleviate the issue of missing some properties in the copy code.
