### PR TITLE
docs(dpg): resolve ambiguous call when adding protocol methods

### DIFF
--- a/doc/DataPlaneCodeGeneration/Add_ProtocolMethods_In_Gen1_Convenience_Client_Generated_SDK.md
+++ b/doc/DataPlaneCodeGeneration/Add_ProtocolMethods_In_Gen1_Convenience_Client_Generated_SDK.md
@@ -392,3 +392,32 @@ public class TableServiceClient
     // ...
 }
 ```
+
+### Resolve ambiguous calls
+
+There are cases that your protocol method and convenience method have the same required parameter list, e.g.,
+
+```csharp
+// protocol method
+public virtual async Task<Response> GetMetricFeedbackAsync(string feedId, string category = null, RequestContext context = null);
+// Convenience method
+public virtual async Task<Response<MetricFeedback>> GetMetricFeedbackAsync(string feedId, string category = null, CancellationToken cancellationToken = default);
+```
+
+In such cases, you have to change the protocol method you've just added, otherwise the following codes will fail the compilation.
+
+```csharp
+// ambiguous call
+GetMetricFeedbackAsync(feedId);
+```
+
+#### Suggested solution for ambiguous calls
+
+We suggest to make the all the optional parameters including the tailing `RequestContxt context` in the protocol method as **required parameters**. Below is an example.
+
+```csharp
+// protocol method, all parameters are required
+public virtual async Task<Response> GetMetricFeedbackAsync(string feedId, string category, RequestContext context);
+// Convenience method
+public virtual async Task<Response<MetricFeedback>> GetMetricFeedbackAsync(string feedId, string category = null, CancellationToken cancellationToken = default);
+```


### PR DESCRIPTION
part of #28123

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
