### PR TITLE
[Event Hubs] Enable snippet compilation

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample02_EventProcessorConfiguration.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample02_EventProcessorConfiguration.md
@@ -239,7 +239,7 @@ By default, these certificates are not trusted by the Event Hubs client library 
 var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
 var blobContainerName = "<< NAME OF THE BLOB CONTAINER >>";
 
-var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
+var eventHubsConnectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
 var eventHubName = "<< NAME OF THE EVENT HUB >>";
 var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Snippets/Sample02_EventProcessorConfigurationLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Snippets/Sample02_EventProcessorConfigurationLiveTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Net;
-using System.Net.Http;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using Azure.Messaging.EventHubs.Processor;
@@ -339,7 +338,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
             var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
             var blobContainerName = "<< NAME OF THE BLOB CONTAINER >>";
 
-            var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
+            var eventHubsConnectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
             var eventHubName = "<< NAME OF THE EVENT HUB >>";
             var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
 #else
@@ -513,7 +512,6 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
             Assert.That(options, Is.Not.Null);
         }
 
-#if NETCOREAPP || SNIPPET
         /// <summary>
         ///   Performs basic smoke test validation of the contained snippet.
         /// </summary>
@@ -533,7 +531,6 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
 
             Assert.That(options, Is.Not.Null);
         }
-#endif
 
         #region Snippet:EventHubs_Processor_Sample02_CustomRetryPolicy
 
@@ -563,5 +560,16 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
         }
 
         #endregion
+
+        /// <summary>
+        ///   Serves as a shim to allow the illustration of using
+        ///   the DefaultProxy, which is supported on .NET Core and later,
+        ///   across all target frameworks.
+        /// </summary>
+        ///
+        public static class HttpClient
+        {
+            public static WebProxy DefaultProxy { get; set; }
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample02_EventHubsClientsLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample02_EventHubsClientsLiveTests.cs
@@ -368,7 +368,6 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
             Assert.That(options, Is.Not.Null);
         }
 
-#if NETCOREAPP || SNIPPET
         /// <summary>
         ///   Performs basic smoke test validation of the contained snippet.
         /// </summary>
@@ -388,7 +387,6 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
 
             Assert.That(options, Is.Not.Null);
         }
-#endif
 
         #region Snippet:EventHubs_Sample02_CustomRetryPolicy
 
@@ -418,5 +416,16 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
         }
 
         #endregion
+
+        /// <summary>
+        ///   Serves as a shim to allow the illustration of using
+        ///   the DefaultProxy, which is supported on .NET Core and later,
+        ///   across all target frameworks.
+        /// </summary>
+        ///
+        public static class HttpClient
+        {
+            public static WebProxy DefaultProxy { get; set; }
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample04_PublishingEventsLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample04_PublishingEventsLiveTests.cs
@@ -589,8 +589,6 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
 #else
             var connectionString = EventHubsTestEnvironment.Instance.EventHubsConnectionString;
             var eventHubName = scope.EventHubName;
-            var sentEventCount = 0;
-            var batchEventCount = 0;
 #endif
 
             var producer = new EventHubProducerClient(connectionString, eventHubName);
@@ -606,15 +604,9 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
 
                 batches = await BuildBatchesAsync(eventsToSend, producer);
 
-#if !SNIPPET
-                batchEventCount = batches.Sum(batch => batch.Count);
-#endif
                 foreach (var batch in batches)
                 {
                     await producer.SendAsync(batch);
-#if !SNIPPET
-                    sentEventCount += batch.Count;
-#endif
                 }
             }
             finally
@@ -628,10 +620,6 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
             }
 
             #endregion
-
-#if !SNIPPET
-            Assert.That(batchEventCount, Is.EqualTo(sentEventCount));
-#endif
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample04_PublishingEventsLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample04_PublishingEventsLiveTests.cs
@@ -629,7 +629,9 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
 
             #endregion
 
+#if !SNIPPET
             Assert.That(batchEventCount, Is.EqualTo(sentEventCount));
+#endif
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/CHANGELOG.md
@@ -47,9 +47,10 @@ Example: Create an Event Hub:
 
 Before upgrade:
 ```csharp
-// using Microsoft.Azure.Management.EventHub;
-// using Microsoft.Azure.Management.EventHub.Models;
-
+using Microsoft.Azure.Management.EventHub;
+using Microsoft.Azure.Management.EventHub.Models;
+```
+```csharp
 var tokenCredentials = new TokenCredentials("YOUR ACCESS TOKEN");
 var eventHubManagementClient = new EventHubManagementClient(tokenCredentials);
 eventHubManagementClient.SubscriptionId = subscriptionId;
@@ -100,12 +101,13 @@ var createEventHubResponse = this.EventHubManagementClient.EventHubs.CreateOrUpd
 ```
 
 After upgrade:
+```C# Snippet:ChangeLog_Sample_Usings
+using Azure.Identity;
+using Azure.ResourceManager.Resources;
+using Azure.ResourceManager.EventHubs.Models;
+using Azure.Core;
+```
 ```C# Snippet:ChangeLog_Sample
-// using Azure.Identity;
-// using Azure.ResourceManager.Resources;
-// using Azure.ResourceManager.EventHubs.Models;
-// using Azure.Core;
-
 string namespaceName = "myNamespace";
 string eventhubName = "myEventhub";
 string resourceGroupName = "myResourceGroup";

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/CHANGELOG.md
@@ -47,8 +47,8 @@ Example: Create an Event Hub:
 
 Before upgrade:
 ```csharp
-using Microsoft.Azure.Management.EventHub;
-using Microsoft.Azure.Management.EventHub.Models;
+// using Microsoft.Azure.Management.EventHub;
+// using Microsoft.Azure.Management.EventHub.Models;
 
 var tokenCredentials = new TokenCredentials("YOUR ACCESS TOKEN");
 var eventHubManagementClient = new EventHubManagementClient(tokenCredentials);
@@ -101,10 +101,10 @@ var createEventHubResponse = this.EventHubManagementClient.EventHubs.CreateOrUpd
 
 After upgrade:
 ```C# Snippet:ChangeLog_Sample
-using Azure.Identity;
-using Azure.ResourceManager.Resources;
-using Azure.ResourceManager.EventHubs.Models;
-using Azure.Core;
+// using Azure.Identity;
+// using Azure.ResourceManager.Resources;
+// using Azure.ResourceManager.EventHubs.Models;
+// using Azure.Core;
 
 string namespaceName = "myNamespace";
 string eventhubName = "myEventhub";

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/README.md
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/README.md
@@ -28,9 +28,10 @@ The default option to create an authenticated client is to use `DefaultAzureCred
 
 To authenticate to Azure and create an `ArmClient`, do the following:
 
+```C# Snippet:Managing_Namespaces_AuthClient_Usings
+using Azure.Identity;
+```
 ```C# Snippet:Managing_Namespaces_AuthClient
-// using Azure.Identity;
-
 ArmClient armClient = new ArmClient(new DefaultAzureCredential());
 ```
 

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/README.md
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/README.md
@@ -29,7 +29,7 @@ The default option to create an authenticated client is to use `DefaultAzureCred
 To authenticate to Azure and create an `ArmClient`, do the following:
 
 ```C# Snippet:Managing_Namespaces_AuthClient
-using Azure.Identity;
+// using Azure.Identity;
 
 ArmClient armClient = new ArmClient(new DefaultAzureCredential());
 ```
@@ -158,4 +158,4 @@ more information see the Code of Conduct FAQ or contact
 [style-guide-msft]: https://docs.microsoft.com/style-guide/capitalization
 [style-guide-cloud]: https://aka.ms/azsdk/cloud-style-guide
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Ftemplate%2FAzure.Template%2FREADME.png)
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Ftemplate%2FAzure.ResourceManager.EventHubs%2FREADME.png)

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Samples/ChangeLog.cs
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Samples/ChangeLog.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#region Snippet:ChangeLog_Sample_Usings
 using Azure.Identity;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.EventHubs.Models;
 using Azure.Core;
+#endregion
+
 using NUnit.Framework;
 using System.Threading.Tasks;
 
@@ -17,12 +20,6 @@ namespace Azure.ResourceManager.EventHubs.Tests.Samples
         public async Task ChangelogSample()
         {
             #region Snippet:ChangeLog_Sample
-
-            // using Azure.Identity;
-            // using Azure.ResourceManager.Resources;
-            // using Azure.ResourceManager.EventHubs.Models;
-            // using Azure.Core;
-
             string namespaceName = "myNamespace";
             string eventhubName = "myEventhub";
             string resourceGroupName = "myResourceGroup";

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Samples/ChangeLog.cs
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Samples/ChangeLog.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#region Snippet:ChangeLog_Sample
+
 using Azure.Identity;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.EventHubs.Models;
 using Azure.Core;
-
-#if !SNIPPET
 using NUnit.Framework;
 using System.Threading.Tasks;
+
 namespace Azure.ResourceManager.EventHubs.Tests.Samples
 {
     public class ChangeLog
@@ -17,50 +16,56 @@ namespace Azure.ResourceManager.EventHubs.Tests.Samples
         [Ignore("Only verifying that the sample builds")]
         public async Task ChangelogSample()
         {
-#endif
-string namespaceName = "myNamespace";
-string eventhubName = "myEventhub";
-string resourceGroupName = "myResourceGroup";
-ArmClient client = new ArmClient(new DefaultAzureCredential());
-SubscriptionResource subscription = await client.GetDefaultSubscriptionAsync();
-ResourceGroupResource resourceGroup = subscription.GetResourceGroups().Get(resourceGroupName);
-//create namespace
-EventHubNamespaceData parameters = new EventHubNamespaceData(AzureLocation.WestUS)
-{
-    Sku = new EventHubsSku(EventHubsSkuName.Standard)
-    {
-        Tier = EventHubsSkuTier.Standard,
-    }
-};
-parameters.Tags.Add("tag1", "value1");
-parameters.Tags.Add("tag2", "value2");
-EventHubNamespaceCollection eHNamespaceCollection = resourceGroup.GetEventHubNamespaces();
-EventHubNamespaceResource eventHubNamespace = eHNamespaceCollection.CreateOrUpdate(WaitUntil.Completed, namespaceName, parameters).Value;
+            #region Snippet:ChangeLog_Sample
 
-//create eventhub
-EventHubCollection eventHubCollection = eventHubNamespace.GetEventHubs();
-EventHubData eventHubData = new EventHubData()
-{
-    MessageRetentionInDays = 4,
-    PartitionCount = 4,
-    Status = EntityStatus.Active,
-    CaptureDescription = new CaptureDescription()
-    {
-        Enabled = true,
-        Encoding = EncodingCaptureDescription.Avro,
-        IntervalInSeconds = 120,
-        SizeLimitInBytes = 10485763,
-        Destination = new EventHubDestination()
-        {
-            Name = "EventHubArchive.AzureBlockBlob",
-            BlobContainer = "Container",
-            ArchiveNameFormat = "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
-            StorageAccountResourceId = subscription.Id.ToString() + "/resourcegroups/v-ajnavtest/providers/Microsoft.Storage/storageAccounts/testingsdkeventhubnew"
-        },
-        SkipEmptyArchives = true
-    }
-};
-EventHubResource eventHub = eventHubCollection.CreateOrUpdate(WaitUntil.Completed, eventhubName, eventHubData).Value;
+            // using Azure.Identity;
+            // using Azure.ResourceManager.Resources;
+            // using Azure.ResourceManager.EventHubs.Models;
+            // using Azure.Core;
+
+            string namespaceName = "myNamespace";
+            string eventhubName = "myEventhub";
+            string resourceGroupName = "myResourceGroup";
+            ArmClient client = new ArmClient(new DefaultAzureCredential());
+            SubscriptionResource subscription = await client.GetDefaultSubscriptionAsync();
+            ResourceGroupResource resourceGroup = subscription.GetResourceGroups().Get(resourceGroupName);
+            //create namespace
+            EventHubNamespaceData parameters = new EventHubNamespaceData(AzureLocation.WestUS)
+            {
+                Sku = new EventHubsSku(EventHubsSkuName.Standard)
+                {
+                    Tier = EventHubsSkuTier.Standard,
+                }
+            };
+            parameters.Tags.Add("tag1", "value1");
+            parameters.Tags.Add("tag2", "value2");
+            EventHubNamespaceCollection eHNamespaceCollection = resourceGroup.GetEventHubNamespaces();
+            EventHubNamespaceResource eventHubNamespace = eHNamespaceCollection.CreateOrUpdate(WaitUntil.Completed, namespaceName, parameters).Value;
+
+            //create eventhub
+            EventHubCollection eventHubCollection = eventHubNamespace.GetEventHubs();
+            EventHubData eventHubData = new EventHubData()
+            {
+                MessageRetentionInDays = 4,
+                PartitionCount = 4,
+                Status = EntityStatus.Active,
+                CaptureDescription = new CaptureDescription()
+                {
+                    Enabled = true,
+                    Encoding = EncodingCaptureDescription.Avro,
+                    IntervalInSeconds = 120,
+                    SizeLimitInBytes = 10485763,
+                    Destination = new EventHubDestination()
+                    {
+                        Name = "EventHubArchive.AzureBlockBlob",
+                        BlobContainer = "Container",
+                        ArchiveNameFormat = "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+                        StorageAccountResourceId = subscription.Id.ToString() + "/resourcegroups/v-ajnavtest/providers/Microsoft.Storage/storageAccounts/testingsdkeventhubnew"
+                    },
+                    SkipEmptyArchives = true
+                }
+            };
+            EventHubResource eventHub = eventHubCollection.CreateOrUpdate(WaitUntil.Completed, eventhubName, eventHubData).Value;
             #endregion
         }
     }

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Samples/Readme.cs
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Samples/Readme.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#region Snippet:Managing_Namespaces_AuthClient
 using Azure.Identity;
-#if !SNIPPET
 using NUnit.Framework;
 
 namespace Azure.ResourceManager.EventHubs.Tests.Samples
@@ -14,9 +12,10 @@ namespace Azure.ResourceManager.EventHubs.Tests.Samples
         [Ignore("Only verifying that the sample builds")]
         public void ClientAuth()
         {
-#endif
+            #region Snippet:Managing_Namespaces_AuthClient
+            // using Azure.Identity;
 
-ArmClient armClient = new ArmClient(new DefaultAzureCredential());
+            ArmClient armClient = new ArmClient(new DefaultAzureCredential());
             #endregion
         }
     }

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Samples/Readme.cs
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Samples/Readme.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#region Snippet:Managing_Namespaces_AuthClient_Usings
 using Azure.Identity;
+#endregion
+
 using NUnit.Framework;
 
 namespace Azure.ResourceManager.EventHubs.Tests.Samples
@@ -13,8 +16,6 @@ namespace Azure.ResourceManager.EventHubs.Tests.Samples
         public void ClientAuth()
         {
             #region Snippet:Managing_Namespaces_AuthClient
-            // using Azure.Identity;
-
             ArmClient armClient = new ArmClient(new DefaultAzureCredential());
             #endregion
         }

--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -38,6 +38,7 @@ extends:
   parameters:
     SDKType: client
     ServiceDirectory: eventhub
+    BuildSnippets: true
     ArtifactName: packages
     Artifacts:
     - name: Azure.Messaging.EventHubs


### PR DESCRIPTION
# Summary 

The focus of these changes is to opt-into building snippets during CI runs and fixing the snippet build errors across all track two projects in the `eventhub` service directory.

# References and Related

- [Make sure snippets can be compiled (#27619)](https://github.com/Azure/azure-sdk-for-net/issues/27619)