### PR TITLE
Case insensitive matching resource types when fetch api-version for `GenericResource`

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Custom/ResourceProviderCollection.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Custom/ResourceProviderCollection.cs
@@ -85,7 +85,7 @@ namespace Azure.ResourceManager.Resources
 
         private static Dictionary<string, string> GetVersionsFromResult(ResourceProviderResource results)
         {
-            Dictionary<string, string> resourceVersions = new Dictionary<string, string>();
+            Dictionary<string, string> resourceVersions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (var type in results.Data.ResourceTypes)
             {
                 if (type.ApiVersions.Count == 0)


### PR DESCRIPTION
Fixes https://github.com/azure/azure-sdk-for-net/issues/27819

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
