### PR TITLE
Don't save recordings for failed tests

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -268,7 +268,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TestProxyVersion>1.0.0-dev.20220404.1</TestProxyVersion>
+    <TestProxyVersion>1.0.0-dev.20220413.1</TestProxyVersion>
   </PropertyGroup>
 
 </Project>

--- a/sdk/core/Azure.Core.TestFramework/src/Generated/TestProxyRestClient.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/Generated/TestProxyRestClient.cs
@@ -239,7 +239,7 @@ namespace Azure.Core.TestFramework
             }
         }
 
-        internal HttpMessage CreateStopRecordRequest(string xRecordingId, IDictionary<string, string> variables)
+        internal HttpMessage CreateStopRecordRequest(string xRecordingId, IDictionary<string, string> variables, string xRecordingSkip)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -249,6 +249,10 @@ namespace Azure.Core.TestFramework
             uri.AppendPath("/record/stop", false);
             request.Uri = uri;
             request.Headers.Add("x-recording-id", xRecordingId);
+            if (xRecordingSkip != null)
+            {
+                request.Headers.Add("x-recording-skip", xRecordingSkip);
+            }
             request.Headers.Add("Content-Type", "application/json");
             var content = new Utf8JsonRequestContent();
             content.JsonWriter.WriteStartObject();
@@ -265,9 +269,10 @@ namespace Azure.Core.TestFramework
         /// <summary> Stop recording for a test. </summary>
         /// <param name="xRecordingId"> The recording ID. </param>
         /// <param name="variables"> Variables for the recording. </param>
+        /// <param name="xRecordingSkip"> Set to request-response to skip recording this session. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="xRecordingId"/> or <paramref name="variables"/> is null. </exception>
-        public async Task<Response> StopRecordAsync(string xRecordingId, IDictionary<string, string> variables, CancellationToken cancellationToken = default)
+        public async Task<Response> StopRecordAsync(string xRecordingId, IDictionary<string, string> variables, string xRecordingSkip = null, CancellationToken cancellationToken = default)
         {
             if (xRecordingId == null)
             {
@@ -278,7 +283,7 @@ namespace Azure.Core.TestFramework
                 throw new ArgumentNullException(nameof(variables));
             }
 
-            using var message = CreateStopRecordRequest(xRecordingId, variables);
+            using var message = CreateStopRecordRequest(xRecordingId, variables, xRecordingSkip);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -292,9 +297,10 @@ namespace Azure.Core.TestFramework
         /// <summary> Stop recording for a test. </summary>
         /// <param name="xRecordingId"> The recording ID. </param>
         /// <param name="variables"> Variables for the recording. </param>
+        /// <param name="xRecordingSkip"> Set to request-response to skip recording this session. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="xRecordingId"/> or <paramref name="variables"/> is null. </exception>
-        public Response StopRecord(string xRecordingId, IDictionary<string, string> variables, CancellationToken cancellationToken = default)
+        public Response StopRecord(string xRecordingId, IDictionary<string, string> variables, string xRecordingSkip = null, CancellationToken cancellationToken = default)
         {
             if (xRecordingId == null)
             {
@@ -305,7 +311,7 @@ namespace Azure.Core.TestFramework
                 throw new ArgumentNullException(nameof(variables));
             }
 
-            using var message = CreateStopRecordRequest(xRecordingId, variables);
+            using var message = CreateStopRecordRequest(xRecordingId, variables, xRecordingSkip);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {
@@ -404,7 +410,7 @@ namespace Azure.Core.TestFramework
             return message;
         }
 
-        /// <summary> Stop recording for a test. </summary>
+        /// <summary> Add header sanitizer. </summary>
         /// <param name="sanitizer"> The body for a header regex sanitizer. </param>
         /// <param name="xRecordingId"> The recording ID to apply the sanitizer to. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
@@ -427,7 +433,7 @@ namespace Azure.Core.TestFramework
             }
         }
 
-        /// <summary> Stop recording for a test. </summary>
+        /// <summary> Add header sanitizer. </summary>
         /// <param name="sanitizer"> The body for a header regex sanitizer. </param>
         /// <param name="xRecordingId"> The recording ID to apply the sanitizer to. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
@@ -97,6 +97,28 @@ namespace Azure.Core.TestFramework
         /// </summary>
         public List<(string Header, string QueryParameter)> SanitizedQueryParametersInHeaders { get; } = new();
 
+        /// <summary>
+        /// Flag you can (temporarily) enable to save failed test recordings
+        /// and debug/re-run at the point of failure without re-running
+        /// potentially lengthy live tests.  This should never be checked in
+        /// and will throw an exception from CI builds to help make that easier
+        /// to spot.
+        /// The list of JSON path sanitizers to use when sanitizing a JSON request or response body.
+        /// </summary>
+        public bool SaveDebugRecordingsOnFailure
+        {
+            get => _saveDebugRecordingsOnFailure;
+            set
+            {
+                if (value && TestEnvironment.GlobalIsRunningInCI)
+                {
+                    throw new AssertionException($"Setting {nameof(SaveDebugRecordingsOnFailure)} must not be merged");
+                }
+                _saveDebugRecordingsOnFailure = value;
+            }
+        }
+        private bool _saveDebugRecordingsOnFailure;
+
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string ReplacementHost
         {
@@ -331,9 +353,13 @@ namespace Azure.Core.TestFramework
                 throw new InvalidOperationException("The test didn't instrument any clients but had recordings. Please call InstrumentClient for the client being recorded.");
             }
 
+            bool save = testPassed;
+#if DEBUG
+            save |= SaveDebugRecordingsOnFailure;
+#endif
             if (Recording != null)
             {
-                await Recording.DisposeAsync();
+                await Recording.DisposeAsync(save);
             }
 
             _proxy?.CheckForErrors();

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
@@ -103,7 +103,6 @@ namespace Azure.Core.TestFramework
         /// potentially lengthy live tests.  This should never be checked in
         /// and will throw an exception from CI builds to help make that easier
         /// to spot.
-        /// The list of JSON path sanitizers to use when sanitizing a JSON request or response body.
         /// </summary>
         public bool SaveDebugRecordingsOnFailure
         {

--- a/sdk/core/Azure.Core.TestFramework/src/TestRecording.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestRecording.cs
@@ -241,12 +241,17 @@ namespace Azure.Core.TestFramework
         /// </summary>
         public DateTimeOffset UtcNow => Now.ToUniversalTime();
 
-        public async ValueTask DisposeAsync()
+        public async ValueTask DisposeAsync(bool save)
         {
             if (Mode == RecordedTestMode.Record)
             {
-                await _proxy.Client.StopRecordAsync(RecordingId, Variables);
+                await _proxy.Client.StopRecordAsync(RecordingId, Variables, save ? null : "request-response");
             }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await DisposeAsync(true);
         }
 
         public HttpPipelineTransport CreateTransport(HttpPipelineTransport currentTransport)

--- a/sdk/core/Azure.Core.TestFramework/src/testproxy.json
+++ b/sdk/core/Azure.Core.TestFramework/src/testproxy.json
@@ -576,16 +576,6 @@
         "modelAsString": false
       }
     },
-    "SkipRecordingType": {
-      "type": "string",
-      "enum": [
-        "RequestResponse"
-      ],
-      "x-ms-enum": {
-        "name": "SkipRecordingType",
-        "modelAsString": false
-      }
-    },
     "TransformType": {
       "type": "string",
       "enum": [

--- a/sdk/core/Azure.Core.TestFramework/src/testproxy.json
+++ b/sdk/core/Azure.Core.TestFramework/src/testproxy.json
@@ -149,6 +149,12 @@
             "type": "string"
           },
           {
+            "name": "x-recording-skip",
+            "in": "header",
+            "description": "Set to request-response to skip recording this session.",
+            "type": "string"
+          },
+          {
             "name": "variables",
             "in": "body",
             "description": "Variables for the recording.",
@@ -237,7 +243,7 @@
     "/admin/addsanitizer?overload=HeaderRegexSanitizer": {
       "post": {
         "summary": "Add a sanitizer.",
-        "description": "Stop recording for a test.",
+        "description": "Add header sanitizer.",
         "operationId": "TestProxy_AddHeaderSanitizer",
         "consumes": [
           "application/json"
@@ -567,6 +573,16 @@
       ],
       "x-ms-enum": {
         "name": "MatcherType",
+        "modelAsString": false
+      }
+    },
+    "SkipRecordingType": {
+      "type": "string",
+      "enum": [
+        "RequestResponse"
+      ],
+      "x-ms-enum": {
+        "name": "SkipRecordingType",
         "modelAsString": false
       }
     },


### PR DESCRIPTION
Also add back SaveDebugRecordingsOnFailure that @heaths added prior to Test Proxy migration, now that there is a way to control whether or not to save in Test Proxy.