### PR TITLE
Add management release job to yml

### DIFF
--- a/eng/pipelines/mgmt.yml
+++ b/eng/pipelines/mgmt.yml
@@ -1,3 +1,18 @@
+resources:
+  repositories:
+    - repository: azure-sdk-build-tools
+      type: git
+      name: internal/azure-sdk-build-tools
+      ref: refs/tags/azure-sdk-build-tools_20211215.1
+
+parameters: 
+- name: ShouldPublish
+  type: boolean
+  default: false
+- name: Scope
+  type: string
+  default: ''
+
 trigger: none
 pr:
   branches:
@@ -178,7 +193,18 @@ variables:
   value: /p:PullRequestNumber=$(system.pullrequest.pullrequestnumber) /p:RepoHtmlUrl=https://github.com/$(build.repository.id) /p:CIBuildId=$(OfficialBuildId)
 - name: timeoutInMinutes
   value: 120
-jobs:
-- template: /eng/pipelines/templates/jobs/ci.mgmt.yml
-  parameters:
-    Scope: $(Scope)
+
+stages:
+  - stage: Build
+    jobs:
+      - template: /eng/pipelines/templates/jobs/ci.mgmt.yml
+        parameters:
+          Scope: ${{ parameters.Scope }}
+          ShouldPublish: ${{ parameters.ShouldPublish }}
+
+  # The Release job is conditioned on whether we are building a pull request and the branch.
+  - ${{ if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal')) }}:
+    - template: /eng/pipelines/templates/jobs/mgmt-release.yml
+      parameters:
+        ShouldPublish: ${{ parameters.ShouldPublish }}
+        DependsOn: Build

--- a/eng/pipelines/templates/jobs/ci.mgmt.yml
+++ b/eng/pipelines/templates/jobs/ci.mgmt.yml
@@ -1,3 +1,11 @@
+parameters: 
+- name: ShouldPublish
+  type: boolean
+  default: false
+- name: Scope
+  type: string
+  default: ''
+
 jobs:
   - job: Build
     timeoutInMinutes: 100
@@ -9,7 +17,7 @@ jobs:
       - template: /eng/pipelines/templates/steps/install-dotnet.yml
       - script: |
           if "$(BuildConfiguration)" == "Release" (set SkipTests=true) else (set SkipTests=false)
-          dotnet msbuild mgmt.proj /v:m /t:CreateNugetPackage /p:Configuration=$(BuildConfiguration) /p:SkipTests=%SkipTests% /p:PackageOutputPath=$(Build.ArtifactStagingDirectory) /p:Scope=${{parameters.Scope}} /p:ForPublishing=$(ShouldPublish) $(loggingArgs) $(RPScopeArgs)"
+          dotnet msbuild mgmt.proj /v:m /t:CreateNugetPackage /p:Configuration=$(BuildConfiguration) /p:SkipTests=%SkipTests% /p:PackageOutputPath=$(Build.ArtifactStagingDirectory) /p:Scope=${{ parameters.Scope }} /p:ForPublishing=${{ parameters.ShouldPublish }} $(loggingArgs) $(RPScopeArgs)"
         displayName: "Build & Package"
       - task: PowerShell@2
         displayName: "Verify generated code"
@@ -62,7 +70,7 @@ jobs:
           AgentImage: $(OSVmImage)
       - script: "echo $(system.pullrequest.pullrequestnumber), http://github.com/$(build.repository.id), http://github.com/$(build.repository.ID)"
       - template: /eng/pipelines/templates/steps/install-dotnet.yml
-      - script: "dotnet msbuild mgmt.proj /v:n /t:RunTests /p:Scope=${{parameters.Scope}} /p:ForPublishing=$(ShouldPublish) /clp:ShowtimeStamp $(RPScopeArgs)"
+      - script: "dotnet msbuild mgmt.proj /v:n /t:RunTests /p:Scope=${{ parameters.Scope }} /p:ForPublishing=${{ parameters.ShouldPublish }} /clp:ShowtimeStamp $(RPScopeArgs)"
         displayName: "Build & Run Tests"
       - task: PublishTestResults@2
         condition: succeededOrFailed()

--- a/eng/pipelines/templates/jobs/mgmt-release.yml
+++ b/eng/pipelines/templates/jobs/mgmt-release.yml
@@ -1,0 +1,102 @@
+parameters: 
+- name: ShouldPublish
+  type: boolean
+  default: false
+- name: BuildToolsPath
+  type: string
+  default: '$(Build.SourcesDirectory)/azure-sdk-build-tools'
+- name: NugetVersion
+  type: string
+  default: '5.4.x'
+- name: PartnerDropsSubscription
+  type: string
+  default: 'azuresdkpartnerdrops-kv Secrets'
+- name: PartnerDropsStorageName
+  type: string
+  default: 'azuresdkpartnerdrops'
+- name: PartnerDropsContainerName
+  type: string
+  default: 'mgmt-netsdk-signed'
+- name: PartnerDropsBlobDestPrefix
+  type: string
+  default: '$(System.DefinitionId)-$(Build.BuildId)-$(System.JobAttempt)'
+- name: DependsOn
+  type: string
+  default: Build
+
+stages:
+  - stage: Release
+    dependsOn: ${{parameters.DependsOn}}
+    jobs:
+      - deployment: Release
+        environment: nuget
+        pool:
+          name: azsdk-pool-mms-win-2019-general
+          vmImage: MMS2019
+
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - checkout: self
+                - checkout: azure-sdk-build-tools
+
+                - download: current
+                  artifact: packages
+                  displayName: Download published Nuget Packages
+
+                - task: Powershell@2
+                  displayName: 'Verify Package Tags and Create Git Releases'
+                  inputs:
+                    filePath: ${{ parameters.BuildToolsPath }}/scripts/create-tags-and-git-release.ps1
+                    arguments: >
+                      -artifactLocation '$(PIPELINE.WORKSPACE)/packages'
+                      -workingDirectory $(System.DefaultWorkingDirectory)
+                      -packageRepository 'Nuget'
+                      -releaseSha '$(Build.SourceVersion)'
+                      -repoOwner 'azure-sdk-for-net'
+                      -repoName 'Azure'
+                    pwsh: true
+                  env:
+                    GH_TOKEN: $(azuresdk-github-pat)
+                  condition: and(succeeded(), ne(variables['SkipCreateTagAndGitRelease'], 'true'))
+
+                - ${{ if eq(parameters.ShouldPublish, true) }}:
+                  - template: pipelines/steps/net-signing.yml@azure-sdk-build-tools
+                    parameters:
+                      PackagesPath: '$(PIPELINE.WORKSPACE)/packages'
+                      BuildToolsPath: '${{ parameters.BuildToolsPath }}'
+
+                  - task: MSBuild@1
+                    displayName: 'Upload Symbols'
+                    inputs:
+                      solution: '${{ parameters.BuildToolsPath }}/tools/symboltool/SymbolUploader.proj'
+                      msbuildArguments: >
+                        /p:PackagesPath='$(PIPELINE.WORKSPACE)/packages'
+                        /p:MSPublicSymbolsPAT=$(azuresdk-microsoftpublicsymbols-devops-pat)
+                        /p:MSSymbolsPAT=$(azuresdk-microsoft-devops-pat)
+                        /p:AzureSDKSymbolsPAT=$(azuresdk-azure-sdk-devops-pat)
+
+                  - task: NuGetToolInstaller@1
+                    displayName: 'Use NuGet ${{ parameters.NugetVersion }}'
+                    inputs:
+                      versionSpec: ${{ parameters.NugetVersion }}
+
+                  - task: NuGetCommand@2
+                    displayName: 'Publish to Nuget'
+                    inputs:
+                      command: push
+                      packagesToPush: '$(PIPELINE.WORKSPACE)/packages/**/*.nupkg;!$(PIPELINE.WORKSPACE)/packages/**/*.symbols.nupkg'
+                      nuGetFeedType: external
+                      publishFeedCredentials: Nuget.org
+
+                  - task: AzureFileCopy@2
+                    displayName: 'Copy Signed Files to Blob'
+                    inputs:
+                      SourcePath: '$(PIPELINE.WORKSPACE)/packages'
+                      azureSubscription: '${{ parameters.PartnerDropsSubscription }}'
+                      Destination: AzureBlob
+                      storage: '${{ parameters.PartnerDropsStorageName }}'
+                      ContainerName: '${{ parameters.PartnerDropsContainerName }}'
+                      BlobPrefix: '${{ parameters.PartnerDropsBlobDestPrefix }}'
+                    condition: and(succeeded(), ne(variables['SkipCopySignedFilestoBlob'], 'true'))

--- a/eng/pipelines/templates/jobs/mgmt-release.yml
+++ b/eng/pipelines/templates/jobs/mgmt-release.yml
@@ -8,18 +8,6 @@ parameters:
 - name: NugetVersion
   type: string
   default: '5.4.x'
-- name: PartnerDropsSubscription
-  type: string
-  default: 'azuresdkpartnerdrops-kv Secrets'
-- name: PartnerDropsStorageName
-  type: string
-  default: 'azuresdkpartnerdrops'
-- name: PartnerDropsContainerName
-  type: string
-  default: 'mgmt-netsdk-signed'
-- name: PartnerDropsBlobDestPrefix
-  type: string
-  default: '$(System.DefinitionId)-$(Build.BuildId)-$(System.JobAttempt)'
 - name: DependsOn
   type: string
   default: Build
@@ -76,11 +64,13 @@ stages:
                         /p:MSPublicSymbolsPAT=$(azuresdk-microsoftpublicsymbols-devops-pat)
                         /p:MSSymbolsPAT=$(azuresdk-microsoft-devops-pat)
                         /p:AzureSDKSymbolsPAT=$(azuresdk-azure-sdk-devops-pat)
+                    condition: and(succeeded(), eq(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net'))
 
                   - task: NuGetToolInstaller@1
                     displayName: 'Use NuGet ${{ parameters.NugetVersion }}'
                     inputs:
                       versionSpec: ${{ parameters.NugetVersion }}
+                    condition: and(succeeded(), eq(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net'))
 
                   - task: NuGetCommand@2
                     displayName: 'Publish to Nuget'
@@ -89,14 +79,9 @@ stages:
                       packagesToPush: '$(PIPELINE.WORKSPACE)/packages/**/*.nupkg;!$(PIPELINE.WORKSPACE)/packages/**/*.symbols.nupkg'
                       nuGetFeedType: external
                       publishFeedCredentials: Nuget.org
+                    condition: and(succeeded(), eq(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net'))
 
-                  - task: AzureFileCopy@2
-                    displayName: 'Copy Signed Files to Blob'
-                    inputs:
-                      SourcePath: '$(PIPELINE.WORKSPACE)/packages'
-                      azureSubscription: '${{ parameters.PartnerDropsSubscription }}'
-                      Destination: AzureBlob
-                      storage: '${{ parameters.PartnerDropsStorageName }}'
-                      ContainerName: '${{ parameters.PartnerDropsContainerName }}'
-                      BlobPrefix: '${{ parameters.PartnerDropsBlobDestPrefix }}'
-                    condition: and(succeeded(), ne(variables['SkipCopySignedFilestoBlob'], 'true'))
+                  - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
+                    parameters:
+                      ArtifactPath: '$(PIPELINE.WORKSPACE)/packages'
+                      ArtifactName: 'packages-signed'


### PR DESCRIPTION
- Single pipeline for publishing artifacts from mgmt pipelines to nuget.
- To serve as replacement for [net - mgmt to nuget](https://dev.azure.com/azure-sdk/internal/_release?view=all&_a=releases&definitionId=58), [net - new MultiAPI to nuget](https://dev.azure.com/azure-sdk/internal/_release?view=all&_a=releases&definitionId=99), [net - MultiAPI to nuget](https://dev.azure.com/azure-sdk/internal/_release?view=all&_a=releases&definitionId=97)