### PR TITLE
Trigger template instead of core for eng/common

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -12,6 +12,7 @@ trigger:
     - eng/
     exclude:
     - eng/mgmt/
+    - eng/common/
 
 pr:
   branches:
@@ -28,6 +29,7 @@ pr:
     - samples/
     exclude:
     - eng/mgmt/
+    - eng/common/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -28,10 +28,10 @@ pr:
     # The following paths should only be included in template/ci.yml, and removed from any other SDKs which copy this file.
     # The surrounding conditions should accomplish that when installed with `dotnet new azsdk`.
     # eng/common code changes trigger template pipeline for basic checking.
+    - eng/common/
     - common/Perf/
     - common/PerfStressShared/
     - common/Stress/
-    - eng/common/
 #endif
 
 extends:

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -21,14 +21,14 @@ pr:
   paths:
     include:
     - sdk/template/
-    # eng/common code changes trigger template pipeline for basic checking.
-    - eng/common/
 #if (false)
     # The following paths should only be included in template/ci.yml, and removed from any other SDKs which copy this file.
     # The surrounding conditions should accomplish that when installed with `dotnet new azsdk`.
+    # eng/common code changes trigger template pipeline for basic checking.
     - common/Perf/
     - common/PerfStressShared/
     - common/Stress/
+    - eng/common/
 #endif
 
 extends:

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -7,7 +7,9 @@ trigger:
     - release/*
   paths:
     include:
-    - sdk/template/
+    - sdk/template/ 
+    # eng/common code changes trigger template pipeline for basic checking.
+    - eng/common/
 
 pr:
   branches:
@@ -19,6 +21,8 @@ pr:
   paths:
     include:
     - sdk/template/
+    # eng/common code changes trigger template pipeline for basic checking.
+    - eng/common/
 #if (false)
     # The following paths should only be included in template/ci.yml, and removed from any other SDKs which copy this file.
     # The surrounding conditions should accomplish that when installed with `dotnet new azsdk`.

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -7,7 +7,10 @@ trigger:
     - release/*
   paths:
     include:
-    - sdk/template/ 
+    - sdk/template/
+#if (false)
+    # The following paths should only be included in template/ci.yml, and removed from any other SDKs which copy this file.
+    # The surrounding conditions should accomplish that when installed with `dotnet new azsdk`.
     # eng/common code changes trigger template pipeline for basic checking.
     - eng/common/
 


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

**Current workflow for eng work:**
For work under `eng/common` like PR: https://github.com/Azure/azure-sdk-tools/pull/2861.

It will trigger 9 PRs like below:
<img width="842" alt="image" src="https://user-images.githubusercontent.com/48036328/158711136-401f0b2e-ff1a-4398-be0c-fd4a8922ce41.png">

For PR to lang repo, they trigger core pipeline for testing the changes. Like sync PR here: https://github.com/Azure/azure-sdk-for-net/pull/27550

Java has switched to template already and run for a while. The PR is to align with Java trigger branch and path.