### PR TITLE
[ACR] Add back comparison of 'Accept' header in tests

### DIFF
--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/ContainerRegistryRecordedTestBase.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/ContainerRegistryRecordedTestBase.cs
@@ -37,9 +37,6 @@ namespace Azure.Containers.ContainerRegistry.Tests
             {
                 GroupForReplace = "group"
             });
-
-            // Ignore comparison of 'Accept' header values till issue is resolved in Core test proxy code
-            IgnoredHeaders.Add("Accept");
         }
 
         public ContainerRegistryClient CreateClient(bool anonymousAccess = false)


### PR DESCRIPTION
Remove the workaround in ACR tests now that a fix for the header comparison issue has been provided in test proxy (#27986)