### PR TITLE
Queue message is not removed from the queue after stopping QueueListener.

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 5.0.1 (Unreleased)
+### Bugs Fixed
+- Queue message is not removed from the queue after stopping QueueListener. (#28156)
+
 ## 5.0.0 (2021-10-26)
 - General availability of Microsoft.Azure.WebJobs.Extensions.Storage.Blobs 5.0.0.
 - Fixed bug where internal message format of blob trigger didn't interop with previous major versions of the extension.

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>5.0.0</Version>
+    <Version>5.0.1</Version>
     <Description>This extension adds bindings for Storage</Description>
     <!-- https://github.com/Azure/azure-sdk-for-net/issues/19222 -->
     <NoWarn>$(NoWarn);IDT002;IDT003</NoWarn>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Release History
 
-## 5.0.0-beta.4 (Unreleased)
-### Bugs Fixed
-- Queue message is not removed from the queue after stopping QueueListener. (#28156)
-
 ## 5.0.0-beta.3 (2021-03-09)
 - This release contains bug fixes to improve quality.
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 5.0.0-beta.4 (Unreleased)
+### Bugs Fixed
+- Queue message is not removed from the queue after stopping QueueListener. (#28156)
+
 ## 5.0.0-beta.3 (2021-03-09)
 - This release contains bug fixes to improve quality.
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Microsoft.Azure.WebJobs.Extensions.Storage.Common.csproj
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Microsoft.Azure.WebJobs.Extensions.Storage.Common.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>5.0.0-beta.1</Version>
+    <Version>5.0.0-beta.3</Version>
     <Description>This extension adds bindings for Storage</Description>
   </PropertyGroup>
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Timers/TaskSeriesTimer.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Timers/TaskSeriesTimer.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Timers
 
         private async Task StopAsyncCore(CancellationToken cancellationToken)
         {
-            await Task.Delay(0, cancellationToken).ConfigureAwait(false);
+            await Task.Delay(0, CancellationToken.None).ConfigureAwait(false);
             TaskCompletionSource<object> cancellationTaskSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using (cancellationToken.Register(() => cancellationTaskSource.SetCanceled()))

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 5.0.1 (Unreleased)
+### Bugs Fixed
+- Queue message is not removed from the queue after stopping QueueListener. (#28156)
+
 ## 5.0.0 (2021-10-26)
 - General availability of Microsoft.Azure.WebJobs.Extensions.Storage.Queues 5.0.0.
 - Change `QueueProcessor.MessageAddedToPoisonQueue` to async event and rename to `QueueProcessor.MessageAddedToPoisonQueueAsync`.

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.csproj
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>5.0.0</Version>
+    <Version>5.0.1</Version>
     <Description>This extension adds bindings for Storage</Description>
     <!-- https://github.com/Azure/azure-sdk-for-net/issues/19222 -->
     <NoWarn>$(NoWarn);IDT002</NoWarn>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 5.0.1 (Unreleased)
+### Bugs Fixed
+- Queue message is not removed from the queue after stopping QueueListener. (#28156)
+
 ## 5.0.0 (2021-10-26)
 - General availability of Microsoft.Azure.WebJobs.Extensions.Storage 5.0.0.
 Please refer to [`Microsoft.Azure.WebJobs.Extension.Storage.Blobs`](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md) and [`Microsoft.Azure.WebJobs.Extension.Storage.Queues`](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md) for detailed list of changes.

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/src/Microsoft.Azure.WebJobs.Extensions.Storage.csproj
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/src/Microsoft.Azure.WebJobs.Extensions.Storage.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>5.0.0</Version>
+    <Version>5.0.1</Version>
     <Description>This extension adds bindings for Storage</Description>
     <!-- This package is a metapackage. The flag below makes sure it doesn't include any DLL-->
     <IncludeBuildOutput>false</IncludeBuildOutput>


### PR DESCRIPTION
The bug was introduced on migrating from [track1](https://github.com/Azure/azure-webjobs-sdk/blob/dev/src/Microsoft.Azure.WebJobs.Host/Timers/TaskSeriesTimer.cs#L81) to [track2](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Timers/TaskSeriesTimer.cs#L83).

After stopping `QueueListener` the proccesed message will not removed from the queue due `OperationCanceledException` on the [line](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs#L384). as `cancellationToken` is already canceled.

I am wondering why there is `await Task.Dealy(0)` in general and if it can be removed.
Related [CRI](https://portal.microsofticm.com/imp/v3/incidents/details/294662992/home)