### PR TITLE
Synchronize OperationInternalBase calls

### DIFF
--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -190,6 +190,7 @@
 
   <!-- *********** Files needed for LRO ************* -->
   <ItemGroup Condition="'$(IncludeOperationsSharedSource)' == 'true'">
+    <Compile Include="$(AzureCoreSharedSources)AsyncLockWithValue.cs" LinkBase="Shared/Core" />
     <Compile Include="$(AzureCoreSharedSources)OperationHelpers.cs" LinkBase="Shared/Core" />
     <Compile Include="$(AzureCoreSharedSources)OperationInternal.cs" LinkBase="Shared/Core" />
     <Compile Include="$(AzureCoreSharedSources)OperationInternalBase.cs" LinkBase="Shared/Core" />

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/PostLedgerEntryOperation.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/PostLedgerEntryOperation.cs
@@ -61,15 +61,13 @@ namespace Azure.Security.ConfidentialLedger
                     .ConfigureAwait(false)
                 : _client.GetTransactionStatus(Id, new RequestContext { CancellationToken = cancellationToken, ErrorOptions = ErrorOptions.NoThrow });
 
-            _operationInternal.RawResponse = statusResponse;
-
             if (statusResponse.Status != (int)HttpStatusCode.OK)
             {
                 var error = new ResponseError(null, exceptionMessage);
                 var ex = async
                     ? await _client.ClientDiagnostics.CreateRequestFailedExceptionAsync(statusResponse, error).ConfigureAwait(false)
                     : _client.ClientDiagnostics.CreateRequestFailedException(statusResponse, error);
-                return OperationState.Failure(GetRawResponse(), new RequestFailedException(exceptionMessage, ex));
+                return OperationState.Failure(statusResponse, new RequestFailedException(exceptionMessage, ex));
             }
 
             string status = JsonDocument.Parse(statusResponse.Content)

--- a/sdk/core/Azure.Core/src/Shared/AsyncLockWithValue.cs
+++ b/sdk/core/Azure.Core/src/Shared/AsyncLockWithValue.cs
@@ -1,0 +1,227 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core.Pipeline;
+
+namespace Azure.Core
+{
+    /// <summary>
+    /// Primitive that combines async lock and value cache
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal sealed class AsyncLockWithValue<T>
+    {
+        private readonly object _syncObj = new object();
+        private Queue<TaskCompletionSource<Lock>>? _waiters;
+        private bool _isLocked;
+        private bool _hasValue;
+        private T? _value;
+
+        public bool HasValue
+        {
+            get
+            {
+                lock (_syncObj)
+                {
+                    return _hasValue;
+                }
+            }
+        }
+
+        public AsyncLockWithValue() { }
+
+        public AsyncLockWithValue(T value)
+        {
+            _hasValue = true;
+            _value = value;
+        }
+
+        public bool TryGetValue(
+            out T? value)
+        {
+            lock (_syncObj)
+            {
+                if (_hasValue)
+                {
+                    value = _value;
+                    return true;
+                }
+            }
+
+            value = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Method that either returns cached value or acquire a lock.
+        /// If one caller has acquired a lock, other callers will be waiting for the lock to be released.
+        /// If value is set, lock is released and all waiters get that value.
+        /// If value isn't set, the next waiter in the queue will get the lock.
+        /// </summary>
+        /// <param name="async"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async ValueTask<Lock> GetLockOrValueAsync(bool async, CancellationToken cancellationToken = default)
+        {
+            TaskCompletionSource<Lock> valueTcs;
+            lock (_syncObj)
+            {
+                // If there is a value, just return it
+                if (_hasValue)
+                {
+                    return new Lock(_value!);
+                }
+
+                // If lock isn't acquire yet, acquire it and return to the caller
+                if (!_isLocked)
+                {
+                    _isLocked = true;
+                    return new Lock(this);
+                }
+
+                // Check cancellationToken before instantiating waiter
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // If lock is already taken, create a waiter and wait either until value is set or lock can be acquired by this waiter
+                _waiters ??= new Queue<TaskCompletionSource<Lock>>();
+                // if async == false, valueTcs will be waited only in this thread and only synchronously, so RunContinuationsAsynchronously isn't needed.
+                valueTcs = new TaskCompletionSource<Lock>(async ? TaskCreationOptions.RunContinuationsAsynchronously : TaskCreationOptions.None);
+                _waiters.Enqueue(valueTcs);
+            }
+
+            try
+            {
+                if (async)
+                {
+                    return await valueTcs.Task.AwaitWithCancellation(cancellationToken);
+                }
+
+#pragma warning disable AZC0104 // Use EnsureCompleted() directly on asynchronous method return value.
+#pragma warning disable AZC0111 // DO NOT use EnsureCompleted in possibly asynchronous scope.
+                valueTcs.Task.Wait(cancellationToken);
+                return valueTcs.Task.EnsureCompleted();
+#pragma warning restore AZC0111 // DO NOT use EnsureCompleted in possibly asynchronous scope.
+#pragma warning restore AZC0104 // Use EnsureCompleted() directly on asynchronous method return value.
+            }
+            catch (OperationCanceledException)
+            {
+                // Throw OperationCanceledException only if another thread hasn't set a value to this waiter
+                // by calling either Reset or SetValue
+                if (valueTcs.TrySetCanceled(cancellationToken))
+                {
+                    throw;
+                }
+
+                return valueTcs.Task.Result;
+            }
+        }
+
+        /// <summary>
+        /// Set value to the cache and to all the waiters
+        /// </summary>
+        /// <param name="value"></param>
+        private void SetValue(T value)
+        {
+            Queue<TaskCompletionSource<Lock>> waiters;
+            lock (_syncObj)
+            {
+                _value = value;
+                _hasValue = true;
+                _isLocked = false;
+                if (_waiters == default)
+                {
+                    return;
+                }
+
+                waiters = _waiters;
+                _waiters = default;
+            }
+
+            while (waiters.Count > 0)
+            {
+                waiters.Dequeue().TrySetResult(new Lock(value));
+            }
+        }
+
+        /// <summary>
+        /// Release the lock and allow next waiter acquire it
+        /// </summary>
+        private void Reset()
+        {
+            TaskCompletionSource<Lock>? nextWaiter = UnlockOrGetNextWaiter();
+            while (nextWaiter != default && !nextWaiter.TrySetResult(new Lock(this)))
+            {
+                nextWaiter = UnlockOrGetNextWaiter();
+            }
+        }
+
+        private TaskCompletionSource<Lock>? UnlockOrGetNextWaiter()
+        {
+            lock (_syncObj)
+            {
+                if (!_isLocked)
+                {
+                    return default;
+                }
+
+                if (_waiters == default)
+                {
+                    _isLocked = false;
+                    return default;
+                }
+
+                while (_waiters.Count > 0)
+                {
+                    var nextWaiter = _waiters.Dequeue();
+                    if (!nextWaiter.Task.IsCompleted)
+                    {
+                        // Return the waiter only if it wasn't canceled already
+                        return nextWaiter;
+                    }
+                }
+
+                _isLocked = false;
+                return default;
+            }
+        }
+
+        public readonly struct Lock : IDisposable
+        {
+            private readonly AsyncLockWithValue<T>? _owner;
+            public bool HasValue => _owner == default;
+            public T? Value { get; }
+
+            public Lock(T value)
+            {
+                _owner = default;
+                Value = value;
+            }
+
+            public Lock(AsyncLockWithValue<T> owner)
+            {
+                _owner = owner;
+                Value = default;
+            }
+
+            public void SetValue(T value)
+            {
+                if (_owner != null)
+                {
+                    _owner.SetValue(value);
+                }
+                else
+                {
+                    throw new InvalidOperationException("Value for the lock is set already");
+                }
+            }
+
+            public void Dispose() => _owner?.Reset();
+        }
+    }
+}

--- a/sdk/core/Azure.Core/tests/AsyncLockWithValueTests.cs
+++ b/sdk/core/Azure.Core/tests/AsyncLockWithValueTests.cs
@@ -1,0 +1,251 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    public class AsyncLockWithValueTests
+    {
+        [Test]
+        public async Task AsyncLockWithValue_SetValueInCtor([Values(true, false)] bool async)
+        {
+            var alwv = new AsyncLockWithValue<int>(42);
+
+            Assert.IsTrue(alwv.HasValue);
+            Assert.IsTrue(alwv.TryGetValue(out var value));
+            Assert.AreEqual(42, value);
+
+            using var asyncLock = await alwv.GetLockOrValueAsync(async).ConfigureAwait(false);
+            Assert.IsTrue(asyncLock.HasValue);
+            Assert.AreEqual(42, asyncLock.Value);
+        }
+
+        [Test]
+        public async Task AsyncLockWithValue_GetLockOrValueAsync([Values(true, false)] bool async)
+        {
+            var alwv = new AsyncLockWithValue<int>();
+            AsyncLockWithValue<int>.Lock asyncLock;
+
+            Assert.IsFalse(alwv.HasValue);
+            Assert.IsFalse(alwv.TryGetValue(out _));
+            using (asyncLock = await alwv.GetLockOrValueAsync(async).ConfigureAwait(false))
+            {
+                Assert.IsFalse(asyncLock.HasValue);
+                asyncLock.SetValue(42);
+            }
+
+            Assert.IsTrue(alwv.HasValue);
+            Assert.IsTrue(alwv.TryGetValue(out var value));
+            Assert.AreEqual(42, value);
+            using (asyncLock = await alwv.GetLockOrValueAsync(async).ConfigureAwait(false))
+            {
+                Assert.IsTrue(asyncLock.HasValue);
+                Assert.AreEqual(42, asyncLock.Value);
+            }
+        }
+
+        [Test]
+        public async Task AsyncLockWithValue_ThrowOnValueOverride([Values(true, false)] bool async)
+        {
+            var alwv = new AsyncLockWithValue<int>();
+            AsyncLockWithValue<int>.Lock asyncLock;
+
+            Assert.IsFalse(alwv.HasValue);
+            Assert.IsFalse(alwv.TryGetValue(out _));
+            using (asyncLock = await alwv.GetLockOrValueAsync(async).ConfigureAwait(false))
+            {
+                Assert.IsFalse(asyncLock.HasValue);
+                asyncLock.SetValue(42);
+            }
+
+            Assert.IsTrue(alwv.HasValue);
+            Assert.IsTrue(alwv.TryGetValue(out var value));
+            Assert.AreEqual(42, value);
+            using (asyncLock = await alwv.GetLockOrValueAsync(async).ConfigureAwait(false))
+            {
+                Assert.IsTrue(asyncLock.HasValue);
+                Assert.Throws<InvalidOperationException>(() => asyncLock.SetValue(6*9));
+            }
+        }
+
+        [Test]
+        public async Task AsyncLockWithValue_GetLockOrValueAsync_Canceled([Values(true, false)] bool async)
+        {
+            var alwv = new AsyncLockWithValue<int>();
+            using var asyncLock = await alwv.GetLockOrValueAsync(async).ConfigureAwait(false);
+
+            var cts = new CancellationTokenSource();
+            var task = Task.Run(async () =>
+            {
+                using var secondLock = await alwv.GetLockOrValueAsync(async, cts.Token);
+            }, default);
+
+            Assert.IsFalse(task.IsCompleted);
+            cts.Cancel();
+            Assert.CatchAsync<OperationCanceledException>(async () => await task);
+
+            asyncLock.SetValue(42);
+        }
+
+        [Test]
+        public async Task AsyncLockWithValue_GetLockOrValueAsync_FirstFailedSecondSucceeded([Values(true, false)] bool async)
+        {
+            var alwv = new AsyncLockWithValue<int>();
+            var tcs = new TaskCompletionSource<int>();
+            var tcsWait = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var task1 = Task.Run(async () => {
+                using var lock1 = await alwv.GetLockOrValueAsync(async);
+                tcsWait.SetResult(0);
+                return async ? await tcs.Task : tcs.Task.GetAwaiter().GetResult();
+            });
+
+            await tcsWait.Task;
+
+            var task2 = Task.Run(async () => {
+                using var lock2 = await alwv.GetLockOrValueAsync(async);
+                lock2.SetValue(42);
+            });
+
+            Assert.IsFalse(task1.IsCompleted);
+            Assert.IsFalse(task2.IsCompleted);
+
+            tcs.SetException(new InvalidOperationException());
+            Assert.CatchAsync<InvalidOperationException>(async () => await task1);
+            await task2;
+
+            using var lock3 = await alwv.GetLockOrValueAsync(async).ConfigureAwait(false);
+            Assert.IsTrue(lock3.HasValue);
+            Assert.AreEqual(42, lock3.Value);
+        }
+
+        [Test]
+        public async Task AsyncLockWithValue_GetLockOrValueAsync_SecondCanceled([Values(true, false)] bool async)
+        {
+            var alwv = new AsyncLockWithValue<int>();
+            var tcs = new TaskCompletionSource<int>();
+            var tcs1 = new TaskCompletionSource<int>();
+
+            var cts = new CancellationTokenSource();
+            var task1 = Task.Run(async () =>
+            {
+                using var lock1 = await alwv.GetLockOrValueAsync(async, default);
+                tcs1.SetResult(0);
+                return async ? await tcs.Task : tcs.Task.GetAwaiter().GetResult();
+            }, default);
+
+            await tcs1.Task;
+
+            var task2 = Task.Run(async () =>
+            {
+                using var lock2 = await alwv.GetLockOrValueAsync(async, cts.Token);
+            }, default);
+
+            var task3 = Task.Run(async () =>
+            {
+                using var lock3 = await alwv.GetLockOrValueAsync(async, default);
+                lock3.SetValue(42);
+            }, default);
+
+            Assert.IsFalse(task1.IsCompleted);
+            Assert.IsFalse(task2.IsCompleted);
+            Assert.IsFalse(task3.IsCompleted);
+
+            cts.Cancel();
+            Assert.CatchAsync<OperationCanceledException>(async () => await task2);
+
+            tcs.SetResult(0);
+            await task1;
+            await task3;
+
+            var lock4 = await alwv.GetLockOrValueAsync(async, default);
+            Assert.IsTrue(lock4.HasValue);
+            Assert.AreEqual(42, lock4.Value);
+        }
+
+        [Test]
+        public async Task AsyncLockWithValue_GetLockOrValueAsync_OneHundredCalls_HasNoValue([Values(true, false)] bool async)
+        {
+            var alwv = new AsyncLockWithValue<int>();
+            var firstLock = await alwv.GetLockOrValueAsync(async);
+            var tasks = new List<Task>();
+            for (var i = 0; i < 50; i++)
+            {
+                tasks.Add(Task.Run(async () =>
+                {
+                    Assert.IsFalse(alwv.HasValue);
+                    Assert.IsFalse(alwv.TryGetValue(out _));
+                    using var asyncLock = await alwv.GetLockOrValueAsync(async);
+                    Assert.IsFalse(asyncLock.HasValue);
+                }));
+            }
+
+            firstLock.Dispose();
+            await Task.WhenAll(tasks);
+            Assert.IsFalse(alwv.HasValue);
+            Assert.IsFalse(alwv.TryGetValue(out _));
+        }
+
+        [Test]
+        public async Task AsyncLockWithValue_GetLockOrValueAsync_OneHundredCalls_HasValue([Values(true, false)] bool async)
+        {
+            var alwv = new AsyncLockWithValue<int>();
+            var firstLock = await alwv.GetLockOrValueAsync(async);
+            var tasks = new List<Task>();
+            for (var i = 0; i < 50; i++)
+            {
+                tasks.Add(Task.Run(async () =>
+                {
+                    using var asyncLock = await alwv.GetLockOrValueAsync(async);
+                    Assert.IsTrue(asyncLock.HasValue);
+                    Assert.AreEqual(asyncLock.Value, 42);
+                }));
+            }
+
+            firstLock.SetValue(42);
+            await Task.WhenAll(tasks);
+        }
+
+        [Test]
+        public async Task AsyncLockWithValue_GetLockOrValueAsync_OneHundredCalls_Canceled([Values(true, false)] bool async)
+        {
+            var alwv = new AsyncLockWithValue<int>();
+            var firstLock = await alwv.GetLockOrValueAsync(async);
+
+            var startingTasks = new List<Task>();
+            var tasks = new List<Task>();
+            var cts = new CancellationTokenSource();
+            for (var i = 0; i < 10; i++)
+            {
+                var token = i % 2 == 0 ? cts.Token : default;
+                var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+                tasks.Add(CreateTask(alwv, tcs, async, token));
+                startingTasks.Add(tcs.Task);
+            }
+
+            await Task.WhenAll(startingTasks);
+            for (var i = 0; i < 40; i++)
+            {
+                var token = i % 2 == 0 ? cts.Token : default;
+                tasks.Add(CreateTask(alwv, default, async, token));
+            }
+
+            cts.Cancel();
+            firstLock.Dispose();
+            Assert.CatchAsync<OperationCanceledException>(async () => await Task.WhenAll(tasks));
+
+            static Task CreateTask(AsyncLockWithValue<int> lockWithValue, TaskCompletionSource<int> tcs, bool isAsync, CancellationToken token) =>
+                Task.Run(async () =>
+                {
+                    tcs?.SetResult(0);
+                    using var asyncLock = await lockWithValue.GetLockOrValueAsync(isAsync, token);
+                    Assert.IsFalse(asyncLock.HasValue);
+                }, default);
+        }
+    }
+}

--- a/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
+++ b/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\src\Shared\Multipart\*.cs" LinkBase="Shared\Multipart" />
+    <Compile Include="..\src\Shared\AsyncLockWithValue.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\ArrayBufferWriter.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\ARMChallengeAuthenticationPolicy.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />

--- a/sdk/core/Azure.Core/tests/TestClients/MockOperationInternal.cs
+++ b/sdk/core/Azure.Core/tests/TestClients/MockOperationInternal.cs
@@ -17,8 +17,7 @@ namespace Azure.Core.Tests
             Func<MockResponse> responseFactory,
             string operationTypeName,
             IEnumerable<KeyValuePair<string, string>> scopeAttributes,
-            DelayStrategy pollingStrategy,
-            OperationState? completedState = null)
+            DelayStrategy pollingStrategy)
             : base(clientDiagnostics, operation, responseFactory(), operationTypeName, scopeAttributes, pollingStrategy)
         { }
 

--- a/sdk/core/Azure.Core/tests/TestClients/MockOperationInternal.cs
+++ b/sdk/core/Azure.Core/tests/TestClients/MockOperationInternal.cs
@@ -17,7 +17,8 @@ namespace Azure.Core.Tests
             Func<MockResponse> responseFactory,
             string operationTypeName,
             IEnumerable<KeyValuePair<string, string>> scopeAttributes,
-            DelayStrategy pollingStrategy)
+            DelayStrategy pollingStrategy,
+            OperationState? completedState = null)
             : base(clientDiagnostics, operation, responseFactory(), operationTypeName, scopeAttributes, pollingStrategy)
         { }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/DeleteKeyOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/DeleteKeyOperation.cs
@@ -24,18 +24,16 @@ namespace Azure.Security.KeyVault.Keys
         {
             _pipeline = pipeline;
             _value = response.Value ?? throw new InvalidOperationException("The response does not contain a value.");
+
+            // The recoveryId is only returned if soft delete is enabled.
+            // If soft delete is not enabled, deleting is immediate so set success accordingly.
+            OperationState? finalState = _value.RecoveryId is null ? OperationState.Success(response.GetRawResponse()) : null;
+
             _operationInternal = new(_pipeline.Diagnostics, this, response.GetRawResponse(), nameof(DeleteKeyOperation), new[]
             {
                 new KeyValuePair<string, string>("secret", _value.Name), // Retained for backward compatibility.
                 new KeyValuePair<string, string>("key", _value.Name),
-            });
-
-            // The recoveryId is only returned if soft delete is enabled.
-            if (_value.RecoveryId is null)
-            {
-                // If soft delete is not enabled, deleting is immediate so set success accordingly.
-                _operationInternal.SetState(OperationState.Success(response.GetRawResponse()));
-            }
+            }, finalState: finalState);
         }
 
         /// <summary> Initializes a new instance of <see cref="DeleteKeyOperation" /> for mocking. </summary>

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/DeleteSecretOperation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/DeleteSecretOperation.cs
@@ -24,14 +24,12 @@ namespace Azure.Security.KeyVault.Secrets
         {
             _pipeline = pipeline;
             _value = response.Value ?? throw new InvalidOperationException("The response does not contain a value.");
-            _operationInternal = new(_pipeline.Diagnostics, this, response.GetRawResponse(), nameof(DeleteSecretOperation), new[] { new KeyValuePair<string, string>("secret", _value.Name) });
 
             // The recoveryId is only returned if soft delete is enabled.
-            if (_value.RecoveryId is null)
-            {
-                // If soft delete is not enabled, deleting is immediate so set success accordingly.
-                _operationInternal.SetState(OperationState.Success(response.GetRawResponse()));
-            }
+            // If soft delete is not enabled, deleting is immediate so set success accordingly.
+            OperationState? finalState = _value.RecoveryId is null ? OperationState.Success(response.GetRawResponse()) : null;
+
+            _operationInternal = new(_pipeline.Diagnostics, this, response.GetRawResponse(), nameof(DeleteSecretOperation), new[] { new KeyValuePair<string, string>("secret", _value.Name) }, finalState: finalState);
         }
 
         /// <summary> Initializes a new instance of <see cref="DeleteSecretOperation" /> for mocking. </summary>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeHealthcareEntitiesOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeHealthcareEntitiesOperation.cs
@@ -244,7 +244,7 @@ namespace Azure.AI.TextAnalytics
             try
             {
                 ResponseWithHeaders<TextAnalyticsCancelHealthJobHeaders> response = _serviceClient.CancelHealthJob(new Guid(_jobId), cancellationToken);
-                _operationInternal.RawResponse = response.GetRawResponse();
+                _operationInternal.TrySetPendingResponse(response.GetRawResponse(), cancellationToken);
             }
             catch (Exception e)
             {
@@ -266,7 +266,7 @@ namespace Azure.AI.TextAnalytics
             try
             {
                 ResponseWithHeaders<TextAnalyticsCancelHealthJobHeaders> response = await _serviceClient.CancelHealthJobAsync(new Guid(_jobId), cancellationToken).ConfigureAwait(false);
-                _operationInternal.RawResponse = response.GetRawResponse();
+                await _operationInternal.TrySetPendingResponseAsync(response.GetRawResponse(), cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
This is a draft of the change to resolve several issues:
- When two `WaitForCompletion` calls are made concurrently, `RawResponse` property may contain response that is not from the final state. For details, see:  https://github.com/Azure/azure-sdk-for-net/pull/19105#discussion_r621554812
- Because of the problem above, right now we have a workaround that every call for `WaitForCompletion` makes at least one call even if operation is completed, including cases when operation was created as completed
- `OperationInternal<T>.Value` may contain value that can't be recreated from `RawResponse`
- `OperationInternal<T>.HasValue` may be `true` while `RawResponse` contains "pending" response