### PR TITLE
[Event Hubs] Release Prep

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.7.0-beta.5 (Unreleased)
+## 5.7.0-beta.5 (2022-04-05)
 
 Thank you to our developer community members who helped to make the Event Hubs client libraries better with their contributions to this release:
 
@@ -11,10 +11,6 @@ Thank you to our developer community members who helped to make the Event Hubs c
 - An additional base class for event processors, `PluggableCheckpointStoreEventProcessor<T>`, has been added to simplify creating customized event processors and integrate with concrete `CheckpointStore` implementations.
 
 - An abstract `CheckpointStore` is now available for use with the `PluggableCheckpointStoreEventProcessor<T>` to simplify creating customized event processors and allow reusing existing checkpoint store implementations. 
-
-### Breaking Changes
-
-### Bugs Fixed
 
 ### Other Changes
 


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare the Event Hubs core library for its April release.