### PR TITLE
[TextAnalytics] Make sure snippets can be compiled

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample11_MultiCategoryClassify.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample11_MultiCategoryClassify.md
@@ -31,7 +31,7 @@ var batchInput = new List<string>
 };
 
 // Set project and deployment names of the target model
-// To train a model to classify your documents, see https://aka.ms/azsdk/textanalytics/customfunctionalities            
+// To train a model to classify your documents, see https://aka.ms/azsdk/textanalytics/customfunctionalities
 string projectName = "<projectName>";
 string deploymentName = "<deploymentName>";
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample9_RecognizeCustomEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample9_RecognizeCustomEntities.md
@@ -50,7 +50,7 @@ var actions = new TextAnalyticsActions()
 {
     RecognizeCustomEntitiesActions = new List<RecognizeCustomEntitiesAction>()
     {
-        new RecognizeCustomEntitiesAction(projectName, deploymentName);
+        new RecognizeCustomEntitiesAction(projectName, deploymentName)
     }
 };
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample11_MultiCategoryClassifyConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample11_MultiCategoryClassifyConvenienceAsync.cs
@@ -32,7 +32,7 @@ namespace Azure.AI.TextAnalytics.Samples
 
             // Set project and deployment names of the target model
 #if SNIPPET
-            // To train a model to classify your documents, see https://aka.ms/azsdk/textanalytics/customfunctionalities            
+            // To train a model to classify your documents, see https://aka.ms/azsdk/textanalytics/customfunctionalities
             string projectName = "<projectName>";
             string deploymentName = "<deploymentName>";
 #else

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample9_RecognizeCustomEntitiesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample9_RecognizeCustomEntitiesAsync.cs
@@ -51,7 +51,7 @@ namespace Azure.AI.TextAnalytics.Samples
             {
                 RecognizeCustomEntitiesActions = new List<RecognizeCustomEntitiesAction>()
                 {
-                    new RecognizeCustomEntitiesAction(projectName, deploymentName);
+                    new RecognizeCustomEntitiesAction(projectName, deploymentName)
                 }
             };
 #else

--- a/sdk/textanalytics/ci.yml
+++ b/sdk/textanalytics/ci.yml
@@ -25,6 +25,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: textanalytics
+    BuildSnippets: true
     ArtifactName: packages
     Artifacts:
     - name: Azure.AI.TextAnalytics


### PR DESCRIPTION
Setting the `BuildSnippets` flag to `true` so ci can check if snippets can build successfully. This fixes the extra `;` issue we were aware of, and removes some trailing spaces from one snippet.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/27649.
Part of https://github.com/Azure/azure-sdk-for-net/issues/27619.