### PR TITLE
upgrade autorest.csharp version and remove data-plane flag

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -152,7 +152,7 @@
     All should have PrivateAssets="All" set so they don't become package dependencies
   -->
   <ItemGroup>
-    <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20220407.2" PrivateAssets="All" />
+    <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20220412.1" PrivateAssets="All" />
     <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20220111.2" PrivateAssets="All" />
     <PackageReference Update="coverlet.collector" Version="1.3.0" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" PrivateAssets="All" />

--- a/sdk/agrifood/Azure.Verticals.AgriFood.Farming/src/autorest.md
+++ b/sdk/agrifood/Azure.Verticals.AgriFood.Farming/src/autorest.md
@@ -6,7 +6,6 @@ Run `dotnet build /t:GenerateCode` to generate code.
 title: FarmBeats
 input-file: https://github.com/Azure/azure-rest-api-specs/blob/683e3f4849ee1d84629d0d0fa17789e80a9cee08/specification/agfood/data-plane/Microsoft.AgFoodPlatform/preview/2021-03-31-preview/agfood.json
 namespace: Azure.Verticals.AgriFood.Farming
-data-plane: true
 security: AADToken
 security-scopes: https://farmbeats.azure.net/.default
 ```

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/autorest.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/autorest.md
@@ -16,7 +16,6 @@ batch:
 - input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/b791f57426508cb2793a8911650a416dcb11c6a6/specification/cognitiveservices/data-plane/Language/stable/2021-10-01/questionanswering-authoring.json
 # namespace: Azure.AI.Language.QuestionAnswering.Projects
   add-credentials: true
-  data-plane: true
 
 modelerfour:
   lenient-model-deduplication: true

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/autorest.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/autorest.md
@@ -7,7 +7,6 @@ title: ConfidentialLedger
 namespace: Azure.Security.ConfidentialLedger 
 security: AADToken
 security-scopes: "https://confidential-ledger.azure.com/.default"
-data-plane: true
 input-file:
     -  https://github.com/Azure/azure-rest-api-specs/blob/e34c5f11d61ca17fdc9fd0f70446dd54b94d67f1/specification/confidentialledger/data-plane/Microsoft.ConfidentialLedger/preview/0.1-preview/common.json
     -  https://github.com/Azure/azure-rest-api-specs/blob/e34c5f11d61ca17fdc9fd0f70446dd54b94d67f1/specification/confidentialledger/data-plane/Microsoft.ConfidentialLedger/preview/0.1-preview/confidentialledger.json

--- a/sdk/core/Azure.Core.TestFramework/src/autorest.md
+++ b/sdk/core/Azure.Core.TestFramework/src/autorest.md
@@ -5,4 +5,5 @@ Run `dotnet build /t:GenerateCode` to generate code.
 ``` yaml
 title: TestProxyClient
 input-file: testproxy.json
+generation1-convenience-client: true
 ```

--- a/sdk/deviceupdate/Azure.IoT.DeviceUpdate/src/autorest.md
+++ b/sdk/deviceupdate/Azure.IoT.DeviceUpdate/src/autorest.md
@@ -10,7 +10,6 @@ public-clients: true
 title: DeviceUpdate
 input-file: https://github.com/dpokluda/azure-rest-api-specs/blob/0161086e0d0a91dd1ef313dfce138be2fec0ab11/specification/deviceupdate/data-plane/Microsoft.DeviceUpdate/preview/2021-06-01-preview/deviceupdate.json
 namespace: Azure.IoT.DeviceUpdate
-data-plane: true
 security: AADToken
 security-scopes:  https://api.adu.microsoft.com/.default
 ```

--- a/sdk/keyvault/samples/sharelink/autorest.md
+++ b/sdk/keyvault/samples/sharelink/autorest.md
@@ -12,6 +12,7 @@ namespace: Azure.Security.KeyVault.Storage
 include-csproj: disable
 input-file:
 - https://github.com/Azure/azure-rest-api-specs/blob/615259b6d33d3029de2d6e403ffe0c12776da1d4/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.1/storage.json
+generation1-convenience-client: true
 ```
 
 ## Swagger hacks

--- a/sdk/purview/Azure.Analytics.Purview.Account/src/autorest.md
+++ b/sdk/purview/Azure.Analytics.Purview.Account/src/autorest.md
@@ -6,7 +6,6 @@ Run `dotnet build /t:GenerateCode` to generate code.
 title: PurviewAccount
 input-file: https://github.com/Azure/azure-rest-api-specs/blob/b2bddfe2e59b5b14e559e0433b6e6d057bcff95d/specification/purview/data-plane/Azure.Analytics.Purview.Account/preview/2019-11-01-preview/account.json
 namespace: Azure.Analytics.Purview.Account
-data-plane: true
 security: AADToken
 security-scopes:  https://purview.azure.net/.default
 ```

--- a/sdk/purview/Azure.Analytics.Purview.Administration/src/autorest.md
+++ b/sdk/purview/Azure.Analytics.Purview.Administration/src/autorest.md
@@ -8,7 +8,6 @@ input-file:
   - https://github.com/Azure/azure-rest-api-specs/blob/b2bddfe2e59b5b14e559e0433b6e6d057bcff95d/specification/purview/data-plane/Azure.Analytics.Purview.Account/preview/2019-11-01-preview/account.json
   - https://github.com/Azure/azure-rest-api-specs/blob/1424fc4a1f82af852a626c6ab6d1d296b5fe4df1/specification/purview/data-plane/Azure.Analytics.Purview.MetadataPolicies/preview/2021-07-01/purviewMetadataPolicy.json
 namespace: Azure.Analytics.Purview.Administration
-data-plane: true
 modelerfour:
     lenient-model-deduplication: true
 security: AADToken

--- a/sdk/purview/Azure.Analytics.Purview.Catalog/src/autorest.md
+++ b/sdk/purview/Azure.Analytics.Purview.Catalog/src/autorest.md
@@ -7,7 +7,6 @@ title: PurviewCatalog
 input-file:
 - https://github.com/Azure/azure-rest-api-specs/blob/2c66a689c610dbef623d6c4e4c4e913446d5ac68/specification/purview/data-plane/Azure.Analytics.Purview.Catalog/preview/2021-05-01-preview/purviewcatalog.json
 namespace: Azure.Analytics.Purview.Catalog
-data-plane: true
 security: AADToken
 security-scopes:  https://purview.azure.net/.default
 ```

--- a/sdk/purview/Azure.Analytics.Purview.Scanning/src/autorest.md
+++ b/sdk/purview/Azure.Analytics.Purview.Scanning/src/autorest.md
@@ -6,7 +6,6 @@ Run `dotnet build /t:GenerateCode` to generate code.
 title: PurviewScanningService
 input-file: https://github.com/Azure/azure-rest-api-specs/blob/1c7df99f6a84335cfd7bf5be8c800d72c1dddbc2/specification/purview/data-plane/Azure.Analytics.Purview.Scanning/preview/2018-12-01-preview/scanningService.json
 namespace: Azure.Analytics.Purview.Scanning
-data-plane: true
 security: AADToken
 security-scopes:  https://purview.azure.net/.default
 modelerfour:

--- a/sdk/synapse/Azure.Analytics.Synapse.AccessControl/src/autorest.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.AccessControl/src/autorest.md
@@ -11,7 +11,6 @@ require:
     - https://github.com/Azure/azure-rest-api-specs/blob/37c4ff1612668f5acec62dea729ca3a66b591d7f/specification/synapse/data-plane/readme.md
 namespace: Azure.Analytics.Synapse.AccessControl
 public-clients: true
-data-plane: true
 security: AADToken
 security-scopes: https://dev.azuresynapse.net/.default
 ```

--- a/sdk/template/Azure.Template/src/autorest.md
+++ b/sdk/template/Azure.Template/src/autorest.md
@@ -5,4 +5,5 @@ Run `dotnet build /t:GenerateCode` to generate code.
 ``` yaml
 input-file:
     -  $(this-folder)/swagger/mini-secrets.json
+generation1-convenience-client: true
 ```

--- a/sdk/videoanalyzer/Azure.Media.VideoAnalyzer.Edge/src/autorest.md
+++ b/sdk/videoanalyzer/Azure.Media.VideoAnalyzer.Edge/src/autorest.md
@@ -11,7 +11,7 @@ directive:
     $["x-csharp-formats"] = "json";
 
 require: https://github.com/Azure/azure-rest-api-specs/blob/694fe69245024447f8d3647be1da88e9ad942058/specification/videoanalyzer/data-plane/readme.md
-azure-arm: false
+generation1-convenience-client: true
 payload-flattening-threshold: 2
 license-header: MICROSOFT_MIT_NO_VERSION
 clear-output-folder: true

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/src/autorest.md
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/src/autorest.md
@@ -10,7 +10,6 @@ Run `dotnet build /t:GenerateCode` to generate code.
 title: WebPubSubServiceClient
 input-file:
 - https://github.com/Azure/azure-rest-api-specs/blob/39c7d63c21b9a29efe3907d9b949d1c77b021907/specification/webpubsub/data-plane/WebPubSub/stable/2021-10-01/webpubsub.json
-data-plane: true
 credential-types: AzureKeyCredential
 credential-header-name: Ocp-Apim-Subscription-Key
 ```


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

We will set 'data-plane' as autorest.csharp codegen default target. and will add new tag 'generation1-convenience-client' tag for the HLC Client Library.

In order to upgrade to the new autorest.csharp which will use 'data-plane' as default target, we need to migrate current SDKs in azure-sdk-for-net step by step as following:

1. Add new flag 'generation1-convenience-client' to all HLC SDKs
2. Merge change in autorest.csharp https://github.com/Azure/autorest.csharp/pull/2146
3. Upgrade autorest.csharp version and Remove old flag (data-plane) from the DPG SDKs

This pull request is #3