### PR TITLE
Update Chaos SDK to latest version of the OpenAPI spec

### DIFF
--- a/eng/mgmt/mgmtmetadata/chaos_resource-manager.txt
+++ b/eng/mgmt/mgmtmetadata/chaos_resource-manager.txt
@@ -3,13 +3,13 @@ AutoRest installed successfully.
 Commencing code generation
 Generating CSharp code
 Executing AutoRest command
-cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/main/specification/chaos/resource-manager/readme.md --csharp --version=v2 --reflect-api-versions --csharp-sdks-folder=C:\azure-sdk-for-net\sdk
+cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/main/specification/chaos/resource-manager/readme.md --csharp --version=2.0.4421 --reflect-api-versions --csharp-sdks-folder=C:\workspace\azure-sdk-for-net\sdk
 Autorest CSharp Version: 2.3.82
-2021-11-04 22:44:16 UTC
+2022-04-20 18:21:48 UTC
 Azure-rest-api-specs repository information
 GitHub fork: Azure
 Branch:      main
-Commit:      7b60a35565f42011dd6033bf52eb3ccc2b6e8f49
+Commit:      b5d8eef5bf187dc99f1c18e8323b19e0c37a7124
 AutoRest information
-Requested version: v2
+Requested version: 2.0.4421
 Bootstrapper version:    autorest@2.0.4413

--- a/sdk/chaos/Microsoft.Azure.Management.Chaos/src/Generated/Models/ActionStatus.cs
+++ b/sdk/chaos/Microsoft.Azure.Management.Chaos/src/Generated/Models/ActionStatus.cs
@@ -34,12 +34,18 @@ namespace Microsoft.Azure.Management.Chaos.Models
         /// <param name="name">The name of the action status.</param>
         /// <param name="id">The id of the action status.</param>
         /// <param name="status">The status of the action.</param>
+        /// <param name="startTime">String that represents the start time of
+        /// the action.</param>
+        /// <param name="endTime">String that represents the end time of the
+        /// action.</param>
         /// <param name="targets">The array of targets.</param>
-        public ActionStatus(string name = default(string), string id = default(string), string status = default(string), IList<ExperimentExecutionActionTargetDetailsProperties> targets = default(IList<ExperimentExecutionActionTargetDetailsProperties>))
+        public ActionStatus(string name = default(string), string id = default(string), string status = default(string), System.DateTime? startTime = default(System.DateTime?), System.DateTime? endTime = default(System.DateTime?), IList<ExperimentExecutionActionTargetDetailsProperties> targets = default(IList<ExperimentExecutionActionTargetDetailsProperties>))
         {
             Name = name;
             Id = id;
             Status = status;
+            StartTime = startTime;
+            EndTime = endTime;
             Targets = targets;
             CustomInit();
         }
@@ -66,6 +72,18 @@ namespace Microsoft.Azure.Management.Chaos.Models
         /// </summary>
         [JsonProperty(PropertyName = "status")]
         public string Status { get; private set; }
+
+        /// <summary>
+        /// Gets string that represents the start time of the action.
+        /// </summary>
+        [JsonProperty(PropertyName = "startTime")]
+        public System.DateTime? StartTime { get; private set; }
+
+        /// <summary>
+        /// Gets string that represents the end time of the action.
+        /// </summary>
+        [JsonProperty(PropertyName = "endTime")]
+        public System.DateTime? EndTime { get; private set; }
 
         /// <summary>
         /// Gets the array of targets.

--- a/sdk/chaos/Microsoft.Azure.Management.Chaos/src/Generated/SdkInfo_ChaosManagementClient.cs
+++ b/sdk/chaos/Microsoft.Azure.Management.Chaos/src/Generated/SdkInfo_ChaosManagementClient.cs
@@ -29,12 +29,12 @@ namespace Microsoft.Azure.Management.Chaos
           }
       }
       // BEGIN: Code Generation Metadata Section
-      public static readonly String AutoRestVersion = "v2";
+      public static readonly String AutoRestVersion = "2.0.4421";
       public static readonly String AutoRestBootStrapperVersion = "autorest@2.0.4413";
-      public static readonly String AutoRestCmdExecuted = "cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/main/specification/chaos/resource-manager/readme.md --csharp --version=v2 --reflect-api-versions --csharp-sdks-folder=C:\\azure-sdk-for-net\\sdk";
+      public static readonly String AutoRestCmdExecuted = "cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/main/specification/chaos/resource-manager/readme.md --csharp --version=2.0.4421 --reflect-api-versions --csharp-sdks-folder=C:\\workspace\\azure-sdk-for-net\\sdk";
       public static readonly String GithubForkName = "Azure";
       public static readonly String GithubBranchName = "main";
-      public static readonly String GithubCommidId = "7b60a35565f42011dd6033bf52eb3ccc2b6e8f49";
+      public static readonly String GithubCommidId = "b5d8eef5bf187dc99f1c18e8323b19e0c37a7124";
       public static readonly String CodeGenerationErrors = "";
       public static readonly String GithubRepoName = "azure-rest-api-specs";
       // END: Code Generation Metadata Section

--- a/sdk/chaos/Microsoft.Azure.Management.Chaos/src/Microsoft.Azure.Management.Chaos.csproj
+++ b/sdk/chaos/Microsoft.Azure.Management.Chaos/src/Microsoft.Azure.Management.Chaos.csproj
@@ -6,19 +6,15 @@
   <PropertyGroup>
   <PackageId>Microsoft.Azure.Management.Chaos</PackageId>
     <Description>Provides developers with libraries for the Chaos under Azure Resource manager to manage Chaos Experiments, Targets, Capabilities and child resources and their available management capabilities. Create, Delete, Update Chaos Experiments, Targets, Capabilities and child resources. Note: This client library is for Chaos under Azure Resource Manager.</Description>
-    <Version>0.9.15-preview</Version>
+    <Version>0.9.15-preview.1</Version>
     <AssemblyName>Microsoft.Azure.Management.Chaos</AssemblyName>
     <PackageTags>management;chaos;</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[
-      This corresponds to the 2021-09-15-preview API vresion which 
-        Introduce the Experiments, Targets and Capabilities:
-          - Added PUT, DELETE, GET and POST start, POST cancel experiment operations.
-          - Added PUT, DELETE, GET target resource operations.
-          - Added PUT, DELETE, GET capability resource operations.
-          - Added GET capability type resources operations.
-          - Added GET target type resource operations.
-          - Added GET operation resource type operations.
+      This is a public preview release of the Azure Chaos Studio SDK for the 2021-09-15-preview API version.
+      Included in this release is:
+      - Updated constraints on experiment name parameter.
+      - Added start and end time to experiment execution details model.
       ]]>
     </PackageReleaseNotes>
   </PropertyGroup>

--- a/sdk/chaos/Microsoft.Azure.Management.Chaos/src/Properties/AssemblyInfo.cs
+++ b/sdk/chaos/Microsoft.Azure.Management.Chaos/src/Properties/AssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Chaos Management Library")]
 [assembly: AssemblyDescription("Provides management functionality for Microsoft Azure Chaos Resources.")]
 
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("0.9.15-preview.1")]
+[assembly: AssemblyFileVersion("0.9.15-preview.1")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]

--- a/sdk/chaos/Microsoft.Azure.Management.Chaos/src/Properties/AssemblyInfo.cs
+++ b/sdk/chaos/Microsoft.Azure.Management.Chaos/src/Properties/AssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Chaos Management Library")]
 [assembly: AssemblyDescription("Provides management functionality for Microsoft Azure Chaos Resources.")]
 
-[assembly: AssemblyVersion("0.9.15-preview.1")]
-[assembly: AssemblyFileVersion("0.9.15-preview.1")]
+[assembly: AssemblyVersion("0.9.15.1")]
+[assembly: AssemblyFileVersion("0.9.15.1")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]


### PR DESCRIPTION
- Incremented version from `0.9.15-preview` to `0.9.15-preview.1`.
- Includes change for `startTime` and `endTime` in `ActionStatus` model.
- Includes change for `experimentName` Regex pattern in the OpenAPI spec, but this change is not applied to SDK because client-side validation is not enabled.