### PR TITLE
Bump up version number for sourceResourceId property changes

### DIFF
--- a/sdk/sqlmanagement/Microsoft.Azure.Management.Sql/src/Microsoft.Azure.Management.Sql.csproj
+++ b/sdk/sqlmanagement/Microsoft.Azure.Management.Sql/src/Microsoft.Azure.Management.Sql.csproj
@@ -7,16 +7,11 @@
 		<PackageId>Microsoft.Azure.Management.Sql</PackageId>
 		<Description>Azure SQL Management SDK library</Description>
 		<AssemblyName>Microsoft.Azure.Management.Sql</AssemblyName>
-		<Version>2.1.0-preview</Version>
+		<Version>2.1.1-preview</Version>
 		<PackageTags>Microsoft Azure SQL Management;SQL;SQL Management;</PackageTags>
 		<PackageReleaseNotes>
 			<![CDATA[
 New features:
-- Update TDE operations to use "2021-02-01-preview" API version
-- Backup storage redundancy now has GeoZone option and this is why API version upgrade was needed (2021-05-01-preview) for following operations: ManagedInstances, Databases, LongTermRetentionBackups, LongTermRetentionManagedInstanceBackups,
-RestorableDroppedDatabases, RestorableDroppedManagedDatabases, ServerConnecionPolicies
-- ManagedInstances StorageAccountType parameter is now replaced with RequestedBackupStorageRedundancy and CurrentBackupStorageRedundancy
-- Add IPv6 firewall rules management API (2021-08-01-preview)
 - Add optional parameter SourceResourceId to Databases, which allows cross-subscription restore for DataWarehouse edition 
       ]]>
 		</PackageReleaseNotes>

--- a/sdk/sqlmanagement/Microsoft.Azure.Management.Sql/src/Properties/AssemblyInfo.cs
+++ b/sdk/sqlmanagement/Microsoft.Azure.Management.Sql/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,6 @@
 ﻿using System.Reflection;
-using System.Runtime.InteropServices;
-using System;
 using System.Resources;
+using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -22,4 +21,4 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure SQL Management Library")]
 [assembly: AssemblyDescription("Provides management functionality for Microsoft Azure SQL.")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]


### PR DESCRIPTION
As `2.1.0-preview` version for the nuGet package `Microsoft.Azure.Management.Sql` is already published on https://www.nuget.org/, the new changes for adding support for `sourceResourceId` should be included in a new un-published package version ie 2.1.1-preview. [Reference the PR https://github.com/Azure/azure-sdk-for-net/pull/27541, to view these sourceResourceId related changes]

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
