### PR TITLE
[Fabric Bot Rules] Update Service Contacts

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1928,7 +1928,9 @@
             "johngallardo",
             "efriesner",
             "abhinav-gha",
-            "Aashish93-stack"
+            "Aashish93-stack",
+            "sjiherzig",
+            "Satya-Kolluri"
           ]
         },
         {


### PR DESCRIPTION
# Summary 

The focus of these changes is to update the contacts for the Digital Twins service in sync with the CODEOWNERS changes from [#27823](https://github.com/Azure/azure-sdk-for-net/pull/27823).