### PR TITLE
[Storage][Blobs] Fix NRE in OpenWriteAsync API

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
@@ -1797,6 +1797,8 @@ namespace Azure.Storage.Blobs
             bool async,
             CancellationToken cancellationToken)
         {
+            options ??= new BlobOpenWriteOptions();
+
             if (UsingClientSideEncryption)
             {
                 // TODO #27253

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClientSideEncryptor.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClientSideEncryptor.cs
@@ -83,6 +83,8 @@ namespace Azure.Storage.Blobs
             bool async,
             CancellationToken cancellationToken)
         {
+            options ??= new BlockBlobOpenWriteOptions();
+
             Stream encryptionWriteStream = await _encryptor.EncryptedOpenWriteInternal(
                 async (encryptiondata, funcAsync, funcCancellationToken) =>
                 {

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientOpenWriteTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientOpenWriteTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -129,6 +129,27 @@ namespace Azure.Storage.Blobs.Tests
             await TestHelper.AssertExpectedExceptionAsync<ArgumentException>(
                 OpenWriteAsync(client, overwrite: false, maxDataSize: Constants.KB),
                 e => Assert.AreEqual("BlockBlobClient.OpenWrite only supports overwriting", e.Message));
+        }
+
+        [RecordedTest]
+        public virtual async Task OpenWriteAsync_DefaultOptions()
+        {
+            // Arrange
+            await using IDisposingContainer<BlobContainerClient> disposingContainer = await GetDisposingContainerAsync();
+            BlobClient client = GetResourceClient(disposingContainer.Container);
+
+            // Act
+            Exception exceptionThrown = null;
+            try
+            {
+                await client.OpenWriteAsync(overwrite: true);
+            }
+            catch (Exception ex)
+            {
+                exceptionThrown = ex;
+            }
+
+            Assert.Null(exceptionThrown);
         }
         #endregion
     }

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptedBlobClientOpenWriteTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptedBlobClientOpenWriteTests.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -148,6 +149,27 @@ namespace Azure.Storage.Blobs.Tests
             Assert.AreEqual(data.Length - (data.Length % 16) + 16, progress.List[progress.List.Count - 1]);
 
             await (AdditionalAssertions?.Invoke(client) ?? Task.CompletedTask);
+        }
+
+        [Test]
+        public override async Task OpenWriteAsync_DefaultOptions()
+        {
+            // Arrange
+            await using IDisposingContainer<BlobContainerClient> disposingContainer = await GetDisposingContainerAsync();
+            BlobClient client = GetResourceClient(disposingContainer.Container);
+
+            // Act
+            Exception exceptionThrown = null;
+            try
+            {
+                await client.OpenWriteAsync(overwrite: true);
+            }
+            catch (Exception ex)
+            {
+                exceptionThrown = ex;
+            }
+
+            Assert.Null(exceptionThrown);
         }
         #endregion
     }


### PR DESCRIPTION
A customer reached about the `OpenWriteAsync` API throwing a NRE when called without explicitly passing options. This PR addresses that.

I've added tests to cover this scenario but had some issues with recording one the live test and could use some pointers there.

resolves #27831