### PR TITLE
Smoke test dependency on publishpackage in release pipeline

### DIFF
--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -15,6 +15,8 @@ parameters:
 jobs:
   - ${{ if eq(parameters.Daily, false) }}:
     - job: smoke_test_eligibility
+      dependsOn: PublishPackage
+      condition: succeeded()
       pool:
         name: "azsdk-pool-mms-ubuntu-2004-general"
         vmImage: "MMSUbuntu20.04"

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -48,11 +48,11 @@ stages:
               displayName: "Create release tag"
               condition: ne(variables['Skip.TagRepository'], 'true')
               environment: github
-  
+
               pool:
                 name: azsdk-pool-mms-win-2019-general
                 vmImage: MMS2019
-  
+
               strategy:
                 runOnce:
                   deploy:


### PR DESCRIPTION
 skip running the smoke tests with the same condition if we skip publishing to reduce noise from smoke test failure if we skip publish.
 
 Pipeline Ref:
 New: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1483815&view=results
 Original: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1483814&view=results