### PR TITLE
[Event Hubs] Cancellation Token Exception Guards

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -2453,6 +2453,54 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance has encountered an exception while canceling the main task
+        ///   while attempting to stop processing during a call to <see cref="EventProcessor{TPartition}.StopProcessingAsync" /> or
+        ///   <see cref="EventProcessor{TPartition}.StopProcessing" />.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(120, Level = EventLevel.Warning, Message = "Error observed during token cancellation while attempting to stop the processor instance with identifier '{0}' for Event Hub: {1} and Consumer Group: {2}.  This is most often caused by a CancellationToken.Register callback throwing.  Error Message: '{3}'")]
+        public virtual void ProcessorStoppingCancellationWarning(string identifier,
+                                                                 string eventHubName,
+                                                                 string consumerGroup,
+                                                                 string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(120, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance has encountered an exception while canceling the main task
+        ///   while attempting to stop processing during a call to <see cref="EventProcessor{TPartition}.StopProcessingAsync" /> or
+        ///   <see cref="EventProcessor{TPartition}.StopProcessing" />.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition of the processor.</param>
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(121, Level = EventLevel.Warning, Message = "Error observed during token cancellation while attempting to stop the partition '{0}' processing task for the processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.  This is most often caused by a CancellationToken.Register callback throwing.  Error Message: '{4}'")]
+        public virtual void PartitionProcessorStoppingCancellationWarning(string partitionId,
+                                                                          string identifier,
+                                                                          string eventHubName,
+                                                                          string consumerGroup,
+                                                                          string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(121, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
         ///   Indicates that the publishing of events has completed, writing into a stack allocated
         ///   <see cref="EventSource.EventData"/> struct to avoid the parameter array allocation on the WriteEvent methods.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
@@ -64,11 +64,8 @@ namespace Azure.Messaging.EventHubs.Producer
         /// <summary>The default interval to delay for events to be available when building a batch to publish.</summary>
         private static readonly TimeSpan DefaultPublishingDelayInterval = TimeSpan.FromMilliseconds(25);
 
-        /// <summary>
-        ///   The set of client options to use when options were not passed when the producer was instantiated.
-        /// </summary>
-        ///
-        private static EventHubBufferedProducerClientOptions DefaultOptions { get; } =
+        /// <summary>The set of client options to use when options were not passed when the producer was instantiated.</summary>
+        private static readonly EventHubBufferedProducerClientOptions DefaultOptions =
             new EventHubBufferedProducerClientOptions
             {
                 RetryOptions = new EventHubsRetryOptions { MaximumRetries = 15, TryTimeout = TimeSpan.FromMinutes(3) }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
@@ -1875,5 +1875,79 @@ namespace Azure.Messaging.EventHubs.Tests
                     expectedException.Message),
                  Times.Once);
         }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingLogsWarningForTokenCancellationErrors()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var firstCall = true;
+            var partition = new EventProcessorPartition { PartitionId = "omgno" };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) } };
+            var handlerCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockLogger = new Mock<EventHubsEventSource>();
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                 .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                 .Returns(() => firstCall switch
+                 {
+                     true => Task.FromResult<IReadOnlyList<EventData>>(new List<EventData> { new EventData("Test") }),
+                     false => Task.FromResult<IReadOnlyList<EventData>>(new List<EventData>())
+                 });
+
+            mockProcessor.Object.Logger = mockLogger.Object;
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object);
+
+            mockProcessor
+                 .Setup(processor => processor.ProcessEventBatchAsync(It.IsAny<EventProcessorPartition>(), It.IsAny<IReadOnlyList<EventData>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                 .Callback<EventProcessorPartition, IReadOnlyList<EventData>, bool, CancellationToken>((partition, events, dispatchEmpties, cancellationToken) =>
+                 {
+                     if (firstCall)
+                     {
+                         cancellationToken.Register(() => throw new DivideByZeroException());
+                         handlerCompletion.TrySetResult(true);
+                         firstCall = false;
+                     }
+                 })
+                 .Returns(Task.CompletedTask);
+
+            using var processorCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationSource.Token, CancellationToken.None);
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, processorCancellationSource, EventPosition.Earliest);
+
+            Assert.That(() => GetActivePartitionProcessors(mockProcessor.Object).TryAdd(partition.PartitionId, partitionProcessor), Is.True, "The partition processor should have been registered for tracking.");
+
+            await Task.WhenAny(handlerCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            Assert.That(async () => await InvokeTryStopProcessingPartitionAsync(mockProcessor.Object, partition.PartitionId, Processor.ProcessingStoppedReason.OwnershipLost, cancellationSource.Token), Is.True, "Processing should have been stopped.");
+            Assert.That(async () => await partitionProcessor.ProcessingTask, Throws.InstanceOf<TaskCanceledException>(), "The partition processor should have been canceled.");
+
+            mockLogger
+                .Verify(log => log.PartitionProcessorStoppingCancellationWarning(
+                    partition.PartitionId,
+                    mockProcessor.Object.Identifier,
+                    mockProcessor.Object.EventHubName,
+                    mockProcessor.Object.ConsumerGroup,
+                    It.IsAny<string>()),
+                Times.Once);
+
+            cancellationSource.Cancel();
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
@@ -12,6 +12,7 @@ using Azure.Core;
 using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Primitives;
+using Azure.Messaging.EventHubs.Processor;
 using NUnit.Framework;
 
 namespace Azure.Messaging.EventHubs.Tests
@@ -96,6 +97,29 @@ namespace Azure.Messaging.EventHubs.Tests
                 typeof(EventProcessor<T>)
                     .GetProperty("ActivePartitionProcessors", BindingFlags.Instance | BindingFlags.NonPublic)
                     .GetValue(processor);
+
+        /// <summary>
+        ///   Invokes the processor infrastructure method responsible for stopping a partition
+        ///   processing task, using its private accessor.
+        /// </summary>
+        ///
+        /// <typeparam name="T">The partition type to which the processor is bound.</typeparam>
+        ///
+        /// <param name="processor">The processor instance to operate on.</param>
+        /// <param name="partitionId">The identifier of the Event Hub partition whose processing should be stopped.</param>
+        /// <param name="reason">The reason why the processing is being stopped.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <returns><c>true</c> if the <paramref name="partitionId"/> was owned and was being processed; otherwise, <c>false</c>.</returns>
+        ///
+        private static Task<bool> InvokeTryStopProcessingPartitionAsync<T>(EventProcessor<T> processor,
+                                                                          string partitionId,
+                                                                          ProcessingStoppedReason reason,
+                                                                          CancellationToken cancellationToken) where T : EventProcessorPartition, new() =>
+            (Task<bool>)
+                typeof(EventProcessor<T>)
+                    .GetMethod("TryStopProcessingPartitionAsync", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .Invoke(processor, new object[] { partitionId, reason, cancellationToken });
 
         /// <summary>
         ///   A basic custom partition type, allowing for testing or processor functionality.


### PR DESCRIPTION
# Summary

The focus of these changes is to guard against callbacks defined using `CancellationToken.Register` in handlers which throw.  These exceptions bubble up from developer code through the linked tokens and can cause processor infrastructure to fail when the processor is stopping.

These guards will intercept the exceptions and log a warning before ignoring them so that the shutdown process is able to complete normally.