### PR TITLE
Add additional transaction tests

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -745,9 +745,13 @@ namespace Azure.Messaging.ServiceBus
                     {
                         // Nothing to do here.  These exceptions are expected.
                     }
-
-                    ActiveReceiveTask.Dispose();
-                    ActiveReceiveTask = null;
+                    finally
+                    {
+                        // If an unexpected exception occurred while awaiting the receive task, we still want to dispose and set to null
+                        // as the task is complete and there is no use in awaiting it again if StopProcessingAsync is called again.
+                        ActiveReceiveTask.Dispose();
+                        ActiveReceiveTask = null;
+                    }
                 }
             }
             catch (Exception exception)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
@@ -49,6 +49,22 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
         }
 
         [Test]
+        public async Task SendWithNamedKeyCredential()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                var properties = ServiceBusConnectionStringProperties.Parse(TestEnvironment.ServiceBusConnectionString);
+                var credential = new AzureNamedKeyCredential(properties.SharedAccessKeyName, properties.SharedAccessKey);
+                await using var client = new ServiceBusClient(TestEnvironment.FullyQualifiedNamespace, credential, new ServiceBusClientOptions
+                {
+                    TransportType = ServiceBusTransportType.AmqpWebSockets
+                });
+                var sender = client.CreateSender(scope.QueueName);
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
+            }
+        }
+
+        [Test]
         public async Task SendConnectionTopic()
         {
             await using (var scope = await ServiceBusScope.CreateWithTopic(enablePartitioning: false, enableSession: false))

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Transactions/TransactionLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Transactions/TransactionLiveTests.cs
@@ -372,7 +372,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
             {
                 await using var client = CreateClient();
                 ServiceBusSender sender1 = client.CreateSender(scope1.QueueName);
-                ServiceBusReceiver receiver = client.CreateReceiver(scope1.QueueName, new ServiceBusReceiverOptions { PrefetchCount = 10});
+                ServiceBusReceiver receiver = client.CreateReceiver(scope1.QueueName);
 
                 await using var scope2 = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false);
                 ServiceBusSender sender2 = client.CreateSender(scope2.QueueName);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Transactions/TransactionLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Transactions/TransactionLiveTests.cs
@@ -390,7 +390,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
                     await receiver.CompleteMessageAsync(receivedMessage).ConfigureAwait(false);
                     tcs.SetResult(true);
                     await sender1.SendMessageAsync(message).ConfigureAwait(false);
-                    await sender2.SendMessageAsync(message).ConfigureAwait(false);
+                    await sender1.SendMessageAsync(message).ConfigureAwait(false);
                     ts.Complete();
                 }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Transactions/TransactionLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Transactions/TransactionLiveTests.cs
@@ -383,7 +383,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
 
                 var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                _ = SendMessageAsync();
+                var sendMessageTask = SendMessageAsync();
 
                 using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                 {
@@ -402,6 +402,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
                     await sender1.SendMessageAsync(message).ConfigureAwait(false);
                     await sender2.SendMessageAsync(message).ConfigureAwait(false);
                 }
+
+                // make sure task is completed to surface any exceptions
+                await sendMessageTask;
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Transactions/TransactionLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Transactions/TransactionLiveTests.cs
@@ -421,7 +421,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
                     {
                         tcs.SetResult(true);
                     }
-
+                    Assert.IsNull(Transaction.Current);
                     await sender2.SendMessageAsync(message).ConfigureAwait(false);
                 }
 


### PR DESCRIPTION
Validates that a sender can be reused across non-tx and tx simultaneously. 