### PR TITLE
[Draft] Minimize noisy Storage exceptions via DPG methods

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/RequestContextExtensions.cs
+++ b/sdk/core/Azure.Core/src/Shared/RequestContextExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading;
 
 namespace Azure.Core
@@ -11,7 +12,8 @@ namespace Azure.Core
 	internal static class RequestContextExtensions
 	{
         /// <summary>
-        /// Singleton RequestContext to use when we don't have an instance.
+        /// Singleton <see cref="RequestContext"/> to use when we don't have an
+        /// instance.
         /// </summary>
         public static RequestContext Empty { get; } = new RequestContext();
 
@@ -20,7 +22,7 @@ namespace Azure.Core
         /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>
-        /// A RequestContext wrapping the cancellation token.
+        /// A <see cref="RequestContext"/> wrapping the cancellation token.
         /// </returns>
         public static RequestContext ToRequestContext(this CancellationToken cancellationToken) =>
             cancellationToken == CancellationToken.None ?
@@ -30,9 +32,14 @@ namespace Azure.Core
         /// <summary>
         /// Link a CancellationToken with an existing RequestContext.
         /// </summary>
-        /// <param name="context">The RequestContext.</param>
+        /// <param name="context">
+        /// The <see cref="RequestContext"/> for the current operation.
+        /// </param>
         /// <param name="cancellationToken">A cancellation token.</param>
-        public static void Link(this RequestContext context, CancellationToken cancellationToken)
+        /// <returns>
+        /// The <see cref="RequestContext"/> for the current operation.
+        /// </returns>
+        public static RequestContext Link(this RequestContext context, CancellationToken cancellationToken)
         {
             if (cancellationToken == CancellationToken.None)
             {
@@ -51,6 +58,102 @@ namespace Azure.Core
                     cancellationToken);
                 context.CancellationToken = source.Token;
             }
+            return context;
         }
-	}
+
+        /// <summary>
+        /// Customizes the <see cref="ResponseClassifier"/> for this operation
+        /// to change the default <see cref="Response"/> classification behavior
+        /// so that it evalutes the anonymous classifier to determine whether
+        /// an error occured or not.
+        ///
+        /// Custom classifiers are applied after all
+        /// <see cref="ResponseClassificationHandler"/> classifiers.  This is
+        /// useful for cases where you'd like to prevent specific situations
+        /// from being treated as errors by logging and distributed tracing
+        /// policies -- that is, if a response is not classified as an error,
+        /// it will not appear as an error in logs or distributed traces.
+        /// </summary>
+        /// <param name="context">
+        /// The <see cref="RequestContext"/> for the current operation.
+        /// </param>
+        /// <param name="classifier">
+        /// A function to classify the response.  It should return true if the
+        /// message contains an error, false if not an error, and null if it
+        /// was unable to classify.
+        /// </param>
+        /// <returns>
+        /// The <see cref="RequestContext"/> for the current operation.
+        /// </returns>
+        public static RequestContext AddClassifier(this RequestContext context, Func<HttpMessage, bool?> classifier)
+        {
+            Argument.AssertNotNull(context, nameof(context));
+            Argument.AssertNotNull(classifier, nameof(classifier));
+            context.AddClassifier(new LambdaClassifier(classifier));
+            return context;
+        }
+
+        // Anonymous reponse classifier
+        private class LambdaClassifier : ResponseClassificationHandler
+        {
+            private Func<HttpMessage, bool?> _classifier;
+
+            public LambdaClassifier(Func<HttpMessage, bool?> classifier) =>
+                _classifier = classifier;
+
+            public override bool TryClassify(HttpMessage message, out bool isError)
+            {
+                if (message.HasResponse)
+                {
+                    bool? result = _classifier(message);
+                    if (result is not null)
+                    {
+                        isError = result.Value;
+                        return true;
+                    }
+                }
+
+                isError = false;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Customizes the <see cref="ResponseClassifier"/> for this operation
+        /// to change the default <see cref="Response"/> classification behavior
+        /// so that it considers the passed-in status code and error code to be
+        /// an error or not, as specified.
+        ///
+        /// Custom classifiers are applied after all
+        /// <see cref="ResponseClassificationHandler"/> classifiers.  This is
+        /// useful for cases where you'd like to prevent specific response
+        /// status and error codes from being treated as errors by logging and
+        /// distributed tracing policies -- that is, if a response is not
+        /// classified as an error, it will not appear as an error in logs or
+        /// distributed traces.
+        /// </summary>
+        /// <param name="context">
+        /// The <see cref="RequestContext"/> for the current operation.
+        /// </param>
+        /// <param name="statusCode">
+        /// The status code to customize classification for.
+        /// </param>
+        /// <param name="errorCode">
+        /// The error code to customize classification for.
+        /// </param>
+        /// <param name="isError">
+        /// Whether the passed-in status code should be classified as an error.
+        /// </param>
+        /// <returns>
+        /// The <see cref="RequestContext"/> for the current operation.
+        /// </returns>
+        public static RequestContext AddClassifier(this RequestContext context, int statusCode, string errorCode, bool isError) =>
+            context.AddClassifier(
+                message =>
+                    message.Response.Status == statusCode &&
+                    message.Response.Headers.TryGetValue("x-ms-error-code", out string code) &&
+                    code == errorCode ?
+                        isError :
+                        null);
+    }
 }

--- a/sdk/core/Azure.Core/src/Shared/RequestContextExtensions.cs
+++ b/sdk/core/Azure.Core/src/Shared/RequestContextExtensions.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+
+namespace Azure.Core
+{
+    /// <summary>
+    /// Shared source helpers for <see cref="RequestContext"/>.
+    /// </summary>
+	internal static class RequestContextExtensions
+	{
+        /// <summary>
+        /// Singleton RequestContext to use when we don't have an instance.
+        /// </summary>
+        public static RequestContext Empty { get; } = new RequestContext();
+
+        /// <summary>
+        /// Create a RequestContext instance from a CancellationToken.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// A RequestContext wrapping the cancellation token.
+        /// </returns>
+        public static RequestContext ToRequestContext(this CancellationToken cancellationToken) =>
+            cancellationToken == CancellationToken.None ?
+                Empty :
+                new() { CancellationToken = cancellationToken };
+
+        /// <summary>
+        /// Link a CancellationToken with an existing RequestContext.
+        /// </summary>
+        /// <param name="context">The RequestContext.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public static void Link(this RequestContext context, CancellationToken cancellationToken)
+        {
+            if (cancellationToken == CancellationToken.None)
+            {
+                // Don't link if there's nothing there
+            }
+            else if (context.CancellationToken == CancellationToken.None)
+            {
+                // Don't link if we can just replace
+                context.CancellationToken = cancellationToken;
+            }
+            else
+            {
+                // Otherwise link them together
+                CancellationTokenSource source = CancellationTokenSource.CreateLinkedTokenSource(
+                    context.CancellationToken,
+                    cancellationToken);
+                context.CancellationToken = source.Token;
+            }
+        }
+	}
+}

--- a/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.0.cs
@@ -1578,7 +1578,9 @@ namespace Azure.Storage.Blobs.Specialized
         protected virtual Azure.Storage.Blobs.BlobContainerClient BlobContainerClient { get { throw null; } }
         public virtual string LeaseId { get { throw null; } }
         public System.Uri Uri { get { throw null; } }
+        public virtual Azure.Response<Azure.Storage.Blobs.Models.BlobLease> Acquire(System.TimeSpan duration, Azure.RequestConditions conditions, Azure.RequestContext context) { throw null; }
         public virtual Azure.Response<Azure.Storage.Blobs.Models.BlobLease> Acquire(System.TimeSpan duration, Azure.RequestConditions conditions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobLease>> AcquireAsync(System.TimeSpan duration, Azure.RequestConditions conditions, Azure.RequestContext context) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobLease>> AcquireAsync(System.TimeSpan duration, Azure.RequestConditions conditions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Storage.Blobs.Models.BlobLease> Break(System.TimeSpan? breakPeriod = default(System.TimeSpan?), Azure.RequestConditions conditions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobLease>> BreakAsync(System.TimeSpan? breakPeriod = default(System.TimeSpan?), Azure.RequestConditions conditions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
@@ -35,6 +35,7 @@
     <Compile Include="$(AzureCoreSharedSources)ForwardsClientCallsAttribute.cs" LinkBase="SharedCore" />
     <Compile Include="$(AzureCoreSharedSources)HashCodeBuilder.cs" LinkBase="SharedCore" />
     <Compile Include="$(AzureCoreSharedSources)NoBodyResponseOfT.cs" LinkBase="SharedCore" />
+    <Compile Include="$(AzureCoreSharedSources)RequestContextExtensions.cs" LinkBase="SharedCore" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(AzureStorageSharedSources)ClientsideEncryption\*.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Storage.Blobs.Models;
@@ -302,6 +303,125 @@ namespace Azure.Storage.Blobs
                     return ResponseWithHeaders.FromValue(headers, message.Response);
                 default:
                     throw ClientDiagnostics.CreateRequestFailedException(message.Response);
+            }
+        }
+
+        internal HttpMessage CreateGetPropertiesRequest(string snapshot, string versionId, int? timeout, string leaseId, string encryptionKey, string encryptionKeySha256, EncryptionAlgorithmTypeInternal? encryptionAlgorithm, string ifTags, RequestConditions requestConditions, RequestContext context)
+        {
+            var message = _pipeline.CreateMessage(context, ResponseClassifier200);
+            var request = message.Request;
+            request.Method = RequestMethod.Head;
+            var uri = new RawRequestUriBuilder();
+            uri.AppendRaw(_url, false);
+            if (snapshot != null)
+            {
+                uri.AppendQuery("snapshot", snapshot, true);
+            }
+            if (versionId != null)
+            {
+                uri.AppendQuery("versionid", versionId, true);
+            }
+            if (timeout != null)
+            {
+                uri.AppendQuery("timeout", timeout.Value, true);
+            }
+            request.Uri = uri;
+            if (leaseId != null)
+            {
+                request.Headers.Add("x-ms-lease-id", leaseId);
+            }
+            if (encryptionKey != null)
+            {
+                request.Headers.Add("x-ms-encryption-key", encryptionKey);
+            }
+            if (encryptionKeySha256 != null)
+            {
+                request.Headers.Add("x-ms-encryption-key-sha256", encryptionKeySha256);
+            }
+            if (encryptionAlgorithm != null)
+            {
+                request.Headers.Add("x-ms-encryption-algorithm", encryptionAlgorithm.Value.ToSerialString());
+            }
+            if (ifTags != null)
+            {
+                request.Headers.Add("x-ms-if-tags", ifTags);
+            }
+            request.Headers.Add("x-ms-version", _version);
+            request.Headers.Add("Accept", "application/xml");
+            if (requestConditions != null)
+            {
+                request.Headers.Add(requestConditions, "R");
+            }
+            return message;
+        }
+
+        /// <summary> The Get Properties operation returns all user-defined metadata, standard HTTP properties, and system properties for the blob. It does not return the content of the blob. </summary>
+        /// <param name="snapshot"> The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more information on working with blob snapshots, see &lt;a href=&quot;https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob&quot;&gt;Creating a Snapshot of a Blob.&lt;/a&gt;. </param>
+        /// <param name="versionId"> The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on. It&apos;s for service version 2019-10-10 and newer. </param>
+        /// <param name="timeout"> The timeout parameter is expressed in seconds. For more information, see &lt;a href=&quot;https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations&quot;&gt;Setting Timeouts for Blob Service Operations.&lt;/a&gt;. </param>
+        /// <param name="leaseId"> If specified, the operation only succeeds if the resource&apos;s lease is active and matches this ID. </param>
+        /// <param name="encryptionKey"> Optional. Specifies the encryption key to use to encrypt the data provided in the request. If not specified, encryption is performed with the root account encryption key.  For more information, see Encryption at Rest for Azure Storage Services. </param>
+        /// <param name="encryptionKeySha256"> The SHA-256 hash of the provided encryption key. Must be provided if the x-ms-encryption-key header is provided. </param>
+        /// <param name="encryptionAlgorithm"> The algorithm used to produce the encryption key hash. Currently, the only accepted value is &quot;AES256&quot;. Must be provided if the x-ms-encryption-key header is provided. </param>
+        /// <param name="ifTags"> Specify a SQL where clause on blob tags to operate only on blobs with a matching value. </param>
+        /// <param name="requestConditions"> The content to send as the request conditions of the request. </param>
+        /// <param name="context"> The request context, which can override default behaviors on the request on a per-call basis. </param>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   Message: string
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
+        public virtual async Task<Response> GetPropertiesAsync(string snapshot = null, string versionId = null, int? timeout = null, string leaseId = null, string encryptionKey = null, string encryptionKeySha256 = null, EncryptionAlgorithmTypeInternal? encryptionAlgorithm = null, string ifTags = null, RequestConditions requestConditions = null, RequestContext context = null)
+        {
+            using var scope = ClientDiagnostics.CreateScope("BlobClient.GetProperties");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateGetPropertiesRequest(snapshot, versionId, timeout, leaseId, encryptionKey, encryptionKeySha256, encryptionAlgorithm, ifTags, requestConditions, context);
+                return await _pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary> The Get Properties operation returns all user-defined metadata, standard HTTP properties, and system properties for the blob. It does not return the content of the blob. </summary>
+        /// <param name="snapshot"> The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more information on working with blob snapshots, see &lt;a href=&quot;https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob&quot;&gt;Creating a Snapshot of a Blob.&lt;/a&gt;. </param>
+        /// <param name="versionId"> The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on. It&apos;s for service version 2019-10-10 and newer. </param>
+        /// <param name="timeout"> The timeout parameter is expressed in seconds. For more information, see &lt;a href=&quot;https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations&quot;&gt;Setting Timeouts for Blob Service Operations.&lt;/a&gt;. </param>
+        /// <param name="leaseId"> If specified, the operation only succeeds if the resource&apos;s lease is active and matches this ID. </param>
+        /// <param name="encryptionKey"> Optional. Specifies the encryption key to use to encrypt the data provided in the request. If not specified, encryption is performed with the root account encryption key.  For more information, see Encryption at Rest for Azure Storage Services. </param>
+        /// <param name="encryptionKeySha256"> The SHA-256 hash of the provided encryption key. Must be provided if the x-ms-encryption-key header is provided. </param>
+        /// <param name="encryptionAlgorithm"> The algorithm used to produce the encryption key hash. Currently, the only accepted value is &quot;AES256&quot;. Must be provided if the x-ms-encryption-key header is provided. </param>
+        /// <param name="ifTags"> Specify a SQL where clause on blob tags to operate only on blobs with a matching value. </param>
+        /// <param name="requestConditions"> The content to send as the request conditions of the request. </param>
+        /// <param name="context"> The request context, which can override default behaviors on the request on a per-call basis. </param>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   Message: string
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
+        public virtual Response GetProperties(string snapshot = null, string versionId = null, int? timeout = null, string leaseId = null, string encryptionKey = null, string encryptionKeySha256 = null, EncryptionAlgorithmTypeInternal? encryptionAlgorithm = null, string ifTags = null, RequestConditions requestConditions = null, RequestContext context = null)
+        {
+            using var scope = ClientDiagnostics.CreateScope("BlobClient.GetProperties");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateGetPropertiesRequest(snapshot, versionId, timeout, leaseId, encryptionKey, encryptionKeySha256, encryptionAlgorithm, ifTags, requestConditions, context);
+                return _pipeline.ProcessMessage(message, context);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
             }
         }
 
@@ -1040,6 +1160,103 @@ namespace Azure.Storage.Blobs
                     return ResponseWithHeaders.FromValue(headers, message.Response);
                 default:
                     throw ClientDiagnostics.CreateRequestFailedException(message.Response);
+            }
+        }
+
+        internal HttpMessage CreateAcquireLeaseRequest(int? timeout, long? duration, string proposedLeaseId, string ifTags, RequestConditions requestConditions, RequestContext context)
+        {
+            var message = _pipeline.CreateMessage(context, ResponseClassifier201);
+            var request = message.Request;
+            request.Method = RequestMethod.Put;
+            var uri = new RawRequestUriBuilder();
+            uri.AppendRaw(_url, false);
+            uri.AppendQuery("comp", "lease", true);
+            if (timeout != null)
+            {
+                uri.AppendQuery("timeout", timeout.Value, true);
+            }
+            request.Uri = uri;
+            request.Headers.Add("x-ms-lease-action", "acquire");
+            if (duration != null)
+            {
+                request.Headers.Add("x-ms-lease-duration", duration.Value);
+            }
+            if (proposedLeaseId != null)
+            {
+                request.Headers.Add("x-ms-proposed-lease-id", proposedLeaseId);
+            }
+            if (ifTags != null)
+            {
+                request.Headers.Add("x-ms-if-tags", ifTags);
+            }
+            request.Headers.Add("x-ms-version", _version);
+            request.Headers.Add("Accept", "application/xml");
+            if (requestConditions != null)
+            {
+                request.Headers.Add(requestConditions, "R");
+            }
+            return message;
+        }
+
+        /// <summary> [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations. </summary>
+        /// <param name="timeout"> The timeout parameter is expressed in seconds. For more information, see &lt;a href=&quot;https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations&quot;&gt;Setting Timeouts for Blob Service Operations.&lt;/a&gt;. </param>
+        /// <param name="duration"> Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite lease can be between 15 and 60 seconds. A lease duration cannot be changed using renew or change. </param>
+        /// <param name="proposedLeaseId"> Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request) if the proposed lease ID is not in the correct format. See Guid Constructor (String) for a list of valid GUID string formats. </param>
+        /// <param name="ifTags"> Specify a SQL where clause on blob tags to operate only on blobs with a matching value. </param>
+        /// <param name="requestConditions"> The content to send as the request conditions of the request. </param>
+        /// <param name="context"> The request context, which can override default behaviors on the request on a per-call basis. </param>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   Message: string
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
+        public virtual async Task<Response> AcquireLeaseAsync(int? timeout = null, long? duration = null, string proposedLeaseId = null, string ifTags = null, RequestConditions requestConditions = null, RequestContext context = null)
+        {
+            using var scope = ClientDiagnostics.CreateScope("BlobClient.AcquireLease");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateAcquireLeaseRequest(timeout, duration, proposedLeaseId, ifTags, requestConditions, context);
+                return await _pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary> [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations. </summary>
+        /// <param name="timeout"> The timeout parameter is expressed in seconds. For more information, see &lt;a href=&quot;https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations&quot;&gt;Setting Timeouts for Blob Service Operations.&lt;/a&gt;. </param>
+        /// <param name="duration"> Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite lease can be between 15 and 60 seconds. A lease duration cannot be changed using renew or change. </param>
+        /// <param name="proposedLeaseId"> Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request) if the proposed lease ID is not in the correct format. See Guid Constructor (String) for a list of valid GUID string formats. </param>
+        /// <param name="ifTags"> Specify a SQL where clause on blob tags to operate only on blobs with a matching value. </param>
+        /// <param name="requestConditions"> The content to send as the request conditions of the request. </param>
+        /// <param name="context"> The request context, which can override default behaviors on the request on a per-call basis. </param>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   Message: string
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
+        public virtual Response AcquireLease(int? timeout = null, long? duration = null, string proposedLeaseId = null, string ifTags = null, RequestConditions requestConditions = null, RequestContext context = null)
+        {
+            using var scope = ClientDiagnostics.CreateScope("BlobClient.AcquireLease");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateAcquireLeaseRequest(timeout, duration, proposedLeaseId, ifTags, requestConditions, context);
+                return _pipeline.ProcessMessage(message, context);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
             }
         }
 
@@ -2395,5 +2612,10 @@ namespace Azure.Storage.Blobs
                     throw ClientDiagnostics.CreateRequestFailedException(message.Response);
             }
         }
+
+        private static ResponseClassifier _responseClassifier200;
+        private static ResponseClassifier ResponseClassifier200 => _responseClassifier200 ??= new StatusCodeClassifier(stackalloc ushort[] { 200 });
+        private static ResponseClassifier _responseClassifier201;
+        private static ResponseClassifier ResponseClassifier201 => _responseClassifier201 ??= new StatusCodeClassifier(stackalloc ushort[] { 201 });
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/src/Generated/ContainerRestClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Generated/ContainerRestClient.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Storage.Blobs.Models;
@@ -171,6 +172,84 @@ namespace Azure.Storage.Blobs
                     return ResponseWithHeaders.FromValue(headers, message.Response);
                 default:
                     throw ClientDiagnostics.CreateRequestFailedException(message.Response);
+            }
+        }
+
+        internal HttpMessage CreateGetPropertiesRequest(int? timeout, string leaseId, RequestContext context)
+        {
+            var message = _pipeline.CreateMessage(context, ResponseClassifier200);
+            var request = message.Request;
+            request.Method = RequestMethod.Get;
+            var uri = new RawRequestUriBuilder();
+            uri.AppendRaw(_url, false);
+            uri.AppendQuery("restype", "container", true);
+            if (timeout != null)
+            {
+                uri.AppendQuery("timeout", timeout.Value, true);
+            }
+            request.Uri = uri;
+            if (leaseId != null)
+            {
+                request.Headers.Add("x-ms-lease-id", leaseId);
+            }
+            request.Headers.Add("x-ms-version", _version);
+            request.Headers.Add("Accept", "application/xml");
+            return message;
+        }
+
+        /// <summary> returns all user-defined metadata and system properties for the specified container. The data returned does not include the container&apos;s list of blobs. </summary>
+        /// <param name="timeout"> The timeout parameter is expressed in seconds. For more information, see &lt;a href=&quot;https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations&quot;&gt;Setting Timeouts for Blob Service Operations.&lt;/a&gt;. </param>
+        /// <param name="leaseId"> If specified, the operation only succeeds if the resource&apos;s lease is active and matches this ID. </param>
+        /// <param name="context"> The request context, which can override default behaviors on the request on a per-call basis. </param>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   Message: string
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
+        public virtual async Task<Response> GetPropertiesAsync(int? timeout = null, string leaseId = null, RequestContext context = null)
+        {
+            using var scope = ClientDiagnostics.CreateScope("ContainerClient.GetProperties");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateGetPropertiesRequest(timeout, leaseId, context);
+                return await _pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary> returns all user-defined metadata and system properties for the specified container. The data returned does not include the container&apos;s list of blobs. </summary>
+        /// <param name="timeout"> The timeout parameter is expressed in seconds. For more information, see &lt;a href=&quot;https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations&quot;&gt;Setting Timeouts for Blob Service Operations.&lt;/a&gt;. </param>
+        /// <param name="leaseId"> If specified, the operation only succeeds if the resource&apos;s lease is active and matches this ID. </param>
+        /// <param name="context"> The request context, which can override default behaviors on the request on a per-call basis. </param>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   Message: string
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
+        public virtual Response GetProperties(int? timeout = null, string leaseId = null, RequestContext context = null)
+        {
+            using var scope = ClientDiagnostics.CreateScope("ContainerClient.GetProperties");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateGetPropertiesRequest(timeout, leaseId, context);
+                return _pipeline.ProcessMessage(message, context);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
             }
         }
 
@@ -883,6 +962,104 @@ namespace Azure.Storage.Blobs
             }
         }
 
+        internal HttpMessage CreateAcquireLeaseRequest(int? timeout, long? duration, string proposedLeaseId, RequestConditions requestConditions, RequestContext context)
+        {
+            var message = _pipeline.CreateMessage(context, ResponseClassifier201);
+            var request = message.Request;
+            request.Method = RequestMethod.Put;
+            var uri = new RawRequestUriBuilder();
+            uri.AppendRaw(_url, false);
+            uri.AppendQuery("comp", "lease", true);
+            uri.AppendQuery("restype", "container", true);
+            if (timeout != null)
+            {
+                uri.AppendQuery("timeout", timeout.Value, true);
+            }
+            request.Uri = uri;
+            request.Headers.Add("x-ms-lease-action", "acquire");
+            if (duration != null)
+            {
+                request.Headers.Add("x-ms-lease-duration", duration.Value);
+            }
+            if (proposedLeaseId != null)
+            {
+                request.Headers.Add("x-ms-proposed-lease-id", proposedLeaseId);
+            }
+            request.Headers.Add("x-ms-version", _version);
+            request.Headers.Add("Accept", "application/xml");
+            if (requestConditions != null)
+            {
+                request.Headers.Add(requestConditions, "R");
+            }
+            return message;
+        }
+
+        /// <summary> [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds, or can be infinite. </summary>
+        /// <param name="timeout"> The timeout parameter is expressed in seconds. For more information, see &lt;a href=&quot;https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations&quot;&gt;Setting Timeouts for Blob Service Operations.&lt;/a&gt;. </param>
+        /// <param name="duration"> Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite lease can be between 15 and 60 seconds. A lease duration cannot be changed using renew or change. </param>
+        /// <param name="proposedLeaseId"> Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request) if the proposed lease ID is not in the correct format. See Guid Constructor (String) for a list of valid GUID string formats. </param>
+        /// <param name="requestConditions"> The content to send as the request conditions of the request. </param>
+        /// <param name="context"> The request context, which can override default behaviors on the request on a per-call basis. </param>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   Message: string
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
+        public virtual async Task<Response> AcquireLeaseAsync(int? timeout = null, long? duration = null, string proposedLeaseId = null, RequestConditions requestConditions = null, RequestContext context = null)
+        {
+            Argument.AssertNull(requestConditions.IfMatch, nameof(requestConditions), "Service does not support the If-Match header for this operation.");
+            Argument.AssertNull(requestConditions.IfNoneMatch, nameof(requestConditions), "Service does not support the If-None-Match header for this operation.");
+
+            using var scope = ClientDiagnostics.CreateScope("ContainerClient.AcquireLease");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateAcquireLeaseRequest(timeout, duration, proposedLeaseId, requestConditions, context);
+                return await _pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary> [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds, or can be infinite. </summary>
+        /// <param name="timeout"> The timeout parameter is expressed in seconds. For more information, see &lt;a href=&quot;https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations&quot;&gt;Setting Timeouts for Blob Service Operations.&lt;/a&gt;. </param>
+        /// <param name="duration"> Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite lease can be between 15 and 60 seconds. A lease duration cannot be changed using renew or change. </param>
+        /// <param name="proposedLeaseId"> Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request) if the proposed lease ID is not in the correct format. See Guid Constructor (String) for a list of valid GUID string formats. </param>
+        /// <param name="requestConditions"> The content to send as the request conditions of the request. </param>
+        /// <param name="context"> The request context, which can override default behaviors on the request on a per-call basis. </param>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   Message: string
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
+        public virtual Response AcquireLease(int? timeout = null, long? duration = null, string proposedLeaseId = null, RequestConditions requestConditions = null, RequestContext context = null)
+        {
+            Argument.AssertNull(requestConditions.IfMatch, nameof(requestConditions), "Service does not support the If-Match header for this operation.");
+            Argument.AssertNull(requestConditions.IfNoneMatch, nameof(requestConditions), "Service does not support the If-None-Match header for this operation.");
+
+            using var scope = ClientDiagnostics.CreateScope("ContainerClient.AcquireLease");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateAcquireLeaseRequest(timeout, duration, proposedLeaseId, requestConditions, context);
+                return _pipeline.ProcessMessage(message, context);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
         internal HttpMessage CreateReleaseLeaseRequest(string leaseId, int? timeout, DateTimeOffset? ifModifiedSince, DateTimeOffset? ifUnmodifiedSince)
         {
             var message = _pipeline.CreateMessage();
@@ -1574,5 +1751,10 @@ namespace Azure.Storage.Blobs
                     throw ClientDiagnostics.CreateRequestFailedException(message.Response);
             }
         }
+
+        private static ResponseClassifier _responseClassifier200;
+        private static ResponseClassifier ResponseClassifier200 => _responseClassifier200 ??= new StatusCodeClassifier(stackalloc ushort[] { 200 });
+        private static ResponseClassifier _responseClassifier201;
+        private static ResponseClassifier ResponseClassifier201 => _responseClassifier201 ??= new StatusCodeClassifier(stackalloc ushort[] { 201 });
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/src/autorest.md
+++ b/sdk/storage/Azure.Storage.Blobs/src/autorest.md
@@ -342,3 +342,13 @@ directive:
     $.BlobItemInternal.properties["OrMetadata"] = $.BlobItemInternal.properties["ObjectReplicationMetadata"];
     delete $.BlobItemInternal.properties["ObjectReplicationMetadata"];
 ```
+
+### Generate DPG methods
+(note that these are just the latter half of OperationIds today but will
+possibly change to full OperationIds in the future and this will break.
+See https://github.com/Azure/autorest.csharp/issues/2078)
+```yaml
+protocol-method-list:
+  - GetProperties
+  - AcquireLease
+```

--- a/sdk/storage/Azure.Storage.Common/src/Azure.Storage.Common.csproj
+++ b/sdk/storage/Azure.Storage.Common/src/Azure.Storage.Common.csproj
@@ -20,7 +20,12 @@
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
   <ItemGroup>
+    <!-- [TODO: uncomment when Azure.Core ships]
     <PackageReference Include="Azure.Core" />
+    [/TODO]-->
+    <!-- [TODO: remove when Azure.Core ships] -->
+    <ProjectReference Include="..\..\..\core\Azure.Core\src\Azure.Core.csproj" />
+    <!-- [/TODO]-->
     <PackageReference Include="System.IO.Hashing" />
   </ItemGroup>
   <ItemGroup>

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageExceptionExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageExceptionExtensions.cs
@@ -20,7 +20,7 @@ namespace Azure.Storage
         /// <param name="response">The response.</param>
         /// <param name="errorCode">An optional error code.</param>
         /// <returns>The response's error code.</returns>
-        public static string GetErrorCode(this Response response, string errorCode)
+        public static string GetErrorCode(this Response response, string errorCode = null)
         {
             if (string.IsNullOrEmpty(errorCode))
             {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
@@ -24,6 +24,8 @@
   <ItemGroup>
     <Compile Include="$(AzureStorageWebjobsExtensionSharedSources)\**\*.cs" LinkBase="Shared" />
     <Compile Include="$(MicrosoftAzureWebJobsExtensionsClientsSources)\**\*.cs" LinkBase="Shared" />
+	<Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="Shared\Core" />
+	<Compile Include="$(AzureCoreSharedSources)RequestContextExtensions.cs" LinkBase="Shared\Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
@@ -12,7 +12,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
+	<!-- [TODO: uncomment when Azure.Storage.Blobs ships]
     <PackageReference Include="Azure.Storage.Blobs" />
+    [/TODO]-->
+    <!-- [TODO: remove when Azure.Storage.Blobs ships] -->
+    <ProjectReference Include="..\..\Azure.Storage.Blobs\src\Azure.Storage.Blobs.csproj" />
+	<!-- [/TODO]-->
     <PackageReference Include="Azure.Storage.Queues" />
   </ItemGroup>
 


### PR DESCRIPTION
This shows how we can reduce logging noise for expected failures by using DPG methods from HLCs.  https://github.com/Azure/azure-sdk-for-net/issues/25626 is tracking the meta issue, but this is a proof of concept for both internal only (like BlobClient.Exists for https://github.com/Azure/azure-sdk-for-net/issues/18592) and externally visible (like BlobLeaseClient.Acquire for https://github.com/Azure/azure-sdk-for-net/issues/21511) cases.

This is currently blocked on https://github.com/Azure/azure-sdk-for-net/issues/27614 before we can ship it.

There are also a few tests in DataLake like FileClientTest.ExistsAsync_CPK complaining about not matching the recordings, but it's difficult to debug at the moment because of a known issue in the test proxy.  I'm ignoring those for the moment.