### PR TITLE
[FormRecognizer] Making sure snippets can be compiled

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/MigrationGuide.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/MigrationGuide.md
@@ -96,7 +96,7 @@ Differences between the versions:
 
 Analyzing prebuilt models like business cards, identity documents, invoices, and receipts with `3.1.x`:
 ```C# Snippet:FormRecognizerSampleRecognizeInvoicesUri
-    Uri invoiceUri = <invoiceUri>;
+    Uri invoiceUri = new Uri("<invoiceUri>");
     var options = new RecognizeInvoicesOptions() { Locale = "en-US" };
 
     RecognizeInvoicesOperation operation = await client.StartRecognizeInvoicesFromUriAsync(invoiceUri, options);
@@ -222,7 +222,7 @@ Analyzing prebuilt models like business cards, identity documents, invoices, and
 
 Analyzing prebuilt models like business cards, identity documents, invoices, and receipts with `4.0.x`:
 ```C# Snippet:FormRecognizerAnalyzeWithPrebuiltModelFromUriAsync
-string fileUri = "<fileUri>";
+Uri fileUri = new Uri("<fileUri>");
 
 AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentFromUriAsync("prebuilt-invoice", fileUri);
 
@@ -328,7 +328,7 @@ Analyzing document content with `3.1.x`:
 > NOTE: With version `3.1.x` of the library this method had an optional `Language` parameter to hint at the language for the document, whereas in version `4.0.x` of the library `Locale` is used for this purpose.
 
 ```C# Snippet:FormRecognizerSampleRecognizeContentFromUri
-Uri formUri = <formUri>;
+Uri formUri = new Uri("<formUri>");
 
 Response<FormPageCollection> response = await client.StartRecognizeContentFromUriAsync(formUri).WaitForCompletionAsync();
 FormPageCollection formPages = response.Value;
@@ -384,7 +384,7 @@ foreach (FormPage page in formPages)
 
 Analyzing document layout with `4.0.x`:
 ```C# Snippet:FormRecognizerExtractLayoutFromUriAsync
-string fileUri = "<fileUri>";
+Uri fileUri = new Uri("<fileUri>");
 
 AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentFromUriAsync("prebuilt-layout", fileUri);
 
@@ -459,7 +459,7 @@ Analyzing general prebuilt document types with `4.0.x`:
 > NOTE: Analyzing a document with the `prebuilt-document` model replaces training without labels in version `3.1.x` of the library.
 
 ```C# Snippet:FormRecognizerAnalyzePrebuiltDocumentFromUriAsync
-string fileUri = "<fileUri>";
+Uri fileUri = new Uri("<fileUri>");
 
 AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentFromUriAsync("prebuilt-document", fileUri);
 
@@ -579,7 +579,7 @@ Train a custom model with `3.1.x`:
 // For instructions to create a label file for your training forms, please see:
 // https://docs.microsoft.com/azure/cognitive-services/form-recognizer/label-tool?tabs=v2-1
 
-Uri trainingFileUri = <trainingFileUri>;
+Uri trainingFileUri = new Uri("<trainingFileUri>");
 string modelName = "My Model with labels";
 FormTrainingClient client = new FormTrainingClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
@@ -620,7 +620,7 @@ Train a custom model with `4.0.x`:
 // For instructions to set up documents for training in an Azure Blob Storage Container, please see:
 // https://aka.ms/azsdk/formrecognizer/buildcustommodel
 
-Uri trainingFileUri = <trainingFileUri>;
+Uri trainingFileUri = new Uri("<trainingFileUri>");
 var client = new DocumentModelAdministrationClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
 // We are selecting the Template build mode in this sample. For more information about the available
@@ -656,7 +656,7 @@ Differences between the versions:
 Analyze a document using a custom model with `3.1.x`:
 ```C# Snippet:FormRecognizerSampleRecognizeCustomFormsFromUri
 string modelId = "<modelId>";
-Uri formUri = <formUri>;
+Uri formUri = new Uri("<formUri>");
 var options = new RecognizeCustomFormsOptions() { IncludeFieldElements = true };
 
 RecognizeCustomFormsOperation operation = await client.StartRecognizeCustomFormsFromUriAsync(modelId, formUri, options);
@@ -714,7 +714,7 @@ foreach (RecognizedForm form in forms)
 Analyze a document using a custom model with `4.0.x`:
 ```C# Snippet:FormRecognizerAnalyzeWithCustomModelFromUriAsync
 string modelId = "<modelId>";
-string fileUri = "<fileUri>";
+Uri fileUri = new Uri("<fileUri>");
 
 AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentFromUriAsync(modelId, fileUri);
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -208,7 +208,7 @@ The following section provides several code snippets illustrating common pattern
 Extract text, selection marks, text styles, and table structures, along with their bounding region coordinates from documents.
 
 ```C# Snippet:FormRecognizerExtractLayoutFromUriAsync
-string fileUri = "<fileUri>";
+Uri fileUri = new Uri("<fileUri>");
 
 AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentFromUriAsync("prebuilt-layout", fileUri);
 
@@ -284,7 +284,7 @@ For more information and samples see [here][extract_layout].
 Analyze key-value pairs, entities, tables, and selection marks from documents using the general prebuilt document model.
 
 ```C# Snippet:FormRecognizerAnalyzePrebuiltDocumentFromUriAsync
-string fileUri = "<fileUri>";
+Uri fileUri = new Uri("<fileUri>");
 
 AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentFromUriAsync("prebuilt-document", fileUri);
 
@@ -388,7 +388,7 @@ For more information and samples see [here][analyze_prebuilt_document].
 Analyze textual elements, such as page words and lines, styles, and text language information from documents using the prebuilt read model.
 
 ```C# Snippet:FormRecognizerAnalyzePrebuiltReadFromUriAsync
-string fileUri = "<fileUri>";
+Uri fileUri = new Uri("<fileUri>");
 
 AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentFromUriAsync("prebuilt-read", fileUri);
 
@@ -572,7 +572,7 @@ Build a custom model on your own document type. The resulting model can be used 
 // For instructions to set up documents for training in an Azure Blob Storage Container, please see:
 // https://aka.ms/azsdk/formrecognizer/buildcustommodel
 
-Uri trainingFileUri = <trainingFileUri>;
+Uri trainingFileUri = new Uri("<trainingFileUri>");
 var client = new DocumentModelAdministrationClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
 // We are selecting the Template build mode in this sample. For more information about the available
@@ -605,7 +605,7 @@ Analyze text, field values, selection marks, and table data from custom document
 
 ```C# Snippet:FormRecognizerAnalyzeWithCustomModelFromUriAsync
 string modelId = "<modelId>";
-string fileUri = "<fileUri>";
+Uri fileUri = new Uri("<fileUri>");
 
 AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentFromUriAsync(modelId, fileUri);
 
@@ -661,7 +661,7 @@ await foreach (DocumentModelInfo modelInfo in models)
 }
 
 // Create a new model to store in the account
-Uri trainingFileUri = <trainingFileUri>;
+Uri trainingFileUri = new Uri("<trainingFileUri>");
 BuildModelOperation operation = await client.StartBuildModelAsync(trainingFileUri, DocumentBuildMode.Template);
 Response<DocumentModel> operationResponse = await operation.WaitForCompletionAsync();
 DocumentModel model = operationResponse.Value;
@@ -707,7 +707,7 @@ foreach (DocumentModelInfo modelInfo in models.Take(10))
 
 // Create a new model to store in the account
 
-Uri trainingFileUri = <trainingFileUri>;
+Uri trainingFileUri = new Uri("<trainingFileUri>");
 BuildModelOperation operation = client.StartBuildModel(trainingFileUri, DocumentBuildMode.Template);
 Response<DocumentModel> operationResponse = await operation.WaitForCompletionAsync();
 DocumentModel model = operationResponse.Value;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltDocument.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltDocument.md
@@ -22,7 +22,7 @@ var client = new DocumentAnalysisClient(new Uri(endpoint), credential);
 To analyze a given file at a URI, use the `StartAnalyzeDocumentFromUri` method and pass `prebuilt-document` as the model ID. The returned value is an `AnalyzeResult` object containing data about the submitted document.
 
 ```C# Snippet:FormRecognizerAnalyzePrebuiltDocumentFromUriAsync
-string fileUri = "<fileUri>";
+Uri fileUri = new Uri("<fileUri>");
 
 AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentFromUriAsync("prebuilt-document", fileUri);
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltRead.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltRead.md
@@ -22,7 +22,7 @@ var client = new DocumentAnalysisClient(new Uri(endpoint), credential);
 To analyze a given file at a URI, use the `StartAnalyzeDocumentFromUri` method and pass `prebuilt-read` as the model ID. The returned value is an `AnalyzeResult` object containing data about the submitted document.
 
 ```C# Snippet:FormRecognizerAnalyzePrebuiltReadFromUriAsync
-string fileUri = "<fileUri>";
+Uri fileUri = new Uri("<fileUri>");
 
 AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentFromUriAsync("prebuilt-read", fileUri);
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithCustomModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithCustomModel.md
@@ -23,7 +23,7 @@ To analyze a given file at a URI, use the `StartAnalyzeDocumentFromUri` method. 
 
 ```C# Snippet:FormRecognizerAnalyzeWithCustomModelFromUriAsync
 string modelId = "<modelId>";
-string fileUri = "<fileUri>";
+Uri fileUri = new Uri("<fileUri>");
 
 AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentFromUriAsync(modelId, fileUri);
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithPrebuiltModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithPrebuiltModel.md
@@ -36,7 +36,7 @@ To analyze a given file at a URI, use the `StartAnalyzeDocumentFromUri` method. 
 For simplicity, we are not showing all the fields that the service returns. To see the list of all the supported fields returned by service and its corresponding types, consult the [Choosing the prebuilt model ID][choosing-the-prebuilt-model-id] section.
 
 ```C# Snippet:FormRecognizerAnalyzeWithPrebuiltModelFromUriAsync
-string fileUri = "<fileUri>";
+Uri fileUri = new Uri("<fileUri>");
 
 AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentFromUriAsync("prebuilt-invoice", fileUri);
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_BuildCustomModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_BuildCustomModel.md
@@ -38,7 +38,7 @@ A `DocumentModel` is returned indicating the document types the model will recog
 // For instructions to set up documents for training in an Azure Blob Storage Container, please see:
 // https://aka.ms/azsdk/formrecognizer/buildcustommodel
 
-Uri trainingFileUri = <trainingFileUri>;
+Uri trainingFileUri = new Uri("<trainingFileUri>");
 var client = new DocumentModelAdministrationClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
 // We are selecting the Template build mode in this sample. For more information about the available

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_CopyCustomModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_CopyCustomModel.md
@@ -21,20 +21,20 @@ You can set `endpoint` and `apiKey` based on an environment variable, a configur
 The source client that contains the custom model we want to copy.
 
 ```C# Snippet:FormRecognizerSampleCreateCopySourceClient
-string endpoint = "<source_endpoint>";
-string apiKey = "<source_apiKey>";
-var sourcecredential = new AzureKeyCredential(apiKey);
-var sourceClient = new DocumentModelAdministrationClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
+string sourceEndpoint = "<source_endpoint>";
+string sourceApiKey = "<source_apiKey>";
+var sourcecredential = new AzureKeyCredential(sourceApiKey);
+var sourceClient = new DocumentModelAdministrationClient(new Uri(sourceEndpoint), new AzureKeyCredential(sourceApiKey));
 ```
 
 ### Target client
 The target client where we want to copy the custom model to.
 
 ```C# Snippet:FormRecognizerSampleCreateCopyTargetClient
-string endpoint = "<target_endpoint>";
-string apiKey = "<target_apiKey>";
-var targetCredential = new AzureKeyCredential(apiKey);
-var targetClient = new DocumentModelAdministrationClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
+string targetEndpoint = "<target_endpoint>";
+string targetApiKey = "<target_apiKey>";
+var targetCredential = new AzureKeyCredential(targetApiKey);
+var targetClient = new DocumentModelAdministrationClient(new Uri(targetEndpoint), new AzureKeyCredential(targetApiKey));
 ```
 
 ### Authorize the copy

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ExtractLayout.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ExtractLayout.md
@@ -22,7 +22,7 @@ var client = new DocumentAnalysisClient(new Uri(endpoint), credential);
 To extract the layout from a given file at a URI, use the `StartAnalyzeDocumentFromUri` method and pass `prebuilt-layout` as the model ID. The returned value is an `AnalyzeResult` object containing data about the submitted document.
 
 ```C# Snippet:FormRecognizerExtractLayoutFromUriAsync
-string fileUri = "<fileUri>";
+Uri fileUri = new Uri("<fileUri>");
 
 AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentFromUriAsync("prebuilt-layout", fileUri);
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_GetAndListOperations.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_GetAndListOperations.md
@@ -28,7 +28,7 @@ If the operation failed, the error information can be accessed using the `Error`
 var client = new DocumentModelAdministrationClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
 // Make sure there is at least one operation, so we are going to build a custom model.
-Uri trainingFileUri = <trainingFileUri>;
+Uri trainingFileUri = new Uri("<trainingFileUri>");
 BuildModelOperation operation = await client.StartBuildModelAsync(trainingFileUri, DocumentBuildMode.Template);
 await operation.WaitForCompletionAsync();
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ManageModels.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ManageModels.md
@@ -51,7 +51,7 @@ await foreach (DocumentModelInfo modelInfo in models)
 }
 
 // Create a new model to store in the account
-Uri trainingFileUri = <trainingFileUri>;
+Uri trainingFileUri = new Uri("<trainingFileUri>");
 BuildModelOperation operation = await client.StartBuildModelAsync(trainingFileUri, DocumentBuildMode.Template);
 Response<DocumentModel> operationResponse = await operation.WaitForCompletionAsync();
 DocumentModel model = operationResponse.Value;
@@ -96,7 +96,7 @@ foreach (DocumentModelInfo modelInfo in models.Take(10))
 
 // Create a new model to store in the account
 
-Uri trainingFileUri = <trainingFileUri>;
+Uri trainingFileUri = new Uri("<trainingFileUri>");
 BuildModelOperation operation = client.StartBuildModel(trainingFileUri, DocumentBuildMode.Template);
 Response<DocumentModel> operationResponse = await operation.WaitForCompletionAsync();
 DocumentModel model = operationResponse.Value;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ModelCompose.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ModelCompose.md
@@ -29,28 +29,28 @@ In our case, we will be writing an application that collects the expenses a comp
 // For instructions on setting up forms for training in an Azure Storage Blob Container, see
 // https://aka.ms/azsdk/formrecognizer/buildtrainingset
 
-Uri officeSuppliesUri = <purchaseOrderOfficeSuppliesUri>;
+Uri officeSuppliesUri = new Uri("<purchaseOrderOfficeSuppliesUri>");
 var officeSupplieOptions = new BuildModelOptions() { ModelDescription = "Purchase order - Office supplies" };
 
 BuildModelOperation suppliesOperation = await client.StartBuildModelAsync(officeSuppliesUri, DocumentBuildMode.Template, buildModelOptions: officeSupplieOptions);
 Response<DocumentModel> suppliesOperationResponse = await suppliesOperation.WaitForCompletionAsync();
 DocumentModel officeSuppliesModel = suppliesOperationResponse.Value;
 
-Uri officeEquipmentUri = <purchaseOrderOfficeEquipmentUri>;
+Uri officeEquipmentUri = new Uri("<purchaseOrderOfficeEquipmentUri>");
 var equipmentOptions = new BuildModelOptions() { ModelDescription = "Purchase order - Office Equipment" };
 
 BuildModelOperation equipmentOperation = await client.StartBuildModelAsync(officeSuppliesUri, DocumentBuildMode.Template, buildModelOptions: equipmentOptions);
 Response<DocumentModel> equipmentOperationResponse = await equipmentOperation.WaitForCompletionAsync();
 DocumentModel officeEquipmentModel = equipmentOperationResponse.Value;
 
-Uri furnitureUri = <purchaseOrderFurnitureUri>;
+Uri furnitureUri = new Uri("<purchaseOrderFurnitureUri>");
 var furnitureOptions = new BuildModelOptions() { ModelDescription = "Purchase order - Furniture" };
 
 BuildModelOperation furnitureOperation = await client.StartBuildModelAsync(officeSuppliesUri, DocumentBuildMode.Template, buildModelOptions: equipmentOptions);
 Response<DocumentModel> furnitureOperationResponse = await furnitureOperation.WaitForCompletionAsync();
 DocumentModel furnitureModel = furnitureOperationResponse.Value;
 
-Uri cleaningSuppliesUri = <purchaseOrderCleaningSuppliesUri>;
+Uri cleaningSuppliesUri = new Uri("<purchaseOrderCleaningSuppliesUri>");
 var cleaningOptions = new BuildModelOptions() { ModelDescription = "Purchase order - Cleaning Supplies" };
 
 BuildModelOperation cleaningOperation = await client.StartBuildModelAsync(officeSuppliesUri, DocumentBuildMode.Template, buildModelOptions: equipmentOptions);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample10_RecognizeInvoices.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample10_RecognizeInvoices.md
@@ -24,7 +24,7 @@ To recognize invoices from a URI, use the `StartRecognizeInvoicesFromUriAsync` m
 For simplicity, we are not showing all the fields that the service returns. To see the list of all the supported fields returned by service and its corresponding types, consult: [here](https://aka.ms/formrecognizer/invoicefields).
 
 ```C# Snippet:FormRecognizerSampleRecognizeInvoicesUri
-    Uri invoiceUri = <invoiceUri>;
+    Uri invoiceUri = new Uri("<invoiceUri>");
     var options = new RecognizeInvoicesOptions() { Locale = "en-US" };
 
     RecognizeInvoicesOperation operation = await client.StartRecognizeInvoicesFromUriAsync(invoiceUri, options);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample11_RecognizeIdentityDocuments.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample11_RecognizeIdentityDocuments.md
@@ -24,7 +24,7 @@ To recognize identity documents from a URI, use the `StartRecognizeIdentityDocum
 For simplicity, we are not showing all the fields that the service returns. To see the list of all the supported fields returned by service and its corresponding types, consult: [here](https://aka.ms/formrecognizer/iddocumentfields).
 
 ```C# Snippet:FormRecognizerSampleRecognizeIdentityDocumentsUri
-Uri sourceUri = <sourceUri>;
+Uri sourceUri = new Uri("<sourceUri>");
 
 RecognizeIdentityDocumentsOperation operation = await client.StartRecognizeIdentityDocumentsFromUriAsync(sourceUri);
 Response<RecognizedFormCollection> operationResponse = await operation.WaitForCompletionAsync();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample1_RecognizeFormContent.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample1_RecognizeFormContent.md
@@ -22,7 +22,7 @@ var client = new FormRecognizerClient(new Uri(endpoint), credential);
 To recognize the content from a given file at a URI, use the `StartRecognizeContentFromUri` method. The returned value is a collection of `FormPage` objects -- one for each page in the submitted document.
 
 ```C# Snippet:FormRecognizerSampleRecognizeContentFromUri
-Uri formUri = <formUri>;
+Uri formUri = new Uri("<formUri>");
 
 Response<FormPageCollection> response = await client.StartRecognizeContentFromUriAsync(formUri).WaitForCompletionAsync();
 FormPageCollection formPages = response.Value;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample2_RecognizeCustomForms.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample2_RecognizeCustomForms.md
@@ -23,7 +23,7 @@ To recognize form fields and other content from your custom forms from a given f
 
 ```C# Snippet:FormRecognizerSampleRecognizeCustomFormsFromUri
 string modelId = "<modelId>";
-Uri formUri = <formUri>;
+Uri formUri = new Uri("<formUri>");
 var options = new RecognizeCustomFormsOptions() { IncludeFieldElements = true };
 
 RecognizeCustomFormsOperation operation = await client.StartRecognizeCustomFormsFromUriAsync(modelId, formUri, options);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample3_RecognizeReceipts.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample3_RecognizeReceipts.md
@@ -24,7 +24,7 @@ To recognize receipts from a URI, use the `StartRecognizeReceiptsFromUri` method
 For simplicity, we are not showing all the fields that the service returns. To see the list of all the supported fields returned by service and its corresponding types, consult: [here](https://aka.ms/formrecognizer/receiptfields).
 
 ```C# Snippet:FormRecognizerSampleRecognizeReceiptFileFromUri
-Uri receiptUri = <receiptUri>;
+Uri receiptUri = new Uri("<receiptUri>");
 
 RecognizeReceiptsOperation operation = await client.StartRecognizeReceiptsFromUriAsync(receiptUri);
 Response<RecognizedFormCollection> operationResponse = await operation.WaitForCompletionAsync();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample4_StronglyTypingARecognizedForm.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample4_StronglyTypingARecognizedForm.md
@@ -56,7 +56,7 @@ public Receipt(RecognizedForm recognizedForm)
 Here we illustrate how to use the `Receipt` wrapper class described above.
 
 ```C# Snippet:FormRecognizerSampleStronglyTypingARecognizedForm
-Uri receiptUri = <receiptUri>;
+Uri receiptUri = new Uri("<receiptUri>");
 
 RecognizeReceiptsOperation operation = await client.StartRecognizeReceiptsFromUriAsync(receiptUri);
 Response<RecognizedFormCollection> operationResponse = await operation.WaitForCompletionAsync();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample5_TrainModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample5_TrainModel.md
@@ -32,7 +32,7 @@ Train custom models to recognize all fields and values found in your custom form
 // For instructions on setting up forms for training in an Azure Blob Storage Container, see
 // https://docs.microsoft.com/azure/cognitive-services/form-recognizer/build-training-data-set#upload-your-training-data
 
-Uri trainingFileUri = <trainingFileUri>;
+Uri trainingFileUri = new Uri("<trainingFileUri>");
 FormTrainingClient client = new FormTrainingClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
 TrainingOperation operation = await client.StartTrainingAsync(trainingFileUri, useTrainingLabels: false, "My Model");
@@ -78,7 +78,7 @@ Train custom models to recognize specific fields and values you specify by label
 // For instructions to create a label file for your training forms, please see:
 // https://docs.microsoft.com/azure/cognitive-services/form-recognizer/label-tool?tabs=v2-1
 
-Uri trainingFileUri = <trainingFileUri>;
+Uri trainingFileUri = new Uri("<trainingFileUri>");
 string modelName = "My Model with labels";
 FormTrainingClient client = new FormTrainingClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample6_ManageCustomModels.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample6_ManageCustomModels.md
@@ -50,7 +50,7 @@ await foreach (CustomFormModelInfo modelInfo in models)
 }
 
 // Create a new model to store in the account
-Uri trainingFileUri = <trainingFileUri>;
+Uri trainingFileUri = new Uri("<trainingFileUri>");
 TrainingOperation operation = await client.StartTrainingAsync(trainingFileUri, useTrainingLabels: false, "My new model");
 Response<CustomFormModel> operationResponse = await operation.WaitForCompletionAsync();
 CustomFormModel model = operationResponse.Value;
@@ -106,7 +106,7 @@ foreach (CustomFormModelInfo modelInfo in models.Take(10))
 
 // Create a new model to store in the account
 
-Uri trainingFileUri = <trainingFileUri>;
+Uri trainingFileUri = new Uri("<trainingFileUri>");
 TrainingOperation operation = client.StartTraining(trainingFileUri, useTrainingLabels: false, "My new model");
 Response<CustomFormModel> operationResponse = await operation.WaitForCompletionAsync();
 CustomFormModel model = operationResponse.Value;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample7_CopyCustomModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample7_CopyCustomModel.md
@@ -21,20 +21,20 @@ You can set `endpoint` and `apiKey` based on an environment variable, a configur
 The source client that contains the custom model we want to copy.
 
 ```C# Snippet:FormRecognizerSampleCreateCopySourceClientV3
-string endpoint = "<source_endpoint>";
-string apiKey = "<source_apiKey>";
-var sourcecredential = new AzureKeyCredential(apiKey);
-var sourceClient = new FormTrainingClient(new Uri(endpoint), sourcecredential);
+string sourceEndpoint = "<source_endpoint>";
+string sourceApiKey = "<source_apiKey>";
+var sourcecredential = new AzureKeyCredential(sourceApiKey);
+var sourceClient = new FormTrainingClient(new Uri(sourceEndpoint), sourcecredential);
 ```
 
 ### Target client
 The target client where we want to copy the custom model to.
 
 ```C# Snippet:FormRecognizerSampleCreateCopyTargetClientV3
-string endpoint = "<target_endpoint>";
-string apiKey = "<target_apiKey>";
-var targetCredential = new AzureKeyCredential(apiKey);
-var targetClient = new FormTrainingClient(new Uri(endpoint), targetCredential);
+string targetEndpoint = "<target_endpoint>";
+string targetApiKey = "<target_apiKey>";
+var targetCredential = new AzureKeyCredential(targetApiKey);
+var targetClient = new FormTrainingClient(new Uri(targetEndpoint), targetCredential);
 ```
 
 ### Authorize the copy

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample8_ModelCompose.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample8_ModelCompose.md
@@ -37,28 +37,28 @@ In our case, we will be writing an application that collects the expenses a comp
 
 bool useLabels = true;
 
-Uri officeSuppliesUri = <purchaseOrderOfficeSuppliesUri>;
+Uri officeSuppliesUri = new Uri("<purchaseOrderOfficeSuppliesUri>");
 string suppliesModelName = "Purchase order - Office supplies";
 
 TrainingOperation suppliesOperation = await client.StartTrainingAsync(officeSuppliesUri, useLabels, suppliesModelName);
 Response<CustomFormModel> suppliesOperationResponse = await suppliesOperation.WaitForCompletionAsync();
 CustomFormModel officeSuppliesModel = suppliesOperationResponse.Value;
 
-Uri officeEquipmentUri = <purchaseOrderOfficeEquipmentUri>;
+Uri officeEquipmentUri = new Uri("<purchaseOrderOfficeEquipmentUri>");
 string equipmentModelName = "Purchase order - Office Equipment";
 
 TrainingOperation equipmentOperation = await client.StartTrainingAsync(officeEquipmentUri, useLabels, equipmentModelName);
 Response<CustomFormModel> equipmentOperationResponse = await equipmentOperation.WaitForCompletionAsync();
 CustomFormModel officeEquipmentModel = equipmentOperationResponse.Value;
 
-Uri furnitureUri = <purchaseOrderFurnitureUri>;
+Uri furnitureUri = new Uri("<purchaseOrderFurnitureUri>");
 string furnitureModelName = "Purchase order - Furniture";
 
 TrainingOperation furnitureOperation = await client.StartTrainingAsync(furnitureUri, useLabels, furnitureModelName);
 Response<CustomFormModel> furnitureOperationResponse = await furnitureOperation.WaitForCompletionAsync();
 CustomFormModel furnitureModel = furnitureOperationResponse.Value;
 
-Uri cleaningSuppliesUri = <purchaseOrderCleaningSuppliesUri>;
+Uri cleaningSuppliesUri = new Uri("<purchaseOrderCleaningSuppliesUri>");
 string cleaningModelName = "Purchase order - Cleaning Supplies";
 
 TrainingOperation cleaningOperation = await client.StartTrainingAsync(cleaningSuppliesUri, useLabels, cleaningModelName);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample9_RecognizeBusinessCards.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample9_RecognizeBusinessCards.md
@@ -24,7 +24,7 @@ To recognize business cards from a URI, use the `StartRecognizeBusinessCardsFrom
 For simplicity, we are not showing all the fields that the service returns. To see the list of all the supported fields returned by service and its corresponding types, consult: [here](https://aka.ms/formrecognizer/businesscardfields).
 
 ```C# Snippet:FormRecognizerSampleRecognizeBusinessCardsFromUri
-Uri businessCardUri = <businessCardUri>;
+Uri businessCardUri = new Uri("<businessCardUri>");
 
 RecognizeBusinessCardsOperation operation = await client.StartRecognizeBusinessCardsFromUriAsync(businessCardUri);
 Response<RecognizedFormCollection> operationResponse = await operation.WaitForCompletionAsync();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltDocumentFromUriAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltDocumentFromUriAsync.cs
@@ -21,7 +21,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 
             #region Snippet:FormRecognizerAnalyzePrebuiltDocumentFromUriAsync
 #if SNIPPET
-            string fileUri = "<fileUri>";
+            Uri fileUri = new Uri("<fileUri>");
 #else
             Uri fileUri = DocumentAnalysisTestEnvironment.CreateUri("Form_1.jpg");
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromUriAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromUriAsync.cs
@@ -21,7 +21,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 
             #region Snippet:FormRecognizerAnalyzePrebuiltReadFromUriAsync
 #if SNIPPET
-            string fileUri = "<fileUri>";
+            Uri fileUri = new Uri("<fileUri>");
 #else
             Uri fileUri = DocumentAnalysisTestEnvironment.CreateUri("Form_1.jpg");
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithCustomModelFromUriAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithCustomModelFromUriAsync.cs
@@ -38,10 +38,10 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
             #region Snippet:FormRecognizerAnalyzeWithCustomModelFromUriAsync
 #if SNIPPET
             string modelId = "<modelId>";
-            string fileUri = "<fileUri>";
+            Uri fileUri = new Uri("<fileUri>");
 #else
-            Uri fileUri = DocumentAnalysisTestEnvironment.CreateUri("Form_1.jpg");
             string modelId = customModel.ModelId;
+            Uri fileUri = DocumentAnalysisTestEnvironment.CreateUri("Form_1.jpg");
 #endif
 
             AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentFromUriAsync(modelId, fileUri);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromUriAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromUriAsync.cs
@@ -22,7 +22,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 
             #region Snippet:FormRecognizerAnalyzeWithPrebuiltModelFromUriAsync
 #if SNIPPET
-            string fileUri = "<fileUri>";
+            Uri fileUri = new Uri("<fileUri>");
 #else
             Uri fileUri = DocumentAnalysisTestEnvironment.CreateUri("Form_1.jpg");
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_BuildCustomModelAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_BuildCustomModelAsync.cs
@@ -28,7 +28,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
             // https://aka.ms/azsdk/formrecognizer/buildcustommodel
 
 #if SNIPPET
-            Uri trainingFileUri = <trainingFileUri>;
+            Uri trainingFileUri = new Uri("<trainingFileUri>");
 #else
             Uri trainingFileUri = new Uri(TestEnvironment.BlobContainerSasUrl);
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_CopyModelAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_CopyModelAsync.cs
@@ -14,22 +14,22 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
         [Test]
         public async Task CopyModelAsync()
         {
-            string endpoint = TestEnvironment.Endpoint;
-            string apiKey = TestEnvironment.ApiKey;
-
             #region Snippet:FormRecognizerSampleCreateCopySourceClient
 #if SNIPPET
-            string endpoint = "<source_endpoint>";
-            string apiKey = "<source_apiKey>";
+            string sourceEndpoint = "<source_endpoint>";
+            string sourceApiKey = "<source_apiKey>";
+#else
+            string sourceEndpoint = TestEnvironment.Endpoint;
+            string sourceApiKey = TestEnvironment.ApiKey;
 #endif
-            var sourcecredential = new AzureKeyCredential(apiKey);
-            var sourceClient = new DocumentModelAdministrationClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
+            var sourcecredential = new AzureKeyCredential(sourceApiKey);
+            var sourceClient = new DocumentModelAdministrationClient(new Uri(sourceEndpoint), new AzureKeyCredential(sourceApiKey));
             #endregion
 
             // For the purpose of this sample, we are going to create a model to copy. Please note that
             // if you already have a model, this is not necessary.
 #if SNIPPET
-            Uri trainingFileUri = <trainingFileUri>;
+            Uri trainingFileUri = new Uri("<trainingFileUri>");
 #else
             Uri trainingFileUri = new Uri(TestEnvironment.BlobContainerSasUrl);
 #endif
@@ -39,11 +39,14 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 
             #region Snippet:FormRecognizerSampleCreateCopyTargetClient
 #if SNIPPET
-            string endpoint = "<target_endpoint>";
-            string apiKey = "<target_apiKey>";
+            string targetEndpoint = "<target_endpoint>";
+            string targetApiKey = "<target_apiKey>";
+#else
+            string targetEndpoint = TestEnvironment.Endpoint;
+            string targetApiKey = TestEnvironment.ApiKey;
 #endif
-            var targetCredential = new AzureKeyCredential(apiKey);
-            var targetClient = new DocumentModelAdministrationClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
+            var targetCredential = new AzureKeyCredential(targetApiKey);
+            var targetClient = new DocumentModelAdministrationClient(new Uri(targetEndpoint), new AzureKeyCredential(targetApiKey));
             #endregion
 
             #region Snippet:FormRecognizerSampleGetCopyAuthorization

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_CreateComposedModelAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_CreateComposedModelAsync.cs
@@ -28,7 +28,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
             // https://aka.ms/azsdk/formrecognizer/buildtrainingset
 
 #if SNIPPET
-            Uri officeSuppliesUri = <purchaseOrderOfficeSuppliesUri>;
+            Uri officeSuppliesUri = new Uri("<purchaseOrderOfficeSuppliesUri>");
 #else
             Uri officeSuppliesUri = new Uri(trainingFileUrl);
 #endif
@@ -39,7 +39,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
             DocumentModel officeSuppliesModel = suppliesOperationResponse.Value;
 
 #if SNIPPET
-            Uri officeEquipmentUri = <purchaseOrderOfficeEquipmentUri>;
+            Uri officeEquipmentUri = new Uri("<purchaseOrderOfficeEquipmentUri>");
 #else
             Uri officeEquipmentUri = new Uri(trainingFileUrl);
 #endif
@@ -50,7 +50,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
             DocumentModel officeEquipmentModel = equipmentOperationResponse.Value;
 
 #if SNIPPET
-            Uri furnitureUri = <purchaseOrderFurnitureUri>;
+            Uri furnitureUri = new Uri("<purchaseOrderFurnitureUri>");
 #else
             Uri furnitureUri = new Uri(trainingFileUrl);
 #endif
@@ -61,7 +61,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
             DocumentModel furnitureModel = furnitureOperationResponse.Value;
 
 #if SNIPPET
-            Uri cleaningSuppliesUri = <purchaseOrderCleaningSuppliesUri>;
+            Uri cleaningSuppliesUri = new Uri("<purchaseOrderCleaningSuppliesUri>");
 #else
             Uri cleaningSuppliesUri = new Uri(trainingFileUrl);
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ExtractLayoutFromUriAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ExtractLayoutFromUriAsync.cs
@@ -21,7 +21,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 
             #region Snippet:FormRecognizerExtractLayoutFromUriAsync
 #if SNIPPET
-            string fileUri = "<fileUri>";
+            Uri fileUri = new Uri("<fileUri>");
 #else
             Uri fileUri = DocumentAnalysisTestEnvironment.CreateUri("Form_1.jpg");
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_GetAndListOperationsAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_GetAndListOperationsAsync.cs
@@ -23,7 +23,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 
             // Make sure there is at least one operation, so we are going to build a custom model.
 #if SNIPPET
-            Uri trainingFileUri = <trainingFileUri>;
+            Uri trainingFileUri = new Uri("<trainingFileUri>");
 #else
             Uri trainingFileUri = new Uri(TestEnvironment.BlobContainerSasUrl);
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ManageModels.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ManageModels.cs
@@ -42,7 +42,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
             // Create a new model to store in the account
 
 #if SNIPPET
-            Uri trainingFileUri = <trainingFileUri>;
+            Uri trainingFileUri = new Uri("<trainingFileUri>");
 #else
             Uri trainingFileUri = new Uri(TestEnvironment.BlobContainerSasUrl);
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ManageModelsAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ManageModelsAsync.cs
@@ -43,7 +43,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 
             // Create a new model to store in the account
 #if SNIPPET
-            Uri trainingFileUri = <trainingFileUri>;
+            Uri trainingFileUri = new Uri("<trainingFileUri>");
 #else
             Uri trainingFileUri = new Uri(TestEnvironment.BlobContainerSasUrl);
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample11_ComposedModel.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample11_ComposedModel.cs
@@ -34,7 +34,7 @@ namespace Azure.AI.FormRecognizer.Samples
             bool useLabels = true;
 
 #if SNIPPET
-            Uri officeSuppliesUri = <purchaseOrderOfficeSuppliesUri>;
+            Uri officeSuppliesUri = new Uri("<purchaseOrderOfficeSuppliesUri>");
 #else
             Uri officeSuppliesUri = new Uri(trainingFileUrl);
 #endif
@@ -45,7 +45,7 @@ namespace Azure.AI.FormRecognizer.Samples
             CustomFormModel officeSuppliesModel = suppliesOperationResponse.Value;
 
 #if SNIPPET
-            Uri officeEquipmentUri = <purchaseOrderOfficeEquipmentUri>;
+            Uri officeEquipmentUri = new Uri("<purchaseOrderOfficeEquipmentUri>");
 #else
             Uri officeEquipmentUri = new Uri(trainingFileUrl);
 #endif
@@ -56,7 +56,7 @@ namespace Azure.AI.FormRecognizer.Samples
             CustomFormModel officeEquipmentModel = equipmentOperationResponse.Value;
 
 #if SNIPPET
-            Uri furnitureUri = <purchaseOrderFurnitureUri>;
+            Uri furnitureUri = new Uri("<purchaseOrderFurnitureUri>");
 #else
             Uri furnitureUri = new Uri(trainingFileUrl);
 #endif
@@ -67,7 +67,7 @@ namespace Azure.AI.FormRecognizer.Samples
             CustomFormModel furnitureModel = furnitureOperationResponse.Value;
 
 #if SNIPPET
-            Uri cleaningSuppliesUri = <purchaseOrderCleaningSuppliesUri>;
+            Uri cleaningSuppliesUri = new Uri("<purchaseOrderCleaningSuppliesUri>");
 #else
             Uri cleaningSuppliesUri = new Uri(trainingFileUrl);
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample12_RecognizeBusinessCardsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample12_RecognizeBusinessCardsFromUri.cs
@@ -23,7 +23,7 @@ namespace Azure.AI.FormRecognizer.Samples
 
             #region Snippet:FormRecognizerSampleRecognizeBusinessCardsFromUri
 #if SNIPPET
-            Uri businessCardUri = <businessCardUri>;
+            Uri businessCardUri = new Uri("<businessCardUri>");
 #else
             Uri businessCardUri = FormRecognizerTestEnvironment.CreateUri("businessCard.jpg");
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample13_RecognizeInvoicesFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample13_RecognizeInvoicesFromUri.cs
@@ -24,7 +24,7 @@ namespace Azure.AI.FormRecognizer.Samples
 
             #region Snippet:FormRecognizerSampleRecognizeInvoicesUri
 #if SNIPPET
-            Uri invoiceUri = <invoiceUri>;
+            Uri invoiceUri = new Uri("<invoiceUri>");
 #else
             Uri invoiceUri = FormRecognizerTestEnvironment.CreateUri("recommended_invoice.jpg");
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample14_RecognizeIdentityDocumentsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample14_RecognizeIdentityDocumentsFromUri.cs
@@ -23,7 +23,7 @@ namespace Azure.AI.FormRecognizer.Samples
 
             #region Snippet:FormRecognizerSampleRecognizeIdentityDocumentsUri
 #if SNIPPET
-            Uri sourceUri = <sourceUri>;
+            Uri sourceUri = new Uri("<sourceUri>");
 #else
             Uri sourceUri = FormRecognizerTestEnvironment.CreateUri("license.jpg");
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample1_RecognizeContentFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample1_RecognizeContentFromUri.cs
@@ -22,7 +22,7 @@ namespace Azure.AI.FormRecognizer.Samples
 
             #region Snippet:FormRecognizerSampleRecognizeContentFromUri
 #if SNIPPET
-            Uri formUri = <formUri>;
+            Uri formUri = new Uri("<formUri>");
 #else
             Uri formUri = FormRecognizerTestEnvironment.CreateUri("Invoice_1.pdf");
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample2_RecognizeCustomFormsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample2_RecognizeCustomFormsFromUri.cs
@@ -35,7 +35,7 @@ namespace Azure.AI.FormRecognizer.Samples
             #region Snippet:FormRecognizerSampleRecognizeCustomFormsFromUri
 #if SNIPPET
             string modelId = "<modelId>";
-            Uri formUri = <formUri>;
+            Uri formUri = new Uri("<formUri>");
 #else
             Uri formUri = FormRecognizerTestEnvironment.CreateUri("Form_1.jpg");
             string modelId = model.ModelId;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample3_RecognizeReceiptsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample3_RecognizeReceiptsFromUri.cs
@@ -23,7 +23,7 @@ namespace Azure.AI.FormRecognizer.Samples
 
             #region Snippet:FormRecognizerSampleRecognizeReceiptFileFromUri
 #if SNIPPET
-            Uri receiptUri = <receiptUri>;
+            Uri receiptUri = new Uri("<receiptUri>");
 #else
             Uri receiptUri = FormRecognizerTestEnvironment.CreateUri("contoso-receipt.jpg");
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample4_StronglyTypingARecognizedForm.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample4_StronglyTypingARecognizedForm.cs
@@ -22,7 +22,7 @@ namespace Azure.AI.FormRecognizer.Samples
 
             #region Snippet:FormRecognizerSampleStronglyTypingARecognizedForm
 #if SNIPPET
-            Uri receiptUri = <receiptUri>;
+            Uri receiptUri = new Uri("<receiptUri>");
 #else
             Uri receiptUri = FormRecognizerTestEnvironment.CreateUri("contoso-receipt.jpg");
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample5_TrainModelWithForms.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample5_TrainModelWithForms.cs
@@ -28,7 +28,7 @@ namespace Azure.AI.FormRecognizer.Samples
             // https://docs.microsoft.com/azure/cognitive-services/form-recognizer/build-training-data-set#upload-your-training-data
 
 #if SNIPPET
-            Uri trainingFileUri = <trainingFileUri>;
+            Uri trainingFileUri = new Uri("<trainingFileUri>");
 #else
             Uri trainingFileUri = new Uri(TestEnvironment.BlobContainerSasUrlV2);
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample6_TrainModelWithFormsAndLabels.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample6_TrainModelWithFormsAndLabels.cs
@@ -31,7 +31,7 @@ namespace Azure.AI.FormRecognizer.Samples
             // https://docs.microsoft.com/azure/cognitive-services/form-recognizer/label-tool?tabs=v2-1
 
 #if SNIPPET
-            Uri trainingFileUri = <trainingFileUri>;
+            Uri trainingFileUri = new Uri("<trainingFileUri>");
 #else
             Uri trainingFileUri = new Uri(TestEnvironment.BlobContainerSasUrlV2);
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample7_ManageCustomModels.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample7_ManageCustomModels.cs
@@ -45,7 +45,7 @@ namespace Azure.AI.FormRecognizer.Samples
             // Create a new model to store in the account
 
 #if SNIPPET
-            Uri trainingFileUri = <trainingFileUri>;
+            Uri trainingFileUri = new Uri("<trainingFileUri>");
 #else
             Uri trainingFileUri = new Uri(TestEnvironment.BlobContainerSasUrlV2);
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample7_ManageCustomModelsAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample7_ManageCustomModelsAsync.cs
@@ -43,7 +43,7 @@ namespace Azure.AI.FormRecognizer.Samples
 
             // Create a new model to store in the account
 #if SNIPPET
-            Uri trainingFileUri = <trainingFileUri>;
+            Uri trainingFileUri = new Uri("<trainingFileUri>");
 #else
             Uri trainingFileUri = new Uri(TestEnvironment.BlobContainerSasUrlV2);
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample8_CopyModel.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample8_CopyModel.cs
@@ -15,22 +15,22 @@ namespace Azure.AI.FormRecognizer.Samples
         [Test]
         public async Task CopyModel()
         {
-            string endpoint = TestEnvironment.Endpoint;
-            string apiKey = TestEnvironment.ApiKey;
-
             #region Snippet:FormRecognizerSampleCreateCopySourceClientV3
 #if SNIPPET
-            string endpoint = "<source_endpoint>";
-            string apiKey = "<source_apiKey>";
+            string sourceEndpoint = "<source_endpoint>";
+            string sourceApiKey = "<source_apiKey>";
+#else
+            string sourceEndpoint = TestEnvironment.Endpoint;
+            string sourceApiKey = TestEnvironment.ApiKey;
 #endif
-            var sourcecredential = new AzureKeyCredential(apiKey);
-            var sourceClient = new FormTrainingClient(new Uri(endpoint), sourcecredential);
+            var sourcecredential = new AzureKeyCredential(sourceApiKey);
+            var sourceClient = new FormTrainingClient(new Uri(sourceEndpoint), sourcecredential);
             #endregion
 
             // For the purpose of this sample, we are going to create a trained model to copy. Please note that
             // if you already have a model, this is not necessary.
 #if SNIPPET
-            Uri trainingFileUri = <trainingFileUri>;
+            Uri trainingFileUri = new Uri("<trainingFileUri>");
 #else
             Uri trainingFileUri = new Uri(TestEnvironment.BlobContainerSasUrlV2);
 #endif
@@ -40,11 +40,14 @@ namespace Azure.AI.FormRecognizer.Samples
 
             #region Snippet:FormRecognizerSampleCreateCopyTargetClientV3
 #if SNIPPET
-            string endpoint = "<target_endpoint>";
-            string apiKey = "<target_apiKey>";
+            string targetEndpoint = "<target_endpoint>";
+            string targetApiKey = "<target_apiKey>";
+#else
+            string targetEndpoint = TestEnvironment.Endpoint;
+            string targetApiKey = TestEnvironment.ApiKey;
 #endif
-            var targetCredential = new AzureKeyCredential(apiKey);
-            var targetClient = new FormTrainingClient(new Uri(endpoint), targetCredential);
+            var targetCredential = new AzureKeyCredential(targetApiKey);
+            var targetClient = new FormTrainingClient(new Uri(targetEndpoint), targetCredential);
             #endregion
 
             #region Snippet:FormRecognizerSampleGetCopyAuthorizationV3

--- a/sdk/formrecognizer/ci.yml
+++ b/sdk/formrecognizer/ci.yml
@@ -25,6 +25,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: formrecognizer
+    BuildSnippets: true
     ArtifactName: packages
     Artifacts:
     - name: Azure.AI.FormRecognizer


### PR DESCRIPTION
Setting the `BuildSnippets` flag to `true` so ci can check if snippets can build successfully. We were able to find a couple of issues and get them fixed.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/27648.
Part of https://github.com/Azure/azure-sdk-for-net/issues/27619.