### PR TITLE
Log details on start/stop of storage blob/queue listeners (track 2)

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListener.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
         public BlobListener(ISharedListener sharedListener, BlobContainerClient containerClient, IBlobPathSource blobPathSource, ILoggerFactory loggerFactory)
         {
             _sharedListener = sharedListener;
-            _details = $"blob container={containerClient.Name}, storage account name={containerClient.AccountName}, blob name pattern={blobPathSource.BlobNamePattern}";
+            _details = $"blob container name={containerClient.Name}, storage account name={containerClient.AccountName}, blob name pattern={blobPathSource.BlobNamePattern}";
             _logger = loggerFactory.CreateLogger<BlobListener>();
         }
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListener.cs
@@ -54,10 +54,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                 _logger.LogError(ex, $"Storage blob listener exception during starting ({_details.Value})");
                 throw;
             }
-            finally
-            {
-                _logger.LogDebug($"Storage blob listener stopped ({_details.Value})");
-            }
         }
 
         private async Task StartAsyncCore(CancellationToken cancellationToken)

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListener.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             _logger = loggerFactory.CreateLogger<BlobListener>();
         }
 
-        public Task StartAsync(CancellationToken cancellationToken)
+        public async Task StartAsync(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
 
@@ -44,8 +44,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                 throw new InvalidOperationException("The listener has already been started.");
             }
 
+            await StartAsyncCore(cancellationToken);
             _logger.LogDebug($"Storage blob listener started ({_details})");
-            return StartAsyncCore(cancellationToken);
         }
 
         private async Task StartAsyncCore(CancellationToken cancellationToken)
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             _started = true;
         }
 
-        public Task StopAsync(CancellationToken cancellationToken)
+        public async Task StopAsync(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
 
@@ -66,8 +66,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                     "The listener has not yet been started or has already been stopped.");
             }
 
+            await StopAsyncCore(cancellationToken);
             _logger.LogDebug($"Storage blob listener stopped ({_details})");
-            return StopAsyncCore(cancellationToken);
         }
 
         private async Task StopAsyncCore(CancellationToken cancellationToken)

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListener.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                 throw new InvalidOperationException("The listener has already been started.");
             }
 
-            await StartAsyncCore(cancellationToken);
+            await StartAsyncCore(cancellationToken).ConfigureAwait(false);
             _logger.LogDebug($"Storage blob listener started ({_details})");
         }
 
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                     "The listener has not yet been started or has already been stopped.");
             }
 
-            await StopAsyncCore(cancellationToken);
+            await StopAsyncCore(cancellationToken).ConfigureAwait(false);
             _logger.LogDebug($"Storage blob listener stopped ({_details})");
         }
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListener.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
 
         private bool _started;
         private bool _disposed;
-        private Lazy<string> _details;
+        private string _details;
 
         // for mock test purposes only
         internal BlobListener(ISharedListener sharedListener)
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
         public BlobListener(ISharedListener sharedListener, BlobContainerClient containerClient, IBlobPathSource blobPathSource, ILoggerFactory loggerFactory)
         {
             _sharedListener = sharedListener;
-            _details = new Lazy<string>(() => $"blob container={containerClient.Name}, storage account name={containerClient.AccountName}, blob name pattern={blobPathSource.BlobNamePattern}");
+            _details = $"blob container={containerClient.Name}, storage account name={containerClient.AccountName}, blob name pattern={blobPathSource.BlobNamePattern}";
             _logger = loggerFactory.CreateLogger<BlobListener>();
         }
 
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                 throw new InvalidOperationException("The listener has already been started.");
             }
 
-            _logger.LogDebug($"Storage blob listener started ({_details.Value})");
+            _logger.LogDebug($"Storage blob listener started ({_details})");
             return StartAsyncCore(cancellationToken);
         }
 
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                     "The listener has not yet been started or has already been stopped.");
             }
 
-            _logger.LogDebug($"Storage blob listener stopped ({_details.Value})");
+            _logger.LogDebug($"Storage blob listener stopped ({_details})");
             return StopAsyncCore(cancellationToken);
         }
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListener.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, $"Storage blob listener exception during starting ({_details.Value})");
+                _logger.LogError(ex, $"Storage blob listener encountered an error during starting ({_details.Value})");
                 throw;
             }
         }
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, $"Storage blob listener exception during stopping ({_details.Value})");
+                _logger.LogError(ex, $"Storage blob listener encountered an error during stopping ({_details.Value})");
                 throw;
             }
             finally

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListenerFactory.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListenerFactory.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             SharedBlobQueueListener sharedBlobQueueListener = _sharedContextProvider.GetOrCreateInstance<SharedBlobQueueListener>(
                 new SharedBlobQueueListenerFactory(_hostQueueServiceClient, blobTriggerQueueWriter.SharedQueueWatcher, blobTriggerQueueWriter.QueueClient,
                      _blobsOptions, _exceptionHandler, _loggerFactory, sharedBlobListener?.BlobWritterWatcher, _functionDescriptor, _blobTriggerSource, _concurrencyManager));
-            var queueListener = new BlobListener(sharedBlobQueueListener);
+            var queueListener = new BlobListener(sharedBlobQueueListener, _container, _loggerFactory);
 
             // the client to use for the poison queue
             // by default this should target the same storage account
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                 // want a single instance of the blob poll/scan logic to be running
                 // across host instances
                 var singletonBlobListener = _singletonManager.CreateHostSingletonListener(
-                    new BlobListener(sharedBlobListener), SingletonBlobListenerScopeId);
+                    new BlobListener(sharedBlobListener, _container, _loggerFactory), SingletonBlobListenerScopeId);
                 _sharedContextProvider.SetValue(SingletonBlobListenerScopeId, true);
 
                 return new CompositeListener(singletonBlobListener, queueListener);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListenerFactory.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListenerFactory.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             SharedBlobQueueListener sharedBlobQueueListener = _sharedContextProvider.GetOrCreateInstance<SharedBlobQueueListener>(
                 new SharedBlobQueueListenerFactory(_hostQueueServiceClient, blobTriggerQueueWriter.SharedQueueWatcher, blobTriggerQueueWriter.QueueClient,
                      _blobsOptions, _exceptionHandler, _loggerFactory, sharedBlobListener?.BlobWritterWatcher, _functionDescriptor, _blobTriggerSource, _concurrencyManager));
-            var queueListener = new BlobListener(sharedBlobQueueListener, _container, _loggerFactory);
+            var queueListener = new BlobListener(sharedBlobQueueListener, _container, _input, _loggerFactory);
 
             // the client to use for the poison queue
             // by default this should target the same storage account
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                 // want a single instance of the blob poll/scan logic to be running
                 // across host instances
                 var singletonBlobListener = _singletonManager.CreateHostSingletonListener(
-                    new BlobListener(sharedBlobListener, _container, _loggerFactory), SingletonBlobListenerScopeId);
+                    new BlobListener(sharedBlobListener, _container, _input, _loggerFactory), SingletonBlobListenerScopeId);
                 _sharedContextProvider.SetValue(SingletonBlobListenerScopeId, true);
 
                 return new CompositeListener(singletonBlobListener, queueListener);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
         private bool _disposed;
         private TaskCompletionSource<object> _stopWaitingTaskSource;
         private ConcurrencyManager _concurrencyManager;
-        private Lazy<string> _details;
+        private string _details;
 
         // for mock testing only
         internal QueueListener()
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
             _logger = loggerFactory.CreateLogger<QueueListener>();
             _functionDescriptor = functionDescriptor ?? throw new ArgumentNullException(nameof(functionDescriptor));
             _functionId = functionId ?? _functionDescriptor.Id;
-            _details = new Lazy<string>(() => $"queue name='{_queue.Name}', storage account name='{_queue.AccountName}'");
+            _details = $"queue name='{_queue.Name}', storage account name='{_queue.AccountName}'";
 
             // if the function runs longer than this, the invisibility will be updated
             // on a timer periodically for the duration of the function execution
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
         {
             ThrowIfDisposed();
             _timer.Start();
-            _logger.LogDebug($"Storage queue listener started ({_details.Value})");
+            _logger.LogDebug($"Storage queue listener started ({_details})");
             return Task.FromResult(0);
         }
 
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
                 _timer.Cancel();
                 await Task.WhenAll(_processing).ConfigureAwait(false);
                 await _timer.StopAsync(cancellationToken).ConfigureAwait(false);
-                _logger.LogDebug($"Storage queue listener stopped ({_details.Value})");
+                _logger.LogDebug($"Storage queue listener stopped ({_details})");
             }
         }
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
@@ -147,39 +147,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
-            try
-            {
-                ThrowIfDisposed();
-                _timer.Start();
-                _logger.LogDebug($"Storage queue listener started ({_details.Value})");
-                return Task.FromResult(0);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, $"Storage queue listener encountered an error while starting ({_details.Value})");
-                throw;
-            }
+            ThrowIfDisposed();
+            _timer.Start();
+            _logger.LogDebug($"Storage queue listener started ({_details.Value})");
+            return Task.FromResult(0);
         }
 
         public async Task StopAsync(CancellationToken cancellationToken)
         {
             using (cancellationToken.Register(() => _shutdownCancellationTokenSource.Cancel()))
             {
-                try
-                {
-                    ThrowIfDisposed();
-                    _timer.Cancel();
-                    await Task.WhenAll(_processing).ConfigureAwait(false);
-                    await _timer.StopAsync(cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogDebug(ex, $"Storage queue listener encountered an error while stopping ({_details.Value})");
-                }
-                finally
-                {
-                    _logger.LogDebug($"Storage queue listener stopped ({_details.Value})");
-                }
+                ThrowIfDisposed();
+                _timer.Cancel();
+                await Task.WhenAll(_processing).ConfigureAwait(false);
+                await _timer.StopAsync(cancellationToken).ConfigureAwait(false);
+                _logger.LogDebug($"Storage queue listener stopped ({_details.Value})");
             }
         }
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueListener.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, $"Storage queue listener exception while starting ({_details.Value})");
+                _logger.LogDebug(ex, $"Storage queue listener encountered an error while starting ({_details.Value})");
                 throw;
             }
         }
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogDebug(ex, $"Storage queue listener exception while stopping ({_details.Value})");
+                    _logger.LogDebug(ex, $"Storage queue listener encountered an error while stopping ({_details.Value})");
                 }
                 finally
                 {


### PR DESCRIPTION
Log the details of a storage blob/queue listener on start/stop operations. Addresses this WI: https://dev.azure.com/FunctionsExtensions/Functions%20Extensions/_workitems/edit/36. Port of https://github.com/Azure/azure-webjobs-sdk/pull/2856 in track 1