### PR TITLE
add generation1-convenience-client flag

### DIFF
--- a/sdk/anomalydetector/Azure.AI.AnomalyDetector/src/autorest.md
+++ b/sdk/anomalydetector/Azure.AI.AnomalyDetector/src/autorest.md
@@ -7,6 +7,7 @@ tag: release_1_1_preview.1
 require:
     -  https://github.com/Azure/azure-rest-api-specs/blob/725b20c866d7f4a6512adff8d0647f0fe3baa069/specification/cognitiveservices/data-plane/AnomalyDetector/readme.md
 namespace: Azure.AI.AnomalyDetector
+generation1-convenience-client: true
 public-clients: true
 security:
   - AADToken

--- a/sdk/attestation/Azure.Security.Attestation/src/autorest.md
+++ b/sdk/attestation/Azure.Security.Attestation/src/autorest.md
@@ -10,6 +10,7 @@ title: Azure.Security.Attestation
 require:
     - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/45c7ae94a46920c94b5e03e6a7d128d6cb7a364e/specification/attestation/data-plane/readme.md
 namespace: Azure.Security.Attestation
+generation1-convenience-client: true
 tag: package-2020-10-01
 azure-arm: false
 

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/autorest.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/autorest.md
@@ -11,6 +11,7 @@ batch:
 - input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/472892b0addc164993e68f48fb2629c664c08065/specification/cognitiveservices/data-plane/Language/preview/2022-03-01-preview/analyzeconversations.json
   clear-output-folder: true
   model-namespace: false
+  generation1-convenience-client: true
 
 # TODO: Uncomment when we ship authoring support and remove ./ConversationsClientOptions.cs.
 # - input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/33138867cd88a4a8689feb591a98dda26d96a63e/specification/cognitiveservices/data-plane/Language/preview/2021-07-15-preview/analyzeconversations-authoring.json

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/autorest.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/autorest.md
@@ -11,6 +11,7 @@ batch:
 - input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/2fe971edcf58b3351e6e5e67d269d4b4c7cc2c5f/specification/cognitiveservices/data-plane/Language/stable/2021-10-01/questionanswering.json
   clear-output-folder: true
   model-namespace: false
+  generation1-convenience-client: true
 
 - input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/b791f57426508cb2793a8911650a416dcb11c6a6/specification/cognitiveservices/data-plane/Language/stable/2021-10-01/questionanswering-authoring.json
 # namespace: Azure.AI.Language.QuestionAnswering.Projects

--- a/sdk/communication/Azure.Communication.CallingServer/src/autorest.md
+++ b/sdk/communication/Azure.Communication.CallingServer/src/autorest.md
@@ -18,6 +18,7 @@ require:
     -  https://raw.githubusercontent.com/Azure/azure-rest-api-specs/3893616381e816729ef9cdd768e87fb2845e189d/specification/communication/data-plane/CallingServer/readme.md
 payload-flattening-threshold: 10
 clear-output-folder: true
+generation1-convenience-client: true
 ```
 
 ### Fixing RecordingChannel 

--- a/sdk/communication/Azure.Communication.Chat/src/autorest.md
+++ b/sdk/communication/Azure.Communication.Chat/src/autorest.md
@@ -16,3 +16,4 @@ model-namespace: false
 require:
     -  https://raw.githubusercontent.com/Azure/azure-rest-api-specs/d0d60267975bf5823a9173ce0c926659bc9775bb/specification/communication/data-plane/Chat/readme.md
 payload-flattening-threshold: 10
+generation1-convenience-client: true

--- a/sdk/communication/Azure.Communication.Identity/src/autorest.md
+++ b/sdk/communication/Azure.Communication.Identity/src/autorest.md
@@ -10,4 +10,5 @@ tag: package-preview-2021-10
 require:
     -  https://raw.githubusercontent.com/Azure/azure-rest-api-specs/6f40b65610a4fad7a03f3fe8c57e8c0a9c3b77d0/specification/communication/data-plane/Identity/readme.md
 payload-flattening-threshold: 3
+generation1-convenience-client: true
 ```

--- a/sdk/communication/Azure.Communication.NetworkTraversal/src/autorest.md
+++ b/sdk/communication/Azure.Communication.NetworkTraversal/src/autorest.md
@@ -12,4 +12,5 @@ model-namespace: false
 require:
     - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/6282e522ef78366170de518e76b8adb0e27563a2/specification/communication/data-plane/NetworkTraversal/readme.md
 payload-flattening-threshold: 3
+generation1-convenience-client: true
 ```

--- a/sdk/communication/Azure.Communication.PhoneNumbers/src/autorest.md
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/src/autorest.md
@@ -13,4 +13,5 @@ require:
     -  https://raw.githubusercontent.com/Azure/azure-rest-api-specs/02fce64677f78021ba70d69bb8bd0d916d653927/specification/communication/data-plane/PhoneNumbers/readme.md
 title: Phone numbers
 payload-flattening-threshold: 3
+generation1-convenience-client: true
 ```

--- a/sdk/communication/Azure.Communication.ShortCodes/src/autorest.md
+++ b/sdk/communication/Azure.Communication.ShortCodes/src/autorest.md
@@ -8,6 +8,7 @@ Run `dotnet msbuild /t:GenerateCode` to generate code.
 input-file:
     -  $(this-folder)/swagger/2021-10-25-preview/swagger.json
 payload-flattening-threshold: 3
+generation1-convenience-client: true
 ```
 
 ### Customizations

--- a/sdk/communication/Azure.Communication.Sms/src/autorest.md
+++ b/sdk/communication/Azure.Communication.Sms/src/autorest.md
@@ -11,4 +11,5 @@ model-namespace: false
 require:
     -  https://raw.githubusercontent.com/Azure/azure-rest-api-specs/896d05e37dbb00712726620b8d679cc3c3be09fb/specification/communication/data-plane/Sms/readme.md
 payload-flattening-threshold: 10
+generation1-convenience-client: true
 ```

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/src/autorest.md
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/src/autorest.md
@@ -8,6 +8,7 @@ input-file:
  - https://github.com/Azure/azure-rest-api-specs/blob/c8d9a26a2857828e095903efa72512cf3a76c15d/specification/containerregistry/data-plane/Azure.ContainerRegistry/stable/2021-07-01/containerregistry.json
  
 model-namespace: false
+generation1-convenience-client: true
 modelerfour:
     seal-single-value-enum-by-default: true
 ```

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/autorest.md
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/autorest.md
@@ -10,6 +10,7 @@ Run `generate.ps1` in this directory or run `dotnet build /t:GenerateCode` to ge
 tag: package-2020-10-31
 require: 
   - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/14fb40342c19f8b483e132038f8424ee62b745d9/specification/digitaltwins/data-plane/readme.md
+generation1-convenience-client: true
 ```
 
 ### Directives

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/autorest.md
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/autorest.md
@@ -5,6 +5,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 ``` yaml
 title: EventGridClient
 require: https://github.com/Azure/azure-rest-api-specs/blob/f8811b7dd784712c3fb0941e04d9042f59a4d367/specification/eventgrid/data-plane/readme.md
+generation1-convenience-client: true
 ```
 
 ## Swagger workarounds

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/autorest.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/autorest.md
@@ -12,6 +12,7 @@ Run `dotnet build /t:GenerateCode` to generate code. Notice how there are two ma
 ``` yaml
 input-file:
     -  https://github.com/Azure/azure-rest-api-specs/blob/7043b48f4be1fdd40757b9ef372b65f054daf48f/specification/cognitiveservices/data-plane/FormRecognizer/stable/v2.1/FormRecognizer.json
+generation1-convenience-client: true
 ```
 
 ## Make the API version parameterized so we generate a multi-versioned API

--- a/sdk/iot/Azure.IoT.Hub.Service/src/autorest.md
+++ b/sdk/iot/Azure.IoT.Hub.Service/src/autorest.md
@@ -8,6 +8,7 @@ Run `./generateCode.ps1` in this directory to generate the code.
 ``` yaml
 input-file:
     -  $(this-folder)/swagger/iothubservice.json
+generation1-convenience-client: true
 modelerfour:
     seal-single-value-enum-by-default: true
 ```

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/autorest.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/autorest.md
@@ -12,6 +12,7 @@ input-file:
     - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/e2ef44b87405b412403ccb005bfb3975411adf60/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/rbac.json
     - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/e2ef44b87405b412403ccb005bfb3975411adf60/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/backuprestore.json
 namespace: Azure.Security.KeyVault.Administration
+generation1-convenience-client: true
 include-csproj: disable
 ```
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/autorest.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/autorest.md
@@ -8,6 +8,7 @@ Run `dotnet msbuild /t:GenerateCode` to generate code.
 ``` yaml
 input-file:
     - https://github.com/Azure/azure-rest-api-specs/blob/08f5e391f2153a99580b458cc71ef88e45dd0531/specification/cognitiveservices/data-plane/MetricsAdvisor/preview/v1.0/MetricsAdvisor.json
+generation1-convenience-client: true
 ```
 
 ### Make generated models internal by default

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/src/autorest.md
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/src/autorest.md
@@ -5,4 +5,5 @@ Run `dotnet build /t:GenerateCode` to generate code.
 ``` yaml
 input-file:
     -  https://raw.githubusercontent.com/Azure/azure-rest-api-specs/aa19725fe79aea2a9dc580f3c66f77f89cc34563/specification/mixedreality/data-plane/Microsoft.MixedReality/preview/2019-02-28-preview/mr-sts.json
+generation1-convenience-client: true
 ```

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/autorest.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/autorest.md
@@ -5,6 +5,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 ``` yaml
 input-file:
     -  https://raw.githubusercontent.com/Azure/azure-rest-api-specs/0ae35fd0c27e0f06004d820e75a13c615b9c2e96/specification/applicationinsights/data-plane/Monitor.Exporters/preview/2020-09-15_Preview/swagger.json
+generation1-convenience-client: true
 ```
 
 ``` yaml

--- a/sdk/monitor/Azure.Monitor.Query/src/autorest.md
+++ b/sdk/monitor/Azure.Monitor.Query/src/autorest.md
@@ -9,6 +9,7 @@ input-file:
     - https://github.com/Azure/azure-rest-api-specs/blob/dba6ed1f03bda88ac6884c0a883246446cc72495/specification/monitor/resource-manager/Microsoft.Insights/stable/2018-01-01/metricDefinitions_API.json
     - https://github.com/Azure/azure-rest-api-specs/blob/dba6ed1f03bda88ac6884c0a883246446cc72495/specification/monitor/resource-manager/Microsoft.Insights/stable/2018-01-01/metrics_API.json
     - https://github.com/Azure/azure-rest-api-specs/blob/dba6ed1f03bda88ac6884c0a883246446cc72495/specification/monitor/resource-manager/Microsoft.Insights/preview/2017-12-01-preview/metricNamespaces_API.json
+generation1-convenience-client: true
 modelerfour:
     lenient-model-deduplication: true
     seal-single-value-enum-by-default: true

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/autorest.md
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/autorest.md
@@ -5,4 +5,5 @@ Run `dotnet build /t:GenerateCode` to generate code.
 ``` yaml
 input-file:
     -  https://raw.githubusercontent.com/Azure/azure-rest-api-specs/5e3607a19fee8f1f12b9bc9cdfc0b684ac8e1cb8/specification/mixedreality/data-plane/Microsoft.MixedReality/preview/0.3-preview.0/mr-aoa.json
+generation1-convenience-client: true
 ```

--- a/sdk/quantum/Azure.Quantum.Jobs/src/autorest.md
+++ b/sdk/quantum/Azure.Quantum.Jobs/src/autorest.md
@@ -4,4 +4,5 @@ Run `dotnet build /t:GenerateCode` to generate code.
 
 ``` yaml
 require: https://github.com/Azure/azure-rest-api-specs/blob/50adac0106ba23718cb6b736d69cf834ae37f505/specification/quantum/data-plane/readme.md
+generation1-convenience-client: true
 ```

--- a/sdk/remoterendering/Azure.MixedReality.RemoteRendering/src/autorest.md
+++ b/sdk/remoterendering/Azure.MixedReality.RemoteRendering/src/autorest.md
@@ -5,4 +5,5 @@ Run `dotnet build /t:GenerateCode` to generate code.
 ``` yaml
 input-file:
     - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/2a65b0a2bbd9113b91c889f187d8778c2725c0b9/specification/mixedreality/data-plane/Microsoft.MixedReality/stable/2021-01-01/mr-arr.json
+generation1-convenience-client: true
 ```

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/autorest.md
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/autorest.md
@@ -5,6 +5,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 ``` yaml
 title: SchemaRegistryClient
 require: https://github.com/Azure/azure-rest-api-specs/blob/7aefe11d56a0b48615b0ab01cad566d6c39a5b08/specification/schemaregistry/data-plane/readme.md
+generation1-convenience-client: true
 ```
 
 ## Swagger workarounds

--- a/sdk/search/Azure.Search.Documents/src/autorest.md
+++ b/sdk/search/Azure.Search.Documents/src/autorest.md
@@ -13,6 +13,7 @@ title: SearchServiceClient
 input-file:
  - https://github.com/Azure/azure-rest-api-specs/blob/d850f41f89530917000d8e6bb463f42bb745b930/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchindex.json
  - https://github.com/Azure/azure-rest-api-specs/blob/d850f41f89530917000d8e6bb463f42bb745b930/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchservice.json
+generation1-convenience-client: true
 modelerfour:
     seal-single-value-enum-by-default: true
 ```

--- a/sdk/storage/Azure.Storage.Blobs.Batch/src/autorest.md
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/src/autorest.md
@@ -5,6 +5,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 ``` yaml
 input-file:
     - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/f8c3f91da6a9ed64b687711af64e8d70cb500e1d/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-06-12/blob.json
+generation1-convenience-client: true
 modelerfour:
     seal-single-value-enum-by-default: true
 ```

--- a/sdk/storage/Azure.Storage.Blobs/src/autorest.md
+++ b/sdk/storage/Azure.Storage.Blobs/src/autorest.md
@@ -5,6 +5,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 ``` yaml
 input-file:
     - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/e432d9cc87bfed320d8feead4b448be9481c9181/specification/storage/data-plane/Microsoft.BlobStorage/preview/2021-04-10/blob.json
+generation1-convenience-client: true
 # https://github.com/Azure/autorest/issues/4075
 skip-semantics-validation: true
 modelerfour:

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/autorest.md
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/autorest.md
@@ -5,6 +5,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 ``` yaml
 input-file:
     - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/6bacb496a7c84297e72747c52f82e4a0e6c8930d/specification/storage/data-plane/Azure.Storage.Files.DataLake/preview/2021-06-08/DataLakeStorage.json
+generation1-convenience-client: true
 modelerfour:
     seal-single-value-enum-by-default: true
 ```

--- a/sdk/storage/Azure.Storage.Files.Shares/src/autorest.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/autorest.md
@@ -5,6 +5,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 ``` yaml
 input-file:
     - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/e432d9cc87bfed320d8feead4b448be9481c9181/specification/storage/data-plane/Microsoft.FileStorage/preview/2021-06-08/file.json
+generation1-convenience-client: true
 # https://github.com/Azure/autorest/issues/4075
 skip-semantics-validation: true
 modelerfour:

--- a/sdk/storage/Azure.Storage.Queues/src/autorest.md
+++ b/sdk/storage/Azure.Storage.Queues/src/autorest.md
@@ -5,6 +5,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 ``` yaml
 input-file:
     - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/4a93ab078fba7f087116283c8ed169f9b8e30397/specification/storage/data-plane/Microsoft.QueueStorage/preview/2018-03-28/queue.json
+generation1-convenience-client: true
 # https://github.com/Azure/autorest/issues/4075
 skip-semantics-validation: true
 modelerfour:

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/src/autorest.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/src/autorest.md
@@ -10,6 +10,7 @@ tag: package-artifacts-composite-v3
 require:
     - https://github.com/Azure/azure-rest-api-specs/blob/8c1b6936238a1734036c22e3ae98b31c6b9f04cb/specification/synapse/data-plane/readme.md
 namespace: Azure.Analytics.Synapse.Artifacts
+generation1-convenience-client: true
 public-clients: true
 security: AADToken
 security-scopes: https://dev.azuresynapse.net/.default

--- a/sdk/synapse/Azure.Analytics.Synapse.ManagedPrivateEndpoints/src/autorest.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.ManagedPrivateEndpoints/src/autorest.md
@@ -11,6 +11,7 @@ tag: package-vnet-2020-12-01
 require:
     - https://github.com/Azure/azure-rest-api-specs/blob/37c4ff1612668f5acec62dea729ca3a66b591d7f/specification/synapse/data-plane/readme.md
 namespace: Azure.Analytics.Synapse.ManagedPrivateEndpoints
+generation1-convenience-client: true
 public-clients: true
 security: AADToken
 security-scopes: https://dev.azuresynapse.net/.default

--- a/sdk/synapse/Azure.Analytics.Synapse.Monitoring/src/autorest.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.Monitoring/src/autorest.md
@@ -10,6 +10,7 @@ tag: package-monitoring-2019-11-01-preview
 require:
     - https://github.com/Azure/azure-rest-api-specs/blob/fc5e2fbcfc3f585d38bdb1c513ce1ad2c570cf3d/specification/synapse/data-plane/readme.md
 namespace: Azure.Analytics.Synapse.Monitoring
+generation1-convenience-client: true
 public-clients: true
 security: AADToken
 security-scopes: https://dev.azuresynapse.net/.default

--- a/sdk/synapse/Azure.Analytics.Synapse.Spark/src/autorest.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.Spark/src/autorest.md
@@ -10,6 +10,7 @@ tag: package-spark-2020-12-01
 require:
     - https://github.com/Azure/azure-rest-api-specs/blob/c9992af7235a6550087d4fed8f081ed35019f605/specification/synapse/data-plane/readme.md
 namespace: Azure.Analytics.Synapse.Spark
+generation1-convenience-client: true
 public-clients: true
 security: AADToken
 security-scopes: https://dev.azuresynapse.net/.default

--- a/sdk/tables/Azure.Data.Tables/src/autorest.md
+++ b/sdk/tables/Azure.Data.Tables/src/autorest.md
@@ -12,6 +12,7 @@ azure-validator: false
 require:
     - https://github.com/Azure/azure-rest-api-specs/blob/2df8b07bf9af7c96066ca4dda21b79297307d108/specification/cosmos-db/data-plane/readme.md
 namespace: Azure.Data.Tables
+generation1-convenience-client: true
 include-csproj: disable
 modelerfour:
   seal-single-value-enum-by-default: true

--- a/sdk/testcommon/Azure.Graph.Rbac/src/autorest.md
+++ b/sdk/testcommon/Azure.Graph.Rbac/src/autorest.md
@@ -6,5 +6,6 @@ Run `dotnet build /t:GenerateCode` to generate code.
 azure-arm: true
 title: Rbac
 require: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/7fe24f57e1d0e3560535be0730db43feb3239a36/specification/graphrbac/data-plane/readme.md
+generation1-convenience-client: true
 skip-semantics-validation: true
 ```

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/autorest.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/autorest.md
@@ -8,6 +8,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 ``` yaml
 input-file:
     - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/11cb5c629a836dc99454d85c233405f952b555d8/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.2-preview.2/TextAnalytics.json
+generation1-convenience-client: true
 ```
 
 ### Make generated models internal by default

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/autorest.md
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/src/autorest.md
@@ -71,4 +71,5 @@ directive:
 
 # It is highly recommended that you generate the REST layer from the official source. However, in this case we are using a local file because there are a couple of minor issues fixed in the local swagger. These fixes should be made on the official source.
 input-file: $(this-folder)/swagger/timeseriesinsights.json
+generation1-convenience-client: true
 ```

--- a/sdk/translation/Azure.AI.Translation.Document/src/autorest.md
+++ b/sdk/translation/Azure.AI.Translation.Document/src/autorest.md
@@ -9,6 +9,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 tag: release_1_0
 require:
     - https://github.com/Azure/azure-rest-api-specs/blob/3196a62202976da192d6da86f44b02246ca2aa97/specification/cognitiveservices/data-plane/TranslatorText/readme.md
+generation1-convenience-client: true
 ```
 
 ### Make generated models internal by default

--- a/tools/generate.cmd
+++ b/tools/generate.cmd
@@ -56,7 +56,7 @@ if "%7" == "" (call npm i -g autorest)
 
 :: code generation
 @echo on
-call autorest %configFile% --csharp --csharp-sdks-folder=%sdksFolder% --version=%version% --reflect-api-versions
+call autorest %configFile% --csharp --csharp-sdks-folder=%sdksFolder% --version=%version% --reflect-api-versions --generation1-convenience-client
 @echo off
 
 :: metadata


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

We will set 'data-plane' as autorest.csharp codegen default target. and will add new tag 'generation1-convenience-client' tag for the HLC Client Library.

In order to upgrade to the new autorest.csharp which will use 'data-plane' as default target, we need to migrate current SDKs in azure-sdk-for-net step by step as following:

1. Add new flag 'generation1-convenience-client' to all HLC SDKs
2. Merge change in autorest.csharp https://github.com/Azure/autorest.csharp/pull/2146
3. Upgrade autorest.csharp version and Remove old flag (data-plane) from the DPG SDKs

This pull request is #1