### PR TITLE
Azure Monitor Exporter - Update logs scope

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LogsHelper.cs
@@ -95,29 +95,27 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             void ProcessScope(LogRecordScope scope, IDictionary<string, string> properties)
             {
                 int valueDepth = 1;
-                if (scope.Scope is IEnumerable<KeyValuePair<string, object>>)
+                foreach (KeyValuePair<string, object> scopeItem in scope)
                 {
-                    foreach (KeyValuePair<string, object> scopeItem in scope)
+                    if (string.IsNullOrEmpty(scopeItem.Key))
                     {
-                        if (scopeItem.Key == "{OriginalFormat}")
-                        {
-                            properties.Add($"OriginalFormatScope_{DepthCache.GetOrAdd(originalScopeDepth, ConvertDepthToStringRef)}", Convert.ToString(scope.Scope.ToString(), CultureInfo.InvariantCulture));
-                        }
-                        else if (!properties.TryGetValue(scopeItem.Key, out _))
-                        {
-                            properties.Add(scopeItem.Key, Convert.ToString(scopeItem.Value, CultureInfo.InvariantCulture));
-                        }
-                        else
-                        {
-                            properties.Add($"{scopeItem.Key}_{DepthCache.GetOrAdd(originalScopeDepth, ConvertDepthToStringRef)}_{DepthCache.GetOrAdd(valueDepth, ConvertDepthToStringRef)}", Convert.ToString(scopeItem.Value, CultureInfo.InvariantCulture));
-                            valueDepth++;
-                        }
+                        builder ??= new StringBuilder();
+                        builder.Append(" => ").Append(scope.Scope);
                     }
-                }
-                else
-                {
-                    builder ??= new StringBuilder();
-                    builder.Append(" => ").Append(scope.Scope);
+                    else if (scopeItem.Key == "{OriginalFormat}")
+                    {
+                        properties.Add($"OriginalFormatScope_{DepthCache.GetOrAdd(originalScopeDepth, ConvertDepthToStringRef)}", Convert.ToString(scope.Scope.ToString(), CultureInfo.InvariantCulture));
+                    }
+                    else if (!properties.TryGetValue(scopeItem.Key, out _))
+                    {
+                        properties.Add(scopeItem.Key, Convert.ToString(scopeItem.Value, CultureInfo.InvariantCulture));
+                    }
+                    else
+                    {
+                        properties.Add($"{scopeItem.Key}_{DepthCache.GetOrAdd(originalScopeDepth, ConvertDepthToStringRef)}_{DepthCache.GetOrAdd(valueDepth, ConvertDepthToStringRef)}",
+                                        Convert.ToString(scopeItem.Value, CultureInfo.InvariantCulture));
+                        valueDepth++;
+                    }
                 }
 
                 originalScopeDepth++;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LogsHelper.cs
@@ -99,9 +99,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                         {
                             properties.Add($"OriginalFormatScope_{originalFormatDepth++}", Convert.ToString(scope.Scope.ToString(), CultureInfo.InvariantCulture));
                         }
-                        else
+                        else if (!properties.TryGetValue(scopeItem.Key, out _))
                         {
                             properties.Add(scopeItem.Key, Convert.ToString(scopeItem.Value, CultureInfo.InvariantCulture));
+                        }
+                        else
+                        {
+                            AzureMonitorExporterEventSource.Log.Write($"DuplicateScopeItem{EventLevelSuffix.Informational}", $"Found duplicate scope key - {scopeItem.Key}.");
                         }
                     }
                 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LogsHelper.cs
@@ -95,7 +95,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             void ProcessScope(LogRecordScope scope, IDictionary<string, string> properties)
             {
                 int valueDepth = 1;
-                if (scope.Scope is IEnumerable<KeyValuePair<string, object>> stateDictionary)
+                if (scope.Scope is IEnumerable<KeyValuePair<string, object>>)
                 {
                     foreach (KeyValuePair<string, object> scopeItem in scope)
                     {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LogsHelper.cs
@@ -86,13 +86,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         internal static void WriteScopeInformation(LogRecord logRecord, IDictionary<string, string> properties)
         {
             StringBuilder builder = null;
+            int originalFormatDepth = 1;
             logRecord.ForEachScope(ProcessScope, properties);
 
             void ProcessScope(LogRecordScope scope, IDictionary<string, string> properties)
             {
                 if (scope.Scope is IEnumerable<KeyValuePair<string, object>> stateDictionary)
                 {
-                    int originalFormatDepth = 1;
                     foreach (KeyValuePair<string, object> scopeItem in scope)
                     {
                         if (scopeItem.Key == "{OriginalFormat}")
@@ -105,7 +105,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                         }
                         else
                         {
-                            AzureMonitorExporterEventSource.Log.Write($"DuplicateScopeItem{EventLevelSuffix.Informational}", $"Found duplicate scope key - {scopeItem.Key}.");
+                            AzureMonitorExporterEventSource.Log.Write($"DuplicateScopeItem{EventLevelSuffix.Warning}", $"Found duplicate scope key - {scopeItem.Key}.");
                         }
                     }
                 }


### PR DESCRIPTION
Based on the implementation from [dotnet](https://github.com/dotnet/runtime/blob/57bfe474518ab5b7cfe6bf7424a79ce3af9d6657/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs#L105) and [Application Insights](https://github.com/microsoft/ApplicationInsights-dotnet/blob/ed0015a78a53b3a26e04d18eed442581bc7c571f/LOGGING/src/ILogger/ApplicationInsightsLogger.cs#L186).

```C#
using var loggerFactory = LoggerFactory.Create(builder =>
{
    builder.SetMinimumLevel(LogLevel.Trace);
    builder.AddOpenTelemetry(loggerOptions =>
        {
            loggerOptions.IncludeScopes = true;
            loggerOptions.IncludeFormattedMessage = true;
            loggerOptions.AddAzureMonitorLogExporter(exporterOptions =>
            {
                exporterOptions.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000;EndpointSuffix=ingestion.azuremonitor.com";
            });
        });
});

var _logger = loggerFactory.CreateLogger<DemoTrace>();

using (_logger.BeginScope("Some name"))
{
    _logger.LogInformation("1");
    using (_logger.BeginScope(42))
    {
        _logger.LogInformation("2");
        using (_logger.BeginScope("Formatted {WithValue}", 12345))
        {
            _logger.LogInformation("3");
            using (_logger.BeginScope(new Dictionary<string, object> { ["ViaDictionary"] = 100 }))
            {
                _logger.LogInformation("Format: {0}", 4);
                _logger.LogInformation("Hello from the Index!");
                _logger.LogDebug("Hello is done");
            }
        }
    }
}
```

```json
{
"name": "Message",
...
"data": {
	"baseType": "MessageData",
	"baseData": {
		"message": "1",
		"severityLevel": "Information",
		"properties": {
			"OriginalFormat": "1",
			"Scope": " => Some name"
		},
		"ver": 2
	}
}
}

{
"name": "Message",
...
"data": {
	"baseType": "MessageData",
	"baseData": {
		"message": "2",
		"severityLevel": "Information",
		"properties": {
			"OriginalFormat": "2",
			"Scope": " => Some name => 42"
		},
		"ver": 2
	}
}
}

{
"name": "Message",
...
"data": {
	"baseType": "MessageData",
	"baseData": {
		"message": "3",
		"severityLevel": "Information",
		"properties": {
			"OriginalFormat": "3",
			"WithValue": "12345",
			"OriginalFormatScope_1": "Formatted 12345",
			"Scope": " => Some name => 42"
		},
		"ver": 2
	}
}
}

{
"name": "Message",
...
"data": {
	"baseType": "MessageData",
	"baseData": {
		"message": "Format: 4",
		"severityLevel": "Information",
		"properties": {
			"0": "4",
			"OriginalFormat": "Format: {0}",
			"WithValue": "12345",
			"OriginalFormatScope_1": "Formatted 12345",
			"ViaDictionary": "100",
			"Scope": " => Some name => 42"
		},
		"ver": 2
	}
}
}

{
"name": "Message",
...
"data": {
	"baseType": "MessageData",
	"baseData": {
		"message": "Hello from the Index!",
		"severityLevel": "Information",
		"properties": {
			"OriginalFormat": "Hello from the Index!",
			"WithValue": "12345",
			"OriginalFormatScope_1": "Formatted 12345",
			"Formatted": "100",
			"Scope": " => Some name => 42"
		},
		"ver": 2
	}
}
}

{
"name": "Message",
...
"data": {
	"baseType": "MessageData",
	"baseData": {
		"message": "Hello is done",
		"severityLevel": "Verbose",
		"properties": {
			"OriginalFormat": "Hello is done",
			"WithValue": "12345",
			"OriginalFormatScope_1": "Formatted 12345",
			"ViaDictionary": "100",
			"Scope": " => Some name => 42"
		},
		"ver": 2
	}
}
}
```

**TODO**

Tests are based on `InMemoryExporter`, it does not expose scope. Will add the test in the follow up PR.