### PR TITLE
[Service Bus] Enable snippet compilation

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -423,6 +423,7 @@ Now in `Azure.Messaging.ServiceBus`, there is an `EnableCrossEntityTransactions`
 The below code snippet shows you how to perform cross-entity transactions.
 
 ```C# Snippet:ServiceBusCrossEntityTransaction
+string connectionString = "<connection_string>";
 var options = new ServiceBusClientOptions { EnableCrossEntityTransactions = true };
 await using var client = new ServiceBusClient(connectionString, options);
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
@@ -32,7 +32,7 @@ Use the client library for Azure Service Bus to:
 
 To quickly create the needed Service Bus resources in Azure and to receive a connection string for them, you can deploy our sample template by clicking:
 
-[![Deploy to Azure](https://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-net%2Fmaster%2Fsdk%2Fservicebus%2FAzure.Messaging.ServiceBus%2Fassets%2Fsamples-azure-deploy.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-net%2Fmaster%2Fsdk%2Fservicebus%2FAzure.Messaging.ServiceBus%2Fassets%2Fsamples-azure-deploy.json)
 
 ### Install the package
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample06_Transactions.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample06_Transactions.md
@@ -49,6 +49,7 @@ using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
 When creating senders and receivers that should be part of a cross-entity transaction, you can set the `EnableCrossEntityTransaction` property of the `ServiceBusClientOptions` as shown below. When using cross-entity transactions, the first entity that an operation occurs on becomes the entity through which all subsequent sends will be routed through. This enables the service to perform a transaction that is meant to span multiple entities. This means that subsequent entities that perform their first operation need to either be senders, or if they are receivers they need to be on the same entity as the initial entity through which all sends are routed through (otherwise the service would not be able to ensure that the transaction is committed because it cannot route a receive operation through a different entity). For instance, if you have SenderA and ReceiverB that are created from a client with cross-entity transactions enabled, you would need to receive first with ReceiverB to allow this to work. If you first used SenderA to send to QueueA, and then attempted to receive from QueueB, an `InvalidOperationException` would be thrown. You could still receive from a ReceiverA after initially sending to SenderA, since they are both using the same queue. This would be useful if you also had a SenderB that you want to include as part of the transaction (otherwise there would be no need to use cross-entity transactions as you would be dealing with only one entity).
 
 ```C# Snippet:ServiceBusCrossEntityTransaction
+string connectionString = "<connection_string>";
 var options = new ServiceBusClientOptions { EnableCrossEntityTransactions = true };
 await using var client = new ServiceBusClient(connectionString, options);
 
@@ -69,6 +70,7 @@ using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
 In the following snippet, we will look at an incorrect ordering that would cause an `InvalidOperationException` to be thrown.
 Bad:
 ```C# Snippet:ServiceBusCrossEntityTransactionWrongOrder
+string connectionString = "<connection_string>";
 var options = new ServiceBusClientOptions { EnableCrossEntityTransactions = true };
 await using var client = new ServiceBusClient(connectionString, options);
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample07_CrudOperations.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample07_CrudOperations.md
@@ -63,7 +63,7 @@ await client.DeleteQueueAsync(queueName);
 ```C# Snippet:CreateTopicAndSubscription
 string connectionString = "<connection_string>";
 string topicName = "<topic_name>";
-var client = new ServiceBusManagementClient(connectionString);
+var client = new ServiceBusAdministrationClient(connectionString);
 var topicOptions = new CreateTopicOptions(topicName)
 {
     AutoDeleteOnIdle = TimeSpan.FromDays(7),

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample06_Transactions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample06_Transactions.cs
@@ -89,6 +89,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 
             #region Snippet:ServiceBusCrossEntityTransaction
 #if SNIPPET
+            string connectionString = "<connection_string>";
             var options = new ServiceBusClientOptions { EnableCrossEntityTransactions = true };
             await using var client = new ServiceBusClient(connectionString, options);
 
@@ -135,6 +136,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 
             #region Snippet:ServiceBusCrossEntityTransactionWrongOrder
 #if SNIPPET
+            string connectionString = "<connection_string>";
             var options = new ServiceBusClientOptions { EnableCrossEntityTransactions = true };
             await using var client = new ServiceBusClient(connectionString, options);
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample07_CrudOperations.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample07_CrudOperations.cs
@@ -38,16 +38,18 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
         [Test]
         public async Task CreateQueue()
         {
-#if !SNIPPET
-            string queueName = Guid.NewGuid().ToString("D").Substring(0, 8);
-            string connectionString = TestEnvironment.ServiceBusConnectionString;
-#endif
+            string adminQueueName = Guid.NewGuid().ToString("D").Substring(0, 8);
+            string adminConnectionString = TestEnvironment.ServiceBusConnectionString;
+
             try
             {
                 #region Snippet:CreateQueue
 #if SNIPPET
                 string connectionString = "<connection_string>";
                 string queueName = "<queue_name>";
+#else
+                string queueName = adminQueueName;
+                string connectionString = adminConnectionString;
 #endif
                 var client = new ServiceBusAdministrationClient(connectionString);
                 var options = new CreateQueueOptions(queueName)
@@ -78,7 +80,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
             }
             finally
             {
-                await new ServiceBusAdministrationClient(connectionString).DeleteQueueAsync(queueName);
+                await new ServiceBusAdministrationClient(adminConnectionString).DeleteQueueAsync(adminQueueName);
             }
         }
 
@@ -111,20 +113,21 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
         [Test]
         public async Task CreateTopicAndSubscription()
         {
-#if !SNIPPET
-            string topicName = Guid.NewGuid().ToString("D").Substring(0, 8);
-            string subscriptionName = Guid.NewGuid().ToString("D").Substring(0, 8);
-            string connectionString = TestEnvironment.ServiceBusConnectionString;
-            var client = new ServiceBusAdministrationClient(connectionString);
-#endif
+            string adminTopicName = Guid.NewGuid().ToString("D").Substring(0, 8);
+            string adminSubscriptionName = Guid.NewGuid().ToString("D").Substring(0, 8);
+            string adminConnectionString = TestEnvironment.ServiceBusConnectionString;
+
             try
             {
                 #region Snippet:CreateTopicAndSubscription
 #if SNIPPET
                 string connectionString = "<connection_string>";
                 string topicName = "<topic_name>";
-                var client = new ServiceBusManagementClient(connectionString);
+#else
+                string connectionString = adminConnectionString;
+                string topicName = adminTopicName;
 #endif
+                var client = new ServiceBusAdministrationClient(connectionString);
                 var topicOptions = new CreateTopicOptions(topicName)
                 {
                     AutoDeleteOnIdle = TimeSpan.FromDays(7),
@@ -145,6 +148,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 
 #if SNIPPET
                 string subscriptionName = "<subscription_name>";
+#else
+                string subscriptionName = adminSubscriptionName;
 #endif
                 var subscriptionOptions = new CreateSubscriptionOptions(topicName, subscriptionName)
                 {
@@ -160,7 +165,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
             }
             finally
             {
-                await client.DeleteTopicAsync(topicName);
+                await new ServiceBusAdministrationClient(adminConnectionString).DeleteTopicAsync(adminTopicName);
             }
         }
 

--- a/sdk/servicebus/Azure.ResourceManager.ServiceBus/README.md
+++ b/sdk/servicebus/Azure.ResourceManager.ServiceBus/README.md
@@ -28,9 +28,11 @@ The default option to create an authenticated client is to use `DefaultAzureCred
 
 To authenticate to Azure and create an `ArmClient`, do the following:
 
-```C# Snippet:Managing_ServiceBus_AuthClient
-// using Azure.Identity
+```C# Snippet:Managing_ServiceBus_AuthClient_Usings
+using Azure.Identity;
+```
 
+```C# Snippet:Managing_ServiceBus_AuthClient
 ArmClient armClient = new ArmClient(new DefaultAzureCredential());
 ```
 

--- a/sdk/servicebus/Azure.ResourceManager.ServiceBus/README.md
+++ b/sdk/servicebus/Azure.ResourceManager.ServiceBus/README.md
@@ -29,7 +29,7 @@ The default option to create an authenticated client is to use `DefaultAzureCred
 To authenticate to Azure and create an `ArmClient`, do the following:
 
 ```C# Snippet:Managing_ServiceBus_AuthClient
-using Azure.Identity;
+// using Azure.Identity
 
 ArmClient armClient = new ArmClient(new DefaultAzureCredential());
 ```
@@ -156,4 +156,4 @@ more information see the Code of Conduct FAQ or contact
 [style-guide-msft]: https://docs.microsoft.com/style-guide/capitalization
 [style-guide-cloud]: https://aka.ms/azsdk/cloud-style-guide
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Ftemplate%2FAzure.Template%2FREADME.png)
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Ftemplate%2FAzure.ResourceManager.ServiceBus%2FREADME.png)

--- a/sdk/servicebus/Azure.ResourceManager.ServiceBus/tests/Samples/Readme.cs
+++ b/sdk/servicebus/Azure.ResourceManager.ServiceBus/tests/Samples/Readme.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#region Snippet:Managing_ServiceBus_AuthClient
 using Azure.Identity;
-#if !SNIPPET
 using NUnit.Framework;
 
 namespace Azure.ResourceManager.ServiceBus.Tests.Samples
@@ -14,9 +12,10 @@ namespace Azure.ResourceManager.ServiceBus.Tests.Samples
         [Ignore("Only verifying that the sample builds")]
         public void ClientAuth()
         {
-#endif
+            #region Snippet:Managing_ServiceBus_AuthClient
+            // using Azure.Identity
 
-ArmClient armClient = new ArmClient(new DefaultAzureCredential());
+            ArmClient armClient = new ArmClient(new DefaultAzureCredential());
             #endregion
         }
     }

--- a/sdk/servicebus/Azure.ResourceManager.ServiceBus/tests/Samples/Readme.cs
+++ b/sdk/servicebus/Azure.ResourceManager.ServiceBus/tests/Samples/Readme.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#region Snippet:Managing_ServiceBus_AuthClient_Usings
 using Azure.Identity;
+#endregion
+
 using NUnit.Framework;
 
 namespace Azure.ResourceManager.ServiceBus.Tests.Samples
@@ -13,8 +16,6 @@ namespace Azure.ResourceManager.ServiceBus.Tests.Samples
         public void ClientAuth()
         {
             #region Snippet:Managing_ServiceBus_AuthClient
-            // using Azure.Identity
-
             ArmClient armClient = new ArmClient(new DefaultAzureCredential());
             #endregion
         }

--- a/sdk/servicebus/ci.yml
+++ b/sdk/servicebus/ci.yml
@@ -32,6 +32,7 @@ extends:
   parameters:
     SDKType: client
     ServiceDirectory: servicebus
+    BuildSnippets: true
     ArtifactName: packages
     Artifacts:
     - name: Azure.Messaging.ServiceBus


### PR DESCRIPTION
# Summary

The focus of these changes is to opt-into building snippets during CI runs and fixing the snippet build errors across all track two projects in the `servicebus` service directory.  Also riding along is a fix for the deployment button in the Service Bus README.

# References and Related

- [Make sure snippets can be compiled (#27619)](https://github.com/Azure/azure-sdk-for-net/issues/27619)