### PR TITLE
[OperationalInsights] Fix for broken link under remarks

### DIFF
--- a/sdk/operationalinsights/Microsoft.Azure.OperationalInsights/src/Generated/OperationalInsightsDataClient.cs
+++ b/sdk/operationalinsights/Microsoft.Azure.OperationalInsights/src/Generated/OperationalInsightsDataClient.cs
@@ -282,7 +282,7 @@ namespace Microsoft.Azure.OperationalInsights
         /// </summary>
         /// <remarks>
         /// Executes an Analytics query for data.
-        /// [Here](/azure/azure-monitor/logs/api/overview) is an example for using POST
+        /// Please refer to<see href="https://docs.microsoft.com/azure/azure-monitor/logs/api/overview">this example</see> for using POST.
         /// with an Analytics query.
         /// </remarks>
         /// <param name='query'>

--- a/sdk/operationalinsights/Microsoft.Azure.OperationalInsights/src/Generated/OperationalInsightsDataClient.cs
+++ b/sdk/operationalinsights/Microsoft.Azure.OperationalInsights/src/Generated/OperationalInsightsDataClient.cs
@@ -282,7 +282,7 @@ namespace Microsoft.Azure.OperationalInsights
         /// </summary>
         /// <remarks>
         /// Executes an Analytics query for data.
-        /// [Here](/documentation/2-Using-the-API/Query) is an example for using POST
+        /// [Here](/azure/azure-monitor/logs/api/overview) is an example for using POST
         /// with an Analytics query.
         /// </remarks>
         /// <param name='query'>


### PR DESCRIPTION
The Hyperlink for 'Here' is broken and results in 404 error. This PR fixes the broken hyperlink:
Old broken link: /documentation/2-Using-the-API/Query
New correction: /azure/azure-monitor/logs/api/overview

More Info: https://docs.microsoft.com/en-us/rest/api/loganalytics/dataaccess/query

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

Fixes https://github.com/Azure/azure-sdk-for-net/issues/22490