### PR TITLE
Set packageFolderFromFileSearch to false in swagger_to_sdk_config

### DIFF
--- a/eng/swagger_to_sdk_config.json
+++ b/eng/swagger_to_sdk_config.json
@@ -9,5 +9,8 @@
     "initScript": {
       "path": "pwsh ./eng/scripts/Automation-Sdk-Init.ps1"
     }
+  },
+  "packageOptions": {
+    "packageFolderFromFileSearch": false
   }
 }


### PR DESCRIPTION
 In SDK automation, If the [changed input files](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1519441&view=logs&j=03afb3bb-7296-55ad-aa07-ceee610c73b2&t=0f320c29-1c90-5304-d2d3-c58a6bb76437&l=68) don't exists in any of the `autorest.md` config in `azure-sdk-for-net` repo, then we don't update anything and regenerate code because there is nothing to generate. In this case there is nothing to add in the generateOutput.json, hence it is empty like [this](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1519441&view=logs&j=03afb3bb-7296-55ad-aa07-ceee610c73b2&t=0f320c29-1c90-5304-d2d3-c58a6bb76437&l=91) case.

Fixing below issue by setting `packageFolderFromFileSearch` to false
>Error: packageFolderFromFileSearch not configured and could not be found in legacy config