### PR TITLE
Block any project reference to Azure.Core that is approved by core owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,7 @@
 
 # PRLabel: %Azure.Core
 /sdk/core/                                      @JoshLove-msft @christothes @annelo-msft @KrzysztofCwalina
+/eng/AllowedAzureCorePackageReferences.targets  @JoshLove-msft @christothes @annelo-msft @KrzysztofCwalina
 
 # PRLabel: %Azure.Identity
 /sdk/identity/                                  @schaabs @christothes
@@ -597,7 +598,7 @@ sdk/trafficmanager/Microsoft.Azure.Management.TrafficManager/            @tmsupp
 #/sdk/schemaregistry/            @hmlam
 
 # ServiceLabel: %SignalR %Service Attention
-/sdk/signalr/            @sffamily @chenkennt @Y-Sindo     
+/sdk/signalr/            @sffamily @chenkennt @Y-Sindo
 
 # ServiceLabel: %SQL %Service Attention
 #/<NotInRepo>/            @azureSQLGitHub
@@ -693,7 +694,7 @@ sdk/trafficmanager/Microsoft.Azure.Management.TrafficManager/            @tmsupp
 # Reviewers to double check any API changes
 /sdk/**/api/                                    @KrzysztofCwalina @tg-msft
 
-# ######## Eng Sys ######## 
+# ######## Eng Sys ########
 /eng/           @chidozieononiwu @weshaggard @benbp
 /eng/mgmt/      @ArthurMa1978 @m-nash @markcowl
 /**/tests.yml   @chidozieononiwu @weshaggard @benbp
@@ -702,4 +703,4 @@ sdk/trafficmanager/Microsoft.Azure.Management.TrafficManager/            @tmsupp
 # Add owners for notifications for specific pipelines
 /eng/pipelines/aggregate-reports.yml            @AlexGhiondea @maririos
 /sdk/eventhub/tests.data.yml  @serkantkaraca @sjkwak
-/sdk/servicebus/tests.data.yml @shankarsama @DorothySun216 
+/sdk/servicebus/tests.data.yml @shankarsama @DorothySun216

--- a/eng/AllowedAzureCorePackageReferences.targets
+++ b/eng/AllowedAzureCorePackageReferences.targets
@@ -1,0 +1,18 @@
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Projects that are currently approved to take a live project reference to Azure.Core -->
+  <ItemGroup>
+    <CanReferenceAzureCoreProject Include="Azure.Core.Tests" />
+    <CanReferenceAzureCoreProject Include="Azure.Core.TestFramework" />
+  </ItemGroup>
+
+  <Target Name="CheckAzureCoreProjectReferences" BeforeTargets="Build" Condition="'$(UseProjectReferenceToAzureClients)' != 'true'">
+    <ItemGroup>
+      <InAllowedSet Include="@(CanReferenceAzureCoreProject)" Condition="'%(Identity)' == '$(MSBuildProjectName)'" />
+      <AzureCoreProjectReference Include="@(ProjectReference)" Condition="'%(Filename)' == 'Azure.Core'" />
+    </ItemGroup>
+
+    <Error Condition="'@(InAllowedSet)' == '' and '@(AzureCoreProjectReference)' != ''" Text="You cannot have a project reference to Azure.Core without approval." />
+  </Target>
+
+</Project>

--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -174,7 +174,7 @@
     <!-- Add ProjectReferences -->
     <ProjectReference Include="@(ProjectsToConvert -> '%(ProjectPath)')" />
   </ItemGroup>
-  
+
   <!--TODO: update build targets - ADO 5668-->
   <PropertyGroup>
     <MgmtCoreShared>$(MSBuildThisFileDirectory)/../sdk/resourcemanager/Azure.ResourceManager/src/Shared</MgmtCoreShared>
@@ -185,7 +185,7 @@
     <Compile Include="$(MgmtCoreShared)/**/*.cs"
                  LinkBase="Shared/Management" />
   </ItemGroup>
-  
+
   <!--TODO: end-->
 
   <!-- *********** Files needed for LRO ************* -->
@@ -208,13 +208,13 @@
     <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" LinkBase="Shared/Core" />
     <Compile Include="$(AzureCoreSharedSources)AppContextSwitchHelper.cs" LinkBase="Shared/Core" />
   </ItemGroup>
-    
+
     <!-- *********** Management Client Library Override section ************* -->
   <ItemGroup Condition="'$(IsMgmtLibrary)' == 'true' and '$(IsTestProject)' != 'true'">
 
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="System.Text.Json" />
-    
+
     <!-- TODO: Review these file references-->
     <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />
@@ -268,6 +268,8 @@
 
     <Error Condition="'@(PreviewPackageReferences)' != ''" Text="When the project has a release version it shouldn't reference any pre-release libraries. Found the following pre-release references: @(PreviewPackageReferences, ', ')" />
   </Target>
+
+  <Import Project="AllowedAzureCorePackageReferences.targets" />
 
   <!-- InheritDoc-->
   <ItemGroup Condition="'$(InheritDocEnabled)' != 'false'">


### PR DESCRIPTION
This is a proof of concept for how we could make sure that anyone taking a project reference to Azure.Core would need to get review from the owners and get added to a list of approved projects. 