### PR TITLE
[TA] Add new service version

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
@@ -974,7 +974,7 @@ namespace Azure.AI.TextAnalytics
     }
     public partial class TextAnalyticsClientOptions : Azure.Core.ClientOptions
     {
-        public TextAnalyticsClientOptions(Azure.AI.TextAnalytics.TextAnalyticsClientOptions.ServiceVersion version = Azure.AI.TextAnalytics.TextAnalyticsClientOptions.ServiceVersion.V3_2_Preview_2) { }
+        public TextAnalyticsClientOptions(Azure.AI.TextAnalytics.TextAnalyticsClientOptions.ServiceVersion version = Azure.AI.TextAnalytics.TextAnalyticsClientOptions.ServiceVersion.V2022_03_01_Preview) { }
         public Azure.AI.TextAnalytics.TextAnalyticsAudience? Audience { get { throw null; } set { } }
         public string DefaultCountryHint { get { throw null; } set { } }
         public string DefaultLanguage { get { throw null; } set { } }
@@ -983,6 +983,7 @@ namespace Azure.AI.TextAnalytics
             V3_0 = 1,
             V3_1 = 2,
             V3_2_Preview_2 = 3,
+            V2022_03_01_Preview = 4,
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClientOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClientOptions.cs
@@ -16,7 +16,7 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// The latest service version supported by this client library.
         /// </summary>
-        internal const ServiceVersion LatestVersion = ServiceVersion.V3_2_Preview_2;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V2022_03_01_Preview;
 
         /// <summary>
         /// The versions of the Text Analytics service supported by this client library.
@@ -37,7 +37,12 @@ namespace Azure.AI.TextAnalytics
             /// <summary>
             /// Version 3.2-preview.2
             /// </summary>
-            V3_2_Preview_2 = 3
+            V3_2_Preview_2 = 3,
+
+            /// <summary>
+            /// Version 2022-03-01-preview
+            /// </summary>
+            V2022_03_01_Preview = 4
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -87,6 +92,7 @@ namespace Azure.AI.TextAnalytics
                 ServiceVersion.V3_0 => "v3.0",
                 ServiceVersion.V3_1 => "v3.1",
                 ServiceVersion.V3_2_Preview_2 => "v3.2-preview.2",
+                ServiceVersion.V2022_03_01_Preview => "2022-03-01-preview",
 
                 _ => throw new ArgumentException($"Version {version} not supported."),
             };

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/TextAnalyticsSampleBase.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/TextAnalyticsSampleBase.cs
@@ -10,7 +10,8 @@ namespace Azure.AI.TextAnalytics.Samples
     {
         public TextAnalyticsClientOptions CreateSampleOptions()
         {
-            var options = new TextAnalyticsClientOptions();
+            // Until we have new code working, make sure that samples keep working by targeting legacy path
+            var options = new TextAnalyticsClientOptions(TextAnalyticsClientOptions.ServiceVersion.V3_2_Preview_2);
             options.Retry.MaxRetries = TextAnalyticsClientLiveTestBase.MaxRetriesCount;
 
             return options;

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/MockTests/Legacy/AnalyzeOperationMockTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/MockTests/Legacy/AnalyzeOperationMockTests.cs
@@ -28,7 +28,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
         private TextAnalyticsClient CreateTestClient(HttpPipelineTransport transport)
         {
-            var options = new TextAnalyticsClientOptions
+            var options = new TextAnalyticsClientOptions(TextAnalyticsClientOptions.ServiceVersion.V3_2_Preview_2)
             {
                 Transport = transport
             };

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/MockTests/Legacy/OperationsMockTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/MockTests/Legacy/OperationsMockTests.cs
@@ -22,7 +22,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
         private TextAnalyticsClient CreateTestClient(HttpPipelineTransport transport)
         {
-            var options = new TextAnalyticsClientOptions
+            var options = new TextAnalyticsClientOptions(TextAnalyticsClientOptions.ServiceVersion.V3_2_Preview_2)
             {
                 Transport = transport
             };

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/MockTests/Legacy/TextAnalyticsClientMockTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/MockTests/Legacy/TextAnalyticsClientMockTests.cs
@@ -24,7 +24,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
         private TextAnalyticsClient CreateTestClient(HttpPipelineTransport transport)
         {
-            var options = new TextAnalyticsClientOptions
+            var options = new TextAnalyticsClientOptions(TextAnalyticsClientOptions.ServiceVersion.V3_2_Preview_2)
             {
                 Transport = transport
             };

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using Azure.Core;
 using Azure.Core.TestFramework;
 using Azure.Identity;
@@ -10,11 +9,13 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Tests
 {
+    [ClientTestFixture(TextAnalyticsClientOptions.ServiceVersion.V3_2_Preview_2)]
     public class TextAnalyticsClientTests : ClientTestBase
     {
-        public TextAnalyticsClientTests(bool isAsync) : base(isAsync)
+        public TextAnalyticsClientTests(bool isAsync, TextAnalyticsClientOptions.ServiceVersion serviceVersion)
+            : base(isAsync)
         {
-            TextAnalyticsClientOptions options = new TextAnalyticsClientOptions
+            TextAnalyticsClientOptions options = new TextAnalyticsClientOptions(serviceVersion)
             {
                 Transport = new MockTransport(),
             };


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/28273
It also:
- Makes sure we ran samples only against `3.2-preview.2` service version until the new code is ready to be tested.
- Moved Mock tests into their own folder and fixed their service version to `3.2-preview.2`
- Modified the `TextAnalyticsClientTests` so we can run the tests against different service versions