### PR TITLE
[MetricsAdvisor] Make sure snippets can be compiled

### DIFF
--- a/sdk/metricsadvisor/ci.yml
+++ b/sdk/metricsadvisor/ci.yml
@@ -25,6 +25,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: metricsadvisor
+    BuildSnippets: true
     ArtifactName: packages
     Artifacts:
     - name: Azure.AI.MetricsAdvisor


### PR DESCRIPTION
Setting the `BuildSnippets` flag to `true` so ci can check if snippets can build successfully. We don't have many snippets in MA, so no issues were found.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/27650.
Part of https://github.com/Azure/azure-sdk-for-net/issues/27619.