### PR TITLE
[Event Hubs] Processor Release Prep

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Experimental/src/Azure.Messaging.EventHubs.Experimental.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Experimental/src/Azure.Messaging.EventHubs.Experimental.csproj
@@ -14,12 +14,13 @@
   <ItemGroup>
     <!--
         TEMP:
-            Return to a package reference after 5.7.0-beta.6 is released.
+            Version override is needed until the 5.7.x line reaches a stable release.
 
     <PackageReference Include="Azure.Messaging.EventHubs" />
     -->
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" />
+    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.7.0-beta.5" />
     <!-- END TEMP -->
+    
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.Reflection.TypeExtensions" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 5.7.0-beta.5 (Unreleased)
+## 5.7.0-beta.5 (2022-04-05)
 
 ### Features Added
 
 - The `BlobCheckpointStore` implementation used internally by the processor has been made public and now conforms to the `CheckpointStore` contract, allowing it to be used with custom processor implementations.
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 5.7.0-beta.4 (2022-03-11)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -15,20 +15,12 @@
 
   <ItemGroup>
     <!--
-        TEMP: Move Core to an implicit dependency until the MessageWithMetadata are shipped in Azure.Core.
-
-    <PackageReference Include="Azure.Core" />
-    -->
-    <!-- END TEMP -->
-
-    <!--
         TEMP:
-            Project reference is needed until the CheckpointStore is included in a release.  Revert when
-            the 5.7.x line is released for GA.
+            Version override is needed until the 5.7.x line reaches a stable release.
 
     <PackageReference Include="Azure.Messaging.EventHubs" />
     -->
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" />
+    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.7.0-beta.5" />
     <!-- END TEMP -->
 
     <PackageReference Include="Azure.Storage.Blobs" />


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare the Event Hubs Processor package for its April release.