### PR TITLE
[Cdn] Add back tests which was blocked by duration changes temporarily

### DIFF
--- a/sdk/cdn/Azure.ResourceManager.Cdn/tests/Scenario/AfdRuleCollectionTests.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/tests/Scenario/AfdRuleCollectionTests.cs
@@ -20,7 +20,6 @@ namespace Azure.ResourceManager.Cdn.Tests
 
         [TestCase]
         [RecordedTest]
-        [Ignore("Reenable after generator update")]
         public async Task CreateOrUpdate()
         {
             Subscription subscription = await Client.GetDefaultSubscriptionAsync();
@@ -38,7 +37,6 @@ namespace Azure.ResourceManager.Cdn.Tests
 
         [TestCase]
         [RecordedTest]
-        [Ignore("Reenable after generator update")]
         public async Task List()
         {
             Subscription subscription = await Client.GetDefaultSubscriptionAsync();
@@ -59,7 +57,6 @@ namespace Azure.ResourceManager.Cdn.Tests
 
         [TestCase]
         [RecordedTest]
-        [Ignore("Reenable after generator update")]
         public async Task Get()
         {
             Subscription subscription = await Client.GetDefaultSubscriptionAsync();

--- a/sdk/cdn/Azure.ResourceManager.Cdn/tests/Scenario/AfdRuleOperationsTests.cs
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/tests/Scenario/AfdRuleOperationsTests.cs
@@ -19,7 +19,6 @@ namespace Azure.ResourceManager.Cdn.Tests
 
         [TestCase]
         [RecordedTest]
-        [Ignore("Reenable after generator update")]
         public async Task Delete()
         {
             Subscription subscription = await Client.GetDefaultSubscriptionAsync();
@@ -37,7 +36,6 @@ namespace Azure.ResourceManager.Cdn.Tests
 
         [TestCase]
         [RecordedTest]
-        [Ignore("Reenable after generator update")]
         public async Task Update()
         {
             Subscription subscription = await Client.GetDefaultSubscriptionAsync();


### PR DESCRIPTION
Afd-related resources are removed but the tests are kept, we cannot test them but we can merge the PR first in case we forget to do so when we add back Adfe-related resources.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
