### PR TITLE
Rename changes for HybridConnectivity

### DIFF
--- a/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/api/Azure.ResourceManager.HybridConnectivity.netstandard2.0.cs
+++ b/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/api/Azure.ResourceManager.HybridConnectivity.netstandard2.0.cs
@@ -6,13 +6,13 @@ namespace Azure.ResourceManager.HybridConnectivity
         protected EndpointResource() { }
         public virtual Azure.ResourceManager.HybridConnectivity.EndpointResourceData Data { get { throw null; } }
         public virtual bool HasData { get { throw null; } }
-        public static Azure.Core.ResourceIdentifier CreateResourceIdentifier(string resourceUri, string endpointName) { throw null; }
+        public static Azure.Core.ResourceIdentifier CreateResourceIdentifier(string scope, string endpointName) { throw null; }
         public virtual Azure.ResourceManager.ArmOperation Delete(Azure.WaitUntil waitUntil, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.ResourceManager.ArmOperation> DeleteAsync(Azure.WaitUntil waitUntil, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.ResourceManager.HybridConnectivity.EndpointResource> Get(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.ResourceManager.HybridConnectivity.EndpointResource>> GetAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.ResourceManager.HybridConnectivity.Models.EndpointAccessResource> GetCredentials(long? expiresin = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.ResourceManager.HybridConnectivity.Models.EndpointAccessResource>> GetCredentialsAsync(long? expiresin = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.ResourceManager.HybridConnectivity.Models.TargetResourceEndpointAccess> GetCredentials(long? expiresin = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.ResourceManager.HybridConnectivity.Models.TargetResourceEndpointAccess>> GetCredentialsAsync(long? expiresin = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.ResourceManager.HybridConnectivity.EndpointResource> Update(Azure.ResourceManager.HybridConnectivity.EndpointResourceData data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.ResourceManager.HybridConnectivity.EndpointResource>> UpdateAsync(Azure.ResourceManager.HybridConnectivity.EndpointResourceData data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
@@ -74,15 +74,6 @@ namespace Azure.ResourceManager.HybridConnectivity.Models
         public static bool operator !=(Azure.ResourceManager.HybridConnectivity.Models.CreatedByType left, Azure.ResourceManager.HybridConnectivity.Models.CreatedByType right) { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial class EndpointAccessResource
-    {
-        internal EndpointAccessResource() { }
-        public string AccessKey { get { throw null; } }
-        public long? ExpiresOn { get { throw null; } }
-        public string HybridConnectionName { get { throw null; } }
-        public string NamespaceName { get { throw null; } }
-        public string NamespaceNameSuffix { get { throw null; } }
-    }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct EndpointType : System.IEquatable<Azure.ResourceManager.HybridConnectivity.Models.EndpointType>
     {
@@ -100,5 +91,14 @@ namespace Azure.ResourceManager.HybridConnectivity.Models
         public static implicit operator Azure.ResourceManager.HybridConnectivity.Models.EndpointType (string value) { throw null; }
         public static bool operator !=(Azure.ResourceManager.HybridConnectivity.Models.EndpointType left, Azure.ResourceManager.HybridConnectivity.Models.EndpointType right) { throw null; }
         public override string ToString() { throw null; }
+    }
+    public partial class TargetResourceEndpointAccess
+    {
+        internal TargetResourceEndpointAccess() { }
+        public string AccessKey { get { throw null; } }
+        public long? ExpiresOn { get { throw null; } }
+        public string HybridConnectionName { get { throw null; } }
+        public string NamespaceName { get { throw null; } }
+        public string NamespaceNameSuffix { get { throw null; } }
     }
 }

--- a/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/src/Generated/EndpointResource.cs
+++ b/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/src/Generated/EndpointResource.cs
@@ -246,7 +246,7 @@ namespace Azure.ResourceManager.HybridConnectivity
         /// </summary>
         /// <param name="expiresin"> The is how long the endpoint access token is valid (in seconds). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response<EndpointAccessResource>> GetCredentialsAsync(long? expiresin = null, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<TargetResourceEndpointAccess>> GetCredentialsAsync(long? expiresin = null, CancellationToken cancellationToken = default)
         {
             using var scope = _endpointResourceEndpointsClientDiagnostics.CreateScope("EndpointResource.GetCredentials");
             scope.Start();
@@ -269,7 +269,7 @@ namespace Azure.ResourceManager.HybridConnectivity
         /// </summary>
         /// <param name="expiresin"> The is how long the endpoint access token is valid (in seconds). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response<EndpointAccessResource> GetCredentials(long? expiresin = null, CancellationToken cancellationToken = default)
+        public virtual Response<TargetResourceEndpointAccess> GetCredentials(long? expiresin = null, CancellationToken cancellationToken = default)
         {
             using var scope = _endpointResourceEndpointsClientDiagnostics.CreateScope("EndpointResource.GetCredentials");
             scope.Start();

--- a/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/src/Generated/EndpointResource.cs
+++ b/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/src/Generated/EndpointResource.cs
@@ -26,9 +26,9 @@ namespace Azure.ResourceManager.HybridConnectivity
     public partial class EndpointResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="EndpointResource"/> instance. </summary>
-        public static ResourceIdentifier CreateResourceIdentifier(string resourceUri, string endpointName)
+        public static ResourceIdentifier CreateResourceIdentifier(string scope, string endpointName)
         {
-            var resourceId = $"{resourceUri}/providers/Microsoft.HybridConnectivity/endpoints/{endpointName}";
+            var resourceId = $"{scope}/providers/Microsoft.HybridConnectivity/endpoints/{endpointName}";
             return new ResourceIdentifier(resourceId);
         }
 

--- a/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/src/Generated/Models/TargetResourceEndpointAccess.Serialization.cs
+++ b/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/src/Generated/Models/TargetResourceEndpointAccess.Serialization.cs
@@ -10,9 +10,9 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.HybridConnectivity.Models
 {
-    public partial class EndpointAccessResource
+    public partial class TargetResourceEndpointAccess
     {
-        internal static EndpointAccessResource DeserializeEndpointAccessResource(JsonElement element)
+        internal static TargetResourceEndpointAccess DeserializeTargetResourceEndpointAccess(JsonElement element)
         {
             Optional<string> namespaceName = default;
             Optional<string> namespaceNameSuffix = default;
@@ -64,7 +64,7 @@ namespace Azure.ResourceManager.HybridConnectivity.Models
                     continue;
                 }
             }
-            return new EndpointAccessResource(namespaceName.Value, namespaceNameSuffix.Value, hybridConnectionName.Value, accessKey.Value, Optional.ToNullable(expiresOn));
+            return new TargetResourceEndpointAccess(namespaceName.Value, namespaceNameSuffix.Value, hybridConnectionName.Value, accessKey.Value, Optional.ToNullable(expiresOn));
         }
     }
 }

--- a/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/src/Generated/Models/TargetResourceEndpointAccess.cs
+++ b/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/src/Generated/Models/TargetResourceEndpointAccess.cs
@@ -8,20 +8,20 @@
 namespace Azure.ResourceManager.HybridConnectivity.Models
 {
     /// <summary> The endpoint access for the target resource. </summary>
-    public partial class EndpointAccessResource
+    public partial class TargetResourceEndpointAccess
     {
-        /// <summary> Initializes a new instance of EndpointAccessResource. </summary>
-        internal EndpointAccessResource()
+        /// <summary> Initializes a new instance of TargetResourceEndpointAccess. </summary>
+        internal TargetResourceEndpointAccess()
         {
         }
 
-        /// <summary> Initializes a new instance of EndpointAccessResource. </summary>
+        /// <summary> Initializes a new instance of TargetResourceEndpointAccess. </summary>
         /// <param name="namespaceName"> The namespace name. </param>
         /// <param name="namespaceNameSuffix"> The suffix domain name of relay namespace. </param>
         /// <param name="hybridConnectionName"> Azure Relay hybrid connection name for the resource. </param>
         /// <param name="accessKey"> Access key for hybrid connection. </param>
         /// <param name="expiresOn"> The expiration of access key in unix time. </param>
-        internal EndpointAccessResource(string namespaceName, string namespaceNameSuffix, string hybridConnectionName, string accessKey, long? expiresOn)
+        internal TargetResourceEndpointAccess(string namespaceName, string namespaceNameSuffix, string hybridConnectionName, string accessKey, long? expiresOn)
         {
             NamespaceName = namespaceName;
             NamespaceNameSuffix = namespaceNameSuffix;

--- a/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/src/Generated/RestOperations/EndpointsRestOperations.cs
+++ b/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/src/Generated/RestOperations/EndpointsRestOperations.cs
@@ -423,7 +423,7 @@ namespace Azure.ResourceManager.HybridConnectivity
         /// <param name="expiresin"> The is how long the endpoint access token is valid (in seconds). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="scope"/> or <paramref name="endpointName"/> is null. </exception>
-        public async Task<Response<EndpointAccessResource>> ListCredentialsAsync(string scope, string endpointName, long? expiresin = null, CancellationToken cancellationToken = default)
+        public async Task<Response<TargetResourceEndpointAccess>> ListCredentialsAsync(string scope, string endpointName, long? expiresin = null, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(scope, nameof(scope));
             Argument.AssertNotNull(endpointName, nameof(endpointName));
@@ -434,9 +434,9 @@ namespace Azure.ResourceManager.HybridConnectivity
             {
                 case 200:
                     {
-                        EndpointAccessResource value = default;
+                        TargetResourceEndpointAccess value = default;
                         using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                        value = EndpointAccessResource.DeserializeEndpointAccessResource(document.RootElement);
+                        value = TargetResourceEndpointAccess.DeserializeTargetResourceEndpointAccess(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -450,7 +450,7 @@ namespace Azure.ResourceManager.HybridConnectivity
         /// <param name="expiresin"> The is how long the endpoint access token is valid (in seconds). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="scope"/> or <paramref name="endpointName"/> is null. </exception>
-        public Response<EndpointAccessResource> ListCredentials(string scope, string endpointName, long? expiresin = null, CancellationToken cancellationToken = default)
+        public Response<TargetResourceEndpointAccess> ListCredentials(string scope, string endpointName, long? expiresin = null, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(scope, nameof(scope));
             Argument.AssertNotNull(endpointName, nameof(endpointName));
@@ -461,9 +461,9 @@ namespace Azure.ResourceManager.HybridConnectivity
             {
                 case 200:
                     {
-                        EndpointAccessResource value = default;
+                        TargetResourceEndpointAccess value = default;
                         using var document = JsonDocument.Parse(message.Response.ContentStream);
-                        value = EndpointAccessResource.DeserializeEndpointAccessResource(document.RootElement);
+                        value = TargetResourceEndpointAccess.DeserializeTargetResourceEndpointAccess(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:

--- a/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/src/Generated/RestOperations/EndpointsRestOperations.cs
+++ b/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/src/Generated/RestOperations/EndpointsRestOperations.cs
@@ -37,7 +37,7 @@ namespace Azure.ResourceManager.HybridConnectivity
             _userAgent = new TelemetryDetails(GetType().Assembly, applicationId);
         }
 
-        internal HttpMessage CreateListRequest(string resourceUri)
+        internal HttpMessage CreateListRequest(string scope)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -45,7 +45,7 @@ namespace Azure.ResourceManager.HybridConnectivity
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendPath("/", false);
-            uri.AppendPath(resourceUri, false);
+            uri.AppendPath(scope, false);
             uri.AppendPath("/providers/Microsoft.HybridConnectivity/endpoints", false);
             uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
@@ -55,14 +55,14 @@ namespace Azure.ResourceManager.HybridConnectivity
         }
 
         /// <summary> List of endpoints to the target resource. </summary>
-        /// <param name="resourceUri"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
+        /// <param name="scope"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="resourceUri"/> is null. </exception>
-        public async Task<Response<EndpointsList>> ListAsync(string resourceUri, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="scope"/> is null. </exception>
+        public async Task<Response<EndpointsList>> ListAsync(string scope, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(resourceUri, nameof(resourceUri));
+            Argument.AssertNotNull(scope, nameof(scope));
 
-            using var message = CreateListRequest(resourceUri);
+            using var message = CreateListRequest(scope);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -79,14 +79,14 @@ namespace Azure.ResourceManager.HybridConnectivity
         }
 
         /// <summary> List of endpoints to the target resource. </summary>
-        /// <param name="resourceUri"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
+        /// <param name="scope"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="resourceUri"/> is null. </exception>
-        public Response<EndpointsList> List(string resourceUri, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="scope"/> is null. </exception>
+        public Response<EndpointsList> List(string scope, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(resourceUri, nameof(resourceUri));
+            Argument.AssertNotNull(scope, nameof(scope));
 
-            using var message = CreateListRequest(resourceUri);
+            using var message = CreateListRequest(scope);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {
@@ -102,7 +102,7 @@ namespace Azure.ResourceManager.HybridConnectivity
             }
         }
 
-        internal HttpMessage CreateGetRequest(string resourceUri, string endpointName)
+        internal HttpMessage CreateGetRequest(string scope, string endpointName)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -110,7 +110,7 @@ namespace Azure.ResourceManager.HybridConnectivity
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendPath("/", false);
-            uri.AppendPath(resourceUri, false);
+            uri.AppendPath(scope, false);
             uri.AppendPath("/providers/Microsoft.HybridConnectivity/endpoints/", false);
             uri.AppendPath(endpointName, false);
             uri.AppendQuery("api-version", _apiVersion, true);
@@ -121,16 +121,16 @@ namespace Azure.ResourceManager.HybridConnectivity
         }
 
         /// <summary> Gets the endpoint to the resource. </summary>
-        /// <param name="resourceUri"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
+        /// <param name="scope"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
         /// <param name="endpointName"> The endpoint name. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="resourceUri"/> or <paramref name="endpointName"/> is null. </exception>
-        public async Task<Response<EndpointResourceData>> GetAsync(string resourceUri, string endpointName, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="scope"/> or <paramref name="endpointName"/> is null. </exception>
+        public async Task<Response<EndpointResourceData>> GetAsync(string scope, string endpointName, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(resourceUri, nameof(resourceUri));
+            Argument.AssertNotNull(scope, nameof(scope));
             Argument.AssertNotNull(endpointName, nameof(endpointName));
 
-            using var message = CreateGetRequest(resourceUri, endpointName);
+            using var message = CreateGetRequest(scope, endpointName);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -149,16 +149,16 @@ namespace Azure.ResourceManager.HybridConnectivity
         }
 
         /// <summary> Gets the endpoint to the resource. </summary>
-        /// <param name="resourceUri"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
+        /// <param name="scope"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
         /// <param name="endpointName"> The endpoint name. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="resourceUri"/> or <paramref name="endpointName"/> is null. </exception>
-        public Response<EndpointResourceData> Get(string resourceUri, string endpointName, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="scope"/> or <paramref name="endpointName"/> is null. </exception>
+        public Response<EndpointResourceData> Get(string scope, string endpointName, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(resourceUri, nameof(resourceUri));
+            Argument.AssertNotNull(scope, nameof(scope));
             Argument.AssertNotNull(endpointName, nameof(endpointName));
 
-            using var message = CreateGetRequest(resourceUri, endpointName);
+            using var message = CreateGetRequest(scope, endpointName);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {
@@ -176,7 +176,7 @@ namespace Azure.ResourceManager.HybridConnectivity
             }
         }
 
-        internal HttpMessage CreateCreateOrUpdateRequest(string resourceUri, string endpointName, EndpointResourceData data)
+        internal HttpMessage CreateCreateOrUpdateRequest(string scope, string endpointName, EndpointResourceData data)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -184,7 +184,7 @@ namespace Azure.ResourceManager.HybridConnectivity
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendPath("/", false);
-            uri.AppendPath(resourceUri, false);
+            uri.AppendPath(scope, false);
             uri.AppendPath("/providers/Microsoft.HybridConnectivity/endpoints/", false);
             uri.AppendPath(endpointName, false);
             uri.AppendQuery("api-version", _apiVersion, true);
@@ -199,18 +199,18 @@ namespace Azure.ResourceManager.HybridConnectivity
         }
 
         /// <summary> Create or update the endpoint to the target resource. </summary>
-        /// <param name="resourceUri"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
+        /// <param name="scope"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
         /// <param name="endpointName"> The endpoint name. </param>
         /// <param name="data"> Endpoint details. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="resourceUri"/>, <paramref name="endpointName"/> or <paramref name="data"/> is null. </exception>
-        public async Task<Response<EndpointResourceData>> CreateOrUpdateAsync(string resourceUri, string endpointName, EndpointResourceData data, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="scope"/>, <paramref name="endpointName"/> or <paramref name="data"/> is null. </exception>
+        public async Task<Response<EndpointResourceData>> CreateOrUpdateAsync(string scope, string endpointName, EndpointResourceData data, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(resourceUri, nameof(resourceUri));
+            Argument.AssertNotNull(scope, nameof(scope));
             Argument.AssertNotNull(endpointName, nameof(endpointName));
             Argument.AssertNotNull(data, nameof(data));
 
-            using var message = CreateCreateOrUpdateRequest(resourceUri, endpointName, data);
+            using var message = CreateCreateOrUpdateRequest(scope, endpointName, data);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -227,18 +227,18 @@ namespace Azure.ResourceManager.HybridConnectivity
         }
 
         /// <summary> Create or update the endpoint to the target resource. </summary>
-        /// <param name="resourceUri"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
+        /// <param name="scope"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
         /// <param name="endpointName"> The endpoint name. </param>
         /// <param name="data"> Endpoint details. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="resourceUri"/>, <paramref name="endpointName"/> or <paramref name="data"/> is null. </exception>
-        public Response<EndpointResourceData> CreateOrUpdate(string resourceUri, string endpointName, EndpointResourceData data, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="scope"/>, <paramref name="endpointName"/> or <paramref name="data"/> is null. </exception>
+        public Response<EndpointResourceData> CreateOrUpdate(string scope, string endpointName, EndpointResourceData data, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(resourceUri, nameof(resourceUri));
+            Argument.AssertNotNull(scope, nameof(scope));
             Argument.AssertNotNull(endpointName, nameof(endpointName));
             Argument.AssertNotNull(data, nameof(data));
 
-            using var message = CreateCreateOrUpdateRequest(resourceUri, endpointName, data);
+            using var message = CreateCreateOrUpdateRequest(scope, endpointName, data);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {
@@ -254,7 +254,7 @@ namespace Azure.ResourceManager.HybridConnectivity
             }
         }
 
-        internal HttpMessage CreateUpdateRequest(string resourceUri, string endpointName, EndpointResourceData data)
+        internal HttpMessage CreateUpdateRequest(string scope, string endpointName, EndpointResourceData data)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -262,7 +262,7 @@ namespace Azure.ResourceManager.HybridConnectivity
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendPath("/", false);
-            uri.AppendPath(resourceUri, false);
+            uri.AppendPath(scope, false);
             uri.AppendPath("/providers/Microsoft.HybridConnectivity/endpoints/", false);
             uri.AppendPath(endpointName, false);
             uri.AppendQuery("api-version", _apiVersion, true);
@@ -277,18 +277,18 @@ namespace Azure.ResourceManager.HybridConnectivity
         }
 
         /// <summary> Update the endpoint to the target resource. </summary>
-        /// <param name="resourceUri"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
+        /// <param name="scope"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
         /// <param name="endpointName"> The endpoint name. </param>
         /// <param name="data"> Endpoint details. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="resourceUri"/>, <paramref name="endpointName"/> or <paramref name="data"/> is null. </exception>
-        public async Task<Response<EndpointResourceData>> UpdateAsync(string resourceUri, string endpointName, EndpointResourceData data, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="scope"/>, <paramref name="endpointName"/> or <paramref name="data"/> is null. </exception>
+        public async Task<Response<EndpointResourceData>> UpdateAsync(string scope, string endpointName, EndpointResourceData data, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(resourceUri, nameof(resourceUri));
+            Argument.AssertNotNull(scope, nameof(scope));
             Argument.AssertNotNull(endpointName, nameof(endpointName));
             Argument.AssertNotNull(data, nameof(data));
 
-            using var message = CreateUpdateRequest(resourceUri, endpointName, data);
+            using var message = CreateUpdateRequest(scope, endpointName, data);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -305,18 +305,18 @@ namespace Azure.ResourceManager.HybridConnectivity
         }
 
         /// <summary> Update the endpoint to the target resource. </summary>
-        /// <param name="resourceUri"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
+        /// <param name="scope"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
         /// <param name="endpointName"> The endpoint name. </param>
         /// <param name="data"> Endpoint details. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="resourceUri"/>, <paramref name="endpointName"/> or <paramref name="data"/> is null. </exception>
-        public Response<EndpointResourceData> Update(string resourceUri, string endpointName, EndpointResourceData data, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="scope"/>, <paramref name="endpointName"/> or <paramref name="data"/> is null. </exception>
+        public Response<EndpointResourceData> Update(string scope, string endpointName, EndpointResourceData data, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(resourceUri, nameof(resourceUri));
+            Argument.AssertNotNull(scope, nameof(scope));
             Argument.AssertNotNull(endpointName, nameof(endpointName));
             Argument.AssertNotNull(data, nameof(data));
 
-            using var message = CreateUpdateRequest(resourceUri, endpointName, data);
+            using var message = CreateUpdateRequest(scope, endpointName, data);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {
@@ -332,7 +332,7 @@ namespace Azure.ResourceManager.HybridConnectivity
             }
         }
 
-        internal HttpMessage CreateDeleteRequest(string resourceUri, string endpointName)
+        internal HttpMessage CreateDeleteRequest(string scope, string endpointName)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -340,7 +340,7 @@ namespace Azure.ResourceManager.HybridConnectivity
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendPath("/", false);
-            uri.AppendPath(resourceUri, false);
+            uri.AppendPath(scope, false);
             uri.AppendPath("/providers/Microsoft.HybridConnectivity/endpoints/", false);
             uri.AppendPath(endpointName, false);
             uri.AppendQuery("api-version", _apiVersion, true);
@@ -351,16 +351,16 @@ namespace Azure.ResourceManager.HybridConnectivity
         }
 
         /// <summary> Deletes the endpoint access to the target resource. </summary>
-        /// <param name="resourceUri"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
+        /// <param name="scope"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
         /// <param name="endpointName"> The endpoint name. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="resourceUri"/> or <paramref name="endpointName"/> is null. </exception>
-        public async Task<Response> DeleteAsync(string resourceUri, string endpointName, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="scope"/> or <paramref name="endpointName"/> is null. </exception>
+        public async Task<Response> DeleteAsync(string scope, string endpointName, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(resourceUri, nameof(resourceUri));
+            Argument.AssertNotNull(scope, nameof(scope));
             Argument.AssertNotNull(endpointName, nameof(endpointName));
 
-            using var message = CreateDeleteRequest(resourceUri, endpointName);
+            using var message = CreateDeleteRequest(scope, endpointName);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -373,16 +373,16 @@ namespace Azure.ResourceManager.HybridConnectivity
         }
 
         /// <summary> Deletes the endpoint access to the target resource. </summary>
-        /// <param name="resourceUri"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
+        /// <param name="scope"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
         /// <param name="endpointName"> The endpoint name. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="resourceUri"/> or <paramref name="endpointName"/> is null. </exception>
-        public Response Delete(string resourceUri, string endpointName, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="scope"/> or <paramref name="endpointName"/> is null. </exception>
+        public Response Delete(string scope, string endpointName, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(resourceUri, nameof(resourceUri));
+            Argument.AssertNotNull(scope, nameof(scope));
             Argument.AssertNotNull(endpointName, nameof(endpointName));
 
-            using var message = CreateDeleteRequest(resourceUri, endpointName);
+            using var message = CreateDeleteRequest(scope, endpointName);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {
@@ -394,7 +394,7 @@ namespace Azure.ResourceManager.HybridConnectivity
             }
         }
 
-        internal HttpMessage CreateListCredentialsRequest(string resourceUri, string endpointName, long? expiresin)
+        internal HttpMessage CreateListCredentialsRequest(string scope, string endpointName, long? expiresin)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -402,7 +402,7 @@ namespace Azure.ResourceManager.HybridConnectivity
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendPath("/", false);
-            uri.AppendPath(resourceUri, false);
+            uri.AppendPath(scope, false);
             uri.AppendPath("/providers/Microsoft.HybridConnectivity/endpoints/", false);
             uri.AppendPath(endpointName, false);
             uri.AppendPath("/listCredentials", false);
@@ -418,17 +418,17 @@ namespace Azure.ResourceManager.HybridConnectivity
         }
 
         /// <summary> Gets the endpoint access credentials to the resource. </summary>
-        /// <param name="resourceUri"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
+        /// <param name="scope"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
         /// <param name="endpointName"> The endpoint name. </param>
         /// <param name="expiresin"> The is how long the endpoint access token is valid (in seconds). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="resourceUri"/> or <paramref name="endpointName"/> is null. </exception>
-        public async Task<Response<EndpointAccessResource>> ListCredentialsAsync(string resourceUri, string endpointName, long? expiresin = null, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="scope"/> or <paramref name="endpointName"/> is null. </exception>
+        public async Task<Response<EndpointAccessResource>> ListCredentialsAsync(string scope, string endpointName, long? expiresin = null, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(resourceUri, nameof(resourceUri));
+            Argument.AssertNotNull(scope, nameof(scope));
             Argument.AssertNotNull(endpointName, nameof(endpointName));
 
-            using var message = CreateListCredentialsRequest(resourceUri, endpointName, expiresin);
+            using var message = CreateListCredentialsRequest(scope, endpointName, expiresin);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -445,17 +445,17 @@ namespace Azure.ResourceManager.HybridConnectivity
         }
 
         /// <summary> Gets the endpoint access credentials to the resource. </summary>
-        /// <param name="resourceUri"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
+        /// <param name="scope"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
         /// <param name="endpointName"> The endpoint name. </param>
         /// <param name="expiresin"> The is how long the endpoint access token is valid (in seconds). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="resourceUri"/> or <paramref name="endpointName"/> is null. </exception>
-        public Response<EndpointAccessResource> ListCredentials(string resourceUri, string endpointName, long? expiresin = null, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="scope"/> or <paramref name="endpointName"/> is null. </exception>
+        public Response<EndpointAccessResource> ListCredentials(string scope, string endpointName, long? expiresin = null, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(resourceUri, nameof(resourceUri));
+            Argument.AssertNotNull(scope, nameof(scope));
             Argument.AssertNotNull(endpointName, nameof(endpointName));
 
-            using var message = CreateListCredentialsRequest(resourceUri, endpointName, expiresin);
+            using var message = CreateListCredentialsRequest(scope, endpointName, expiresin);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {
@@ -471,7 +471,7 @@ namespace Azure.ResourceManager.HybridConnectivity
             }
         }
 
-        internal HttpMessage CreateListNextPageRequest(string nextLink, string resourceUri)
+        internal HttpMessage CreateListNextPageRequest(string nextLink, string scope)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -487,15 +487,15 @@ namespace Azure.ResourceManager.HybridConnectivity
 
         /// <summary> List of endpoints to the target resource. </summary>
         /// <param name="nextLink"> The URL to the next page of results. </param>
-        /// <param name="resourceUri"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
+        /// <param name="scope"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="nextLink"/> or <paramref name="resourceUri"/> is null. </exception>
-        public async Task<Response<EndpointsList>> ListNextPageAsync(string nextLink, string resourceUri, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="nextLink"/> or <paramref name="scope"/> is null. </exception>
+        public async Task<Response<EndpointsList>> ListNextPageAsync(string nextLink, string scope, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(nextLink, nameof(nextLink));
-            Argument.AssertNotNull(resourceUri, nameof(resourceUri));
+            Argument.AssertNotNull(scope, nameof(scope));
 
-            using var message = CreateListNextPageRequest(nextLink, resourceUri);
+            using var message = CreateListNextPageRequest(nextLink, scope);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -513,15 +513,15 @@ namespace Azure.ResourceManager.HybridConnectivity
 
         /// <summary> List of endpoints to the target resource. </summary>
         /// <param name="nextLink"> The URL to the next page of results. </param>
-        /// <param name="resourceUri"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
+        /// <param name="scope"> The fully qualified Azure Resource manager identifier of the resource to be connected. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="nextLink"/> or <paramref name="resourceUri"/> is null. </exception>
-        public Response<EndpointsList> ListNextPage(string nextLink, string resourceUri, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="nextLink"/> or <paramref name="scope"/> is null. </exception>
+        public Response<EndpointsList> ListNextPage(string nextLink, string scope, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(nextLink, nameof(nextLink));
-            Argument.AssertNotNull(resourceUri, nameof(resourceUri));
+            Argument.AssertNotNull(scope, nameof(scope));
 
-            using var message = CreateListNextPageRequest(nextLink, resourceUri);
+            using var message = CreateListNextPageRequest(nextLink, scope);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {

--- a/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/src/autorest.md
+++ b/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/src/autorest.md
@@ -37,6 +37,9 @@ rename-rules:
   URI: Uri
 
 directive:
+  - rename-model:
+      from: EndpointAccessResource
+      to: TargetResourceEndpointAccess
   - from: swagger-document
     where: $.definitions.EndpointProperties.properties.type
     transform: >

--- a/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/src/autorest.md
+++ b/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/src/autorest.md
@@ -42,5 +42,9 @@ directive:
     transform: >
       $["x-ms-client-name"] = "EndpointType";
       $["x-ms-enum"]["name"] = "EndpointType"
+  - from: swagger-document
+    where: $.parameters.ResourceUriParameter
+    transform: >
+      $["x-ms-client-name"] = "scope"
 
 ```


### PR DESCRIPTION
- Fix `ResourceUri` to `scope`
- Rename `EndpointAcessResource` to `TargetResourceEndpointAccess`