### PR TITLE
Set Operation Name for Consumer Kind

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryItem.cs
@@ -31,12 +31,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             // todo: update swagger to include this key.
             Tags["ai.user.userAgent"] = AzMonList.GetTagValue(ref monitorTags.MappedTags, SemanticConventions.AttributeHttpUserAgent)?.ToString();
 
-            // we only have mapping for server spans
-            // todo: non-server spans
-            if (activity.Kind == ActivityKind.Server)
+            switch (activity.Kind)
             {
-                Tags[ContextTagKeys.AiOperationName.ToString()] = TraceHelper.GetOperationName(activity, ref monitorTags.MappedTags);
-                Tags[ContextTagKeys.AiLocationIp.ToString()] = TraceHelper.GetLocationIp(ref monitorTags.MappedTags);
+                // we only have mapping for server spans
+                // todo: non-server spans
+                case ActivityKind.Server:
+                    Tags[ContextTagKeys.AiOperationName.ToString()] = TraceHelper.GetOperationName(activity, ref monitorTags.MappedTags);
+                    Tags[ContextTagKeys.AiLocationIp.ToString()] = TraceHelper.GetLocationIp(ref monitorTags.MappedTags);
+                    break;
+                case ActivityKind.Consumer:
+                    Tags[ContextTagKeys.AiOperationName.ToString()] = TraceHelper.GetOperationName(activity, ref monitorTags.MappedTags);
+                    break;
             }
 
             SetResourceSdkVersionAndIkey(roleName, roleInstance, instrumentationKey);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
@@ -209,6 +209,23 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         }
 
         [Fact]
+        public void AiOperationNameIsSetForConsumerKind()
+        {
+            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using var activity = activitySource.StartActivity(
+                ActivityName,
+                ActivityKind.Consumer,
+                null,
+                startTime: DateTime.UtcNow);
+
+            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
+
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null, null);
+
+            Assert.Equal(ActivityName, telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()]);
+        }
+
+        [Fact]
         public void AiLocationIpisSetAsNetPeerIpForServerSpans()
         {
             using ActivitySource activitySource = new ActivitySource(ActivitySourceName);


### PR DESCRIPTION
When integrating with Mass Transit's OTEL implementation most items come through perfectly aside from consumer kind traces.

This is just a small update to at least allow the operation name to avoid the below output in app insights:

![image](https://user-images.githubusercontent.com/3485935/162681924-fba96141-d267-40a2-b25e-a1bd1e0f543d.png)
