### PR TITLE
[TA] Make sure our public API hasn't changed in comparison with our latest release

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
@@ -1166,6 +1166,7 @@ namespace Azure.AI.TextAnalytics
         public static Azure.AI.TextAnalytics.TextAnalyticsOperationStatus Cancelling { get { throw null; } }
         public static Azure.AI.TextAnalytics.TextAnalyticsOperationStatus Failed { get { throw null; } }
         public static Azure.AI.TextAnalytics.TextAnalyticsOperationStatus NotStarted { get { throw null; } }
+        public static Azure.AI.TextAnalytics.TextAnalyticsOperationStatus PartiallySucceeded { get { throw null; } }
         public static Azure.AI.TextAnalytics.TextAnalyticsOperationStatus Rejected { get { throw null; } }
         public static Azure.AI.TextAnalytics.TextAnalyticsOperationStatus Running { get { throw null; } }
         public static Azure.AI.TextAnalytics.TextAnalyticsOperationStatus Succeeded { get { throw null; } }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/EntityDataSource.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/EntityDataSource.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Azure.Core;
 
 namespace Azure.AI.TextAnalytics
@@ -11,6 +12,26 @@ namespace Azure.AI.TextAnalytics
     [CodeGenModel("HealthcareEntityLink")]
     public partial class EntityDataSource
     {
+        /// Make constructor internal
+        /// <summary> Initializes a new instance of EntityDataSource. </summary>
+        /// <param name="name"> Entity Catalog. Examples include: UMLS, CHV, MSH, etc. </param>
+        /// <param name="entityId"> Entity id in the given source catalog. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="name"/> or <paramref name="entityId"/> is null. </exception>
+        internal EntityDataSource(string name, string entityId)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+            if (entityId == null)
+            {
+                throw new ArgumentNullException(nameof(entityId));
+            }
+
+            Name = name;
+            EntityId = entityId;
+        }
+
         /// <summary> Entity id in the given source catalog. </summary>
         [CodeGenMember("Id")]
         public string EntityId { get; }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/EntityDataSource.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/EntityDataSource.cs
@@ -12,23 +12,5 @@ namespace Azure.AI.TextAnalytics
     /// <summary> The HealthcareEntityLink. </summary>
     public partial class EntityDataSource
     {
-        /// <summary> Initializes a new instance of EntityDataSource. </summary>
-        /// <param name="name"> Entity Catalog. Examples include: UMLS, CHV, MSH, etc. </param>
-        /// <param name="entityId"> Entity id in the given source catalog. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="name"/> or <paramref name="entityId"/> is null. </exception>
-        public EntityDataSource(string name, string entityId)
-        {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-            if (entityId == null)
-            {
-                throw new ArgumentNullException(nameof(entityId));
-            }
-
-            Name = name;
-            EntityId = entityId;
-        }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/HealthcareEntityAssertion.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/HealthcareEntityAssertion.cs
@@ -10,10 +10,6 @@ namespace Azure.AI.TextAnalytics
     /// <summary> The HealthcareAssertion. </summary>
     public partial class HealthcareEntityAssertion
     {
-        /// <summary> Initializes a new instance of HealthcareEntityAssertion. </summary>
-        public HealthcareEntityAssertion()
-        {
-        }
 
         /// <summary> Initializes a new instance of HealthcareEntityAssertion. </summary>
         /// <param name="conditionality"> Describes any conditionality on the entity. </param>
@@ -25,12 +21,5 @@ namespace Azure.AI.TextAnalytics
             Certainty = certainty;
             Association = association;
         }
-
-        /// <summary> Describes any conditionality on the entity. </summary>
-        public EntityConditionality? Conditionality { get; set; }
-        /// <summary> Describes the entities certainty and polarity. </summary>
-        public EntityCertainty? Certainty { get; set; }
-        /// <summary> Describes if the entity is the subject of the text or if it describes someone else. </summary>
-        public EntityAssociation? Association { get; set; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/HealthcareEntityAssertion.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/HealthcareEntityAssertion.cs
@@ -12,6 +12,20 @@ namespace Azure.AI.TextAnalytics
     [CodeGenModel("HealthcareAssertion")]
     public partial class HealthcareEntityAssertion
     {
+        /// MAke constructor internal
+        /// <summary> Initializes a new instance of HealthcareEntityAssertion. </summary>
+        internal HealthcareEntityAssertion()
+        {
+        }
+
+        /// Remove setters from properties
+        /// <summary> Describes any conditionality on the entity. </summary>
+        public EntityConditionality? Conditionality { get; }
+        /// <summary> Describes the entities certainty and polarity. </summary>
+        public EntityCertainty? Certainty { get; }
+        /// <summary> Describes if the entity is the subject of the text or if it describes someone else. </summary>
+        public EntityAssociation? Association { get; }
+
         /// <summary>
         /// Returns a string that contains the values for the
         /// <see cref="HealthcareEntityAssertion"/> object.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
@@ -1510,33 +1510,23 @@ namespace Azure.AI.TextAnalytics
         }
         #endregion Healthcare
 
-        // added for compilation
-        /// <summary>
-        /// added for compilation
-        /// </summary>
-        /// <returns></returns>
-        public static HealthcareEntityAssertion HealthcareEntityAssertion()
+        /// <summary> Initializes a new instance of HealthcareEntityAssertion. </summary>
+        /// <param name="conditionality"> Describes any conditionality on the entity. </param>
+        /// <param name="certainty"> Describes the entities certainty and polarity. </param>
+        /// <param name="association"> Describes if the entity is the subject of the text or if it describes someone else. </param>
+        /// <returns> A new <see cref="TextAnalytics.HealthcareEntityAssertion"/> instance for mocking. </returns>
+        public static HealthcareEntityAssertion HealthcareEntityAssertion(EntityConditionality? conditionality = null, EntityCertainty? certainty = null, EntityAssociation? association = null)
         {
-            return new HealthcareEntityAssertion();
+            return new HealthcareEntityAssertion(conditionality, certainty, association);
         }
 
-        /// <summary>
-        /// added for compilation
-        /// </summary>
-        /// <returns></returns>
-        public static EntityDataSource EntityDataSource(string name, string entityId)
+        /// <summary> Initializes a new instance of EntityDataSource. </summary>
+        /// <param name="name"> Entity Catalog. Examples include: UMLS, CHV, MSH, etc. </param>
+        /// <param name="entityId"> Entity id in the given source catalog. </param>
+        /// <returns> A new <see cref="TextAnalytics.EntityDataSource"/> instance for mocking. </returns>
+        public static EntityDataSource EntityDataSource(string name = null, string entityId = null)
         {
             return new EntityDataSource(name, entityId);
-        }
-
-        // added for compilation
-        /// <summary>
-        /// added for compilation
-        /// </summary>
-        /// <returns></returns>
-        public static HealthcareEntityAssertion HealthcareEntityAssertion(EntityConditionality? entityConditionality, EntityCertainty? entityCertainty, EntityAssociation? entityAssociation)
-        {
-            return new HealthcareEntityAssertion(entityConditionality, entityCertainty, entityAssociation);
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/autorest.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/autorest.md
@@ -59,15 +59,3 @@ directive:
   transform: >
     $["required"] = ["status", "lastUpdateDateTime"]
 ```
-
-### Add x-ms-paths section if not exists
-
-```yaml
-directive:
-  - from: swagger-document
-    where: $
-    transform: >
-      if (!$["x-ms-paths"]) {
-        $["x-ms-paths"] = {}
-      }
-```


### PR DESCRIPTION
While we change the Text Analytics SDK to call a different service swagger, we need to make sure we don't change the public API from our previous releases.
There is only one real addition, which we are ok with.

The other change I'm doing is to trick the generated code to look like before. The question is, why was it necessary? I have created issue https://github.com/Azure/azure-sdk-for-net/issues/28323 to keep tracking the root cause of this, but need to unblock the build so trying to merge for now.