### PR TITLE
Support camel cased partitionKey and rowKey for output binding

### DIFF
--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/src/TablesExtensionConfigProvider.cs
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/src/TablesExtensionConfigProvider.cs
@@ -184,16 +184,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tables
             foreach (JProperty property in entity.Properties())
             {
                 var key = property.Name;
-                if (key == nameof(TableEntity.ETag))
+
+                // For reserved attributes, normalize to the casing used when communicating with service
+                if (nameof(TableEntity.ETag).Equals(key, StringComparison.OrdinalIgnoreCase))
                 {
                     key = PocoTypeBinder.ETagKeyName;
                 }
-                // normalize casing
                 else if (nameof(TableEntity.PartitionKey).Equals(key, StringComparison.OrdinalIgnoreCase))
                 {
                     key = nameof(TableEntity.PartitionKey);
                 }
-                // normalize casing
                 else if (nameof(TableEntity.RowKey).Equals(key, StringComparison.OrdinalIgnoreCase))
                 {
                     key = nameof(TableEntity.RowKey);

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/src/TablesExtensionConfigProvider.cs
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/src/TablesExtensionConfigProvider.cs
@@ -188,6 +188,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tables
                 {
                     key = PocoTypeBinder.ETagKeyName;
                 }
+                // normalize casing
+                else if (nameof(TableEntity.PartitionKey).Equals(key, StringComparison.OrdinalIgnoreCase))
+                {
+                    key = nameof(TableEntity.PartitionKey);
+                }
+                // normalize casing
+                else if (nameof(TableEntity.RowKey).Equals(key, StringComparison.OrdinalIgnoreCase))
+                {
+                    key = nameof(TableEntity.RowKey);
+                }
 
                 if (property.Value is JValue value)
                 {

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/EntityBindingLiveTests.cs
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/EntityBindingLiveTests.cs
@@ -548,6 +548,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tables.Tests
                     ["RowKey"] = RowKey + "1"
                 });
             }
+
+            public static async Task JObjectCamelCase([Table(TableNameExpression)] IAsyncCollector<JObject> collector, object original, object another)
+            {
+                await collector.AddAsync(new JObject
+                {
+                    ["Value"] = JToken.FromObject(original),
+                    ["partitionKey"] = PartitionKey,
+                    ["rowKey"] = RowKey
+                });
+                await collector.AddAsync(new JObject
+                {
+                    ["Value"] = JToken.FromObject(another),
+                    ["partitionKey"] = PartitionKey,
+                    ["rowKey"] = RowKey + "1"
+                });
+            }
         }
 
         [RecordedTest]
@@ -655,6 +671,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tables.Tests
                     ["Value"] = JToken.FromObject(another),
                     ["PartitionKey"] = PartitionKey,
                     ["RowKey"] = RowKey + "1"
+                });
+            }
+
+            public static async Task JObjectCamelCase([Table(TableNameExpression)] IAsyncCollector<JObject> collector, object original, object another)
+            {
+                await collector.AddAsync(new JObject
+                {
+                    ["Value"] = JToken.FromObject(original),
+                    ["partitionKey"] = PartitionKey,
+                    ["rowKey"] = RowKey
+                });
+                await collector.AddAsync(new JObject
+                {
+                    ["Value"] = JToken.FromObject(another),
+                    ["partitionKey"] = PartitionKey,
+                    ["rowKey"] = RowKey + "1"
                 });
             }
         }

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/EntityBindingLiveTests.cs
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/EntityBindingLiveTests.cs
@@ -458,9 +458,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tables.Tests
             TableEntity entity = await TableClient.GetEntityAsync<TableEntity>(PartitionKey, RowKey);
             Assert.NotNull(entity);
             Assert.AreEqual(values.Value1Base, entity["Value"]);
+            // etag should be interpreted as an Odata etag and not stored with the "etag" or "Etag" key
+            Assert.IsNull(entity["Etag"]);
+            Assert.IsNull(entity["etag"]);
             TableEntity entity2 = await TableClient.GetEntityAsync<TableEntity>(PartitionKey, RowKey + "1");
             Assert.NotNull(entity2);
             Assert.AreEqual(values.Value2Base, entity2["Value"]);
+            Assert.IsNull(entity["Etag"]);
+            Assert.IsNull(entity["etag"]);
         }
 
         private class CanAddEntityUsingCollectorProgram<T>
@@ -539,13 +544,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tables.Tests
                 {
                     ["Value"] = JToken.FromObject(original),
                     ["PartitionKey"] = PartitionKey,
-                    ["RowKey"] = RowKey
+                    ["RowKey"] = RowKey,
+                    ["Etag"] = "*"
                 });
                 collector.Add(new JObject
                 {
                     ["Value"] = JToken.FromObject(another),
                     ["PartitionKey"] = PartitionKey,
-                    ["RowKey"] = RowKey + "1"
+                    ["RowKey"] = RowKey + "1",
+                    ["Etag"] = "*"
                 });
             }
 
@@ -555,13 +562,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tables.Tests
                 {
                     ["Value"] = JToken.FromObject(original),
                     ["partitionKey"] = PartitionKey,
-                    ["rowKey"] = RowKey
+                    ["rowKey"] = RowKey,
+                    ["etag"] = "*"
                 });
                 await collector.AddAsync(new JObject
                 {
                     ["Value"] = JToken.FromObject(another),
                     ["partitionKey"] = PartitionKey,
-                    ["rowKey"] = RowKey + "1"
+                    ["rowKey"] = RowKey + "1",
+                    ["etag"] = "*"
                 });
             }
         }
@@ -587,9 +596,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tables.Tests
             TableEntity entity = await TableClient.GetEntityAsync<TableEntity>(PartitionKey, RowKey);
             Assert.NotNull(entity);
             Assert.AreEqual(values.Value1Base, entity["Value"]);
+            // etag should be interpreted as an Odata etag and not stored with the "etag" or "Etag" key
+            Assert.IsNull(entity["Etag"]);
+            Assert.IsNull(entity["etag"]);
             TableEntity entity2 = await TableClient.GetEntityAsync<TableEntity>(PartitionKey, RowKey + "1");
             Assert.NotNull(entity2);
             Assert.AreEqual(values.Value2Base, entity2["Value"]);
+            Assert.IsNull(entity["Etag"]);
+            Assert.IsNull(entity["etag"]);
         }
 
         private class CanAddEntityUsingAsyncCollectorProgram<T>
@@ -664,13 +678,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tables.Tests
                 {
                     ["Value"] = JToken.FromObject(original),
                     ["PartitionKey"] = PartitionKey,
-                    ["RowKey"] = RowKey
+                    ["RowKey"] = RowKey,
+                    ["Etag"] = "*"
                 });
                 await collector.AddAsync(new JObject
                 {
                     ["Value"] = JToken.FromObject(another),
                     ["PartitionKey"] = PartitionKey,
-                    ["RowKey"] = RowKey + "1"
+                    ["RowKey"] = RowKey + "1",
+                    ["Etag"] = "*"
                 });
             }
 
@@ -680,13 +696,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tables.Tests
                 {
                     ["Value"] = JToken.FromObject(original),
                     ["partitionKey"] = PartitionKey,
-                    ["rowKey"] = RowKey
+                    ["rowKey"] = RowKey,
+                    ["etag"] = "*"
                 });
                 await collector.AddAsync(new JObject
                 {
                     ["Value"] = JToken.FromObject(another),
                     ["partitionKey"] = PartitionKey,
-                    ["rowKey"] = RowKey + "1"
+                    ["rowKey"] = RowKey + "1",
+                    ["etag"] = "*"
                 });
             }
         }

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(False)/CanAddEntityUsingAsyncCollector(%JObject%)Async.json
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(False)/CanAddEntityUsingAsyncCollector(%JObject%)Async.json
@@ -9,35 +9,35 @@
         "Content-Length": "33",
         "Content-Type": "application/json; odata=nometadata",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-5bbfa42a8fb9fc35f4549022feb43858-1ab917a53f4552c7-00",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "d8f39ffda7c3f208995a1e44e8e9ce30",
-        "x-ms-date": "Mon, 31 Jan 2022 22:18:10 GMT",
+        "traceparent": "00-2c3ee2383d90e38d77d3d3e39d38da82-db2db0b8d6a2facf-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "65b4b8e6e30782aac83e02d50a2e91ae",
+        "x-ms-date": "Mon, 04 Apr 2022 05:11:42 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": {
-        "TableName": "testtableQFzD7ph7"
+        "TableName": "testtableNTYzkHKS"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
-        "Date": "Mon, 31 Jan 2022 22:18:10 GMT",
-        "Location": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtableQFzD7ph7\u0027)",
+        "Date": "Mon, 04 Apr 2022 05:11:41 GMT",
+        "Location": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtableNTYzkHKS\u0027)",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d8f39ffda7c3f208995a1e44e8e9ce30",
-        "x-ms-request-id": "c3004053-5002-00a4-4ef0-161518000000",
+        "x-ms-client-request-id": "65b4b8e6e30782aac83e02d50a2e91ae",
+        "x-ms-request-id": "ceda458f-b002-0006-09e2-47a93e000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": {
         "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#Tables/@Element",
-        "TableName": "testtableQFzD7ph7"
+        "TableName": "testtableNTYzkHKS"
       }
     },
     {
@@ -46,44 +46,44 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "1291",
-        "Content-Type": "multipart/mixed; boundary=batch_4de5d911-7f27-46f5-7446-931182878cc9",
+        "Content-Length": "1220",
+        "Content-Type": "multipart/mixed; boundary=batch_7be7f544-43fe-7f13-52ed-a980044e6f7f",
         "DataServiceVersion": "3.0",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "931fcad653e37d8da9ad637c13f66f11",
-        "x-ms-date": "Mon, 31 Jan 2022 22:18:10 GMT",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "47cf2af10c9ea3dea43413193a297e79",
+        "x-ms-date": "Mon, 04 Apr 2022 05:11:42 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
-      "RequestBody": "LS1iYXRjaF80ZGU1ZDkxMS03ZjI3LTQ2ZjUtNzQ0Ni05MzExODI4NzhjYzkNCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfOTdmYjcxN2EtYTdiZi0xOTYwLWQyYTktMDFlMTgwMmZkOGY3DQoNCi0tY2hhbmdlc2V0Xzk3ZmI3MTdhLWE3YmYtMTk2MC1kMmE5LTAxZTE4MDJmZDhmNw0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUE9TVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZVFGekQ3cGg3PyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0DQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpQcmVmZXI6IHJldHVybi1uby1jb250ZW50DQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bWluaW1hbG1ldGFkYXRhDQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bm9tZXRhZGF0YQ0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF85N2ZiNzE3YS1hN2JmLTE5NjAtZDJhOS0wMWUxODAyZmQ4ZjcNCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBPU1QgaHR0cHM6Ly9qb2xvdnRhYmxlc3ByaW0udGFibGUuY29yZS53aW5kb3dzLm5ldC90ZXN0dGFibGVRRnpEN3BoNz8kZm9ybWF0PWFwcGxpY2F0aW9uJTJGanNvbiUzQm9kYXRhJTNEbWluaW1hbG1ldGFkYXRhIEhUVFAvMS4xDQpIb3N0OiBqb2xvdnRhYmxlc3ByaW0udGFibGUuY29yZS53aW5kb3dzLm5ldA0KeC1tcy12ZXJzaW9uOiAyMDE5LTAyLTAyDQpEYXRhU2VydmljZVZlcnNpb246IDMuMA0KUHJlZmVyOiByZXR1cm4tbm8tY29udGVudA0KQWNjZXB0OiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW1pbmltYWxtZXRhZGF0YQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW5vbWV0YWRhdGENCg0KeyJWYWx1ZSI6IkJhciIsIlBhcnRpdGlvbktleSI6IlBLIiwiUm93S2V5IjoiUksxIn0NCi0tY2hhbmdlc2V0Xzk3ZmI3MTdhLWE3YmYtMTk2MC1kMmE5LTAxZTE4MDJmZDhmNy0tDQoNCi0tYmF0Y2hfNGRlNWQ5MTEtN2YyNy00NmY1LTc0NDYtOTMxMTgyODc4Y2M5LS0NCg==",
+      "RequestBody": "LS1iYXRjaF83YmU3ZjU0NC00M2ZlLTdmMTMtNTJlZC1hOTgwMDQ0ZTZmN2YNCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfZTBjYmE5NTQtZTJhMS00YzMwLWZkMzMtZDVmZmFhYzAzNWM2DQoNCi0tY2hhbmdlc2V0X2UwY2JhOTU0LWUyYTEtNGMzMC1mZDMzLWQ1ZmZhYWMwMzVjNg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUFVUIGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvcmUud2luZG93cy5uZXQvdGVzdHRhYmxlTlRZemtIS1MoUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSycpPyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0DQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb24NCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbg0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF9lMGNiYTk1NC1lMmExLTRjMzAtZmQzMy1kNWZmYWFjMDM1YzYNCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBVVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZU5UWXprSEtTKFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJyk/JGZvcm1hdD1hcHBsaWNhdGlvbiUyRmpzb24lM0JvZGF0YSUzRG1pbmltYWxtZXRhZGF0YSBIVFRQLzEuMQ0KSG9zdDogam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvcmUud2luZG93cy5uZXQNCngtbXMtdmVyc2lvbjogMjAxOS0wMi0wMg0KRGF0YVNlcnZpY2VWZXJzaW9uOiAzLjANCkFjY2VwdDogYXBwbGljYXRpb24vanNvbg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uDQoNCnsiVmFsdWUiOiJCYXIiLCJQYXJ0aXRpb25LZXkiOiJQSyIsIlJvd0tleSI6IlJLMSJ9DQotLWNoYW5nZXNldF9lMGNiYTk1NC1lMmExLTRjMzAtZmQzMy1kNWZmYWFjMDM1YzYtLQ0KDQotLWJhdGNoXzdiZTdmNTQ0LTQzZmUtN2YxMy01MmVkLWE5ODAwNDRlNmY3Zi0tDQo=",
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Type": "multipart/mixed; boundary=batchresponse_7cec1734-902f-4a99-9f05-08c1d6c91d69",
-        "Date": "Mon, 31 Jan 2022 22:18:10 GMT",
+        "Content-Type": "multipart/mixed; boundary=batchresponse_875b46ed-4dee-4247-874f-eeddddf805ac",
+        "Date": "Mon, 04 Apr 2022 05:11:41 GMT",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "931fcad653e37d8da9ad637c13f66f11",
-        "x-ms-request-id": "c3004057-5002-00a4-51f0-161518000000",
+        "x-ms-client-request-id": "47cf2af10c9ea3dea43413193a297e79",
+        "x-ms-request-id": "ceda4592-b002-0006-0ae2-47a93e000000",
         "x-ms-version": "2019-02-02"
       },
-      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlXzdjZWMxNzM0LTkwMmYtNGE5OS05ZjA1LTA4YzFkNmM5MWQ2OQ0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlX2NmZWE2NjlmLTQ3NzMtNGQ4Ny05YTBmLWY0YjNjNTlhOTJkOQ0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2NmZWE2NjlmLTQ3NzMtNGQ4Ny05YTBmLWY0YjNjNTlhOTJkOQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpQcmVmZXJlbmNlLUFwcGxpZWQ6IHJldHVybi1uby1jb250ZW50DQpEYXRhU2VydmljZVZlcnNpb246IDMuMDsNCkxvY2F0aW9uOiBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZVFGekQ3cGg3KFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksnKQ0KRGF0YVNlcnZpY2VJZDogaHR0cHM6Ly9qb2xvdnRhYmxlc3ByaW0udGFibGUuY29yZS53aW5kb3dzLm5ldC90ZXN0dGFibGVRRnpEN3BoNyhQYXJ0aXRpb25LZXk9J1BLJyxSb3dLZXk9J1JLJykNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDEtMzFUMjIlM0ExOCUzQTEwLjg1NDEwNDZaJyINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2NmZWE2NjlmLTQ3NzMtNGQ4Ny05YTBmLWY0YjNjNTlhOTJkOQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpQcmVmZXJlbmNlLUFwcGxpZWQ6IHJldHVybi1uby1jb250ZW50DQpEYXRhU2VydmljZVZlcnNpb246IDMuMDsNCkxvY2F0aW9uOiBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZVFGekQ3cGg3KFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJykNCkRhdGFTZXJ2aWNlSWQ6IGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvcmUud2luZG93cy5uZXQvdGVzdHRhYmxlUUZ6RDdwaDcoUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSzEnKQ0KRVRhZzogVy8iZGF0ZXRpbWUnMjAyMi0wMS0zMVQyMiUzQTE4JTNBMTAuODU0MTA0NlonIg0KDQoNCi0tY2hhbmdlc2V0cmVzcG9uc2VfY2ZlYTY2OWYtNDc3My00ZDg3LTlhMGYtZjRiM2M1OWE5MmQ5LS0NCi0tYmF0Y2hyZXNwb25zZV83Y2VjMTczNC05MDJmLTRhOTktOWYwNS0wOGMxZDZjOTFkNjktLQ0K"
+      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlXzg3NWI0NmVkLTRkZWUtNDI0Ny04NzRmLWVlZGRkZGY4MDVhYw0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlX2E3ODI4NzU0LTIxNzYtNDc0Ni1iOWE0LTMyODNiNDQ2MGMxYQ0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2E3ODI4NzU0LTIxNzYtNDc0Ni1iOWE0LTMyODNiNDQ2MGMxYQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpEYXRhU2VydmljZVZlcnNpb246IDEuMDsNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDQtMDRUMDUlM0ExMSUzQTQyLjU2MDA3NTVaJyINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2E3ODI4NzU0LTIxNzYtNDc0Ni1iOWE0LTMyODNiNDQ2MGMxYQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpEYXRhU2VydmljZVZlcnNpb246IDEuMDsNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDQtMDRUMDUlM0ExMSUzQTQyLjU2MDA3NTVaJyINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2E3ODI4NzU0LTIxNzYtNDc0Ni1iOWE0LTMyODNiNDQ2MGMxYS0tDQotLWJhdGNocmVzcG9uc2VfODc1YjQ2ZWQtNGRlZS00MjQ3LTg3NGYtZWVkZGRkZjgwNWFjLS0NCg=="
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtableQFzD7ph7(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtableNTYzkHKS(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata=minimalmetadata",
         "Authorization": "Sanitized",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-7555a7b14ad7e052524bcf1ac5618fe9-4d9465fc6e0a1e7d-00",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "76ca55ce37ed6a7079cc7a7e7d14c545",
-        "x-ms-date": "Mon, 31 Jan 2022 22:18:10 GMT",
+        "traceparent": "00-bb412402068b607343e8bc05b78f1d66-ee82a14d69bbdfe8-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "608183cfb162610cc49a7dcb6d13d592",
+        "x-ms-date": "Mon, 04 Apr 2022 05:11:42 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -92,38 +92,38 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
-        "Date": "Mon, 31 Jan 2022 22:18:10 GMT",
-        "ETag": "W/\u0022datetime\u00272022-01-31T22%3A18%3A10.8541046Z\u0027\u0022",
+        "Date": "Mon, 04 Apr 2022 05:11:41 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T05%3A11%3A42.5600755Z\u0027\u0022",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "76ca55ce37ed6a7079cc7a7e7d14c545",
-        "x-ms-request-id": "c3004058-5002-00a4-52f0-161518000000",
+        "x-ms-client-request-id": "608183cfb162610cc49a7dcb6d13d592",
+        "x-ms-request-id": "ceda4593-b002-0006-0be2-47a93e000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": {
-        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtableQFzD7ph7/@Element",
-        "odata.etag": "W/\u0022datetime\u00272022-01-31T22%3A18%3A10.8541046Z\u0027\u0022",
+        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtableNTYzkHKS/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T05%3A11%3A42.5600755Z\u0027\u0022",
         "PartitionKey": "PK",
         "RowKey": "RK",
-        "Timestamp": "2022-01-31T22:18:10.8541046Z",
+        "Timestamp": "2022-04-04T05:11:42.5600755Z",
         "Value": "Foo"
       }
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtableQFzD7ph7(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtableNTYzkHKS(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata=minimalmetadata",
         "Authorization": "Sanitized",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-2f1c8700f47ff386d340c793a05aadc2-c51f3b797d2fc7f5-00",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "b83a9b6ef96826e6e37ded1143e305dc",
-        "x-ms-date": "Mon, 31 Jan 2022 22:18:10 GMT",
+        "traceparent": "00-ab5a7f7c35311c5f69031a0c592e4430-7029873562709502-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "da8fe3b8277e48e1ca283b6dce1712d3",
+        "x-ms-date": "Mon, 04 Apr 2022 05:11:42 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -132,37 +132,37 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
-        "Date": "Mon, 31 Jan 2022 22:18:10 GMT",
-        "ETag": "W/\u0022datetime\u00272022-01-31T22%3A18%3A10.8541046Z\u0027\u0022",
+        "Date": "Mon, 04 Apr 2022 05:11:41 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T05%3A11%3A42.5600755Z\u0027\u0022",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "b83a9b6ef96826e6e37ded1143e305dc",
-        "x-ms-request-id": "c300405b-5002-00a4-55f0-161518000000",
+        "x-ms-client-request-id": "da8fe3b8277e48e1ca283b6dce1712d3",
+        "x-ms-request-id": "ceda4594-b002-0006-0ce2-47a93e000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": {
-        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtableQFzD7ph7/@Element",
-        "odata.etag": "W/\u0022datetime\u00272022-01-31T22%3A18%3A10.8541046Z\u0027\u0022",
+        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtableNTYzkHKS/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T05%3A11%3A42.5600755Z\u0027\u0022",
         "PartitionKey": "PK",
         "RowKey": "RK1",
-        "Timestamp": "2022-01-31T22:18:10.8541046Z",
+        "Timestamp": "2022-04-04T05:11:42.5600755Z",
         "Value": "Bar"
       }
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtableQFzD7ph7\u0027)",
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtableNTYzkHKS\u0027)",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-9f96c74a915c022c27c56d166229bf08-ffb8773a42dcee0c-00",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "2b13f03961659f095ab51916d90fff94",
-        "x-ms-date": "Mon, 31 Jan 2022 22:18:10 GMT",
+        "traceparent": "00-9aa52d308392bd69ceb90c150740fdc5-abe86092c533f7ef-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "26305bb5d43e40631d6e82038e133591",
+        "x-ms-date": "Mon, 04 Apr 2022 05:11:42 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -171,21 +171,21 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Mon, 31 Jan 2022 22:18:10 GMT",
+        "Date": "Mon, 04 Apr 2022 05:11:41 GMT",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2b13f03961659f095ab51916d90fff94",
-        "x-ms-request-id": "c300405c-5002-00a4-56f0-161518000000",
+        "x-ms-client-request-id": "26305bb5d43e40631d6e82038e133591",
+        "x-ms-request-id": "ceda4595-b002-0006-0de2-47a93e000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "RandomSeed": "1117263635",
+    "RandomSeed": "358709244",
     "STORAGE_ENDPOINT_SUFFIX": "core.windows.net",
     "TABLES_PRIMARY_STORAGE_ACCOUNT_KEY": "Kg==",
     "TABLES_STORAGE_ACCOUNT_NAME": "jolovtablesprim"

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(False)/CanAddEntityUsingAsyncCollector(%JObjectCamelCase%)Async.json
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(False)/CanAddEntityUsingAsyncCollector(%JObjectCamelCase%)Async.json
@@ -1,0 +1,193 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/Tables?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json; odata=minimalmetadata",
+        "Authorization": "Sanitized",
+        "Content-Length": "33",
+        "Content-Type": "application/json; odata=nometadata",
+        "DataServiceVersion": "3.0",
+        "traceparent": "00-342935ddadda2f6b29c2dc662b550023-19fd53966038b2fc-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "8325a3ec6efa0c1f1ebe1a47e804c2bd",
+        "x-ms-date": "Mon, 04 Apr 2022 04:36:25 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": {
+        "TableName": "testtableLwUu5dzl"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Mon, 04 Apr 2022 04:36:25 GMT",
+        "Location": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtableLwUu5dzl\u0027)",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "8325a3ec6efa0c1f1ebe1a47e804c2bd",
+        "x-ms-request-id": "df306ecc-f002-00cc-6edd-47f5b7000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#Tables/@Element",
+        "TableName": "testtableLwUu5dzl"
+      }
+    },
+    {
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/$batch",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "1291",
+        "Content-Type": "multipart/mixed; boundary=batch_4d20b060-ae94-adbc-c750-0758c90da3ee",
+        "DataServiceVersion": "3.0",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ec54bd8a5ffd3e1fe778bcaa67c74210",
+        "x-ms-date": "Mon, 04 Apr 2022 04:36:25 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "LS1iYXRjaF80ZDIwYjA2MC1hZTk0LWFkYmMtYzc1MC0wNzU4YzkwZGEzZWUNCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfNzAwMTc3OTUtZDZkZC04ZDdjLTdiMDYtNjViNzdjZDhkM2YyDQoNCi0tY2hhbmdlc2V0XzcwMDE3Nzk1LWQ2ZGQtOGQ3Yy03YjA2LTY1Yjc3Y2Q4ZDNmMg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUE9TVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZUx3VXU1ZHpsPyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0DQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpQcmVmZXI6IHJldHVybi1uby1jb250ZW50DQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bWluaW1hbG1ldGFkYXRhDQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bm9tZXRhZGF0YQ0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF83MDAxNzc5NS1kNmRkLThkN2MtN2IwNi02NWI3N2NkOGQzZjINCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBPU1QgaHR0cHM6Ly9qb2xvdnRhYmxlc3ByaW0udGFibGUuY29yZS53aW5kb3dzLm5ldC90ZXN0dGFibGVMd1V1NWR6bD8kZm9ybWF0PWFwcGxpY2F0aW9uJTJGanNvbiUzQm9kYXRhJTNEbWluaW1hbG1ldGFkYXRhIEhUVFAvMS4xDQpIb3N0OiBqb2xvdnRhYmxlc3ByaW0udGFibGUuY29yZS53aW5kb3dzLm5ldA0KeC1tcy12ZXJzaW9uOiAyMDE5LTAyLTAyDQpEYXRhU2VydmljZVZlcnNpb246IDMuMA0KUHJlZmVyOiByZXR1cm4tbm8tY29udGVudA0KQWNjZXB0OiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW1pbmltYWxtZXRhZGF0YQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW5vbWV0YWRhdGENCg0KeyJWYWx1ZSI6IkJhciIsIlBhcnRpdGlvbktleSI6IlBLIiwiUm93S2V5IjoiUksxIn0NCi0tY2hhbmdlc2V0XzcwMDE3Nzk1LWQ2ZGQtOGQ3Yy03YjA2LTY1Yjc3Y2Q4ZDNmMi0tDQoNCi0tYmF0Y2hfNGQyMGIwNjAtYWU5NC1hZGJjLWM3NTAtMDc1OGM5MGRhM2VlLS0NCg==",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "multipart/mixed; boundary=batchresponse_61b001e2-bdb8-4659-957a-6016854722e5",
+        "Date": "Mon, 04 Apr 2022 04:36:25 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "ec54bd8a5ffd3e1fe778bcaa67c74210",
+        "x-ms-request-id": "df306ed0-f002-00cc-6fdd-47f5b7000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlXzYxYjAwMWUyLWJkYjgtNDY1OS05NTdhLTYwMTY4NTQ3MjJlNQ0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlX2VhMTI0NWU4LWRlOWEtNDZlNy05MDkzLTc3ZGYwZmE2YTg5OQ0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2VhMTI0NWU4LWRlOWEtNDZlNy05MDkzLTc3ZGYwZmE2YTg5OQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpQcmVmZXJlbmNlLUFwcGxpZWQ6IHJldHVybi1uby1jb250ZW50DQpEYXRhU2VydmljZVZlcnNpb246IDMuMDsNCkxvY2F0aW9uOiBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZUx3VXU1ZHpsKFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksnKQ0KRGF0YVNlcnZpY2VJZDogaHR0cHM6Ly9qb2xvdnRhYmxlc3ByaW0udGFibGUuY29yZS53aW5kb3dzLm5ldC90ZXN0dGFibGVMd1V1NWR6bChQYXJ0aXRpb25LZXk9J1BLJyxSb3dLZXk9J1JLJykNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDQtMDRUMDQlM0EzNiUzQTI1LjQ3OTI5MTRaJyINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2VhMTI0NWU4LWRlOWEtNDZlNy05MDkzLTc3ZGYwZmE2YTg5OQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpQcmVmZXJlbmNlLUFwcGxpZWQ6IHJldHVybi1uby1jb250ZW50DQpEYXRhU2VydmljZVZlcnNpb246IDMuMDsNCkxvY2F0aW9uOiBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZUx3VXU1ZHpsKFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJykNCkRhdGFTZXJ2aWNlSWQ6IGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvcmUud2luZG93cy5uZXQvdGVzdHRhYmxlTHdVdTVkemwoUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSzEnKQ0KRVRhZzogVy8iZGF0ZXRpbWUnMjAyMi0wNC0wNFQwNCUzQTM2JTNBMjUuNDc5MjkxNFonIg0KDQoNCi0tY2hhbmdlc2V0cmVzcG9uc2VfZWExMjQ1ZTgtZGU5YS00NmU3LTkwOTMtNzdkZjBmYTZhODk5LS0NCi0tYmF0Y2hyZXNwb25zZV82MWIwMDFlMi1iZGI4LTQ2NTktOTU3YS02MDE2ODU0NzIyZTUtLQ0K"
+    },
+    {
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtableLwUu5dzl(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json; odata=minimalmetadata",
+        "Authorization": "Sanitized",
+        "DataServiceVersion": "3.0",
+        "traceparent": "00-41ef3e4ea7ef34a9606486eb3af3f37c-af881e1f07981009-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "70b12b1b52038adf3393d18d480431ee",
+        "x-ms-date": "Mon, 04 Apr 2022 04:36:25 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Mon, 04 Apr 2022 04:36:25 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A36%3A25.4792914Z\u0027\u0022",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "70b12b1b52038adf3393d18d480431ee",
+        "x-ms-request-id": "df306ed1-f002-00cc-70dd-47f5b7000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtableLwUu5dzl/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T04%3A36%3A25.4792914Z\u0027\u0022",
+        "PartitionKey": "PK",
+        "RowKey": "RK",
+        "Timestamp": "2022-04-04T04:36:25.4792914Z",
+        "Value": "Foo"
+      }
+    },
+    {
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtableLwUu5dzl(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json; odata=minimalmetadata",
+        "Authorization": "Sanitized",
+        "DataServiceVersion": "3.0",
+        "traceparent": "00-4de43fba54a8bc73e5b868ba7ae20468-c6eb98c5c5d2573c-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "0ccd147cb6b836f158c3886519d225b4",
+        "x-ms-date": "Mon, 04 Apr 2022 04:36:25 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Mon, 04 Apr 2022 04:36:25 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A36%3A25.4792914Z\u0027\u0022",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "0ccd147cb6b836f158c3886519d225b4",
+        "x-ms-request-id": "df306ed2-f002-00cc-71dd-47f5b7000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtableLwUu5dzl/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T04%3A36%3A25.4792914Z\u0027\u0022",
+        "PartitionKey": "PK",
+        "RowKey": "RK1",
+        "Timestamp": "2022-04-04T04:36:25.4792914Z",
+        "Value": "Bar"
+      }
+    },
+    {
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtableLwUu5dzl\u0027)",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f92cffa6bb5d2001723880266158b596-bf35a560507c04e9-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "509b54c4622738eeddcab9698d92f5e3",
+        "x-ms-date": "Mon, 04 Apr 2022 04:36:25 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Mon, 04 Apr 2022 04:36:25 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "509b54c4622738eeddcab9698d92f5e3",
+        "x-ms-request-id": "df306ed3-f002-00cc-72dd-47f5b7000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1722533434",
+    "STORAGE_ENDPOINT_SUFFIX": "core.windows.net",
+    "TABLES_PRIMARY_STORAGE_ACCOUNT_KEY": "Kg==",
+    "TABLES_STORAGE_ACCOUNT_NAME": "jolovtablesprim"
+  }
+}

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(False)/CanAddEntityUsingAsyncCollector(%JObjectCamelCase%)Async.json
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(False)/CanAddEntityUsingAsyncCollector(%JObjectCamelCase%)Async.json
@@ -9,35 +9,35 @@
         "Content-Length": "33",
         "Content-Type": "application/json; odata=nometadata",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-342935ddadda2f6b29c2dc662b550023-19fd53966038b2fc-00",
+        "traceparent": "00-9c007e492a2d0576377375aead38037d-72c8723241ed79ed-00",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "8325a3ec6efa0c1f1ebe1a47e804c2bd",
-        "x-ms-date": "Mon, 04 Apr 2022 04:36:25 GMT",
+        "x-ms-client-request-id": "bdcdcf317f7d0fbc2b9106bbefe5c238",
+        "x-ms-date": "Mon, 04 Apr 2022 04:57:48 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": {
-        "TableName": "testtableLwUu5dzl"
+        "TableName": "testtableLGYgRQdF"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
-        "Date": "Mon, 04 Apr 2022 04:36:25 GMT",
-        "Location": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtableLwUu5dzl\u0027)",
+        "Date": "Mon, 04 Apr 2022 04:57:48 GMT",
+        "Location": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtableLGYgRQdF\u0027)",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8325a3ec6efa0c1f1ebe1a47e804c2bd",
-        "x-ms-request-id": "df306ecc-f002-00cc-6edd-47f5b7000000",
+        "x-ms-client-request-id": "bdcdcf317f7d0fbc2b9106bbefe5c238",
+        "x-ms-request-id": "897d4845-f002-0038-58e0-473e41000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": {
         "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#Tables/@Element",
-        "TableName": "testtableLwUu5dzl"
+        "TableName": "testtableLGYgRQdF"
       }
     },
     {
@@ -46,44 +46,44 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "1291",
-        "Content-Type": "multipart/mixed; boundary=batch_4d20b060-ae94-adbc-c750-0758c90da3ee",
+        "Content-Length": "1220",
+        "Content-Type": "multipart/mixed; boundary=batch_f3b7ead0-7e3a-071a-4a78-e9813ffb8354",
         "DataServiceVersion": "3.0",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "ec54bd8a5ffd3e1fe778bcaa67c74210",
-        "x-ms-date": "Mon, 04 Apr 2022 04:36:25 GMT",
+        "x-ms-client-request-id": "cab1493c7169b321b4c57205953bd02f",
+        "x-ms-date": "Mon, 04 Apr 2022 04:57:49 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
-      "RequestBody": "LS1iYXRjaF80ZDIwYjA2MC1hZTk0LWFkYmMtYzc1MC0wNzU4YzkwZGEzZWUNCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfNzAwMTc3OTUtZDZkZC04ZDdjLTdiMDYtNjViNzdjZDhkM2YyDQoNCi0tY2hhbmdlc2V0XzcwMDE3Nzk1LWQ2ZGQtOGQ3Yy03YjA2LTY1Yjc3Y2Q4ZDNmMg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUE9TVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZUx3VXU1ZHpsPyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0DQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpQcmVmZXI6IHJldHVybi1uby1jb250ZW50DQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bWluaW1hbG1ldGFkYXRhDQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bm9tZXRhZGF0YQ0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF83MDAxNzc5NS1kNmRkLThkN2MtN2IwNi02NWI3N2NkOGQzZjINCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBPU1QgaHR0cHM6Ly9qb2xvdnRhYmxlc3ByaW0udGFibGUuY29yZS53aW5kb3dzLm5ldC90ZXN0dGFibGVMd1V1NWR6bD8kZm9ybWF0PWFwcGxpY2F0aW9uJTJGanNvbiUzQm9kYXRhJTNEbWluaW1hbG1ldGFkYXRhIEhUVFAvMS4xDQpIb3N0OiBqb2xvdnRhYmxlc3ByaW0udGFibGUuY29yZS53aW5kb3dzLm5ldA0KeC1tcy12ZXJzaW9uOiAyMDE5LTAyLTAyDQpEYXRhU2VydmljZVZlcnNpb246IDMuMA0KUHJlZmVyOiByZXR1cm4tbm8tY29udGVudA0KQWNjZXB0OiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW1pbmltYWxtZXRhZGF0YQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW5vbWV0YWRhdGENCg0KeyJWYWx1ZSI6IkJhciIsIlBhcnRpdGlvbktleSI6IlBLIiwiUm93S2V5IjoiUksxIn0NCi0tY2hhbmdlc2V0XzcwMDE3Nzk1LWQ2ZGQtOGQ3Yy03YjA2LTY1Yjc3Y2Q4ZDNmMi0tDQoNCi0tYmF0Y2hfNGQyMGIwNjAtYWU5NC1hZGJjLWM3NTAtMDc1OGM5MGRhM2VlLS0NCg==",
+      "RequestBody": "LS1iYXRjaF9mM2I3ZWFkMC03ZTNhLTA3MWEtNGE3OC1lOTgxM2ZmYjgzNTQNCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfNmQyYzJlNzQtOGQyNy03YWQzLTE3MWEtNGY0NTEwZGNjMmFiDQoNCi0tY2hhbmdlc2V0XzZkMmMyZTc0LThkMjctN2FkMy0xNzFhLTRmNDUxMGRjYzJhYg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUFVUIGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvcmUud2luZG93cy5uZXQvdGVzdHRhYmxlTEdZZ1JRZEYoUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSycpPyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0DQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb24NCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbg0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF82ZDJjMmU3NC04ZDI3LTdhZDMtMTcxYS00ZjQ1MTBkY2MyYWINCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBVVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZUxHWWdSUWRGKFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJyk/JGZvcm1hdD1hcHBsaWNhdGlvbiUyRmpzb24lM0JvZGF0YSUzRG1pbmltYWxtZXRhZGF0YSBIVFRQLzEuMQ0KSG9zdDogam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvcmUud2luZG93cy5uZXQNCngtbXMtdmVyc2lvbjogMjAxOS0wMi0wMg0KRGF0YVNlcnZpY2VWZXJzaW9uOiAzLjANCkFjY2VwdDogYXBwbGljYXRpb24vanNvbg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uDQoNCnsiVmFsdWUiOiJCYXIiLCJQYXJ0aXRpb25LZXkiOiJQSyIsIlJvd0tleSI6IlJLMSJ9DQotLWNoYW5nZXNldF82ZDJjMmU3NC04ZDI3LTdhZDMtMTcxYS00ZjQ1MTBkY2MyYWItLQ0KDQotLWJhdGNoX2YzYjdlYWQwLTdlM2EtMDcxYS00YTc4LWU5ODEzZmZiODM1NC0tDQo=",
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Type": "multipart/mixed; boundary=batchresponse_61b001e2-bdb8-4659-957a-6016854722e5",
-        "Date": "Mon, 04 Apr 2022 04:36:25 GMT",
+        "Content-Type": "multipart/mixed; boundary=batchresponse_055fc9e9-68ba-41f6-b64f-b62f0de3c855",
+        "Date": "Mon, 04 Apr 2022 04:57:48 GMT",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "ec54bd8a5ffd3e1fe778bcaa67c74210",
-        "x-ms-request-id": "df306ed0-f002-00cc-6fdd-47f5b7000000",
+        "x-ms-client-request-id": "cab1493c7169b321b4c57205953bd02f",
+        "x-ms-request-id": "897d484b-f002-0038-59e0-473e41000000",
         "x-ms-version": "2019-02-02"
       },
-      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlXzYxYjAwMWUyLWJkYjgtNDY1OS05NTdhLTYwMTY4NTQ3MjJlNQ0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlX2VhMTI0NWU4LWRlOWEtNDZlNy05MDkzLTc3ZGYwZmE2YTg5OQ0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2VhMTI0NWU4LWRlOWEtNDZlNy05MDkzLTc3ZGYwZmE2YTg5OQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpQcmVmZXJlbmNlLUFwcGxpZWQ6IHJldHVybi1uby1jb250ZW50DQpEYXRhU2VydmljZVZlcnNpb246IDMuMDsNCkxvY2F0aW9uOiBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZUx3VXU1ZHpsKFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksnKQ0KRGF0YVNlcnZpY2VJZDogaHR0cHM6Ly9qb2xvdnRhYmxlc3ByaW0udGFibGUuY29yZS53aW5kb3dzLm5ldC90ZXN0dGFibGVMd1V1NWR6bChQYXJ0aXRpb25LZXk9J1BLJyxSb3dLZXk9J1JLJykNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDQtMDRUMDQlM0EzNiUzQTI1LjQ3OTI5MTRaJyINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2VhMTI0NWU4LWRlOWEtNDZlNy05MDkzLTc3ZGYwZmE2YTg5OQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpQcmVmZXJlbmNlLUFwcGxpZWQ6IHJldHVybi1uby1jb250ZW50DQpEYXRhU2VydmljZVZlcnNpb246IDMuMDsNCkxvY2F0aW9uOiBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZUx3VXU1ZHpsKFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJykNCkRhdGFTZXJ2aWNlSWQ6IGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvcmUud2luZG93cy5uZXQvdGVzdHRhYmxlTHdVdTVkemwoUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSzEnKQ0KRVRhZzogVy8iZGF0ZXRpbWUnMjAyMi0wNC0wNFQwNCUzQTM2JTNBMjUuNDc5MjkxNFonIg0KDQoNCi0tY2hhbmdlc2V0cmVzcG9uc2VfZWExMjQ1ZTgtZGU5YS00NmU3LTkwOTMtNzdkZjBmYTZhODk5LS0NCi0tYmF0Y2hyZXNwb25zZV82MWIwMDFlMi1iZGI4LTQ2NTktOTU3YS02MDE2ODU0NzIyZTUtLQ0K"
+      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlXzA1NWZjOWU5LTY4YmEtNDFmNi1iNjRmLWI2MmYwZGUzYzg1NQ0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlX2NmNTI0ZTA3LTcyNjAtNGE3Zi1hZDU5LWU4NDhiYzAyNGU1Nw0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2NmNTI0ZTA3LTcyNjAtNGE3Zi1hZDU5LWU4NDhiYzAyNGU1Nw0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpEYXRhU2VydmljZVZlcnNpb246IDEuMDsNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDQtMDRUMDQlM0E1NyUzQTQ5LjExNTQ1MzZaJyINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2NmNTI0ZTA3LTcyNjAtNGE3Zi1hZDU5LWU4NDhiYzAyNGU1Nw0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpEYXRhU2VydmljZVZlcnNpb246IDEuMDsNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDQtMDRUMDQlM0E1NyUzQTQ5LjExNTQ1MzZaJyINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2NmNTI0ZTA3LTcyNjAtNGE3Zi1hZDU5LWU4NDhiYzAyNGU1Ny0tDQotLWJhdGNocmVzcG9uc2VfMDU1ZmM5ZTktNjhiYS00MWY2LWI2NGYtYjYyZjBkZTNjODU1LS0NCg=="
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtableLwUu5dzl(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtableLGYgRQdF(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata=minimalmetadata",
         "Authorization": "Sanitized",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-41ef3e4ea7ef34a9606486eb3af3f37c-af881e1f07981009-00",
+        "traceparent": "00-d7fa582c2f83a7e7155768457cb877dc-0ad6b5c5854b1d4e-00",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "70b12b1b52038adf3393d18d480431ee",
-        "x-ms-date": "Mon, 04 Apr 2022 04:36:25 GMT",
+        "x-ms-client-request-id": "c146b20d55b94211163cdc202fd5f66e",
+        "x-ms-date": "Mon, 04 Apr 2022 04:57:49 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -92,38 +92,38 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
-        "Date": "Mon, 04 Apr 2022 04:36:25 GMT",
-        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A36%3A25.4792914Z\u0027\u0022",
+        "Date": "Mon, 04 Apr 2022 04:57:48 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A57%3A49.1154536Z\u0027\u0022",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "70b12b1b52038adf3393d18d480431ee",
-        "x-ms-request-id": "df306ed1-f002-00cc-70dd-47f5b7000000",
+        "x-ms-client-request-id": "c146b20d55b94211163cdc202fd5f66e",
+        "x-ms-request-id": "897d484e-f002-0038-5ae0-473e41000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": {
-        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtableLwUu5dzl/@Element",
-        "odata.etag": "W/\u0022datetime\u00272022-04-04T04%3A36%3A25.4792914Z\u0027\u0022",
+        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtableLGYgRQdF/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T04%3A57%3A49.1154536Z\u0027\u0022",
         "PartitionKey": "PK",
         "RowKey": "RK",
-        "Timestamp": "2022-04-04T04:36:25.4792914Z",
+        "Timestamp": "2022-04-04T04:57:49.1154536Z",
         "Value": "Foo"
       }
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtableLwUu5dzl(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtableLGYgRQdF(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata=minimalmetadata",
         "Authorization": "Sanitized",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-4de43fba54a8bc73e5b868ba7ae20468-c6eb98c5c5d2573c-00",
+        "traceparent": "00-fb3fe89d7a66a8684b216c076f0e25f0-f6340af7529c2483-00",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "0ccd147cb6b836f158c3886519d225b4",
-        "x-ms-date": "Mon, 04 Apr 2022 04:36:25 GMT",
+        "x-ms-client-request-id": "f5443eb6b84a02eb0d79b8611acee5db",
+        "x-ms-date": "Mon, 04 Apr 2022 04:57:49 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -132,37 +132,37 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
-        "Date": "Mon, 04 Apr 2022 04:36:25 GMT",
-        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A36%3A25.4792914Z\u0027\u0022",
+        "Date": "Mon, 04 Apr 2022 04:57:48 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A57%3A49.1154536Z\u0027\u0022",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "0ccd147cb6b836f158c3886519d225b4",
-        "x-ms-request-id": "df306ed2-f002-00cc-71dd-47f5b7000000",
+        "x-ms-client-request-id": "f5443eb6b84a02eb0d79b8611acee5db",
+        "x-ms-request-id": "897d4850-f002-0038-5be0-473e41000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": {
-        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtableLwUu5dzl/@Element",
-        "odata.etag": "W/\u0022datetime\u00272022-04-04T04%3A36%3A25.4792914Z\u0027\u0022",
+        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtableLGYgRQdF/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T04%3A57%3A49.1154536Z\u0027\u0022",
         "PartitionKey": "PK",
         "RowKey": "RK1",
-        "Timestamp": "2022-04-04T04:36:25.4792914Z",
+        "Timestamp": "2022-04-04T04:57:49.1154536Z",
         "Value": "Bar"
       }
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtableLwUu5dzl\u0027)",
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtableLGYgRQdF\u0027)",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f92cffa6bb5d2001723880266158b596-bf35a560507c04e9-00",
+        "traceparent": "00-0143892a8f2aaca28e9de144cf4e7363-89974f43b1213589-00",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "509b54c4622738eeddcab9698d92f5e3",
-        "x-ms-date": "Mon, 04 Apr 2022 04:36:25 GMT",
+        "x-ms-client-request-id": "5e371f4a0096e7f2386fb32c950084de",
+        "x-ms-date": "Mon, 04 Apr 2022 04:57:49 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -171,21 +171,21 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Mon, 04 Apr 2022 04:36:25 GMT",
+        "Date": "Mon, 04 Apr 2022 04:57:48 GMT",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "509b54c4622738eeddcab9698d92f5e3",
-        "x-ms-request-id": "df306ed3-f002-00cc-72dd-47f5b7000000",
+        "x-ms-client-request-id": "5e371f4a0096e7f2386fb32c950084de",
+        "x-ms-request-id": "897d4852-f002-0038-5ce0-473e41000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "RandomSeed": "1722533434",
+    "RandomSeed": "1442267327",
     "STORAGE_ENDPOINT_SUFFIX": "core.windows.net",
     "TABLES_PRIMARY_STORAGE_ACCOUNT_KEY": "Kg==",
     "TABLES_STORAGE_ACCOUNT_NAME": "jolovtablesprim"

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(False)/CanAddEntityUsingCollector(%JObject%)Async.json
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(False)/CanAddEntityUsingCollector(%JObject%)Async.json
@@ -9,35 +9,35 @@
         "Content-Length": "33",
         "Content-Type": "application/json; odata=nometadata",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-da95b13b67b1aeab5cb432fb0269502d-8a034b2e3992be72-00",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "f43a5278c5e7605b57d50f5e91110e4c",
-        "x-ms-date": "Mon, 31 Jan 2022 22:18:12 GMT",
+        "traceparent": "00-e7a68e1fdf8ae8a36b01c8a8d7e1fb01-85a25a89bd38d6e0-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "817db501179813b686d1bd24c4452c65",
+        "x-ms-date": "Mon, 04 Apr 2022 05:11:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": {
-        "TableName": "testtablerKk6aAZ4"
+        "TableName": "testtablecAB7xosj"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
-        "Date": "Mon, 31 Jan 2022 22:18:12 GMT",
-        "Location": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtablerKk6aAZ4\u0027)",
+        "Date": "Mon, 04 Apr 2022 05:11:42 GMT",
+        "Location": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtablecAB7xosj\u0027)",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f43a5278c5e7605b57d50f5e91110e4c",
-        "x-ms-request-id": "c3004090-5002-00a4-04f0-161518000000",
+        "x-ms-client-request-id": "817db501179813b686d1bd24c4452c65",
+        "x-ms-request-id": "ceda4596-b002-0006-0ee2-47a93e000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": {
         "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#Tables/@Element",
-        "TableName": "testtablerKk6aAZ4"
+        "TableName": "testtablecAB7xosj"
       }
     },
     {
@@ -46,44 +46,44 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "1291",
-        "Content-Type": "multipart/mixed; boundary=batch_cf1787de-4675-f458-90d2-621bb52bb948",
+        "Content-Length": "1220",
+        "Content-Type": "multipart/mixed; boundary=batch_16de0f7d-ca93-57ce-6767-5a54e82f6aaf",
         "DataServiceVersion": "3.0",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "2e99ac9f5752319ff94663156240ab2c",
-        "x-ms-date": "Mon, 31 Jan 2022 22:18:12 GMT",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "8ec21a947f1737d0e7251930bd622b57",
+        "x-ms-date": "Mon, 04 Apr 2022 05:11:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
-      "RequestBody": "LS1iYXRjaF9jZjE3ODdkZS00Njc1LWY0NTgtOTBkMi02MjFiYjUyYmI5NDgNCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfOTY0ZjllNjYtYWQ5ZC1iOWZiLWVmMDgtNDI0YTY2MGRiNDE0DQoNCi0tY2hhbmdlc2V0Xzk2NGY5ZTY2LWFkOWQtYjlmYi1lZjA4LTQyNGE2NjBkYjQxNA0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUE9TVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZXJLazZhQVo0PyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0DQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpQcmVmZXI6IHJldHVybi1uby1jb250ZW50DQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bWluaW1hbG1ldGFkYXRhDQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bm9tZXRhZGF0YQ0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF85NjRmOWU2Ni1hZDlkLWI5ZmItZWYwOC00MjRhNjYwZGI0MTQNCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBPU1QgaHR0cHM6Ly9qb2xvdnRhYmxlc3ByaW0udGFibGUuY29yZS53aW5kb3dzLm5ldC90ZXN0dGFibGVyS2s2YUFaND8kZm9ybWF0PWFwcGxpY2F0aW9uJTJGanNvbiUzQm9kYXRhJTNEbWluaW1hbG1ldGFkYXRhIEhUVFAvMS4xDQpIb3N0OiBqb2xvdnRhYmxlc3ByaW0udGFibGUuY29yZS53aW5kb3dzLm5ldA0KeC1tcy12ZXJzaW9uOiAyMDE5LTAyLTAyDQpEYXRhU2VydmljZVZlcnNpb246IDMuMA0KUHJlZmVyOiByZXR1cm4tbm8tY29udGVudA0KQWNjZXB0OiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW1pbmltYWxtZXRhZGF0YQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW5vbWV0YWRhdGENCg0KeyJWYWx1ZSI6IkJhciIsIlBhcnRpdGlvbktleSI6IlBLIiwiUm93S2V5IjoiUksxIn0NCi0tY2hhbmdlc2V0Xzk2NGY5ZTY2LWFkOWQtYjlmYi1lZjA4LTQyNGE2NjBkYjQxNC0tDQoNCi0tYmF0Y2hfY2YxNzg3ZGUtNDY3NS1mNDU4LTkwZDItNjIxYmI1MmJiOTQ4LS0NCg==",
+      "RequestBody": "LS1iYXRjaF8xNmRlMGY3ZC1jYTkzLTU3Y2UtNjc2Ny01YTU0ZTgyZjZhYWYNCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfM2QwYTc0OTYtNzMyNi04YWYwLThiN2QtNTNkZDg1NWY3YzJkDQoNCi0tY2hhbmdlc2V0XzNkMGE3NDk2LTczMjYtOGFmMC04YjdkLTUzZGQ4NTVmN2MyZA0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUFVUIGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvcmUud2luZG93cy5uZXQvdGVzdHRhYmxlY0FCN3hvc2ooUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSycpPyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0DQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb24NCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbg0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF8zZDBhNzQ5Ni03MzI2LThhZjAtOGI3ZC01M2RkODU1ZjdjMmQNCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBVVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZWNBQjd4b3NqKFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJyk/JGZvcm1hdD1hcHBsaWNhdGlvbiUyRmpzb24lM0JvZGF0YSUzRG1pbmltYWxtZXRhZGF0YSBIVFRQLzEuMQ0KSG9zdDogam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvcmUud2luZG93cy5uZXQNCngtbXMtdmVyc2lvbjogMjAxOS0wMi0wMg0KRGF0YVNlcnZpY2VWZXJzaW9uOiAzLjANCkFjY2VwdDogYXBwbGljYXRpb24vanNvbg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uDQoNCnsiVmFsdWUiOiJCYXIiLCJQYXJ0aXRpb25LZXkiOiJQSyIsIlJvd0tleSI6IlJLMSJ9DQotLWNoYW5nZXNldF8zZDBhNzQ5Ni03MzI2LThhZjAtOGI3ZC01M2RkODU1ZjdjMmQtLQ0KDQotLWJhdGNoXzE2ZGUwZjdkLWNhOTMtNTdjZS02NzY3LTVhNTRlODJmNmFhZi0tDQo=",
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Type": "multipart/mixed; boundary=batchresponse_81e2f092-5d4e-490b-9a02-150744bf6c7e",
-        "Date": "Mon, 31 Jan 2022 22:18:12 GMT",
+        "Content-Type": "multipart/mixed; boundary=batchresponse_e29e47d4-12be-4c72-b68e-61d951f63f94",
+        "Date": "Mon, 04 Apr 2022 05:11:42 GMT",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2e99ac9f5752319ff94663156240ab2c",
-        "x-ms-request-id": "c3004092-5002-00a4-05f0-161518000000",
+        "x-ms-client-request-id": "8ec21a947f1737d0e7251930bd622b57",
+        "x-ms-request-id": "ceda4598-b002-0006-0fe2-47a93e000000",
         "x-ms-version": "2019-02-02"
       },
-      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlXzgxZTJmMDkyLTVkNGUtNDkwYi05YTAyLTE1MDc0NGJmNmM3ZQ0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlXzQ5MGMzODIxLTViMjAtNDk0Ni04ZWFhLWE4ZWUxODhmYzAyZQ0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzQ5MGMzODIxLTViMjAtNDk0Ni04ZWFhLWE4ZWUxODhmYzAyZQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpQcmVmZXJlbmNlLUFwcGxpZWQ6IHJldHVybi1uby1jb250ZW50DQpEYXRhU2VydmljZVZlcnNpb246IDMuMDsNCkxvY2F0aW9uOiBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZXJLazZhQVo0KFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksnKQ0KRGF0YVNlcnZpY2VJZDogaHR0cHM6Ly9qb2xvdnRhYmxlc3ByaW0udGFibGUuY29yZS53aW5kb3dzLm5ldC90ZXN0dGFibGVyS2s2YUFaNChQYXJ0aXRpb25LZXk9J1BLJyxSb3dLZXk9J1JLJykNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDEtMzFUMjIlM0ExOCUzQTEyLjgzNzk2NjFaJyINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzQ5MGMzODIxLTViMjAtNDk0Ni04ZWFhLWE4ZWUxODhmYzAyZQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpQcmVmZXJlbmNlLUFwcGxpZWQ6IHJldHVybi1uby1jb250ZW50DQpEYXRhU2VydmljZVZlcnNpb246IDMuMDsNCkxvY2F0aW9uOiBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZXJLazZhQVo0KFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJykNCkRhdGFTZXJ2aWNlSWQ6IGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvcmUud2luZG93cy5uZXQvdGVzdHRhYmxlcktrNmFBWjQoUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSzEnKQ0KRVRhZzogVy8iZGF0ZXRpbWUnMjAyMi0wMS0zMVQyMiUzQTE4JTNBMTIuODM3OTY2MVonIg0KDQoNCi0tY2hhbmdlc2V0cmVzcG9uc2VfNDkwYzM4MjEtNWIyMC00OTQ2LThlYWEtYThlZTE4OGZjMDJlLS0NCi0tYmF0Y2hyZXNwb25zZV84MWUyZjA5Mi01ZDRlLTQ5MGItOWEwMi0xNTA3NDRiZjZjN2UtLQ0K"
+      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlX2UyOWU0N2Q0LTEyYmUtNGM3Mi1iNjhlLTYxZDk1MWY2M2Y5NA0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlXzJjNTI4YjZlLWFhMDAtNDNmYi05OTJiLWI2YWEwZTYxMmFlOQ0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzJjNTI4YjZlLWFhMDAtNDNmYi05OTJiLWI2YWEwZTYxMmFlOQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpEYXRhU2VydmljZVZlcnNpb246IDEuMDsNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDQtMDRUMDUlM0ExMSUzQTQzLjM2NTYyMlonIg0KDQoNCi0tY2hhbmdlc2V0cmVzcG9uc2VfMmM1MjhiNmUtYWEwMC00M2ZiLTk5MmItYjZhYTBlNjEyYWU5DQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2h0dHANCkNvbnRlbnQtVHJhbnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQpIVFRQLzEuMSAyMDQgTm8gQ29udGVudA0KWC1Db250ZW50LVR5cGUtT3B0aW9uczogbm9zbmlmZg0KQ2FjaGUtQ29udHJvbDogbm8tY2FjaGUNCkRhdGFTZXJ2aWNlVmVyc2lvbjogMS4wOw0KRVRhZzogVy8iZGF0ZXRpbWUnMjAyMi0wNC0wNFQwNSUzQTExJTNBNDMuMzY1NjIyWiciDQoNCg0KLS1jaGFuZ2VzZXRyZXNwb25zZV8yYzUyOGI2ZS1hYTAwLTQzZmItOTkyYi1iNmFhMGU2MTJhZTktLQ0KLS1iYXRjaHJlc3BvbnNlX2UyOWU0N2Q0LTEyYmUtNGM3Mi1iNjhlLTYxZDk1MWY2M2Y5NC0tDQo="
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtablerKk6aAZ4(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtablecAB7xosj(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata=minimalmetadata",
         "Authorization": "Sanitized",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-bea4955796424b2e2da861f85246fb21-e7f5c657201457fd-00",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "f2f8c71b77c231ae8b5ddf6d040e8e83",
-        "x-ms-date": "Mon, 31 Jan 2022 22:18:12 GMT",
+        "traceparent": "00-272b8a1e61b4a5dedc130f39db66f74c-65b532869a68570e-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "508e0d66ee3a0a3e1e548a1676f0d208",
+        "x-ms-date": "Mon, 04 Apr 2022 05:11:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -92,38 +92,38 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
-        "Date": "Mon, 31 Jan 2022 22:18:12 GMT",
-        "ETag": "W/\u0022datetime\u00272022-01-31T22%3A18%3A12.8379661Z\u0027\u0022",
+        "Date": "Mon, 04 Apr 2022 05:11:42 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T05%3A11%3A43.365622Z\u0027\u0022",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f2f8c71b77c231ae8b5ddf6d040e8e83",
-        "x-ms-request-id": "c3004094-5002-00a4-07f0-161518000000",
+        "x-ms-client-request-id": "508e0d66ee3a0a3e1e548a1676f0d208",
+        "x-ms-request-id": "ceda4599-b002-0006-10e2-47a93e000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": {
-        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtablerKk6aAZ4/@Element",
-        "odata.etag": "W/\u0022datetime\u00272022-01-31T22%3A18%3A12.8379661Z\u0027\u0022",
+        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtablecAB7xosj/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T05%3A11%3A43.365622Z\u0027\u0022",
         "PartitionKey": "PK",
         "RowKey": "RK",
-        "Timestamp": "2022-01-31T22:18:12.8379661Z",
+        "Timestamp": "2022-04-04T05:11:43.365622Z",
         "Value": "Foo"
       }
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtablerKk6aAZ4(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtablecAB7xosj(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata=minimalmetadata",
         "Authorization": "Sanitized",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-ccab6571fa08f5a837a9de62a3130d09-cd4c45a4f18d6743-00",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "097c4e1d8b920ef6ff1d9c5749e557af",
-        "x-ms-date": "Mon, 31 Jan 2022 22:18:12 GMT",
+        "traceparent": "00-15d3bfb5d5bb1ed1ffa8d621b974824d-a421687177ad9e38-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "cdc02cebdb6c1698a3d3560159c0cc28",
+        "x-ms-date": "Mon, 04 Apr 2022 05:11:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -132,37 +132,37 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
-        "Date": "Mon, 31 Jan 2022 22:18:12 GMT",
-        "ETag": "W/\u0022datetime\u00272022-01-31T22%3A18%3A12.8379661Z\u0027\u0022",
+        "Date": "Mon, 04 Apr 2022 05:11:42 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T05%3A11%3A43.365622Z\u0027\u0022",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "097c4e1d8b920ef6ff1d9c5749e557af",
-        "x-ms-request-id": "c3004096-5002-00a4-09f0-161518000000",
+        "x-ms-client-request-id": "cdc02cebdb6c1698a3d3560159c0cc28",
+        "x-ms-request-id": "ceda459a-b002-0006-11e2-47a93e000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": {
-        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtablerKk6aAZ4/@Element",
-        "odata.etag": "W/\u0022datetime\u00272022-01-31T22%3A18%3A12.8379661Z\u0027\u0022",
+        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtablecAB7xosj/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T05%3A11%3A43.365622Z\u0027\u0022",
         "PartitionKey": "PK",
         "RowKey": "RK1",
-        "Timestamp": "2022-01-31T22:18:12.8379661Z",
+        "Timestamp": "2022-04-04T05:11:43.365622Z",
         "Value": "Bar"
       }
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtablerKk6aAZ4\u0027)",
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtablecAB7xosj\u0027)",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f7168c9ce61628a5b7236fb9e2488761-73a2867a06a6d395-00",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "9e2f165cc2142752fd68a2f477312deb",
-        "x-ms-date": "Mon, 31 Jan 2022 22:18:12 GMT",
+        "traceparent": "00-bee4871a2e63be02fbe119e0931e1d1f-4d8255b9b3e852ff-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "7876fc522cd0a5f2dcb770c3f4bac0f6",
+        "x-ms-date": "Mon, 04 Apr 2022 05:11:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -171,21 +171,21 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Mon, 31 Jan 2022 22:18:12 GMT",
+        "Date": "Mon, 04 Apr 2022 05:11:42 GMT",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "9e2f165cc2142752fd68a2f477312deb",
-        "x-ms-request-id": "c3004097-5002-00a4-0af0-161518000000",
+        "x-ms-client-request-id": "7876fc522cd0a5f2dcb770c3f4bac0f6",
+        "x-ms-request-id": "ceda459b-b002-0006-12e2-47a93e000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "RandomSeed": "1233699236",
+    "RandomSeed": "2133928775",
     "STORAGE_ENDPOINT_SUFFIX": "core.windows.net",
     "TABLES_PRIMARY_STORAGE_ACCOUNT_KEY": "Kg==",
     "TABLES_STORAGE_ACCOUNT_NAME": "jolovtablesprim"

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(False)/CanAddEntityUsingCollector(%JObjectCamelCase%)Async.json
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(False)/CanAddEntityUsingCollector(%JObjectCamelCase%)Async.json
@@ -1,0 +1,193 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/Tables?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json; odata=minimalmetadata",
+        "Authorization": "Sanitized",
+        "Content-Length": "33",
+        "Content-Type": "application/json; odata=nometadata",
+        "DataServiceVersion": "3.0",
+        "traceparent": "00-dae37a1878ee1adc3bc440b1bf293406-3f9d1eceaa586e5a-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "821a95efb9ad4d7db4b3eb2d96e27435",
+        "x-ms-date": "Mon, 04 Apr 2022 04:36:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": {
+        "TableName": "testtablecfBt3JKf"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Mon, 04 Apr 2022 04:36:26 GMT",
+        "Location": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtablecfBt3JKf\u0027)",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "821a95efb9ad4d7db4b3eb2d96e27435",
+        "x-ms-request-id": "df306ef2-f002-00cc-0cdd-47f5b7000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#Tables/@Element",
+        "TableName": "testtablecfBt3JKf"
+      }
+    },
+    {
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/$batch",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "1291",
+        "Content-Type": "multipart/mixed; boundary=batch_6baafeab-0d74-d170-ad4f-83679df41ebc",
+        "DataServiceVersion": "3.0",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "bbe70a5d3b1fe2a32448d55d3615b0bf",
+        "x-ms-date": "Mon, 04 Apr 2022 04:36:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "LS1iYXRjaF82YmFhZmVhYi0wZDc0LWQxNzAtYWQ0Zi04MzY3OWRmNDFlYmMNCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfZmQxZDVhMTktNjIwNy03NWRmLWQ0NGQtNGZkMWRiNDY2MjYxDQoNCi0tY2hhbmdlc2V0X2ZkMWQ1YTE5LTYyMDctNzVkZi1kNDRkLTRmZDFkYjQ2NjI2MQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUE9TVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZWNmQnQzSktmPyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0DQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpQcmVmZXI6IHJldHVybi1uby1jb250ZW50DQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bWluaW1hbG1ldGFkYXRhDQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bm9tZXRhZGF0YQ0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF9mZDFkNWExOS02MjA3LTc1ZGYtZDQ0ZC00ZmQxZGI0NjYyNjENCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBPU1QgaHR0cHM6Ly9qb2xvdnRhYmxlc3ByaW0udGFibGUuY29yZS53aW5kb3dzLm5ldC90ZXN0dGFibGVjZkJ0M0pLZj8kZm9ybWF0PWFwcGxpY2F0aW9uJTJGanNvbiUzQm9kYXRhJTNEbWluaW1hbG1ldGFkYXRhIEhUVFAvMS4xDQpIb3N0OiBqb2xvdnRhYmxlc3ByaW0udGFibGUuY29yZS53aW5kb3dzLm5ldA0KeC1tcy12ZXJzaW9uOiAyMDE5LTAyLTAyDQpEYXRhU2VydmljZVZlcnNpb246IDMuMA0KUHJlZmVyOiByZXR1cm4tbm8tY29udGVudA0KQWNjZXB0OiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW1pbmltYWxtZXRhZGF0YQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW5vbWV0YWRhdGENCg0KeyJWYWx1ZSI6IkJhciIsIlBhcnRpdGlvbktleSI6IlBLIiwiUm93S2V5IjoiUksxIn0NCi0tY2hhbmdlc2V0X2ZkMWQ1YTE5LTYyMDctNzVkZi1kNDRkLTRmZDFkYjQ2NjI2MS0tDQoNCi0tYmF0Y2hfNmJhYWZlYWItMGQ3NC1kMTcwLWFkNGYtODM2NzlkZjQxZWJjLS0NCg==",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "multipart/mixed; boundary=batchresponse_fbc0f285-d570-47a1-abf8-f99065c620dd",
+        "Date": "Mon, 04 Apr 2022 04:36:26 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "bbe70a5d3b1fe2a32448d55d3615b0bf",
+        "x-ms-request-id": "df306ef4-f002-00cc-0ddd-47f5b7000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlX2ZiYzBmMjg1LWQ1NzAtNDdhMS1hYmY4LWY5OTA2NWM2MjBkZA0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlX2EwN2M5MmQzLTk1YmMtNDhmYy05MWFhLTljODBjZjU0ODhiNw0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2EwN2M5MmQzLTk1YmMtNDhmYy05MWFhLTljODBjZjU0ODhiNw0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpQcmVmZXJlbmNlLUFwcGxpZWQ6IHJldHVybi1uby1jb250ZW50DQpEYXRhU2VydmljZVZlcnNpb246IDMuMDsNCkxvY2F0aW9uOiBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZWNmQnQzSktmKFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksnKQ0KRGF0YVNlcnZpY2VJZDogaHR0cHM6Ly9qb2xvdnRhYmxlc3ByaW0udGFibGUuY29yZS53aW5kb3dzLm5ldC90ZXN0dGFibGVjZkJ0M0pLZihQYXJ0aXRpb25LZXk9J1BLJyxSb3dLZXk9J1JLJykNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDQtMDRUMDQlM0EzNiUzQTI2LjgwMDUyNDhaJyINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2EwN2M5MmQzLTk1YmMtNDhmYy05MWFhLTljODBjZjU0ODhiNw0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpQcmVmZXJlbmNlLUFwcGxpZWQ6IHJldHVybi1uby1jb250ZW50DQpEYXRhU2VydmljZVZlcnNpb246IDMuMDsNCkxvY2F0aW9uOiBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZWNmQnQzSktmKFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJykNCkRhdGFTZXJ2aWNlSWQ6IGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvcmUud2luZG93cy5uZXQvdGVzdHRhYmxlY2ZCdDNKS2YoUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSzEnKQ0KRVRhZzogVy8iZGF0ZXRpbWUnMjAyMi0wNC0wNFQwNCUzQTM2JTNBMjYuODAwNTI0OFonIg0KDQoNCi0tY2hhbmdlc2V0cmVzcG9uc2VfYTA3YzkyZDMtOTViYy00OGZjLTkxYWEtOWM4MGNmNTQ4OGI3LS0NCi0tYmF0Y2hyZXNwb25zZV9mYmMwZjI4NS1kNTcwLTQ3YTEtYWJmOC1mOTkwNjVjNjIwZGQtLQ0K"
+    },
+    {
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtablecfBt3JKf(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json; odata=minimalmetadata",
+        "Authorization": "Sanitized",
+        "DataServiceVersion": "3.0",
+        "traceparent": "00-8960bb2cd4b93dc5cf6c14233d72bb78-38bc0405b8c0d66d-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "3b132f9576c5492d1f359626be9ff666",
+        "x-ms-date": "Mon, 04 Apr 2022 04:36:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Mon, 04 Apr 2022 04:36:26 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A36%3A26.8005248Z\u0027\u0022",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "3b132f9576c5492d1f359626be9ff666",
+        "x-ms-request-id": "df306ef5-f002-00cc-0edd-47f5b7000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtablecfBt3JKf/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T04%3A36%3A26.8005248Z\u0027\u0022",
+        "PartitionKey": "PK",
+        "RowKey": "RK",
+        "Timestamp": "2022-04-04T04:36:26.8005248Z",
+        "Value": "Foo"
+      }
+    },
+    {
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtablecfBt3JKf(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json; odata=minimalmetadata",
+        "Authorization": "Sanitized",
+        "DataServiceVersion": "3.0",
+        "traceparent": "00-2c898ba843beb26bb8272574a7ec356a-ce296355a90570b4-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "930a22ed630dde9cb63bd8bf8d813fbf",
+        "x-ms-date": "Mon, 04 Apr 2022 04:36:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Mon, 04 Apr 2022 04:36:26 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A36%3A26.8005248Z\u0027\u0022",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "930a22ed630dde9cb63bd8bf8d813fbf",
+        "x-ms-request-id": "df306ef6-f002-00cc-0fdd-47f5b7000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtablecfBt3JKf/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T04%3A36%3A26.8005248Z\u0027\u0022",
+        "PartitionKey": "PK",
+        "RowKey": "RK1",
+        "Timestamp": "2022-04-04T04:36:26.8005248Z",
+        "Value": "Bar"
+      }
+    },
+    {
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtablecfBt3JKf\u0027)",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-55248b62ecba9ff4b2348420a206da69-baef81ccdf9e7a0b-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ac3b8f9d2632e69cdc9d9ce9a47c2385",
+        "x-ms-date": "Mon, 04 Apr 2022 04:36:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Mon, 04 Apr 2022 04:36:26 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "ac3b8f9d2632e69cdc9d9ce9a47c2385",
+        "x-ms-request-id": "df306ef7-f002-00cc-10dd-47f5b7000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "2130455691",
+    "STORAGE_ENDPOINT_SUFFIX": "core.windows.net",
+    "TABLES_PRIMARY_STORAGE_ACCOUNT_KEY": "Kg==",
+    "TABLES_STORAGE_ACCOUNT_NAME": "jolovtablesprim"
+  }
+}

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(False)/CanAddEntityUsingCollector(%JObjectCamelCase%)Async.json
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(False)/CanAddEntityUsingCollector(%JObjectCamelCase%)Async.json
@@ -9,35 +9,35 @@
         "Content-Length": "33",
         "Content-Type": "application/json; odata=nometadata",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-dae37a1878ee1adc3bc440b1bf293406-3f9d1eceaa586e5a-00",
+        "traceparent": "00-d4bcb9841addee3f077a33dad8c3d085-02ff1c0e3d19ff4e-00",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "821a95efb9ad4d7db4b3eb2d96e27435",
-        "x-ms-date": "Mon, 04 Apr 2022 04:36:26 GMT",
+        "x-ms-client-request-id": "ff3ae27a0fcca51737b12c421683655f",
+        "x-ms-date": "Mon, 04 Apr 2022 05:05:58 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": {
-        "TableName": "testtablecfBt3JKf"
+        "TableName": "testtablekfn7CUmh"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
-        "Date": "Mon, 04 Apr 2022 04:36:26 GMT",
-        "Location": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtablecfBt3JKf\u0027)",
+        "Date": "Mon, 04 Apr 2022 05:05:58 GMT",
+        "Location": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtablekfn7CUmh\u0027)",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "821a95efb9ad4d7db4b3eb2d96e27435",
-        "x-ms-request-id": "df306ef2-f002-00cc-0cdd-47f5b7000000",
+        "x-ms-client-request-id": "ff3ae27a0fcca51737b12c421683655f",
+        "x-ms-request-id": "40f13d46-4002-0002-2be1-472439000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": {
         "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#Tables/@Element",
-        "TableName": "testtablecfBt3JKf"
+        "TableName": "testtablekfn7CUmh"
       }
     },
     {
@@ -46,44 +46,44 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "1291",
-        "Content-Type": "multipart/mixed; boundary=batch_6baafeab-0d74-d170-ad4f-83679df41ebc",
+        "Content-Length": "1220",
+        "Content-Type": "multipart/mixed; boundary=batch_b50b2052-5eea-e920-4693-c0e9e71462d5",
         "DataServiceVersion": "3.0",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "bbe70a5d3b1fe2a32448d55d3615b0bf",
-        "x-ms-date": "Mon, 04 Apr 2022 04:36:26 GMT",
+        "x-ms-client-request-id": "eb9d9acf9a5c1ceec251b8384f2dbd22",
+        "x-ms-date": "Mon, 04 Apr 2022 05:05:58 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
-      "RequestBody": "LS1iYXRjaF82YmFhZmVhYi0wZDc0LWQxNzAtYWQ0Zi04MzY3OWRmNDFlYmMNCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfZmQxZDVhMTktNjIwNy03NWRmLWQ0NGQtNGZkMWRiNDY2MjYxDQoNCi0tY2hhbmdlc2V0X2ZkMWQ1YTE5LTYyMDctNzVkZi1kNDRkLTRmZDFkYjQ2NjI2MQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUE9TVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZWNmQnQzSktmPyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0DQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpQcmVmZXI6IHJldHVybi1uby1jb250ZW50DQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bWluaW1hbG1ldGFkYXRhDQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bm9tZXRhZGF0YQ0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF9mZDFkNWExOS02MjA3LTc1ZGYtZDQ0ZC00ZmQxZGI0NjYyNjENCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBPU1QgaHR0cHM6Ly9qb2xvdnRhYmxlc3ByaW0udGFibGUuY29yZS53aW5kb3dzLm5ldC90ZXN0dGFibGVjZkJ0M0pLZj8kZm9ybWF0PWFwcGxpY2F0aW9uJTJGanNvbiUzQm9kYXRhJTNEbWluaW1hbG1ldGFkYXRhIEhUVFAvMS4xDQpIb3N0OiBqb2xvdnRhYmxlc3ByaW0udGFibGUuY29yZS53aW5kb3dzLm5ldA0KeC1tcy12ZXJzaW9uOiAyMDE5LTAyLTAyDQpEYXRhU2VydmljZVZlcnNpb246IDMuMA0KUHJlZmVyOiByZXR1cm4tbm8tY29udGVudA0KQWNjZXB0OiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW1pbmltYWxtZXRhZGF0YQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW5vbWV0YWRhdGENCg0KeyJWYWx1ZSI6IkJhciIsIlBhcnRpdGlvbktleSI6IlBLIiwiUm93S2V5IjoiUksxIn0NCi0tY2hhbmdlc2V0X2ZkMWQ1YTE5LTYyMDctNzVkZi1kNDRkLTRmZDFkYjQ2NjI2MS0tDQoNCi0tYmF0Y2hfNmJhYWZlYWItMGQ3NC1kMTcwLWFkNGYtODM2NzlkZjQxZWJjLS0NCg==",
+      "RequestBody": "LS1iYXRjaF9iNTBiMjA1Mi01ZWVhLWU5MjAtNDY5My1jMGU5ZTcxNDYyZDUNCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfYzA5MmFiNzQtNGFlYi02ZjU2LWRhNzMtYjcyZjY2NDkyOTg3DQoNCi0tY2hhbmdlc2V0X2MwOTJhYjc0LTRhZWItNmY1Ni1kYTczLWI3MmY2NjQ5Mjk4Nw0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUFVUIGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvcmUud2luZG93cy5uZXQvdGVzdHRhYmxla2ZuN0NVbWgoUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSycpPyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0DQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb24NCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbg0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF9jMDkyYWI3NC00YWViLTZmNTYtZGE3My1iNzJmNjY0OTI5ODcNCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBVVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZWtmbjdDVW1oKFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJyk/JGZvcm1hdD1hcHBsaWNhdGlvbiUyRmpzb24lM0JvZGF0YSUzRG1pbmltYWxtZXRhZGF0YSBIVFRQLzEuMQ0KSG9zdDogam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvcmUud2luZG93cy5uZXQNCngtbXMtdmVyc2lvbjogMjAxOS0wMi0wMg0KRGF0YVNlcnZpY2VWZXJzaW9uOiAzLjANCkFjY2VwdDogYXBwbGljYXRpb24vanNvbg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uDQoNCnsiVmFsdWUiOiJCYXIiLCJQYXJ0aXRpb25LZXkiOiJQSyIsIlJvd0tleSI6IlJLMSJ9DQotLWNoYW5nZXNldF9jMDkyYWI3NC00YWViLTZmNTYtZGE3My1iNzJmNjY0OTI5ODctLQ0KDQotLWJhdGNoX2I1MGIyMDUyLTVlZWEtZTkyMC00NjkzLWMwZTllNzE0NjJkNS0tDQo=",
       "StatusCode": 202,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Type": "multipart/mixed; boundary=batchresponse_fbc0f285-d570-47a1-abf8-f99065c620dd",
-        "Date": "Mon, 04 Apr 2022 04:36:26 GMT",
+        "Content-Type": "multipart/mixed; boundary=batchresponse_6ed6aeaa-cace-4000-a575-ef191f323f46",
+        "Date": "Mon, 04 Apr 2022 05:05:58 GMT",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "bbe70a5d3b1fe2a32448d55d3615b0bf",
-        "x-ms-request-id": "df306ef4-f002-00cc-0ddd-47f5b7000000",
+        "x-ms-client-request-id": "eb9d9acf9a5c1ceec251b8384f2dbd22",
+        "x-ms-request-id": "40f13d49-4002-0002-2ce1-472439000000",
         "x-ms-version": "2019-02-02"
       },
-      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlX2ZiYzBmMjg1LWQ1NzAtNDdhMS1hYmY4LWY5OTA2NWM2MjBkZA0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlX2EwN2M5MmQzLTk1YmMtNDhmYy05MWFhLTljODBjZjU0ODhiNw0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2EwN2M5MmQzLTk1YmMtNDhmYy05MWFhLTljODBjZjU0ODhiNw0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpQcmVmZXJlbmNlLUFwcGxpZWQ6IHJldHVybi1uby1jb250ZW50DQpEYXRhU2VydmljZVZlcnNpb246IDMuMDsNCkxvY2F0aW9uOiBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZWNmQnQzSktmKFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksnKQ0KRGF0YVNlcnZpY2VJZDogaHR0cHM6Ly9qb2xvdnRhYmxlc3ByaW0udGFibGUuY29yZS53aW5kb3dzLm5ldC90ZXN0dGFibGVjZkJ0M0pLZihQYXJ0aXRpb25LZXk9J1BLJyxSb3dLZXk9J1JLJykNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDQtMDRUMDQlM0EzNiUzQTI2LjgwMDUyNDhaJyINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2EwN2M5MmQzLTk1YmMtNDhmYy05MWFhLTljODBjZjU0ODhiNw0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpQcmVmZXJlbmNlLUFwcGxpZWQ6IHJldHVybi1uby1jb250ZW50DQpEYXRhU2VydmljZVZlcnNpb246IDMuMDsNCkxvY2F0aW9uOiBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3JlLndpbmRvd3MubmV0L3Rlc3R0YWJsZWNmQnQzSktmKFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJykNCkRhdGFTZXJ2aWNlSWQ6IGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvcmUud2luZG93cy5uZXQvdGVzdHRhYmxlY2ZCdDNKS2YoUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSzEnKQ0KRVRhZzogVy8iZGF0ZXRpbWUnMjAyMi0wNC0wNFQwNCUzQTM2JTNBMjYuODAwNTI0OFonIg0KDQoNCi0tY2hhbmdlc2V0cmVzcG9uc2VfYTA3YzkyZDMtOTViYy00OGZjLTkxYWEtOWM4MGNmNTQ4OGI3LS0NCi0tYmF0Y2hyZXNwb25zZV9mYmMwZjI4NS1kNTcwLTQ3YTEtYWJmOC1mOTkwNjVjNjIwZGQtLQ0K"
+      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlXzZlZDZhZWFhLWNhY2UtNDAwMC1hNTc1LWVmMTkxZjMyM2Y0Ng0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlXzYwMDJhZTczLTYyMzUtNGY0Ny1iYjczLTI2ZWZkODc0NzZmMA0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzYwMDJhZTczLTYyMzUtNGY0Ny1iYjczLTI2ZWZkODc0NzZmMA0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpEYXRhU2VydmljZVZlcnNpb246IDEuMDsNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDQtMDRUMDUlM0EwNSUzQTU4LjgyNDYxOTZaJyINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzYwMDJhZTczLTYyMzUtNGY0Ny1iYjczLTI2ZWZkODc0NzZmMA0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlDQpEYXRhU2VydmljZVZlcnNpb246IDEuMDsNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDQtMDRUMDUlM0EwNSUzQTU4LjgyNDYxOTZaJyINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzYwMDJhZTczLTYyMzUtNGY0Ny1iYjczLTI2ZWZkODc0NzZmMC0tDQotLWJhdGNocmVzcG9uc2VfNmVkNmFlYWEtY2FjZS00MDAwLWE1NzUtZWYxOTFmMzIzZjQ2LS0NCg=="
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtablecfBt3JKf(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtablekfn7CUmh(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata=minimalmetadata",
         "Authorization": "Sanitized",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-8960bb2cd4b93dc5cf6c14233d72bb78-38bc0405b8c0d66d-00",
+        "traceparent": "00-7cbfd55b383986a9ed25b50c2dd96977-507e4ad4c921576f-00",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "3b132f9576c5492d1f359626be9ff666",
-        "x-ms-date": "Mon, 04 Apr 2022 04:36:26 GMT",
+        "x-ms-client-request-id": "6acd574fa4f00873c99bda77a6f082fc",
+        "x-ms-date": "Mon, 04 Apr 2022 05:05:58 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -92,38 +92,38 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
-        "Date": "Mon, 04 Apr 2022 04:36:26 GMT",
-        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A36%3A26.8005248Z\u0027\u0022",
+        "Date": "Mon, 04 Apr 2022 05:05:58 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T05%3A05%3A58.8246196Z\u0027\u0022",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "3b132f9576c5492d1f359626be9ff666",
-        "x-ms-request-id": "df306ef5-f002-00cc-0edd-47f5b7000000",
+        "x-ms-client-request-id": "6acd574fa4f00873c99bda77a6f082fc",
+        "x-ms-request-id": "40f13d4a-4002-0002-2de1-472439000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": {
-        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtablecfBt3JKf/@Element",
-        "odata.etag": "W/\u0022datetime\u00272022-04-04T04%3A36%3A26.8005248Z\u0027\u0022",
+        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtablekfn7CUmh/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T05%3A05%3A58.8246196Z\u0027\u0022",
         "PartitionKey": "PK",
         "RowKey": "RK",
-        "Timestamp": "2022-04-04T04:36:26.8005248Z",
+        "Timestamp": "2022-04-04T05:05:58.8246196Z",
         "Value": "Foo"
       }
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtablecfBt3JKf(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/testtablekfn7CUmh(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata=minimalmetadata",
         "Authorization": "Sanitized",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-2c898ba843beb26bb8272574a7ec356a-ce296355a90570b4-00",
+        "traceparent": "00-02e192703e6c2191cd5578c36a14dbba-9347693c04b56bee-00",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "930a22ed630dde9cb63bd8bf8d813fbf",
-        "x-ms-date": "Mon, 04 Apr 2022 04:36:26 GMT",
+        "x-ms-client-request-id": "4d19396a7677da78bd76fe9a911e20ac",
+        "x-ms-date": "Mon, 04 Apr 2022 05:05:58 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -132,37 +132,37 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
-        "Date": "Mon, 04 Apr 2022 04:36:26 GMT",
-        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A36%3A26.8005248Z\u0027\u0022",
+        "Date": "Mon, 04 Apr 2022 05:05:58 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T05%3A05%3A58.8246196Z\u0027\u0022",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "930a22ed630dde9cb63bd8bf8d813fbf",
-        "x-ms-request-id": "df306ef6-f002-00cc-0fdd-47f5b7000000",
+        "x-ms-client-request-id": "4d19396a7677da78bd76fe9a911e20ac",
+        "x-ms-request-id": "40f13d4b-4002-0002-2ee1-472439000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": {
-        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtablecfBt3JKf/@Element",
-        "odata.etag": "W/\u0022datetime\u00272022-04-04T04%3A36%3A26.8005248Z\u0027\u0022",
+        "odata.metadata": "https://jolovtablesprim.table.core.windows.net/$metadata#testtablekfn7CUmh/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T05%3A05%3A58.8246196Z\u0027\u0022",
         "PartitionKey": "PK",
         "RowKey": "RK1",
-        "Timestamp": "2022-04-04T04:36:26.8005248Z",
+        "Timestamp": "2022-04-04T05:05:58.8246196Z",
         "Value": "Bar"
       }
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtablecfBt3JKf\u0027)",
+      "RequestUri": "https://jolovtablesprim.table.core.windows.net/Tables(\u0027testtablekfn7CUmh\u0027)",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-55248b62ecba9ff4b2348420a206da69-baef81ccdf9e7a0b-00",
+        "traceparent": "00-bc54f3c12f5df8a567ea6ec3b8721925-7cbd53f0c75976c4-00",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "ac3b8f9d2632e69cdc9d9ce9a47c2385",
-        "x-ms-date": "Mon, 04 Apr 2022 04:36:26 GMT",
+        "x-ms-client-request-id": "0fe094b5be7c2a96279421c0bf7775d2",
+        "x-ms-date": "Mon, 04 Apr 2022 05:05:58 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -171,21 +171,21 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Mon, 04 Apr 2022 04:36:26 GMT",
+        "Date": "Mon, 04 Apr 2022 05:05:58 GMT",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "ac3b8f9d2632e69cdc9d9ce9a47c2385",
-        "x-ms-request-id": "df306ef7-f002-00cc-10dd-47f5b7000000",
+        "x-ms-client-request-id": "0fe094b5be7c2a96279421c0bf7775d2",
+        "x-ms-request-id": "40f13d4c-4002-0002-2fe1-472439000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "RandomSeed": "2130455691",
+    "RandomSeed": "1857591649",
     "STORAGE_ENDPOINT_SUFFIX": "core.windows.net",
     "TABLES_PRIMARY_STORAGE_ACCOUNT_KEY": "Kg==",
     "TABLES_STORAGE_ACCOUNT_NAME": "jolovtablesprim"

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(True)/CanAddEntityUsingAsyncCollector(%JObject%)Async.json
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(True)/CanAddEntityUsingAsyncCollector(%JObject%)Async.json
@@ -9,27 +9,27 @@
         "Content-Length": "33",
         "Content-Type": "application/json; odata=nometadata",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-b8cecd4e303f1b24310d47a35411f355-6a39356bff389594-00",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "af6a24246659b6138772b12674dba98b",
-        "x-ms-date": "Mon, 31 Jan 2022 22:20:39 GMT",
+        "traceparent": "00-64e30ec46cb8e497be7d966c6c9552c3-3ca349bc30763c89-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "e484607db74f4a481d546d36663ecf6f",
+        "x-ms-date": "Mon, 04 Apr 2022 05:12:13 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": {
-        "TableName": "testtableiJ2s02yX"
+        "TableName": "testtableLg36jHYt"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Type": "application/json; odata=minimalmetadata",
-        "Date": "Mon, 31 Jan 2022 22:20:39 GMT",
-        "ETag": "W/\u0022datetime\u00272022-01-31T22%3A20%3A39.8174216Z\u0027\u0022",
-        "Location": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtableiJ2s02yX\u0027)",
+        "Date": "Mon, 04 Apr 2022 05:12:16 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T05%3A12%3A16.3890184Z\u0027\u0022",
+        "Location": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtableLg36jHYt\u0027)",
         "Transfer-Encoding": "chunked",
-        "x-ms-request-id": "0e6675d2-b74d-454d-9b84-c7c1b1238ae7"
+        "x-ms-request-id": "7e47ca42-be72-457d-8c61-6091cfe5d947"
       },
       "ResponseBody": {
-        "TableName": "testtableiJ2s02yX",
+        "TableName": "testtableLg36jHYt",
         "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/$metadata#Tables/@Element"
       }
     },
@@ -39,36 +39,36 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "1291",
-        "Content-Type": "multipart/mixed; boundary=batch_a0bdd84e-775f-7a57-860d-19ba643669c2",
+        "Content-Length": "1220",
+        "Content-Type": "multipart/mixed; boundary=batch_f2ef675f-0a3b-4466-9157-fdfcb30f66a9",
         "DataServiceVersion": "3.0",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "67038184a135ac33ccef294b4c595250",
-        "x-ms-date": "Mon, 31 Jan 2022 22:20:40 GMT",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "3aba164564117253f93f53f8ba4b960e",
+        "x-ms-date": "Mon, 04 Apr 2022 05:12:16 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
-      "RequestBody": "LS1iYXRjaF9hMGJkZDg0ZS03NzVmLTdhNTctODYwZC0xOWJhNjQzNjY5YzINCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfYzExMWY4NmQtOTUyOS00MmJjLWM5Y2UtMGNiYjIxM2JjZmVjDQoNCi0tY2hhbmdlc2V0X2MxMTFmODZkLTk1MjktNDJiYy1jOWNlLTBjYmIyMTNiY2ZlYw0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUE9TVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tL3Rlc3R0YWJsZWlKMnMwMnlYPyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tDQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpQcmVmZXI6IHJldHVybi1uby1jb250ZW50DQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bWluaW1hbG1ldGFkYXRhDQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bm9tZXRhZGF0YQ0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF9jMTExZjg2ZC05NTI5LTQyYmMtYzljZS0wY2JiMjEzYmNmZWMNCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBPU1QgaHR0cHM6Ly9qb2xvdnRhYmxlc3ByaW0udGFibGUuY29zbW9zLmF6dXJlLmNvbS90ZXN0dGFibGVpSjJzMDJ5WD8kZm9ybWF0PWFwcGxpY2F0aW9uJTJGanNvbiUzQm9kYXRhJTNEbWluaW1hbG1ldGFkYXRhIEhUVFAvMS4xDQpIb3N0OiBqb2xvdnRhYmxlc3ByaW0udGFibGUuY29zbW9zLmF6dXJlLmNvbQ0KeC1tcy12ZXJzaW9uOiAyMDE5LTAyLTAyDQpEYXRhU2VydmljZVZlcnNpb246IDMuMA0KUHJlZmVyOiByZXR1cm4tbm8tY29udGVudA0KQWNjZXB0OiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW1pbmltYWxtZXRhZGF0YQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW5vbWV0YWRhdGENCg0KeyJWYWx1ZSI6IkJhciIsIlBhcnRpdGlvbktleSI6IlBLIiwiUm93S2V5IjoiUksxIn0NCi0tY2hhbmdlc2V0X2MxMTFmODZkLTk1MjktNDJiYy1jOWNlLTBjYmIyMTNiY2ZlYy0tDQoNCi0tYmF0Y2hfYTBiZGQ4NGUtNzc1Zi03YTU3LTg2MGQtMTliYTY0MzY2OWMyLS0NCg==",
+      "RequestBody": "LS1iYXRjaF9mMmVmNjc1Zi0wYTNiLTQ0NjYtOTE1Ny1mZGZjYjMwZjY2YTkNCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfMWQzOGRkNDUtOTc0Ny05Yzk3LTg0MjYtMzU1YzZjZmQ0NjFkDQoNCi0tY2hhbmdlc2V0XzFkMzhkZDQ1LTk3NDctOWM5Ny04NDI2LTM1NWM2Y2ZkNDYxZA0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUFVUIGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvc21vcy5henVyZS5jb20vdGVzdHRhYmxlTGczNmpIWXQoUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSycpPyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tDQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb24NCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbg0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF8xZDM4ZGQ0NS05NzQ3LTljOTctODQyNi0zNTVjNmNmZDQ2MWQNCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBVVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tL3Rlc3R0YWJsZUxnMzZqSFl0KFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJyk/JGZvcm1hdD1hcHBsaWNhdGlvbiUyRmpzb24lM0JvZGF0YSUzRG1pbmltYWxtZXRhZGF0YSBIVFRQLzEuMQ0KSG9zdDogam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvc21vcy5henVyZS5jb20NCngtbXMtdmVyc2lvbjogMjAxOS0wMi0wMg0KRGF0YVNlcnZpY2VWZXJzaW9uOiAzLjANCkFjY2VwdDogYXBwbGljYXRpb24vanNvbg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uDQoNCnsiVmFsdWUiOiJCYXIiLCJQYXJ0aXRpb25LZXkiOiJQSyIsIlJvd0tleSI6IlJLMSJ9DQotLWNoYW5nZXNldF8xZDM4ZGQ0NS05NzQ3LTljOTctODQyNi0zNTVjNmNmZDQ2MWQtLQ0KDQotLWJhdGNoX2YyZWY2NzVmLTBhM2ItNDQ2Ni05MTU3LWZkZmNiMzBmNjZhOS0tDQo=",
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Content-Type": "multipart/mixed; boundary=batchresponse_8c802161-a393-4fd6-9377-6b206677bbe0",
-        "Date": "Mon, 31 Jan 2022 22:20:39 GMT",
+        "Content-Type": "multipart/mixed; boundary=batchresponse_02b7d984-2e99-4cf9-ad77-08f37b607749",
+        "Date": "Mon, 04 Apr 2022 05:12:16 GMT",
         "Transfer-Encoding": "chunked",
-        "x-ms-request-id": "e75877a0-8e8b-42b7-856b-7bbc882f7e46"
+        "x-ms-request-id": "5d934405-0ba0-4f88-9070-ba0e5b082a80"
       },
-      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlXzhjODAyMTYxLWEzOTMtNGZkNi05Mzc3LTZiMjA2Njc3YmJlMA0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlXzllMmFlYWI3LTdiMzctNDg4NS1iMDRhLWI3MzU1NWY4MmMwMw0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzllMmFlYWI3LTdiMzctNDg4NS1iMDRhLWI3MzU1NWY4MmMwMwpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2h0dHAKQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5CgpIVFRQLzEuMSAyMDQgTm8gQ29udGVudA0KRVRhZzogVy8iZGF0ZXRpbWUnMjAyMi0wMS0zMVQyMiUzQTIwJTNBNDAuMzgyMTU3NlonIg0KUHJlZmVyZW5jZS1BcHBsaWVkOiByZXR1cm4tbm8tY29udGVudA0KTG9jYXRpb246IGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvc21vcy5henVyZS5jb20vdGVzdHRhYmxlaUoyczAyeVgoUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSycpDQpDb250ZW50LUlEOiAxDQoNCg0KLS1jaGFuZ2VzZXRyZXNwb25zZV85ZTJhZWFiNy03YjM3LTQ4ODUtYjA0YS1iNzM1NTVmODJjMDMKQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwCkNvbnRlbnQtVHJhbnNmZXItRW5jb2Rpbmc6IGJpbmFyeQoKSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDEtMzFUMjIlM0EyMCUzQTQwLjM4MjU2NzJaJyINClByZWZlcmVuY2UtQXBwbGllZDogcmV0dXJuLW5vLWNvbnRlbnQNCkxvY2F0aW9uOiBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tL3Rlc3R0YWJsZWlKMnMwMnlYKFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJykNCkNvbnRlbnQtSUQ6IDINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzllMmFlYWI3LTdiMzctNDg4NS1iMDRhLWI3MzU1NWY4MmMwMy0tCi0tYmF0Y2hyZXNwb25zZV84YzgwMjE2MS1hMzkzLTRmZDYtOTM3Ny02YjIwNjY3N2JiZTAtLQ0K"
+      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlXzAyYjdkOTg0LTJlOTktNGNmOS1hZDc3LTA4ZjM3YjYwNzc0OQ0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlX2UyODM5NDFlLWE4ZTAtNGFlOC1hZTZjLTA5YTcyNzg2ODAwOA0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2UyODM5NDFlLWE4ZTAtNGFlOC1hZTZjLTA5YTcyNzg2ODAwOApDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2h0dHAKQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5CgpIVFRQLzEuMSAyMDQgTm8gQ29udGVudA0KRVRhZzogVy8iZGF0ZXRpbWUnMjAyMi0wNC0wNFQwNSUzQTEyJTNBMTYuODUyNjg1NlonIg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uDQpDb250ZW50LUlEOiAxDQoNCg0KLS1jaGFuZ2VzZXRyZXNwb25zZV9lMjgzOTQxZS1hOGUwLTRhZTgtYWU2Yy0wOWE3Mjc4NjgwMDgKQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwCkNvbnRlbnQtVHJhbnNmZXItRW5jb2Rpbmc6IGJpbmFyeQoKSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDQtMDRUMDUlM0ExMiUzQTE2Ljg1MzA5NTJaJyINCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbg0KQ29udGVudC1JRDogMg0KDQoNCi0tY2hhbmdlc2V0cmVzcG9uc2VfZTI4Mzk0MWUtYThlMC00YWU4LWFlNmMtMDlhNzI3ODY4MDA4LS0KLS1iYXRjaHJlc3BvbnNlXzAyYjdkOTg0LTJlOTktNGNmOS1hZDc3LTA4ZjM3YjYwNzc0OS0tDQo="
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtableiJ2s02yX(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtableLg36jHYt(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata=minimalmetadata",
         "Authorization": "Sanitized",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-e38e8040601d9971746ad2230eca6645-0b370622304d87c6-00",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "7bb9ef08e7cab9621c7bd7906b9c584a",
-        "x-ms-date": "Mon, 31 Jan 2022 22:20:40 GMT",
+        "traceparent": "00-3eabbe0f7f3f306e814aee1317fec897-86c413ba9ceb0b15-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "89f0c4eeb105c827cf536d15d50ad894",
+        "x-ms-date": "Mon, 04 Apr 2022 05:12:16 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -76,31 +76,31 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json; odata=minimalmetadata",
-        "Date": "Mon, 31 Jan 2022 22:20:39 GMT",
-        "ETag": "W/\u0022datetime\u00272022-01-31T22%3A20%3A40.3821576Z\u0027\u0022",
+        "Date": "Mon, 04 Apr 2022 05:12:16 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T05%3A12%3A16.8526856Z\u0027\u0022",
         "Transfer-Encoding": "chunked",
-        "x-ms-request-id": "efaf3efc-abdd-402f-9883-bce2ed8fa54b"
+        "x-ms-request-id": "8ecfcadd-d1f8-43a2-9fd1-dbe55e46c0da"
       },
       "ResponseBody": {
-        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtableiJ2s02yX/$metadata#testtableiJ2s02yX/@Element",
-        "odata.etag": "W/\u0022datetime\u00272022-01-31T22%3A20%3A40.3821576Z\u0027\u0022",
-        "Value": "Foo",
+        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtableLg36jHYt/$metadata#testtableLg36jHYt/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T05%3A12%3A16.8526856Z\u0027\u0022",
         "PartitionKey": "PK",
         "RowKey": "RK",
-        "Timestamp": "2022-01-31T22:20:40.3821576Z"
+        "Value": "Foo",
+        "Timestamp": "2022-04-04T05:12:16.8526856Z"
       }
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtableiJ2s02yX(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtableLg36jHYt(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata=minimalmetadata",
         "Authorization": "Sanitized",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-79c0c342644b73b5f069cece959de6a6-c53b5bbf60ef10b2-00",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "e2352d3e0232cc8dc564f5396c71f670",
-        "x-ms-date": "Mon, 31 Jan 2022 22:20:40 GMT",
+        "traceparent": "00-7a96adc1f4d9244b80f99095fc04c201-cd1df3f11d7378a5-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "9db7e0102b54e09889c62407449ee138",
+        "x-ms-date": "Mon, 04 Apr 2022 05:12:17 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -108,45 +108,46 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json; odata=minimalmetadata",
-        "Date": "Mon, 31 Jan 2022 22:20:39 GMT",
-        "ETag": "W/\u0022datetime\u00272022-01-31T22%3A20%3A40.3825672Z\u0027\u0022",
+        "Date": "Mon, 04 Apr 2022 05:12:16 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T05%3A12%3A16.8530952Z\u0027\u0022",
         "Transfer-Encoding": "chunked",
-        "x-ms-request-id": "c97e451c-c046-4245-a3d4-68933c488720"
+        "x-ms-request-id": "14b04ba4-8413-4ea5-8002-66dbcf1caddb"
       },
       "ResponseBody": {
-        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtableiJ2s02yX/$metadata#testtableiJ2s02yX/@Element",
-        "odata.etag": "W/\u0022datetime\u00272022-01-31T22%3A20%3A40.3825672Z\u0027\u0022",
-        "Value": "Bar",
+        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtableLg36jHYt/$metadata#testtableLg36jHYt/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T05%3A12%3A16.8530952Z\u0027\u0022",
         "PartitionKey": "PK",
         "RowKey": "RK1",
-        "Timestamp": "2022-01-31T22:20:40.3825672Z"
+        "Value": "Bar",
+        "Timestamp": "2022-04-04T05:12:16.8530952Z"
       }
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtableiJ2s02yX\u0027)",
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtableLg36jHYt\u0027)",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-1de3b823c9fb087a7cace876e5eeaf32-d9ea788cf68fd22e-00",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "32b2bb7c53819d221f4a4bb9caa24030",
-        "x-ms-date": "Mon, 31 Jan 2022 22:20:40 GMT",
+        "traceparent": "00-f395e156bc23f18a992cdf60ed2909e6-82bed5aa2bd49067-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "a76e2790bd0c9317eef26abdf63e9cef",
+        "x-ms-date": "Mon, 04 Apr 2022 05:12:17 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "Date": "Mon, 31 Jan 2022 22:20:40 GMT",
-        "x-ms-request-id": "56f7434d-dee6-4bc3-a071-a360a0b6d86b"
+        "Content-Type": "application/json",
+        "Date": "Mon, 04 Apr 2022 05:12:16 GMT",
+        "x-ms-request-id": "79707a0c-c4ad-44f3-a8c8-3dd252a5634f"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
     "COSMOS_TABLES_ENDPOINT_SUFFIX": "cosmos.azure.com",
-    "RandomSeed": "1361513358",
+    "RandomSeed": "1697064538",
     "TABLES_COSMOS_ACCOUNT_NAME": "jolovtablesprim",
     "TABLES_PRIMARY_COSMOS_ACCOUNT_KEY": "Kg=="
   }

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(True)/CanAddEntityUsingAsyncCollector(%JObjectCamelCase%)Async.json
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(True)/CanAddEntityUsingAsyncCollector(%JObjectCamelCase%)Async.json
@@ -1,0 +1,154 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/Tables?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json; odata=minimalmetadata",
+        "Authorization": "Sanitized",
+        "Content-Length": "33",
+        "Content-Type": "application/json; odata=nometadata",
+        "DataServiceVersion": "3.0",
+        "traceparent": "00-b50551f22f54521e642285db040943b0-948ad4db660577e8-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "27fe555507f092ae48453f338cb1b21e",
+        "x-ms-date": "Mon, 04 Apr 2022 04:37:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": {
+        "TableName": "testtableEMNebyfx"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; odata=minimalmetadata",
+        "Date": "Mon, 04 Apr 2022 04:36:59 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A00.3875336Z\u0027\u0022",
+        "Location": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtableEMNebyfx\u0027)",
+        "Transfer-Encoding": "chunked",
+        "x-ms-request-id": "9014b9ea-5651-40c3-8fc5-3bd3285a31ac"
+      },
+      "ResponseBody": {
+        "TableName": "testtableEMNebyfx",
+        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/$metadata#Tables/@Element"
+      }
+    },
+    {
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/$batch",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "1291",
+        "Content-Type": "multipart/mixed; boundary=batch_aee03099-e404-941c-6252-47ad4f0bc172",
+        "DataServiceVersion": "3.0",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f5647ad8aca97180396ac59dbf01433c",
+        "x-ms-date": "Mon, 04 Apr 2022 04:37:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "LS1iYXRjaF9hZWUwMzA5OS1lNDA0LTk0MWMtNjI1Mi00N2FkNGYwYmMxNzINCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfYjJlZWQ3OGYtMjRmMi1mNjNmLTIzMjMtN2FmZTgwYWU5MjVhDQoNCi0tY2hhbmdlc2V0X2IyZWVkNzhmLTI0ZjItZjYzZi0yMzIzLTdhZmU4MGFlOTI1YQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUE9TVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tL3Rlc3R0YWJsZUVNTmVieWZ4PyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tDQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpQcmVmZXI6IHJldHVybi1uby1jb250ZW50DQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bWluaW1hbG1ldGFkYXRhDQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bm9tZXRhZGF0YQ0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF9iMmVlZDc4Zi0yNGYyLWY2M2YtMjMyMy03YWZlODBhZTkyNWENCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBPU1QgaHR0cHM6Ly9qb2xvdnRhYmxlc3ByaW0udGFibGUuY29zbW9zLmF6dXJlLmNvbS90ZXN0dGFibGVFTU5lYnlmeD8kZm9ybWF0PWFwcGxpY2F0aW9uJTJGanNvbiUzQm9kYXRhJTNEbWluaW1hbG1ldGFkYXRhIEhUVFAvMS4xDQpIb3N0OiBqb2xvdnRhYmxlc3ByaW0udGFibGUuY29zbW9zLmF6dXJlLmNvbQ0KeC1tcy12ZXJzaW9uOiAyMDE5LTAyLTAyDQpEYXRhU2VydmljZVZlcnNpb246IDMuMA0KUHJlZmVyOiByZXR1cm4tbm8tY29udGVudA0KQWNjZXB0OiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW1pbmltYWxtZXRhZGF0YQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW5vbWV0YWRhdGENCg0KeyJWYWx1ZSI6IkJhciIsIlBhcnRpdGlvbktleSI6IlBLIiwiUm93S2V5IjoiUksxIn0NCi0tY2hhbmdlc2V0X2IyZWVkNzhmLTI0ZjItZjYzZi0yMzIzLTdhZmU4MGFlOTI1YS0tDQoNCi0tYmF0Y2hfYWVlMDMwOTktZTQwNC05NDFjLTYyNTItNDdhZDRmMGJjMTcyLS0NCg==",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Type": "multipart/mixed; boundary=batchresponse_7bae88a1-0b01-4d44-a167-b527942399cf",
+        "Date": "Mon, 04 Apr 2022 04:36:59 GMT",
+        "Transfer-Encoding": "chunked",
+        "x-ms-request-id": "633ffcde-1f55-4b9f-bbef-6e2dafe19688"
+      },
+      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlXzdiYWU4OGExLTBiMDEtNGQ0NC1hMTY3LWI1Mjc5NDIzOTljZg0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlX2VhNWRlZWM1LTBmMmEtNGJkNy04Y2FjLTYzYzcyYWIwNDI1Nw0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2VhNWRlZWM1LTBmMmEtNGJkNy04Y2FjLTYzYzcyYWIwNDI1NwpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2h0dHAKQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5CgpIVFRQLzEuMSAyMDQgTm8gQ29udGVudA0KRVRhZzogVy8iZGF0ZXRpbWUnMjAyMi0wNC0wNFQwNCUzQTM3JTNBMDAuNzgyMjg1NlonIg0KUHJlZmVyZW5jZS1BcHBsaWVkOiByZXR1cm4tbm8tY29udGVudA0KTG9jYXRpb246IGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvc21vcy5henVyZS5jb20vdGVzdHRhYmxlRU1OZWJ5ZngoUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSycpDQpDb250ZW50LUlEOiAxDQoNCg0KLS1jaGFuZ2VzZXRyZXNwb25zZV9lYTVkZWVjNS0wZjJhLTRiZDctOGNhYy02M2M3MmFiMDQyNTcKQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwCkNvbnRlbnQtVHJhbnNmZXItRW5jb2Rpbmc6IGJpbmFyeQoKSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDQtMDRUMDQlM0EzNyUzQTAwLjc4Mjc5NzZaJyINClByZWZlcmVuY2UtQXBwbGllZDogcmV0dXJuLW5vLWNvbnRlbnQNCkxvY2F0aW9uOiBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tL3Rlc3R0YWJsZUVNTmVieWZ4KFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJykNCkNvbnRlbnQtSUQ6IDINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2VhNWRlZWM1LTBmMmEtNGJkNy04Y2FjLTYzYzcyYWIwNDI1Ny0tCi0tYmF0Y2hyZXNwb25zZV83YmFlODhhMS0wYjAxLTRkNDQtYTE2Ny1iNTI3OTQyMzk5Y2YtLQ0K"
+    },
+    {
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtableEMNebyfx(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json; odata=minimalmetadata",
+        "Authorization": "Sanitized",
+        "DataServiceVersion": "3.0",
+        "traceparent": "00-976e54143a1125bf1812f81f8725d290-c6cdf3f386ca8e46-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b5a3cd8400c2752cf0ea8be1691e13b3",
+        "x-ms-date": "Mon, 04 Apr 2022 04:37:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; odata=minimalmetadata",
+        "Date": "Mon, 04 Apr 2022 04:36:59 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A00.7822856Z\u0027\u0022",
+        "Transfer-Encoding": "chunked",
+        "x-ms-request-id": "70e9662c-56f6-4d05-87e0-7890e4f4ff7d"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtableEMNebyfx/$metadata#testtableEMNebyfx/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A00.7822856Z\u0027\u0022",
+        "Value": "Foo",
+        "PartitionKey": "PK",
+        "RowKey": "RK",
+        "Timestamp": "2022-04-04T04:37:00.7822856Z"
+      }
+    },
+    {
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtableEMNebyfx(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json; odata=minimalmetadata",
+        "Authorization": "Sanitized",
+        "DataServiceVersion": "3.0",
+        "traceparent": "00-f5546fe95028398798a430107218d338-ded8040bcfee67de-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d5d4edbfcba6e2c8567d78885fa13621",
+        "x-ms-date": "Mon, 04 Apr 2022 04:37:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; odata=minimalmetadata",
+        "Date": "Mon, 04 Apr 2022 04:37:00 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A00.7827976Z\u0027\u0022",
+        "Transfer-Encoding": "chunked",
+        "x-ms-request-id": "b4e60d2b-a4d2-4bb6-906c-84a3e2ea8007"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtableEMNebyfx/$metadata#testtableEMNebyfx/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A00.7827976Z\u0027\u0022",
+        "Value": "Bar",
+        "PartitionKey": "PK",
+        "RowKey": "RK1",
+        "Timestamp": "2022-04-04T04:37:00.7827976Z"
+      }
+    },
+    {
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtableEMNebyfx\u0027)",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-acf0257e63b8a1e100646d67c9f1957a-2594f7622d64214a-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b3793de0dd0ad8974eef04bf209f081a",
+        "x-ms-date": "Mon, 04 Apr 2022 04:37:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Type": "application/json",
+        "Date": "Mon, 04 Apr 2022 04:37:00 GMT",
+        "x-ms-request-id": "28afe2f3-340d-4df4-a43d-32bef1a1c59c"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "COSMOS_TABLES_ENDPOINT_SUFFIX": "cosmos.azure.com",
+    "RandomSeed": "343710451",
+    "TABLES_COSMOS_ACCOUNT_NAME": "jolovtablesprim",
+    "TABLES_PRIMARY_COSMOS_ACCOUNT_KEY": "Kg=="
+  }
+}

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(True)/CanAddEntityUsingAsyncCollector(%JObjectCamelCase%)Async.json
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(True)/CanAddEntityUsingAsyncCollector(%JObjectCamelCase%)Async.json
@@ -9,27 +9,27 @@
         "Content-Length": "33",
         "Content-Type": "application/json; odata=nometadata",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-b50551f22f54521e642285db040943b0-948ad4db660577e8-00",
+        "traceparent": "00-596e493fc007dd039cb79f61dc00bd5b-4ffbe40e52398b88-00",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "27fe555507f092ae48453f338cb1b21e",
-        "x-ms-date": "Mon, 04 Apr 2022 04:37:00 GMT",
+        "x-ms-client-request-id": "d816eaffd53e8a4a7598a471f2ef2390",
+        "x-ms-date": "Mon, 04 Apr 2022 05:05:59 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": {
-        "TableName": "testtableEMNebyfx"
+        "TableName": "testtable5VDcXEri"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Type": "application/json; odata=minimalmetadata",
-        "Date": "Mon, 04 Apr 2022 04:36:59 GMT",
-        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A00.3875336Z\u0027\u0022",
-        "Location": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtableEMNebyfx\u0027)",
+        "Date": "Mon, 04 Apr 2022 05:06:02 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T05%3A06%3A02.5262088Z\u0027\u0022",
+        "Location": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtable5VDcXEri\u0027)",
         "Transfer-Encoding": "chunked",
-        "x-ms-request-id": "9014b9ea-5651-40c3-8fc5-3bd3285a31ac"
+        "x-ms-request-id": "bafbf764-ef06-482c-9977-ca7dad023a0c"
       },
       "ResponseBody": {
-        "TableName": "testtableEMNebyfx",
+        "TableName": "testtable5VDcXEri",
         "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/$metadata#Tables/@Element"
       }
     },
@@ -39,36 +39,36 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "1291",
-        "Content-Type": "multipart/mixed; boundary=batch_aee03099-e404-941c-6252-47ad4f0bc172",
+        "Content-Length": "1220",
+        "Content-Type": "multipart/mixed; boundary=batch_6de38e1d-5390-7b1a-ca63-61dad3c1cd72",
         "DataServiceVersion": "3.0",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "f5647ad8aca97180396ac59dbf01433c",
-        "x-ms-date": "Mon, 04 Apr 2022 04:37:00 GMT",
+        "x-ms-client-request-id": "c13e3aea5e78aca9d09b0eda746fb7b4",
+        "x-ms-date": "Mon, 04 Apr 2022 05:06:02 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
-      "RequestBody": "LS1iYXRjaF9hZWUwMzA5OS1lNDA0LTk0MWMtNjI1Mi00N2FkNGYwYmMxNzINCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfYjJlZWQ3OGYtMjRmMi1mNjNmLTIzMjMtN2FmZTgwYWU5MjVhDQoNCi0tY2hhbmdlc2V0X2IyZWVkNzhmLTI0ZjItZjYzZi0yMzIzLTdhZmU4MGFlOTI1YQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUE9TVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tL3Rlc3R0YWJsZUVNTmVieWZ4PyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tDQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpQcmVmZXI6IHJldHVybi1uby1jb250ZW50DQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bWluaW1hbG1ldGFkYXRhDQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bm9tZXRhZGF0YQ0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF9iMmVlZDc4Zi0yNGYyLWY2M2YtMjMyMy03YWZlODBhZTkyNWENCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBPU1QgaHR0cHM6Ly9qb2xvdnRhYmxlc3ByaW0udGFibGUuY29zbW9zLmF6dXJlLmNvbS90ZXN0dGFibGVFTU5lYnlmeD8kZm9ybWF0PWFwcGxpY2F0aW9uJTJGanNvbiUzQm9kYXRhJTNEbWluaW1hbG1ldGFkYXRhIEhUVFAvMS4xDQpIb3N0OiBqb2xvdnRhYmxlc3ByaW0udGFibGUuY29zbW9zLmF6dXJlLmNvbQ0KeC1tcy12ZXJzaW9uOiAyMDE5LTAyLTAyDQpEYXRhU2VydmljZVZlcnNpb246IDMuMA0KUHJlZmVyOiByZXR1cm4tbm8tY29udGVudA0KQWNjZXB0OiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW1pbmltYWxtZXRhZGF0YQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW5vbWV0YWRhdGENCg0KeyJWYWx1ZSI6IkJhciIsIlBhcnRpdGlvbktleSI6IlBLIiwiUm93S2V5IjoiUksxIn0NCi0tY2hhbmdlc2V0X2IyZWVkNzhmLTI0ZjItZjYzZi0yMzIzLTdhZmU4MGFlOTI1YS0tDQoNCi0tYmF0Y2hfYWVlMDMwOTktZTQwNC05NDFjLTYyNTItNDdhZDRmMGJjMTcyLS0NCg==",
+      "RequestBody": "LS1iYXRjaF82ZGUzOGUxZC01MzkwLTdiMWEtY2E2My02MWRhZDNjMWNkNzINCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfZmRjMGFhZWYtMzc1ZC00ODZiLTIwZDYtZWRhMTFkNTNlZDBkDQoNCi0tY2hhbmdlc2V0X2ZkYzBhYWVmLTM3NWQtNDg2Yi0yMGQ2LWVkYTExZDUzZWQwZA0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUFVUIGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvc21vcy5henVyZS5jb20vdGVzdHRhYmxlNVZEY1hFcmkoUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSycpPyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tDQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb24NCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbg0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF9mZGMwYWFlZi0zNzVkLTQ4NmItMjBkNi1lZGExMWQ1M2VkMGQNCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBVVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tL3Rlc3R0YWJsZTVWRGNYRXJpKFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJyk/JGZvcm1hdD1hcHBsaWNhdGlvbiUyRmpzb24lM0JvZGF0YSUzRG1pbmltYWxtZXRhZGF0YSBIVFRQLzEuMQ0KSG9zdDogam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvc21vcy5henVyZS5jb20NCngtbXMtdmVyc2lvbjogMjAxOS0wMi0wMg0KRGF0YVNlcnZpY2VWZXJzaW9uOiAzLjANCkFjY2VwdDogYXBwbGljYXRpb24vanNvbg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uDQoNCnsiVmFsdWUiOiJCYXIiLCJQYXJ0aXRpb25LZXkiOiJQSyIsIlJvd0tleSI6IlJLMSJ9DQotLWNoYW5nZXNldF9mZGMwYWFlZi0zNzVkLTQ4NmItMjBkNi1lZGExMWQ1M2VkMGQtLQ0KDQotLWJhdGNoXzZkZTM4ZTFkLTUzOTAtN2IxYS1jYTYzLTYxZGFkM2MxY2Q3Mi0tDQo=",
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Content-Type": "multipart/mixed; boundary=batchresponse_7bae88a1-0b01-4d44-a167-b527942399cf",
-        "Date": "Mon, 04 Apr 2022 04:36:59 GMT",
+        "Content-Type": "multipart/mixed; boundary=batchresponse_a57365ef-9b30-4256-bb06-130f0454a5bf",
+        "Date": "Mon, 04 Apr 2022 05:06:02 GMT",
         "Transfer-Encoding": "chunked",
-        "x-ms-request-id": "633ffcde-1f55-4b9f-bbef-6e2dafe19688"
+        "x-ms-request-id": "38b8fbcf-0e39-4e9c-a2a0-380458e1da29"
       },
-      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlXzdiYWU4OGExLTBiMDEtNGQ0NC1hMTY3LWI1Mjc5NDIzOTljZg0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlX2VhNWRlZWM1LTBmMmEtNGJkNy04Y2FjLTYzYzcyYWIwNDI1Nw0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2VhNWRlZWM1LTBmMmEtNGJkNy04Y2FjLTYzYzcyYWIwNDI1NwpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2h0dHAKQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5CgpIVFRQLzEuMSAyMDQgTm8gQ29udGVudA0KRVRhZzogVy8iZGF0ZXRpbWUnMjAyMi0wNC0wNFQwNCUzQTM3JTNBMDAuNzgyMjg1NlonIg0KUHJlZmVyZW5jZS1BcHBsaWVkOiByZXR1cm4tbm8tY29udGVudA0KTG9jYXRpb246IGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvc21vcy5henVyZS5jb20vdGVzdHRhYmxlRU1OZWJ5ZngoUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSycpDQpDb250ZW50LUlEOiAxDQoNCg0KLS1jaGFuZ2VzZXRyZXNwb25zZV9lYTVkZWVjNS0wZjJhLTRiZDctOGNhYy02M2M3MmFiMDQyNTcKQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwCkNvbnRlbnQtVHJhbnNmZXItRW5jb2Rpbmc6IGJpbmFyeQoKSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDQtMDRUMDQlM0EzNyUzQTAwLjc4Mjc5NzZaJyINClByZWZlcmVuY2UtQXBwbGllZDogcmV0dXJuLW5vLWNvbnRlbnQNCkxvY2F0aW9uOiBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tL3Rlc3R0YWJsZUVNTmVieWZ4KFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJykNCkNvbnRlbnQtSUQ6IDINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2VhNWRlZWM1LTBmMmEtNGJkNy04Y2FjLTYzYzcyYWIwNDI1Ny0tCi0tYmF0Y2hyZXNwb25zZV83YmFlODhhMS0wYjAxLTRkNDQtYTE2Ny1iNTI3OTQyMzk5Y2YtLQ0K"
+      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlX2E1NzM2NWVmLTliMzAtNDI1Ni1iYjA2LTEzMGYwNDU0YTViZg0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlXzdlOGNmOTI1LTRlYjEtNGRmZS1iZmY2LTU0Y2FmMDE4ZmE3Mg0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzdlOGNmOTI1LTRlYjEtNGRmZS1iZmY2LTU0Y2FmMDE4ZmE3MgpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2h0dHAKQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5CgpIVFRQLzEuMSAyMDQgTm8gQ29udGVudA0KRVRhZzogVy8iZGF0ZXRpbWUnMjAyMi0wNC0wNFQwNSUzQTA2JTNBMDIuOTI4ODQ1NlonIg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uDQpDb250ZW50LUlEOiAxDQoNCg0KLS1jaGFuZ2VzZXRyZXNwb25zZV83ZThjZjkyNS00ZWIxLTRkZmUtYmZmNi01NGNhZjAxOGZhNzIKQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwCkNvbnRlbnQtVHJhbnNmZXItRW5jb2Rpbmc6IGJpbmFyeQoKSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDQtMDRUMDUlM0EwNiUzQTAyLjkyOTM1NzZaJyINCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbg0KQ29udGVudC1JRDogMg0KDQoNCi0tY2hhbmdlc2V0cmVzcG9uc2VfN2U4Y2Y5MjUtNGViMS00ZGZlLWJmZjYtNTRjYWYwMThmYTcyLS0KLS1iYXRjaHJlc3BvbnNlX2E1NzM2NWVmLTliMzAtNDI1Ni1iYjA2LTEzMGYwNDU0YTViZi0tDQo="
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtableEMNebyfx(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtable5VDcXEri(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata=minimalmetadata",
         "Authorization": "Sanitized",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-976e54143a1125bf1812f81f8725d290-c6cdf3f386ca8e46-00",
+        "traceparent": "00-ed0d38bd0aa45e1f8a8c83fe02d1702a-6be72dcca32904f6-00",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "b5a3cd8400c2752cf0ea8be1691e13b3",
-        "x-ms-date": "Mon, 04 Apr 2022 04:37:00 GMT",
+        "x-ms-client-request-id": "488131cb262fe632229b4cba65795e77",
+        "x-ms-date": "Mon, 04 Apr 2022 05:06:02 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -76,31 +76,31 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json; odata=minimalmetadata",
-        "Date": "Mon, 04 Apr 2022 04:36:59 GMT",
-        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A00.7822856Z\u0027\u0022",
+        "Date": "Mon, 04 Apr 2022 05:06:02 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T05%3A06%3A02.9288456Z\u0027\u0022",
         "Transfer-Encoding": "chunked",
-        "x-ms-request-id": "70e9662c-56f6-4d05-87e0-7890e4f4ff7d"
+        "x-ms-request-id": "4606882d-81f1-4923-bf0c-ef6cd3243c9d"
       },
       "ResponseBody": {
-        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtableEMNebyfx/$metadata#testtableEMNebyfx/@Element",
-        "odata.etag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A00.7822856Z\u0027\u0022",
-        "Value": "Foo",
+        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtable5VDcXEri/$metadata#testtable5VDcXEri/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T05%3A06%3A02.9288456Z\u0027\u0022",
         "PartitionKey": "PK",
         "RowKey": "RK",
-        "Timestamp": "2022-04-04T04:37:00.7822856Z"
+        "Value": "Foo",
+        "Timestamp": "2022-04-04T05:06:02.9288456Z"
       }
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtableEMNebyfx(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtable5VDcXEri(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata=minimalmetadata",
         "Authorization": "Sanitized",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-f5546fe95028398798a430107218d338-ded8040bcfee67de-00",
+        "traceparent": "00-7bdc5c127df5e1638891df4d0f6c1e59-6325c690f13560b8-00",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "d5d4edbfcba6e2c8567d78885fa13621",
-        "x-ms-date": "Mon, 04 Apr 2022 04:37:00 GMT",
+        "x-ms-client-request-id": "98ef53760b8291fa00142dc22991d3b0",
+        "x-ms-date": "Mon, 04 Apr 2022 05:06:03 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -108,30 +108,30 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json; odata=minimalmetadata",
-        "Date": "Mon, 04 Apr 2022 04:37:00 GMT",
-        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A00.7827976Z\u0027\u0022",
+        "Date": "Mon, 04 Apr 2022 05:06:02 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T05%3A06%3A02.9293576Z\u0027\u0022",
         "Transfer-Encoding": "chunked",
-        "x-ms-request-id": "b4e60d2b-a4d2-4bb6-906c-84a3e2ea8007"
+        "x-ms-request-id": "28b42eba-7684-4bda-b3f5-2ffcab299071"
       },
       "ResponseBody": {
-        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtableEMNebyfx/$metadata#testtableEMNebyfx/@Element",
-        "odata.etag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A00.7827976Z\u0027\u0022",
-        "Value": "Bar",
+        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtable5VDcXEri/$metadata#testtable5VDcXEri/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T05%3A06%3A02.9293576Z\u0027\u0022",
         "PartitionKey": "PK",
         "RowKey": "RK1",
-        "Timestamp": "2022-04-04T04:37:00.7827976Z"
+        "Value": "Bar",
+        "Timestamp": "2022-04-04T05:06:02.9293576Z"
       }
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtableEMNebyfx\u0027)",
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtable5VDcXEri\u0027)",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-acf0257e63b8a1e100646d67c9f1957a-2594f7622d64214a-00",
+        "traceparent": "00-7279106832f7ecc9819329af679b60b9-b8e498b1dcb4eae3-00",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "b3793de0dd0ad8974eef04bf209f081a",
-        "x-ms-date": "Mon, 04 Apr 2022 04:37:01 GMT",
+        "x-ms-client-request-id": "ecd5391fa5d1c4de07579edc11ef4656",
+        "x-ms-date": "Mon, 04 Apr 2022 05:06:03 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -139,15 +139,15 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Mon, 04 Apr 2022 04:37:00 GMT",
-        "x-ms-request-id": "28afe2f3-340d-4df4-a43d-32bef1a1c59c"
+        "Date": "Mon, 04 Apr 2022 05:06:02 GMT",
+        "x-ms-request-id": "6efb2f92-f06d-4f4b-9506-0666ecbcb174"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
     "COSMOS_TABLES_ENDPOINT_SUFFIX": "cosmos.azure.com",
-    "RandomSeed": "343710451",
+    "RandomSeed": "2137425848",
     "TABLES_COSMOS_ACCOUNT_NAME": "jolovtablesprim",
     "TABLES_PRIMARY_COSMOS_ACCOUNT_KEY": "Kg=="
   }

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(True)/CanAddEntityUsingCollector(%JObject%)Async.json
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(True)/CanAddEntityUsingCollector(%JObject%)Async.json
@@ -9,27 +9,27 @@
         "Content-Length": "33",
         "Content-Type": "application/json; odata=nometadata",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-3c911f3c6d86d5a3511c0f3c701acc91-2386795c30d985b6-00",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "6a39c9b9dca44030cf506bb722106e5b",
-        "x-ms-date": "Mon, 31 Jan 2022 22:20:47 GMT",
+        "traceparent": "00-c6ebbba867a38ad5c243c9304778a2e7-72e4e0382fdf82e0-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "54694dcbc6638d567b4c526ab4a05bd5",
+        "x-ms-date": "Mon, 04 Apr 2022 05:12:25 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": {
-        "TableName": "testtableadN4Ir9L"
+        "TableName": "testtablez1luNTMu"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Type": "application/json; odata=minimalmetadata",
-        "Date": "Mon, 31 Jan 2022 22:20:47 GMT",
-        "ETag": "W/\u0022datetime\u00272022-01-31T22%3A20%3A47.4714120Z\u0027\u0022",
-        "Location": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtableadN4Ir9L\u0027)",
+        "Date": "Mon, 04 Apr 2022 05:12:24 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T05%3A12%3A25.2325896Z\u0027\u0022",
+        "Location": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtablez1luNTMu\u0027)",
         "Transfer-Encoding": "chunked",
-        "x-ms-request-id": "3e18e26e-36e9-44b0-8803-9e196df216b2"
+        "x-ms-request-id": "44f8455e-dc0f-4b49-83c3-8abe662b3f4b"
       },
       "ResponseBody": {
-        "TableName": "testtableadN4Ir9L",
+        "TableName": "testtablez1luNTMu",
         "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/$metadata#Tables/@Element"
       }
     },
@@ -39,36 +39,36 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "1291",
-        "Content-Type": "multipart/mixed; boundary=batch_ed2e23f8-83e6-e82d-2e0d-834414394505",
+        "Content-Length": "1220",
+        "Content-Type": "multipart/mixed; boundary=batch_6afa6817-c779-3a19-a397-fb778893a06a",
         "DataServiceVersion": "3.0",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "58b0715d4df335a89c503b9759ec2b96",
-        "x-ms-date": "Mon, 31 Jan 2022 22:20:47 GMT",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "e5235c7d048704ed332fb0cccbdf04e8",
+        "x-ms-date": "Mon, 04 Apr 2022 05:12:25 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
-      "RequestBody": "LS1iYXRjaF9lZDJlMjNmOC04M2U2LWU4MmQtMmUwZC04MzQ0MTQzOTQ1MDUNCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfZTM0N2IwYmQtNzdlYi1iYTkxLTIwMzYtZDJiZmFhODQ1M2E4DQoNCi0tY2hhbmdlc2V0X2UzNDdiMGJkLTc3ZWItYmE5MS0yMDM2LWQyYmZhYTg0NTNhOA0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUE9TVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tL3Rlc3R0YWJsZWFkTjRJcjlMPyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tDQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpQcmVmZXI6IHJldHVybi1uby1jb250ZW50DQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bWluaW1hbG1ldGFkYXRhDQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bm9tZXRhZGF0YQ0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF9lMzQ3YjBiZC03N2ViLWJhOTEtMjAzNi1kMmJmYWE4NDUzYTgNCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBPU1QgaHR0cHM6Ly9qb2xvdnRhYmxlc3ByaW0udGFibGUuY29zbW9zLmF6dXJlLmNvbS90ZXN0dGFibGVhZE40SXI5TD8kZm9ybWF0PWFwcGxpY2F0aW9uJTJGanNvbiUzQm9kYXRhJTNEbWluaW1hbG1ldGFkYXRhIEhUVFAvMS4xDQpIb3N0OiBqb2xvdnRhYmxlc3ByaW0udGFibGUuY29zbW9zLmF6dXJlLmNvbQ0KeC1tcy12ZXJzaW9uOiAyMDE5LTAyLTAyDQpEYXRhU2VydmljZVZlcnNpb246IDMuMA0KUHJlZmVyOiByZXR1cm4tbm8tY29udGVudA0KQWNjZXB0OiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW1pbmltYWxtZXRhZGF0YQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW5vbWV0YWRhdGENCg0KeyJWYWx1ZSI6IkJhciIsIlBhcnRpdGlvbktleSI6IlBLIiwiUm93S2V5IjoiUksxIn0NCi0tY2hhbmdlc2V0X2UzNDdiMGJkLTc3ZWItYmE5MS0yMDM2LWQyYmZhYTg0NTNhOC0tDQoNCi0tYmF0Y2hfZWQyZTIzZjgtODNlNi1lODJkLTJlMGQtODM0NDE0Mzk0NTA1LS0NCg==",
+      "RequestBody": "LS1iYXRjaF82YWZhNjgxNy1jNzc5LTNhMTktYTM5Ny1mYjc3ODg5M2EwNmENCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfOWMxYTBmYzItYzZkNS0zZjc4LTEyYjAtMjQ1OGIwNWYyMDljDQoNCi0tY2hhbmdlc2V0XzljMWEwZmMyLWM2ZDUtM2Y3OC0xMmIwLTI0NThiMDVmMjA5Yw0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUFVUIGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvc21vcy5henVyZS5jb20vdGVzdHRhYmxlejFsdU5UTXUoUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSycpPyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tDQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb24NCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbg0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF85YzFhMGZjMi1jNmQ1LTNmNzgtMTJiMC0yNDU4YjA1ZjIwOWMNCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBVVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tL3Rlc3R0YWJsZXoxbHVOVE11KFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJyk/JGZvcm1hdD1hcHBsaWNhdGlvbiUyRmpzb24lM0JvZGF0YSUzRG1pbmltYWxtZXRhZGF0YSBIVFRQLzEuMQ0KSG9zdDogam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvc21vcy5henVyZS5jb20NCngtbXMtdmVyc2lvbjogMjAxOS0wMi0wMg0KRGF0YVNlcnZpY2VWZXJzaW9uOiAzLjANCkFjY2VwdDogYXBwbGljYXRpb24vanNvbg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uDQoNCnsiVmFsdWUiOiJCYXIiLCJQYXJ0aXRpb25LZXkiOiJQSyIsIlJvd0tleSI6IlJLMSJ9DQotLWNoYW5nZXNldF85YzFhMGZjMi1jNmQ1LTNmNzgtMTJiMC0yNDU4YjA1ZjIwOWMtLQ0KDQotLWJhdGNoXzZhZmE2ODE3LWM3NzktM2ExOS1hMzk3LWZiNzc4ODkzYTA2YS0tDQo=",
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Content-Type": "multipart/mixed; boundary=batchresponse_f1306c73-9b21-432f-9628-dd47a0a049fd",
-        "Date": "Mon, 31 Jan 2022 22:20:47 GMT",
+        "Content-Type": "multipart/mixed; boundary=batchresponse_e400556e-177e-4c6b-9329-dc4a78c8c640",
+        "Date": "Mon, 04 Apr 2022 05:12:25 GMT",
         "Transfer-Encoding": "chunked",
-        "x-ms-request-id": "3e215a28-0175-4e0f-a176-98ed416deb5d"
+        "x-ms-request-id": "747d5274-11f1-457a-b4f6-9d43fd053af8"
       },
-      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlX2YxMzA2YzczLTliMjEtNDMyZi05NjI4LWRkNDdhMGEwNDlmZA0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlXzQ0ZGQxNGI2LWM4NDUtNGMwOS1hOTA1LWQwYWZlYjE5YTg4Ng0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzQ0ZGQxNGI2LWM4NDUtNGMwOS1hOTA1LWQwYWZlYjE5YTg4NgpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2h0dHAKQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5CgpIVFRQLzEuMSAyMDQgTm8gQ29udGVudA0KRVRhZzogVy8iZGF0ZXRpbWUnMjAyMi0wMS0zMVQyMiUzQTIwJTNBNDguMDUzMzUxMlonIg0KUHJlZmVyZW5jZS1BcHBsaWVkOiByZXR1cm4tbm8tY29udGVudA0KTG9jYXRpb246IGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvc21vcy5henVyZS5jb20vdGVzdHRhYmxlYWRONElyOUwoUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSycpDQpDb250ZW50LUlEOiAxDQoNCg0KLS1jaGFuZ2VzZXRyZXNwb25zZV80NGRkMTRiNi1jODQ1LTRjMDktYTkwNS1kMGFmZWIxOWE4ODYKQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwCkNvbnRlbnQtVHJhbnNmZXItRW5jb2Rpbmc6IGJpbmFyeQoKSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDEtMzFUMjIlM0EyMCUzQTQ4LjA1Mzc2MDhaJyINClByZWZlcmVuY2UtQXBwbGllZDogcmV0dXJuLW5vLWNvbnRlbnQNCkxvY2F0aW9uOiBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tL3Rlc3R0YWJsZWFkTjRJcjlMKFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJykNCkNvbnRlbnQtSUQ6IDINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzQ0ZGQxNGI2LWM4NDUtNGMwOS1hOTA1LWQwYWZlYjE5YTg4Ni0tCi0tYmF0Y2hyZXNwb25zZV9mMTMwNmM3My05YjIxLTQzMmYtOTYyOC1kZDQ3YTBhMDQ5ZmQtLQ0K"
+      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlX2U0MDA1NTZlLTE3N2UtNGM2Yi05MzI5LWRjNGE3OGM4YzY0MA0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlXzBiNjQ1ZmY5LWIzMTYtNDRmNy04ODM5LWZiZWYxZDA4NjQyZA0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzBiNjQ1ZmY5LWIzMTYtNDRmNy04ODM5LWZiZWYxZDA4NjQyZApDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2h0dHAKQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5CgpIVFRQLzEuMSAyMDQgTm8gQ29udGVudA0KRVRhZzogVy8iZGF0ZXRpbWUnMjAyMi0wNC0wNFQwNSUzQTEyJTNBMjUuOTE1MzkyOFonIg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uDQpDb250ZW50LUlEOiAxDQoNCg0KLS1jaGFuZ2VzZXRyZXNwb25zZV8wYjY0NWZmOS1iMzE2LTQ0ZjctODgzOS1mYmVmMWQwODY0MmQKQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwCkNvbnRlbnQtVHJhbnNmZXItRW5jb2Rpbmc6IGJpbmFyeQoKSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDQtMDRUMDUlM0ExMiUzQTI1LjkxNTgwMjRaJyINCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbg0KQ29udGVudC1JRDogMg0KDQoNCi0tY2hhbmdlc2V0cmVzcG9uc2VfMGI2NDVmZjktYjMxNi00NGY3LTg4MzktZmJlZjFkMDg2NDJkLS0KLS1iYXRjaHJlc3BvbnNlX2U0MDA1NTZlLTE3N2UtNGM2Yi05MzI5LWRjNGE3OGM4YzY0MC0tDQo="
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtableadN4Ir9L(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtablez1luNTMu(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata=minimalmetadata",
         "Authorization": "Sanitized",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-ce88406fdf87d5347ce6b1148dc721fa-38ac4e710ae5d317-00",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "71fa660a8ac9816f9173cdafb16d3eaa",
-        "x-ms-date": "Mon, 31 Jan 2022 22:20:48 GMT",
+        "traceparent": "00-b0495ca7233e9ce7d2e624e33ed44fad-497fcabfb7c423cb-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "a4a7e8acbf8650ffefbb57c8a2c18944",
+        "x-ms-date": "Mon, 04 Apr 2022 05:12:25 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -76,31 +76,31 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json; odata=minimalmetadata",
-        "Date": "Mon, 31 Jan 2022 22:20:47 GMT",
-        "ETag": "W/\u0022datetime\u00272022-01-31T22%3A20%3A48.0533512Z\u0027\u0022",
+        "Date": "Mon, 04 Apr 2022 05:12:25 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T05%3A12%3A25.9153928Z\u0027\u0022",
         "Transfer-Encoding": "chunked",
-        "x-ms-request-id": "44aa6bb0-a7a3-4a5c-bc31-90fe70500a0b"
+        "x-ms-request-id": "444b7b32-7173-4a9c-9b65-4ad018b4bd1d"
       },
       "ResponseBody": {
-        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtableadN4Ir9L/$metadata#testtableadN4Ir9L/@Element",
-        "odata.etag": "W/\u0022datetime\u00272022-01-31T22%3A20%3A48.0533512Z\u0027\u0022",
-        "Value": "Foo",
+        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtablez1luNTMu/$metadata#testtablez1luNTMu/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T05%3A12%3A25.9153928Z\u0027\u0022",
         "PartitionKey": "PK",
         "RowKey": "RK",
-        "Timestamp": "2022-01-31T22:20:48.0533512Z"
+        "Value": "Foo",
+        "Timestamp": "2022-04-04T05:12:25.9153928Z"
       }
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtableadN4Ir9L(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtablez1luNTMu(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata=minimalmetadata",
         "Authorization": "Sanitized",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-04fe1479511c2f8d32e3588b208d31a7-8b6afd88534b958f-00",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "a3e7dabaed8970110711479b3bfa6133",
-        "x-ms-date": "Mon, 31 Jan 2022 22:20:48 GMT",
+        "traceparent": "00-734a776e0466ab94115526476ec87af4-8e8ba9e8c203d239-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "2cf95e76ba70bee2221669a616ac7433",
+        "x-ms-date": "Mon, 04 Apr 2022 05:12:26 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -108,45 +108,46 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json; odata=minimalmetadata",
-        "Date": "Mon, 31 Jan 2022 22:20:47 GMT",
-        "ETag": "W/\u0022datetime\u00272022-01-31T22%3A20%3A48.0537608Z\u0027\u0022",
+        "Date": "Mon, 04 Apr 2022 05:12:25 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T05%3A12%3A25.9158024Z\u0027\u0022",
         "Transfer-Encoding": "chunked",
-        "x-ms-request-id": "16d1a7b7-b77f-44b6-bd4d-7516eda3bdd9"
+        "x-ms-request-id": "597062d4-b101-4023-b32a-25e6f229edb4"
       },
       "ResponseBody": {
-        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtableadN4Ir9L/$metadata#testtableadN4Ir9L/@Element",
-        "odata.etag": "W/\u0022datetime\u00272022-01-31T22%3A20%3A48.0537608Z\u0027\u0022",
-        "Value": "Bar",
+        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtablez1luNTMu/$metadata#testtablez1luNTMu/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T05%3A12%3A25.9158024Z\u0027\u0022",
         "PartitionKey": "PK",
         "RowKey": "RK1",
-        "Timestamp": "2022-01-31T22:20:48.0537608Z"
+        "Value": "Bar",
+        "Timestamp": "2022-04-04T05:12:25.9158024Z"
       }
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtableadN4Ir9L\u0027)",
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtablez1luNTMu\u0027)",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-87d1e16e35545e30e36b28ea4da6cf74-03173c0d4eab4484-00",
-        "User-Agent": "azsdk-net-Data.Tables/12.5.0-alpha.20220131.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "43b53c0be18ad2de012ec67f7ff9842e",
-        "x-ms-date": "Mon, 31 Jan 2022 22:20:48 GMT",
+        "traceparent": "00-82e51585e46425db6b14188f7c992133-e1ec223cf55b9b39-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "c8ab3cab7bb8be165cd2f5ccac246172",
+        "x-ms-date": "Mon, 04 Apr 2022 05:12:26 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "Date": "Mon, 31 Jan 2022 22:20:47 GMT",
-        "x-ms-request-id": "84361f26-d0ed-49d7-b171-ff8c283479bd"
+        "Content-Type": "application/json",
+        "Date": "Mon, 04 Apr 2022 05:12:25 GMT",
+        "x-ms-request-id": "605fed4f-93c5-461b-96aa-6b261276f168"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
     "COSMOS_TABLES_ENDPOINT_SUFFIX": "cosmos.azure.com",
-    "RandomSeed": "713609141",
+    "RandomSeed": "1431740547",
     "TABLES_COSMOS_ACCOUNT_NAME": "jolovtablesprim",
     "TABLES_PRIMARY_COSMOS_ACCOUNT_KEY": "Kg=="
   }

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(True)/CanAddEntityUsingCollector(%JObjectCamelCase%)Async.json
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(True)/CanAddEntityUsingCollector(%JObjectCamelCase%)Async.json
@@ -9,27 +9,27 @@
         "Content-Length": "33",
         "Content-Type": "application/json; odata=nometadata",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-59f453617215236a793c8ddd1921211e-d11d42ba40f7772f-00",
+        "traceparent": "00-eeaeb53bddd99449e12b1fb03c08e34e-c747bab38a79d71a-00",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "31eb3a0b61b04257603fe59c53e36600",
-        "x-ms-date": "Mon, 04 Apr 2022 04:37:07 GMT",
+        "x-ms-client-request-id": "7a0e03afc2d5d3140b8a7749d0453bf4",
+        "x-ms-date": "Mon, 04 Apr 2022 05:06:03 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
       "RequestBody": {
-        "TableName": "testtableWEphCTTt"
+        "TableName": "testtableiOm1ptkU"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Type": "application/json; odata=minimalmetadata",
-        "Date": "Mon, 04 Apr 2022 04:37:06 GMT",
-        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A07.6196360Z\u0027\u0022",
-        "Location": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtableWEphCTTt\u0027)",
+        "Date": "Mon, 04 Apr 2022 05:06:03 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T05%3A06%3A03.7618696Z\u0027\u0022",
+        "Location": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtableiOm1ptkU\u0027)",
         "Transfer-Encoding": "chunked",
-        "x-ms-request-id": "b607646a-ab0e-4eed-bb37-9dd7cb020889"
+        "x-ms-request-id": "5d86158f-b12c-40ac-b6ca-3157e3080593"
       },
       "ResponseBody": {
-        "TableName": "testtableWEphCTTt",
+        "TableName": "testtableiOm1ptkU",
         "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/$metadata#Tables/@Element"
       }
     },
@@ -39,36 +39,36 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "1291",
-        "Content-Type": "multipart/mixed; boundary=batch_304de65f-5a90-b50c-f9cb-ce6766ff72e7",
+        "Content-Length": "1220",
+        "Content-Type": "multipart/mixed; boundary=batch_cac03784-b0e7-93ce-ba6f-5b8a1d226372",
         "DataServiceVersion": "3.0",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "baa8f6fdac94b14d2d3638e492f0dc61",
-        "x-ms-date": "Mon, 04 Apr 2022 04:37:07 GMT",
+        "x-ms-client-request-id": "a477b45a11ecfed9357abf66678ab6e8",
+        "x-ms-date": "Mon, 04 Apr 2022 05:06:04 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
-      "RequestBody": "LS1iYXRjaF8zMDRkZTY1Zi01YTkwLWI1MGMtZjljYi1jZTY3NjZmZjcyZTcNCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfY2ZjNjgyYmItOGVlNi0yMjBjLTljMGEtMDRjNGQ1MTMyYTYyDQoNCi0tY2hhbmdlc2V0X2NmYzY4MmJiLThlZTYtMjIwYy05YzBhLTA0YzRkNTEzMmE2Mg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUE9TVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tL3Rlc3R0YWJsZVdFcGhDVFR0PyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tDQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpQcmVmZXI6IHJldHVybi1uby1jb250ZW50DQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bWluaW1hbG1ldGFkYXRhDQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bm9tZXRhZGF0YQ0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF9jZmM2ODJiYi04ZWU2LTIyMGMtOWMwYS0wNGM0ZDUxMzJhNjINCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBPU1QgaHR0cHM6Ly9qb2xvdnRhYmxlc3ByaW0udGFibGUuY29zbW9zLmF6dXJlLmNvbS90ZXN0dGFibGVXRXBoQ1RUdD8kZm9ybWF0PWFwcGxpY2F0aW9uJTJGanNvbiUzQm9kYXRhJTNEbWluaW1hbG1ldGFkYXRhIEhUVFAvMS4xDQpIb3N0OiBqb2xvdnRhYmxlc3ByaW0udGFibGUuY29zbW9zLmF6dXJlLmNvbQ0KeC1tcy12ZXJzaW9uOiAyMDE5LTAyLTAyDQpEYXRhU2VydmljZVZlcnNpb246IDMuMA0KUHJlZmVyOiByZXR1cm4tbm8tY29udGVudA0KQWNjZXB0OiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW1pbmltYWxtZXRhZGF0YQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW5vbWV0YWRhdGENCg0KeyJWYWx1ZSI6IkJhciIsIlBhcnRpdGlvbktleSI6IlBLIiwiUm93S2V5IjoiUksxIn0NCi0tY2hhbmdlc2V0X2NmYzY4MmJiLThlZTYtMjIwYy05YzBhLTA0YzRkNTEzMmE2Mi0tDQoNCi0tYmF0Y2hfMzA0ZGU2NWYtNWE5MC1iNTBjLWY5Y2ItY2U2NzY2ZmY3MmU3LS0NCg==",
+      "RequestBody": "LS1iYXRjaF9jYWMwMzc4NC1iMGU3LTkzY2UtYmE2Zi01YjhhMWQyMjYzNzINCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfOWJiYTVmZTAtMDRjYy01MzFhLWFmODEtMTA5MGY3N2E5YmVkDQoNCi0tY2hhbmdlc2V0XzliYmE1ZmUwLTA0Y2MtNTMxYS1hZjgxLTEwOTBmNzdhOWJlZA0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUFVUIGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvc21vcy5henVyZS5jb20vdGVzdHRhYmxlaU9tMXB0a1UoUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSycpPyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tDQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb24NCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbg0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF85YmJhNWZlMC0wNGNjLTUzMWEtYWY4MS0xMDkwZjc3YTliZWQNCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBVVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tL3Rlc3R0YWJsZWlPbTFwdGtVKFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJyk/JGZvcm1hdD1hcHBsaWNhdGlvbiUyRmpzb24lM0JvZGF0YSUzRG1pbmltYWxtZXRhZGF0YSBIVFRQLzEuMQ0KSG9zdDogam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvc21vcy5henVyZS5jb20NCngtbXMtdmVyc2lvbjogMjAxOS0wMi0wMg0KRGF0YVNlcnZpY2VWZXJzaW9uOiAzLjANCkFjY2VwdDogYXBwbGljYXRpb24vanNvbg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uDQoNCnsiVmFsdWUiOiJCYXIiLCJQYXJ0aXRpb25LZXkiOiJQSyIsIlJvd0tleSI6IlJLMSJ9DQotLWNoYW5nZXNldF85YmJhNWZlMC0wNGNjLTUzMWEtYWY4MS0xMDkwZjc3YTliZWQtLQ0KDQotLWJhdGNoX2NhYzAzNzg0LWIwZTctOTNjZS1iYTZmLTViOGExZDIyNjM3Mi0tDQo=",
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Content-Type": "multipart/mixed; boundary=batchresponse_80515a26-ec71-4fbd-bc5b-876196bbd2f0",
-        "Date": "Mon, 04 Apr 2022 04:37:07 GMT",
+        "Content-Type": "multipart/mixed; boundary=batchresponse_a33442a9-d596-4913-a6de-221f980cde4f",
+        "Date": "Mon, 04 Apr 2022 05:06:03 GMT",
         "Transfer-Encoding": "chunked",
-        "x-ms-request-id": "2b3095fe-6c3c-4dc9-a56f-6d576ff6c72a"
+        "x-ms-request-id": "e0cb2365-36b6-4dd1-b6d4-e9f8933a90b6"
       },
-      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlXzgwNTE1YTI2LWVjNzEtNGZiZC1iYzViLTg3NjE5NmJiZDJmMA0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlXzIwNzRhZWFjLWI5YWUtNDE3Ny05NjI0LWI3OGNlYzdhMWI2MQ0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzIwNzRhZWFjLWI5YWUtNDE3Ny05NjI0LWI3OGNlYzdhMWI2MQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2h0dHAKQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5CgpIVFRQLzEuMSAyMDQgTm8gQ29udGVudA0KRVRhZzogVy8iZGF0ZXRpbWUnMjAyMi0wNC0wNFQwNCUzQTM3JTNBMDguMDY1OTk3NlonIg0KUHJlZmVyZW5jZS1BcHBsaWVkOiByZXR1cm4tbm8tY29udGVudA0KTG9jYXRpb246IGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvc21vcy5henVyZS5jb20vdGVzdHRhYmxlV0VwaENUVHQoUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSycpDQpDb250ZW50LUlEOiAxDQoNCg0KLS1jaGFuZ2VzZXRyZXNwb25zZV8yMDc0YWVhYy1iOWFlLTQxNzctOTYyNC1iNzhjZWM3YTFiNjEKQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwCkNvbnRlbnQtVHJhbnNmZXItRW5jb2Rpbmc6IGJpbmFyeQoKSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDQtMDRUMDQlM0EzNyUzQTA4LjA2NjQwNzJaJyINClByZWZlcmVuY2UtQXBwbGllZDogcmV0dXJuLW5vLWNvbnRlbnQNCkxvY2F0aW9uOiBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tL3Rlc3R0YWJsZVdFcGhDVFR0KFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJykNCkNvbnRlbnQtSUQ6IDINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzIwNzRhZWFjLWI5YWUtNDE3Ny05NjI0LWI3OGNlYzdhMWI2MS0tCi0tYmF0Y2hyZXNwb25zZV84MDUxNWEyNi1lYzcxLTRmYmQtYmM1Yi04NzYxOTZiYmQyZjAtLQ0K"
+      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlX2EzMzQ0MmE5LWQ1OTYtNDkxMy1hNmRlLTIyMWY5ODBjZGU0Zg0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlX2ExZGU2NDZlLTlmYzEtNGJmZS1hNWM2LWY3M2NiOGM4YmY0Mw0KDQotLWNoYW5nZXNldHJlc3BvbnNlX2ExZGU2NDZlLTlmYzEtNGJmZS1hNWM2LWY3M2NiOGM4YmY0MwpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2h0dHAKQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5CgpIVFRQLzEuMSAyMDQgTm8gQ29udGVudA0KRVRhZzogVy8iZGF0ZXRpbWUnMjAyMi0wNC0wNFQwNSUzQTA2JTNBMDQuMTc2MjgyNFonIg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uDQpDb250ZW50LUlEOiAxDQoNCg0KLS1jaGFuZ2VzZXRyZXNwb25zZV9hMWRlNjQ2ZS05ZmMxLTRiZmUtYTVjNi1mNzNjYjhjOGJmNDMKQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwCkNvbnRlbnQtVHJhbnNmZXItRW5jb2Rpbmc6IGJpbmFyeQoKSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDQtMDRUMDUlM0EwNiUzQTA0LjE3NjY5MjBaJyINCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbg0KQ29udGVudC1JRDogMg0KDQoNCi0tY2hhbmdlc2V0cmVzcG9uc2VfYTFkZTY0NmUtOWZjMS00YmZlLWE1YzYtZjczY2I4YzhiZjQzLS0KLS1iYXRjaHJlc3BvbnNlX2EzMzQ0MmE5LWQ1OTYtNDkxMy1hNmRlLTIyMWY5ODBjZGU0Zi0tDQo="
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtableWEphCTTt(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtableiOm1ptkU(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata=minimalmetadata",
         "Authorization": "Sanitized",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-b6cc69c016684129444caada14486abe-2b8f13fe4f7ad0d4-00",
+        "traceparent": "00-5dd4eef67bafae1c98d4447af758b502-311b47b502876880-00",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "d0e0fecd961cd01ad92a93855648e0e5",
-        "x-ms-date": "Mon, 04 Apr 2022 04:37:08 GMT",
+        "x-ms-client-request-id": "706805269f8a7f271d6d1b65a03d9c3f",
+        "x-ms-date": "Mon, 04 Apr 2022 05:06:04 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -76,31 +76,31 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json; odata=minimalmetadata",
-        "Date": "Mon, 04 Apr 2022 04:37:07 GMT",
-        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A08.0659976Z\u0027\u0022",
+        "Date": "Mon, 04 Apr 2022 05:06:03 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T05%3A06%3A04.1762824Z\u0027\u0022",
         "Transfer-Encoding": "chunked",
-        "x-ms-request-id": "b03ccef8-3065-46d4-bedf-5e0416bdc70d"
+        "x-ms-request-id": "c66ef07b-b5b1-43e6-8839-8d5587629a45"
       },
       "ResponseBody": {
-        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtableWEphCTTt/$metadata#testtableWEphCTTt/@Element",
-        "odata.etag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A08.0659976Z\u0027\u0022",
-        "Value": "Foo",
+        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtableiOm1ptkU/$metadata#testtableiOm1ptkU/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T05%3A06%3A04.1762824Z\u0027\u0022",
         "PartitionKey": "PK",
         "RowKey": "RK",
-        "Timestamp": "2022-04-04T04:37:08.0659976Z"
+        "Value": "Foo",
+        "Timestamp": "2022-04-04T05:06:04.1762824Z"
       }
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtableWEphCTTt(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtableiOm1ptkU(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata=minimalmetadata",
         "Authorization": "Sanitized",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-b84358a677cc87adae5e269e5d9110e8-4e7ed95618c44836-00",
+        "traceparent": "00-9121d38ffd304b38198025c0270c95f8-6f92d56d233ba222-00",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "6f696ca0b7560e523415a2b056288fac",
-        "x-ms-date": "Mon, 04 Apr 2022 04:37:08 GMT",
+        "x-ms-client-request-id": "682f6ed4bfabcf8586bb665144b3ec25",
+        "x-ms-date": "Mon, 04 Apr 2022 05:06:04 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -108,30 +108,30 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json; odata=minimalmetadata",
-        "Date": "Mon, 04 Apr 2022 04:37:07 GMT",
-        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A08.0664072Z\u0027\u0022",
+        "Date": "Mon, 04 Apr 2022 05:06:03 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T05%3A06%3A04.1766920Z\u0027\u0022",
         "Transfer-Encoding": "chunked",
-        "x-ms-request-id": "97cc13d3-db52-4a81-9e01-a9c0f66f61e6"
+        "x-ms-request-id": "647551ca-015e-4c9f-af68-27309717f019"
       },
       "ResponseBody": {
-        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtableWEphCTTt/$metadata#testtableWEphCTTt/@Element",
-        "odata.etag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A08.0664072Z\u0027\u0022",
-        "Value": "Bar",
+        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtableiOm1ptkU/$metadata#testtableiOm1ptkU/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T05%3A06%3A04.1766920Z\u0027\u0022",
         "PartitionKey": "PK",
         "RowKey": "RK1",
-        "Timestamp": "2022-04-04T04:37:08.0664072Z"
+        "Value": "Bar",
+        "Timestamp": "2022-04-04T05:06:04.1766920Z"
       }
     },
     {
-      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtableWEphCTTt\u0027)",
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtableiOm1ptkU\u0027)",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-7c8f79fb7423c1229f11d29da9ec56ac-81570ad943f41bed-00",
+        "traceparent": "00-7d7c7b86208a86feafe1ec3b6c8ee6e6-a3eae337df80884d-00",
         "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "d6f7a22e5a336745dcd8e06918c85be5",
-        "x-ms-date": "Mon, 04 Apr 2022 04:37:08 GMT",
+        "x-ms-client-request-id": "f16927cb2a11bb628cf8877ff6735ef7",
+        "x-ms-date": "Mon, 04 Apr 2022 05:06:04 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -139,15 +139,15 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Mon, 04 Apr 2022 04:37:07 GMT",
-        "x-ms-request-id": "d6690659-aa5f-4e31-ac01-7e2685719966"
+        "Date": "Mon, 04 Apr 2022 05:06:04 GMT",
+        "x-ms-request-id": "b8361ddc-5723-44c2-a7a7-de1ed23aca76"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
     "COSMOS_TABLES_ENDPOINT_SUFFIX": "cosmos.azure.com",
-    "RandomSeed": "1980008140",
+    "RandomSeed": "1495072535",
     "TABLES_COSMOS_ACCOUNT_NAME": "jolovtablesprim",
     "TABLES_PRIMARY_COSMOS_ACCOUNT_KEY": "Kg=="
   }

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(True)/CanAddEntityUsingCollector(%JObjectCamelCase%)Async.json
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/tests/SessionRecords/EntityBindingLiveTests(True)/CanAddEntityUsingCollector(%JObjectCamelCase%)Async.json
@@ -1,0 +1,154 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/Tables?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json; odata=minimalmetadata",
+        "Authorization": "Sanitized",
+        "Content-Length": "33",
+        "Content-Type": "application/json; odata=nometadata",
+        "DataServiceVersion": "3.0",
+        "traceparent": "00-59f453617215236a793c8ddd1921211e-d11d42ba40f7772f-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "31eb3a0b61b04257603fe59c53e36600",
+        "x-ms-date": "Mon, 04 Apr 2022 04:37:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": {
+        "TableName": "testtableWEphCTTt"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; odata=minimalmetadata",
+        "Date": "Mon, 04 Apr 2022 04:37:06 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A07.6196360Z\u0027\u0022",
+        "Location": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtableWEphCTTt\u0027)",
+        "Transfer-Encoding": "chunked",
+        "x-ms-request-id": "b607646a-ab0e-4eed-bb37-9dd7cb020889"
+      },
+      "ResponseBody": {
+        "TableName": "testtableWEphCTTt",
+        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/$metadata#Tables/@Element"
+      }
+    },
+    {
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/$batch",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "1291",
+        "Content-Type": "multipart/mixed; boundary=batch_304de65f-5a90-b50c-f9cb-ce6766ff72e7",
+        "DataServiceVersion": "3.0",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "baa8f6fdac94b14d2d3638e492f0dc61",
+        "x-ms-date": "Mon, 04 Apr 2022 04:37:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "LS1iYXRjaF8zMDRkZTY1Zi01YTkwLWI1MGMtZjljYi1jZTY3NjZmZjcyZTcNCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT1jaGFuZ2VzZXRfY2ZjNjgyYmItOGVlNi0yMjBjLTljMGEtMDRjNGQ1MTMyYTYyDQoNCi0tY2hhbmdlc2V0X2NmYzY4MmJiLThlZTYtMjIwYy05YzBhLTA0YzRkNTEzMmE2Mg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUE9TVCBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tL3Rlc3R0YWJsZVdFcGhDVFR0PyRmb3JtYXQ9YXBwbGljYXRpb24lMkZqc29uJTNCb2RhdGElM0RtaW5pbWFsbWV0YWRhdGEgSFRUUC8xLjENCkhvc3Q6IGpvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tDQp4LW1zLXZlcnNpb246IDIwMTktMDItMDINCkRhdGFTZXJ2aWNlVmVyc2lvbjogMy4wDQpQcmVmZXI6IHJldHVybi1uby1jb250ZW50DQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bWluaW1hbG1ldGFkYXRhDQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb247b2RhdGE9bm9tZXRhZGF0YQ0KDQp7IlZhbHVlIjoiRm9vIiwiUGFydGl0aW9uS2V5IjoiUEsiLCJSb3dLZXkiOiJSSyJ9DQotLWNoYW5nZXNldF9jZmM2ODJiYi04ZWU2LTIyMGMtOWMwYS0wNGM0ZDUxMzJhNjINCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vaHR0cA0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBPU1QgaHR0cHM6Ly9qb2xvdnRhYmxlc3ByaW0udGFibGUuY29zbW9zLmF6dXJlLmNvbS90ZXN0dGFibGVXRXBoQ1RUdD8kZm9ybWF0PWFwcGxpY2F0aW9uJTJGanNvbiUzQm9kYXRhJTNEbWluaW1hbG1ldGFkYXRhIEhUVFAvMS4xDQpIb3N0OiBqb2xvdnRhYmxlc3ByaW0udGFibGUuY29zbW9zLmF6dXJlLmNvbQ0KeC1tcy12ZXJzaW9uOiAyMDE5LTAyLTAyDQpEYXRhU2VydmljZVZlcnNpb246IDMuMA0KUHJlZmVyOiByZXR1cm4tbm8tY29udGVudA0KQWNjZXB0OiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW1pbmltYWxtZXRhZGF0YQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uO29kYXRhPW5vbWV0YWRhdGENCg0KeyJWYWx1ZSI6IkJhciIsIlBhcnRpdGlvbktleSI6IlBLIiwiUm93S2V5IjoiUksxIn0NCi0tY2hhbmdlc2V0X2NmYzY4MmJiLThlZTYtMjIwYy05YzBhLTA0YzRkNTEzMmE2Mi0tDQoNCi0tYmF0Y2hfMzA0ZGU2NWYtNWE5MC1iNTBjLWY5Y2ItY2U2NzY2ZmY3MmU3LS0NCg==",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Type": "multipart/mixed; boundary=batchresponse_80515a26-ec71-4fbd-bc5b-876196bbd2f0",
+        "Date": "Mon, 04 Apr 2022 04:37:07 GMT",
+        "Transfer-Encoding": "chunked",
+        "x-ms-request-id": "2b3095fe-6c3c-4dc9-a56f-6d576ff6c72a"
+      },
+      "ResponseBody": "LS1iYXRjaHJlc3BvbnNlXzgwNTE1YTI2LWVjNzEtNGZiZC1iYzViLTg3NjE5NmJiZDJmMA0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PWNoYW5nZXNldHJlc3BvbnNlXzIwNzRhZWFjLWI5YWUtNDE3Ny05NjI0LWI3OGNlYzdhMWI2MQ0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzIwNzRhZWFjLWI5YWUtNDE3Ny05NjI0LWI3OGNlYzdhMWI2MQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2h0dHAKQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5CgpIVFRQLzEuMSAyMDQgTm8gQ29udGVudA0KRVRhZzogVy8iZGF0ZXRpbWUnMjAyMi0wNC0wNFQwNCUzQTM3JTNBMDguMDY1OTk3NlonIg0KUHJlZmVyZW5jZS1BcHBsaWVkOiByZXR1cm4tbm8tY29udGVudA0KTG9jYXRpb246IGh0dHBzOi8vam9sb3Z0YWJsZXNwcmltLnRhYmxlLmNvc21vcy5henVyZS5jb20vdGVzdHRhYmxlV0VwaENUVHQoUGFydGl0aW9uS2V5PSdQSycsUm93S2V5PSdSSycpDQpDb250ZW50LUlEOiAxDQoNCg0KLS1jaGFuZ2VzZXRyZXNwb25zZV8yMDc0YWVhYy1iOWFlLTQxNzctOTYyNC1iNzhjZWM3YTFiNjEKQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwCkNvbnRlbnQtVHJhbnNmZXItRW5jb2Rpbmc6IGJpbmFyeQoKSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNCkVUYWc6IFcvImRhdGV0aW1lJzIwMjItMDQtMDRUMDQlM0EzNyUzQTA4LjA2NjQwNzJaJyINClByZWZlcmVuY2UtQXBwbGllZDogcmV0dXJuLW5vLWNvbnRlbnQNCkxvY2F0aW9uOiBodHRwczovL2pvbG92dGFibGVzcHJpbS50YWJsZS5jb3Ntb3MuYXp1cmUuY29tL3Rlc3R0YWJsZVdFcGhDVFR0KFBhcnRpdGlvbktleT0nUEsnLFJvd0tleT0nUksxJykNCkNvbnRlbnQtSUQ6IDINCg0KDQotLWNoYW5nZXNldHJlc3BvbnNlXzIwNzRhZWFjLWI5YWUtNDE3Ny05NjI0LWI3OGNlYzdhMWI2MS0tCi0tYmF0Y2hyZXNwb25zZV84MDUxNWEyNi1lYzcxLTRmYmQtYmM1Yi04NzYxOTZiYmQyZjAtLQ0K"
+    },
+    {
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtableWEphCTTt(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json; odata=minimalmetadata",
+        "Authorization": "Sanitized",
+        "DataServiceVersion": "3.0",
+        "traceparent": "00-b6cc69c016684129444caada14486abe-2b8f13fe4f7ad0d4-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d0e0fecd961cd01ad92a93855648e0e5",
+        "x-ms-date": "Mon, 04 Apr 2022 04:37:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; odata=minimalmetadata",
+        "Date": "Mon, 04 Apr 2022 04:37:07 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A08.0659976Z\u0027\u0022",
+        "Transfer-Encoding": "chunked",
+        "x-ms-request-id": "b03ccef8-3065-46d4-bedf-5e0416bdc70d"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtableWEphCTTt/$metadata#testtableWEphCTTt/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A08.0659976Z\u0027\u0022",
+        "Value": "Foo",
+        "PartitionKey": "PK",
+        "RowKey": "RK",
+        "Timestamp": "2022-04-04T04:37:08.0659976Z"
+      }
+    },
+    {
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/testtableWEphCTTt(PartitionKey=\u0027PK\u0027,RowKey=\u0027RK1\u0027)?$format=application%2Fjson%3Bodata%3Dminimalmetadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json; odata=minimalmetadata",
+        "Authorization": "Sanitized",
+        "DataServiceVersion": "3.0",
+        "traceparent": "00-b84358a677cc87adae5e269e5d9110e8-4e7ed95618c44836-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "6f696ca0b7560e523415a2b056288fac",
+        "x-ms-date": "Mon, 04 Apr 2022 04:37:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; odata=minimalmetadata",
+        "Date": "Mon, 04 Apr 2022 04:37:07 GMT",
+        "ETag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A08.0664072Z\u0027\u0022",
+        "Transfer-Encoding": "chunked",
+        "x-ms-request-id": "97cc13d3-db52-4a81-9e01-a9c0f66f61e6"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://jolovtablesprim.table.cosmos.azure.com/testtableWEphCTTt/$metadata#testtableWEphCTTt/@Element",
+        "odata.etag": "W/\u0022datetime\u00272022-04-04T04%3A37%3A08.0664072Z\u0027\u0022",
+        "Value": "Bar",
+        "PartitionKey": "PK",
+        "RowKey": "RK1",
+        "Timestamp": "2022-04-04T04:37:08.0664072Z"
+      }
+    },
+    {
+      "RequestUri": "https://jolovtablesprim.table.cosmos.azure.com/Tables(\u0027testtableWEphCTTt\u0027)",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7c8f79fb7423c1229f11d29da9ec56ac-81570ad943f41bed-00",
+        "User-Agent": "azsdk-net-Data.Tables/12.6.0-alpha.20220403.1 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d6f7a22e5a336745dcd8e06918c85be5",
+        "x-ms-date": "Mon, 04 Apr 2022 04:37:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Type": "application/json",
+        "Date": "Mon, 04 Apr 2022 04:37:07 GMT",
+        "x-ms-request-id": "d6690659-aa5f-4e31-ac01-7e2685719966"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "COSMOS_TABLES_ENDPOINT_SUFFIX": "cosmos.azure.com",
+    "RandomSeed": "1980008140",
+    "TABLES_COSMOS_ACCOUNT_NAME": "jolovtablesprim",
+    "TABLES_PRIMARY_COSMOS_ACCOUNT_KEY": "Kg=="
+  }
+}


### PR DESCRIPTION
When using a JS function, the JSON ends up having camel cased properties. This was already handled in the T1 extension here - https://github.com/Azure/azure-webjobs-sdk/blob/3f4ec78be9f43bb041937425ced00b341883aa42/src/Microsoft.Azure.WebJobs.Extensions.Storage/Tables/Config/TablesExtensionConfigProvider.cs#L157-L169

Also made the same update for matching etag which was not converted at all in the T1 extension.
The Etag change should address the issue reported in https://github.com/Azure/azure-sdk-for-net/issues/32637 for the T2 extensions.