### PR TITLE
Use batch size of 1 for single dispatch functions to keep tracing aligned between function and SDK

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubClientFactory.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubClientFactory.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             });
         }
 
-        internal EventProcessorHost GetEventProcessorHost(string eventHubName, string connection, string consumerGroup)
+        internal EventProcessorHost GetEventProcessorHost(string eventHubName, string connection, string consumerGroup, bool singleDispatch)
         {
             consumerGroup ??= EventHubConsumerClient.DefaultConsumerGroupName;
 
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             if (!string.IsNullOrEmpty(connection))
             {
                 var info = ResolveConnectionInformation(connection);
-
+                var maxEventBatchSize = singleDispatch ? 1 : _options.MaxEventBatchSize;
                 if (info.FullyQualifiedEndpoint != null &&
                     info.TokenCredential != null)
                 {
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                         eventHubName: eventHubName,
                         credential: info.TokenCredential,
                         options: _options.EventProcessorOptions,
-                        eventBatchMaximumCount: _options.MaxEventBatchSize,
+                        eventBatchMaximumCount: maxEventBatchSize,
                         exceptionHandler: _options.ExceptionHandler);
                 }
 
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                     connectionString: NormalizeConnectionString(info.ConnectionString, eventHubName),
                     eventHubName: eventHubName,
                     options: _options.EventProcessorOptions,
-                    eventBatchMaximumCount: _options.MaxEventBatchSize,
+                    eventBatchMaximumCount: maxEventBatchSize,
                     exceptionHandler: _options.ExceptionHandler);
             }
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubOptions.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubOptions.cs
@@ -115,7 +115,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         private int _maxEventBatchSize;
 
         /// <summary>
-        /// Gets or sets the maximum number of events delivered in a batch. Default 10.
+        /// Gets or sets the maximum number of events delivered in a batch. This setting applies only to functions that
+        /// receive multiple events. Default 10.
         /// </summary>
         public int MaxEventBatchSize
         {

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Triggers/EventHubTriggerAttributeBindingProvider.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Triggers/EventHubTriggerAttributeBindingProvider.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                  IListener listener = new EventHubListener(
                                                 factoryContext.Descriptor.Id,
                                                 factoryContext.Executor,
-                                                _clientFactory.GetEventProcessorHost(attribute.EventHubName, attribute.Connection, attribute.ConsumerGroup),
+                                                _clientFactory.GetEventProcessorHost(attribute.EventHubName, attribute.Connection, attribute.ConsumerGroup, singleDispatch),
                                                 singleDispatch,
                                                 _clientFactory.GetEventHubConsumerClient(attribute.EventHubName, attribute.Connection, attribute.ConsumerGroup),
                                                 checkpointStore,

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/ConfigurationUtilities.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/ConfigurationUtilities.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Configuration;
+using System.Collections.Generic;
+using Azure.Storage.Blobs;
+using Microsoft.Azure.WebJobs.EventHubs.Processor;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Microsoft.Azure.WebJobs.EventHubs.Tests
+{
+    public static class ConfigurationUtilities
+    {
+        public static IConfiguration CreateConfiguration(params KeyValuePair<string, string>[] data)
+        {
+            return new ConfigurationBuilder().AddInMemoryCollection(data).Build();
+        }
+
+        internal static EventHubClientFactory CreateFactory(IConfiguration configuration, EventHubOptions options, AzureComponentFactory componentFactory = null)
+        {
+            componentFactory ??= Mock.Of<AzureComponentFactory>();
+            var loggerFactory = new NullLoggerFactory();
+            var azureEventSourceLogForwarder = new AzureEventSourceLogForwarder(loggerFactory);
+            return new EventHubClientFactory(
+                configuration,
+                componentFactory,
+                Options.Create(options),
+                new DefaultNameResolver(configuration),
+                azureEventSourceLogForwarder,
+                new CheckpointClientProvider(configuration, componentFactory, azureEventSourceLogForwarder, loggerFactory.CreateLogger<BlobServiceClient>()));
+        }
+    }
+}

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubTriggerAttributeBindingProviderTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubTriggerAttributeBindingProviderTests.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Messaging.EventHubs;
+using Azure.Messaging.EventHubs.Primitives;
+using Azure.Storage.Blobs;
+using Microsoft.Azure.WebJobs.EventHubs;
+using Microsoft.Azure.WebJobs.EventHubs.Listeners;
+using Microsoft.Azure.WebJobs.EventHubs.Processor;
+using Microsoft.Azure.WebJobs.EventHubs.Tests;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.Protocols;
+using Microsoft.Azure.WebJobs.Host.Triggers;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+
+namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.UnitTests
+{
+    public class EventHubTriggerAttributeBindingProviderTests
+    {
+        private readonly EventHubTriggerAttributeBindingProvider _provider;
+
+        public EventHubTriggerAttributeBindingProviderTests()
+        {
+            var configuration =
+                ConfigurationUtilities.CreateConfiguration(
+                    new KeyValuePair<string, string>("connection", "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123=;"),
+                    new KeyValuePair<string, string>("Storage", "Endpoint=sb://test.blob.core.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123="));
+
+            var options = new EventHubOptions();
+
+            Mock<IConverterManager> convertManager = new Mock<IConverterManager>(MockBehavior.Default);
+
+            // mock the BlobServiceClient and BlobContainerClient which are used for the checkpointing
+            var blobServiceClient = new Mock<BlobServiceClient>();
+            blobServiceClient.Setup(client => client.GetBlobContainerClient(It.IsAny<string>()))
+                .Returns(Mock.Of<BlobContainerClient>());
+            var componentFactory = new Mock<AzureComponentFactory>();
+            componentFactory.Setup(
+                factory => factory.CreateClient(
+                    typeof(BlobServiceClient),
+                    It.IsAny<IConfiguration>(),
+                    It.IsAny<TokenCredential>(),
+                    It.IsAny<BlobClientOptions>())).Returns(blobServiceClient.Object);
+
+            var factory = ConfigurationUtilities.CreateFactory(configuration, options, componentFactory.Object);
+            _provider = new EventHubTriggerAttributeBindingProvider(convertManager.Object, Options.Create(options), NullLoggerFactory.Instance, factory);
+        }
+
+        [Test]
+        [TestCase(nameof(SingleDispatch), 1)]
+        [TestCase(nameof(MultipleDispatch), 10)]
+        public async Task TryCreateAsync_BatchCountsDefaultedCorrectly(string function, int expectedBatchCount)
+        {
+            ParameterInfo parameter = GetType().GetMethod(function, BindingFlags.NonPublic | BindingFlags.Static).GetParameters()[0];
+            TriggerBindingProviderContext context = new TriggerBindingProviderContext(parameter, CancellationToken.None);
+
+            ITriggerBinding binding = await _provider.TryCreateAsync(context);
+            Assert.NotNull(binding);
+
+            var listener = await binding.CreateListenerAsync(new ListenerFactoryContext(new FunctionDescriptor(),
+                new Mock<ITriggeredFunctionExecutor>().Object, CancellationToken.None));
+
+            var processorHost = (EventProcessorHost)typeof(EventHubListener)
+                .GetField("_eventProcessorHost", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetValue(listener);
+            var batchCount = (int) typeof(EventProcessor<EventProcessorHostPartition>).GetProperty("EventBatchMaximumCount", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetValue(processorHost);
+            Assert.AreEqual(expectedBatchCount, batchCount);
+        }
+
+        internal static void SingleDispatch(
+            [EventHubTrigger("test", Connection = "connection")]
+            EventData eventData)
+        {
+        }
+
+        internal static void MultipleDispatch(
+            [EventHubTrigger("test", Connection = "connection")]
+            EventData[] eventData)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/28189