### PR TITLE
[FormRecognizer] Updated Form Recognizer sanitized properties

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/FormRecognizerLiveTestBase.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/FormRecognizerLiveTestBase.cs
@@ -28,7 +28,7 @@ namespace Azure.AI.FormRecognizer.Tests
         {
             _serviceVersion = serviceVersion;
             JsonPathSanitizers.Add("$..accessToken");
-            JsonPathSanitizers.Add("$..containerUrl");
+            JsonPathSanitizers.Add("$..source");
             SanitizedHeaders.Add(Constants.AuthorizationHeader);
         }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/FormRecognizerLiveTestBase.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/FormRecognizerLiveTestBase.cs
@@ -30,8 +30,6 @@ namespace Azure.AI.FormRecognizer.Tests
             JsonPathSanitizers.Add("$..accessToken");
             JsonPathSanitizers.Add("$..containerUrl");
             SanitizedHeaders.Add(Constants.AuthorizationHeader);
-            // temporary until https://github.com/Azure/azure-sdk-for-net/issues/27688 is addressed
-            CompareBodies = false;
         }
 
         /// <summary>


### PR DESCRIPTION
Long story short, this is the timeline of events that caused the bug we're fixing in this PR:

- Test Framework introduces a bug that prevents tests from correctly finding mismatches in Playback mode.
- A miscopy updates the FR live test base constructor, sanitizing the wrong property. This would make tests fail, but this goes undetected because of the Test Framework bug.
- The Test Framework bug is detected and fixed. The FR bug is exposed.
- We're fixing the FR bug now.

Fixes https://github.com/azure/azure-sdk-for-net/issues/27701.