### PR TITLE
[Identity] Update static token sample to use DelegatedTokenCredential

### DIFF
--- a/sdk/identity/Azure.Identity/samples/DefiningCustomCredentialTypes.md
+++ b/sdk/identity/Azure.Identity/samples/DefiningCustomCredentialTypes.md
@@ -9,7 +9,8 @@ The following example shows an how an application already using some other mecha
 
 ```C# Snippet:TokenCredentialCreateUsage
 AccessToken token = GetTokenForScope("https://storage.azure.com/.default");
-var credential = TokenCredential.Create((_, _) => token);
+
+var credential = DelegatedTokenCredential.Create((_, _) => token);
 
 var client = new BlobClient(new Uri("https://aka.ms/bloburl"), credential);
 ```

--- a/sdk/identity/Azure.Identity/tests/samples/CustomCredentialSnippets.cs
+++ b/sdk/identity/Azure.Identity/tests/samples/CustomCredentialSnippets.cs
@@ -19,11 +19,10 @@ namespace Azure.Identity.Tests.samples
         {
             #region Snippet:TokenCredentialCreateUsage
             AccessToken token = GetTokenForScope("https://storage.azure.com/.default");
-#if SNIPPET
-            var credential = TokenCredential.Create((_, _) => token);
+
+            var credential = DelegatedTokenCredential.Create((_, _) => token);
 
             var client = new BlobClient(new Uri("https://aka.ms/bloburl"), credential);
-#endif
             #endregion
         }
 


### PR DESCRIPTION
Fixing prefetched token sample which incorrectly calls `TokenCredential.Create` rather than `DelegatedTokenCredential.Create`.
