### PR TITLE
[Text Analytics] Delegation to Serivce Clients

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsOperation.cs
@@ -152,7 +152,7 @@ namespace Azure.AI.TextAnalytics
 
             Id = operationId;
             //_serviceClient = client._serviceRestClient;
-            _diagnostics = client._clientDiagnostics;
+            _diagnostics = client._serviceClient.Diagnostics;
             _operationInternal = new OperationInternal<AsyncPageable<AnalyzeActionsResult>>(_diagnostics, this, rawResponse: null);
         }
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeHealthcareEntitiesOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeHealthcareEntitiesOperation.cs
@@ -139,7 +139,7 @@ namespace Azure.AI.TextAnalytics
 
             Id = operationId;
             //_serviceClient = client._serviceRestClient;
-            _diagnostics = client._clientDiagnostics;
+            _diagnostics = client._serviceClient.Diagnostics;
             _operationInternal = new(_diagnostics, this, rawResponse: null);
         }
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LanguageServiceClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LanguageServiceClient.cs
@@ -54,10 +54,8 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             Argument.AssertNotNull(credential, nameof(credential));
             Argument.AssertNotNull(options, nameof(options));
 
-            Argument.AssertNotNullOrEmpty(defaultLanguage, nameof(defaultLanguage));
-            Argument.AssertNotNullOrEmpty(defaultCountryHint, nameof(defaultCountryHint));
-            Argument.AssertNotNull(authorizationScope, nameof(authorizationScope));
-            Argument.AssertNotNull(serviceVersion, nameof(serviceVersion));
+            Argument.AssertNotNullOrEmpty(authorizationScope, nameof(authorizationScope));
+            Argument.AssertNotNullOrEmpty(serviceVersion, nameof(serviceVersion));
 
             _baseUri = endpoint;
             _clientDiagnostics = new TextAnalyticsClientDiagnostics(options);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LanguageServiceClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LanguageServiceClient.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -64,28 +65,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
 
         #region Detect Language
 
-        /// <summary>
-        /// Runs a predictive model to determine the language the passed-in
-        /// document is written in, and returns the detected language as well
-        /// as a score indicating the model's confidence that the inferred
-        /// language is correct. Scores close to 1 indicate high certainty in
-        /// the result.
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="document">The document to analyze.</param>
-        /// <param name="countryHint">Indicates the country of origin of the
-        /// document to assist the Text Analytics model in predicting the language
-        /// it is written in. If unspecified, this value will be set to the
-        /// default country hint in <see cref="TextAnalyticsClientOptions.DefaultCountryHint"/>
-        /// in the request sent to the service.
-        /// To remove this behavior, set to <see cref="DetectLanguageInput.None"/>.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the detected language or an error if
-        /// the model could not analyze the document.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<Response<DetectedLanguage>> DetectLanguageAsync(string document, string countryHint = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(document, nameof(document));
@@ -123,28 +102,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             }
         }
 
-        /// <summary>
-        /// Runs a predictive model to determine the language the passed-in
-        /// document is written in, and returns the detected language as well
-        /// as a score indicating the model's confidence that the inferred
-        /// language is correct. Scores close to 1 indicate high certainty in
-        /// the result.
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="document">The document to analyze.</param>
-        /// <param name="countryHint">Indicates the country of origin of the
-        /// document to assist the Text Analytics model in predicting the language
-        /// it is written in. If unspecified, this value will be set to the
-        /// default country hint in <see cref="TextAnalyticsClientOptions.DefaultCountryHint"/>
-        /// in the request sent to the service.
-        /// To remove this behavior, set to <see cref="DetectLanguageInput.None"/>.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the detected language or an error if
-        /// the model could not analyze the document.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override Response<DetectedLanguage> DetectLanguage(string document, string countryHint = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(document, nameof(document));
@@ -183,129 +140,37 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             }
         }
 
-        /// <summary>
-        /// Runs a predictive model to determine the language the passed-in
-        /// documents are written in, and returns, for each one, the detected
-        /// language as well as a score indicating the model's confidence that
-        /// the inferred language is correct. Scores close to 1 indicate high
-        /// certainty in the result.
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">A collection of documents to analyze.</param>
-        /// <param name="countryHint">Indicates the country of origin of all of
-        /// the documents to assist the Text Analytics model in predicting
-        /// the language they are written in. If unspecified, this value will be
-        /// set to the default country hint in <see cref="TextAnalyticsClientOptions.DefaultCountryHint"/>
-        /// in the request sent to the service.
-        /// To remove this behavior, set to <see cref="DetectLanguageInput.None"/>.</param>
-        /// <param name="options"><see cref="TextAnalyticsRequestOptions"/> used to
-        /// select the version of the predictive model to run, and whether
-        /// statistics are returned in the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the detected language or an error if
-        /// the model could not analyze the documents.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<Response<DetectLanguageResultCollection>> DetectLanguageBatchAsync(IEnumerable<string> documents, string countryHint = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(documents, nameof(documents));
             options ??= s_defaultRequestOptions;
-            LanguageDetectionAnalysisInput detectLanguageInputs = new LanguageDetectionAnalysisInput();
-            detectLanguageInputs = DocumentsToLanguageDetection(documents, detectLanguageInputs, countryHint);
+            LanguageDetectionAnalysisInput detectLanguageInputs = DocumentsToLanguageDetection(documents, countryHint);
 
             return await DetectLanguageBatchAsync(detectLanguageInputs, options, cancellationToken).ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Runs a predictive model to determine the language the passed-in
-        /// documents are written in, and returns, for each one, the detected
-        /// language as well as a score indicating the model's confidence that
-        /// the inferred language is correct. Scores close to 1 indicate high
-        /// certainty in the result.
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">A collection of documents to analyze.</param>
-        /// <param name="countryHint">Indicates the country of origin of all of
-        /// the documents to assist the Text Analytics model in predicting
-        /// the language they are written in. If unspecified, this value will be
-        /// set to the default country hint in <see cref="TextAnalyticsClientOptions.DefaultCountryHint"/>
-        /// in the request sent to the service.
-        /// To remove this behavior, set to <see cref="DetectLanguageInput.None"/>.</param>
-        /// <param name="options"><see cref="TextAnalyticsRequestOptions"/> used to
-        /// select the version of the predictive model to run, and whether
-        /// statistics are returned in the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the detected language or an error if
-        /// the model could not analyze the documents.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override Response<DetectLanguageResultCollection> DetectLanguageBatch(IEnumerable<string> documents, string countryHint = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(documents, nameof(documents));
             options ??= s_defaultRequestOptions;
-            LanguageDetectionAnalysisInput detectLanguageInputs = new LanguageDetectionAnalysisInput();
-            detectLanguageInputs = DocumentsToLanguageDetection(documents, detectLanguageInputs, countryHint);
+            LanguageDetectionAnalysisInput detectLanguageInputs = DocumentsToLanguageDetection(documents, countryHint);
             return DetectLanguageBatch(detectLanguageInputs, options, cancellationToken);
         }
 
-        /// <summary>
-        /// Runs a predictive model to determine the language the passed-in
-        /// documents are written in, and returns, for each one, the detected
-        /// language as well as a score indicating the model's confidence that
-        /// the inferred language is correct. Scores close to 1 indicate high
-        /// certainty in the result.
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">A collection of documents to analyze.</param>
-        /// <param name="options"><see cref="TextAnalyticsRequestOptions"/> used to
-        /// select the version of the predictive model to run, and whether
-        /// statistics are returned in the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the detected language or an error if
-        /// the model could not analyze the documents.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<Response<DetectLanguageResultCollection>> DetectLanguageBatchAsync(IEnumerable<DetectLanguageInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(documents, nameof(documents));
             options ??= s_defaultRequestOptions;
-            LanguageDetectionAnalysisInput detectLanguageInputs = new LanguageDetectionAnalysisInput();
-            detectLanguageInputs = LanguageInputToLanguageDetection(documents, detectLanguageInputs);
+            LanguageDetectionAnalysisInput detectLanguageInputs = LanguageInputToLanguageDetection(documents);
 
             return await DetectLanguageBatchAsync(detectLanguageInputs, options, cancellationToken).ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Runs a predictive model to determine the language the passed-in
-        /// documents are written in, and returns, for each one, the detected
-        /// language as well as a score indicating the model's confidence that
-        /// the inferred language is correct. Scores close to 1 indicate high
-        /// certainty in the result.
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">A collection of documents to analyze.</param>
-        /// <param name="options"><see cref="TextAnalyticsRequestOptions"/> used to
-        /// select the version of the predictive model to run, and whether
-        /// statistics are returned in the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the detected language or an error if
-        /// the model could not analyze the document.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override Response<DetectLanguageResultCollection> DetectLanguageBatch(IEnumerable<DetectLanguageInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(documents, nameof(documents));
             options ??= s_defaultRequestOptions;
-            LanguageDetectionAnalysisInput detectLanguageInputs = new LanguageDetectionAnalysisInput();
-            detectLanguageInputs = LanguageInputToLanguageDetection(documents, detectLanguageInputs);
+            LanguageDetectionAnalysisInput detectLanguageInputs = LanguageInputToLanguageDetection(documents);
 
             return DetectLanguageBatch(detectLanguageInputs, options, cancellationToken);
         }
@@ -366,8 +231,9 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             }
         }
 
-        private LanguageDetectionAnalysisInput DocumentsToLanguageDetection(IEnumerable<string> documents, LanguageDetectionAnalysisInput detectLanguageInputs, string countryHint = default)
+        private LanguageDetectionAnalysisInput DocumentsToLanguageDetection(IEnumerable<string> documents, string countryHint = default)
         {
+            LanguageDetectionAnalysisInput detectLanguageInputs = new LanguageDetectionAnalysisInput();
             int id = 0;
             foreach (var document in documents)
             {
@@ -378,8 +244,9 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             return detectLanguageInputs;
         }
 
-        private static LanguageDetectionAnalysisInput LanguageInputToLanguageDetection(IEnumerable<DetectLanguageInput> documents, LanguageDetectionAnalysisInput detectLanguageInputs)
+        private static LanguageDetectionAnalysisInput LanguageInputToLanguageDetection(IEnumerable<DetectLanguageInput> documents)
         {
+            LanguageDetectionAnalysisInput detectLanguageInputs = new LanguageDetectionAnalysisInput();
             foreach (var document in documents)
             {
                 LanguageInput languageInput = new LanguageInput(document.Id, document.Text);
@@ -393,30 +260,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
 
         #region Recognize Entities
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of named entities
-        /// in the passed-in document, and categorize those entities into types
-        /// such as person, location, or organization.
-        /// <para>For more information on available categories, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/Text-Analytics/named-entity-types"/>.</para>
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="document">The document to analyze.</param>
-        /// <param name="language">The language that the document is written in.
-        /// If unspecified, this value will be set to the default language in
-        /// <see cref="TextAnalyticsClientOptions.DefaultLanguage"/> in the request sent to the
-        /// service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of entities identified
-        /// in the document, as well as a score indicating the confidence
-        /// that the entity correctly matches the identified substring.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<Response<CategorizedEntityCollection>> RecognizeEntitiesAsync(string document, string language = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(document, nameof(document));
@@ -456,30 +299,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             }
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of named entities
-        /// in the passed-in document, and categorize those entities into types
-        /// such as person, location, or organization.
-        /// <para>For more information on available categories, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/Text-Analytics/named-entity-types"/>.</para>
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="document">The document to analyze.</param>
-        /// <param name="language">The language that the document is written in.
-        /// If unspecified, this value will be set to the default language in
-        /// <see cref="TextAnalyticsClientOptions.DefaultLanguage"/> in the request sent to the
-        /// service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of entities identified
-        /// in the document, as well as a score indicating the confidence
-        /// that the entity correctly matches the identified substring.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override Response<CategorizedEntityCollection> RecognizeEntities(string document, string language = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(document, nameof(document));
@@ -519,150 +338,42 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             }
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of named entities
-        /// in the passed-in documents, and categorize those entities into types
-        /// such as person, location, or organization.
-        /// <para>For more information on available categories, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/Text-Analytics/named-entity-types"/>.</para>
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="language">The language that all the documents are
-        /// written in. If unspecified, this value will be set to the default
-        /// language in <see cref="TextAnalyticsClientOptions.DefaultLanguage"/> in the request
-        /// sent to the service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="options"><see cref="TextAnalyticsRequestOptions"/> used to
-        /// select the version of the predictive model to run, and whether
-        /// statistics are returned in the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of entities identified
-        /// for each of the documents, as well as scores indicating the confidence
-        /// that a given entity correctly matches the identified substring.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<Response<RecognizeEntitiesResultCollection>> RecognizeEntitiesBatchAsync(IEnumerable<string> documents, string language = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
         {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new TextAnalyticsRequestOptions();
-            ////MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents, language);
-            //AnalyzeTextEntityRecognitionInput input = ConvertToMultiLanguageInputs(documents, language);
-            //return await RecognizeEntitiesBatchAsync(input, options, cancellationToken).ConfigureAwait(false);
-            await Task.Yield();
-            throw new NotImplementedException();
+            Argument.AssertNotNullOrEmpty(documents, nameof(documents));
+            options ??= s_defaultRequestOptions;
+            AnalyzeTextEntityRecognitionInput input = DocumentsToEntityRecognition(documents, language);
+
+            return await RecognizeEntitiesBatchAsync(input, options, cancellationToken).ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of named entities
-        /// in the passed-in documents, and categorize those entities into types
-        /// such as person, location, or organization.
-        /// <para>For more information on available categories, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/Text-Analytics/named-entity-types"/>.</para>
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="language">The language that all the documents are
-        /// written in. If unspecified, this value will be set to the default
-        /// language in <see cref="TextAnalyticsClientOptions.DefaultLanguage"/> in the request
-        /// sent to the service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="options"><see cref="TextAnalyticsRequestOptions"/> used to
-        /// select the version of the predictive model to run, and whether
-        /// statistics are returned in the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of entities identified
-        /// for each of the documents, as well as scores indicating the confidence
-        /// that a given entity correctly matches the identified substring.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override Response<RecognizeEntitiesResultCollection> RecognizeEntitiesBatch(IEnumerable<string> documents, string language = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
         {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new TextAnalyticsRequestOptions();
-            ////MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents, language);
-            //AnalyzeTextEntityRecognitionInput input = ConvertToMultiLanguageInputs(documents, language);
-            //return RecognizeEntitiesBatch(input, options, cancellationToken);
-            throw new NotImplementedException();
+            Argument.AssertNotNullOrEmpty(documents, nameof(documents));
+            options ??= s_defaultRequestOptions;
+            AnalyzeTextEntityRecognitionInput input = DocumentsToEntityRecognition(documents, language);
+
+            return RecognizeEntitiesBatch(input, options, cancellationToken);
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of named entities
-        /// in the passed-in documents, and categorize those entities into types
-        /// such as person, location, or organization.
-        /// <para>For more information on available categories, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/Text-Analytics/named-entity-types"/>.</para>
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="options"><see cref="TextAnalyticsRequestOptions"/> used to
-        /// select the version of the predictive model to run, and whether
-        /// statistics are returned in the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of entities identified
-        /// for each of the documents, as well as scores indicating the confidence
-        /// that a given entity correctly matches the identified substring.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<Response<RecognizeEntitiesResultCollection>> RecognizeEntitiesBatchAsync(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
         {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new TextAnalyticsRequestOptions();
-            ////MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents);
+            Argument.AssertNotNullOrEmpty(documents, nameof(documents));
+            options ??= s_defaultRequestOptions;
+            AnalyzeTextEntityRecognitionInput input = TextDocumentInputToEntityRecognition(documents);
 
-            //AnalyzeTextEntityRecognitionInput input = ConvertToMultiLanguageInputs(documents);
-            //return await RecognizeEntitiesBatchAsync(input, options, cancellationToken).ConfigureAwait
-            //(false);
-            await Task.Yield();
-            throw new NotImplementedException();
+            return await RecognizeEntitiesBatchAsync(input, options, cancellationToken).ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of named entities
-        /// in the passed-in documents, and categorize those entities into types
-        /// such as person, location, or organization.
-        /// <para>For more information on available categories, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/Text-Analytics/named-entity-types"/>.</para>
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="options"><see cref="TextAnalyticsRequestOptions"/> used to
-        /// select the version of the predictive model to run, and whether
-        /// statistics are returned in the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of entities identified
-        /// for each of the documents, as well as scores indicating the confidence
-        /// that a given entity correctly matches the identified substring.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override Response<RecognizeEntitiesResultCollection> RecognizeEntitiesBatch(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
         {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new TextAnalyticsRequestOptions();
-            ////MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents);
+            Argument.AssertNotNullOrEmpty(documents, nameof(documents));
+            options ??= s_defaultRequestOptions;
+            AnalyzeTextEntityRecognitionInput input = TextDocumentInputToEntityRecognition(documents);
 
-            //AnalyzeTextEntityRecognitionInput input = ConvertToMultiLanguageInputs(documents);
-            //return RecognizeEntitiesBatch(input, options, cancellationToken);
-            throw new NotImplementedException();
+            return RecognizeEntitiesBatch(input, options, cancellationToken);
         }
 
-        //CHANGED: Overload for new Swagger
         private async Task<Response<RecognizeEntitiesResultCollection>> RecognizeEntitiesBatchAsync(AnalyzeTextEntityRecognitionInput entityRecognitionInput, TextAnalyticsRequestOptions options, CancellationToken cancellationToken)
         {
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(RecognizeEntitiesBatch)}");
@@ -670,19 +381,16 @@ namespace Azure.AI.TextAnalytics.ServiceClients
 
             try
             {
-                var input = entityRecognitionInput.AnalysisInput;
-                var analyzeRecognizeEntities = new AnalyzeTextEntityRecognitionInput { AnalysisInput = input };
-                analyzeRecognizeEntities.Parameters.ModelVersion = options.ModelVersion;
-                analyzeRecognizeEntities.Parameters.LoggingOptOut = options.DisableServiceLogs;
+                entityRecognitionInput.Parameters = new EntitiesTaskParameters(options.DisableServiceLogs, options.ModelVersion, Constants.DefaultStringIndexType);
 
                 Response<AnalyzeTextTaskResult> result = await _languageRestClient.AnalyzeAsync(
-                    analyzeRecognizeEntities, options.IncludeStatistics,
+                    entityRecognitionInput, options.IncludeStatistics,
                     cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 var entityRecognition = (EntitiesTaskResult)result.Value;
                 Response response = result.GetRawResponse();
 
-                IDictionary<string, int> map = CreateIdToIndexMap(input.Documents);
+                IDictionary<string, int> map = CreateIdToIndexMap(entityRecognitionInput.AnalysisInput.Documents);
                 RecognizeEntitiesResultCollection results = Transforms.ConvertToRecognizeEntitiesResultCollection(entityRecognition.Results, map);
                 return Response.FromValue(results, response);
             }
@@ -693,7 +401,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             }
         }
 
-        //CHANGED: Overload for new Swagger
         private Response<RecognizeEntitiesResultCollection> RecognizeEntitiesBatch(AnalyzeTextEntityRecognitionInput entityRecognitionInput, TextAnalyticsRequestOptions options, CancellationToken cancellationToken)
         {
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(RecognizeEntitiesBatch)}");
@@ -701,19 +408,16 @@ namespace Azure.AI.TextAnalytics.ServiceClients
 
             try
             {
-                var input = entityRecognitionInput.AnalysisInput;
-                var analyzeRecognizeEntities = new AnalyzeTextEntityRecognitionInput { AnalysisInput = input };
-                analyzeRecognizeEntities.Parameters.ModelVersion = options.ModelVersion;
-                analyzeRecognizeEntities.Parameters.LoggingOptOut = options.DisableServiceLogs;
+                entityRecognitionInput.Parameters = new EntitiesTaskParameters(options.DisableServiceLogs, options.ModelVersion, Constants.DefaultStringIndexType);
 
                 Response<AnalyzeTextTaskResult> result = _languageRestClient.Analyze(
-                    analyzeRecognizeEntities, options.IncludeStatistics,
+                    entityRecognitionInput, options.IncludeStatistics,
                     cancellationToken: cancellationToken);
 
                 var entityRecognition = (EntitiesTaskResult)result.Value;
                 Response response = result.GetRawResponse();
 
-                IDictionary<string, int> map = CreateIdToIndexMap(input.Documents);
+                IDictionary<string, int> map = CreateIdToIndexMap(entityRecognitionInput.AnalysisInput.Documents);
                 RecognizeEntitiesResultCollection results = Transforms.ConvertToRecognizeEntitiesResultCollection(entityRecognition.Results, map);
                 return Response.FromValue(results, response);
             }
@@ -724,40 +428,38 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             }
         }
 
+        private static AnalyzeTextEntityRecognitionInput DocumentsToEntityRecognition(IEnumerable<string> documents, string language)
+        {
+            AnalyzeTextEntityRecognitionInput textEntityInputs = new AnalyzeTextEntityRecognitionInput();
+            int id = 0;
+            foreach (var document in documents)
+            {
+                var input = new MultiLanguageInput(id: id.ToString(CultureInfo.InvariantCulture), text: document);
+                id++;
+                input.Language = language;
+                textEntityInputs.AnalysisInput.Documents.Add(input);
+            }
+
+            return textEntityInputs;
+        }
+
+        private static AnalyzeTextEntityRecognitionInput TextDocumentInputToEntityRecognition(IEnumerable<TextDocumentInput> documents)
+        {
+            AnalyzeTextEntityRecognitionInput textEntityInputs = new AnalyzeTextEntityRecognitionInput();
+            foreach (var document in documents)
+            {
+                var input = new MultiLanguageInput(document.Id, document.Text);
+                input.Language = document.Language;
+                textEntityInputs.AnalysisInput.Documents.Add(input);
+            }
+
+            return textEntityInputs;
+        }
+
         #endregion
 
         #region Recognize PII Entities
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of entities containing
-        /// Personally Identifiable Information found in the passed-in document,
-        /// and categorize those entities into types such as US social security
-        /// number, drivers license number, or credit card number.
-        /// <para>For more information on available categories, see
-        /// <see href="https://aka.ms/tanerpii"/>.</para>
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <remarks>
-        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1"/> and up.
-        /// </remarks>
-        /// <param name="document">The document to analyze.</param>
-        /// <param name="language">The language that the document is written in.
-        /// If unspecified, this value will be set to the default language in
-        /// <see cref="TextAnalyticsClientOptions.DefaultLanguage"/> in the request sent to the
-        /// service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="options">The additional configurable <see cref="RecognizePiiEntitiesOptions"/> that may be passed when
-        /// recognizing PII entities. Options include entity domain filters, model version, and more.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of entities identified
-        /// in the document, as well as a score indicating the confidence
-        /// that the entity correctly matches the identified substring.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<Response<PiiEntityCollection>> RecognizePiiEntitiesAsync(string document, string language = default, RecognizePiiEntitiesOptions options = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(document, nameof(document));
@@ -798,36 +500,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             }
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of entities containing
-        /// Personally Identifiable Information found in the passed-in document,
-        /// and categorize those entities into types such as US social security
-        /// number, drivers license number, or credit card number.
-        /// <para>For more information on available categories, see
-        /// <see href="https://aka.ms/tanerpii"/>.</para>
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <remarks>
-        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1"/> and up.
-        /// </remarks>
-        /// <param name="document">The document to analyze.</param>
-        /// <param name="language">The language that the document is written in.
-        /// If unspecified, this value will be set to the default language in
-        /// <see cref="TextAnalyticsClientOptions.DefaultLanguage"/> in the request sent to the
-        /// service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="options">The additional configurable <see cref="RecognizePiiEntitiesOptions"/> that may be passed when
-        /// recognizing PII entities. Options include entity domain filters, model version, and more.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of entities identified
-        /// in the document, as well as a score indicating the confidence
-        /// that the entity correctly matches the identified substring.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override Response<PiiEntityCollection> RecognizePiiEntities(string document, string language = default, RecognizePiiEntitiesOptions options = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(document, nameof(document));
@@ -868,36 +540,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             }
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of entities containing
-        /// Personally Identifiable Information found in the passed-in document,
-        /// and categorize those entities into types such as US social security
-        /// number, drivers license number, or credit card number.
-        /// <para>For more information on available categories, see
-        /// <see href="https://aka.ms/tanerpii"/>.</para>
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <remarks>
-        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1"/> and up.
-        /// </remarks>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="language">The language that the document is written in.
-        /// If unspecified, this value will be set to the default language in
-        /// <see cref="TextAnalyticsClientOptions.DefaultLanguage"/> in the request sent to the
-        /// service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="options">The additional configurable <see cref="RecognizePiiEntitiesOptions"/> that may be passed when
-        /// recognizing PII entities. Options include entity domain filters, model version, and more.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of entities identified
-        /// for each of the documents, as well as scores indicating the confidence
-        /// that a given entity correctly matches the identified substring.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<Response<RecognizePiiEntitiesResultCollection>> RecognizePiiEntitiesBatchAsync(IEnumerable<string> documents, string language = default, RecognizePiiEntitiesOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -908,36 +550,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of entities containing
-        /// Personally Identifiable Information found in the passed-in document,
-        /// and categorize those entities into types such as US social security
-        /// number, drivers license number, or credit card number.
-        /// <para>For more information on available categories, see
-        /// <see href="https://aka.ms/tanerpii"/>.</para>
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <remarks>
-        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1"/> and up.
-        /// </remarks>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="language">The language that the document is written in.
-        /// If unspecified, this value will be set to the default language in
-        /// <see cref="TextAnalyticsClientOptions.DefaultLanguage"/> in the request sent to the
-        /// service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="options">The additional configurable <see cref="RecognizePiiEntitiesOptions"/> that may be passed when
-        /// recognizing PII entities. Options include entity domain filters, model version, and more.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of entities identified
-        /// for each of the documents, as well as scores indicating the confidence
-        /// that a given entity correctly matches the identified substring.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override Response<RecognizePiiEntitiesResultCollection> RecognizePiiEntitiesBatch(IEnumerable<string> documents, string language = default, RecognizePiiEntitiesOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -948,31 +560,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of entities containing
-        /// Personally Identifiable Information found in the passed-in document,
-        /// and categorize those entities into types such as US social security
-        /// number, drivers license number, or credit card number.
-        /// <para>For more information on available categories, see
-        /// <see href="https://aka.ms/tanerpii"/>.</para>
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <remarks>
-        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1"/> and up.
-        /// </remarks>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="options">The additional configurable <see cref="RecognizePiiEntitiesOptions"/> that may be passed when
-        /// recognizing PII entities. Options include entity domain filters, model version, and more.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of entities identified
-        /// for each of the documents, as well as scores indicating the confidence
-        /// that a given entity correctly matches the identified substring.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<Response<RecognizePiiEntitiesResultCollection>> RecognizePiiEntitiesBatchAsync(IEnumerable<TextDocumentInput> documents, RecognizePiiEntitiesOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -984,31 +571,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of entities containing
-        /// Personally Identifiable Information found in the passed-in document,
-        /// and categorize those entities into types such as US social security
-        /// number, drivers license number, or credit card number.
-        /// <para>For more information on available categories, see
-        /// <see href="https://aka.ms/tanerpii"/>.</para>
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <remarks>
-        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1"/> and up.
-        /// </remarks>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="options">The additional configurable <see cref="RecognizePiiEntitiesOptions"/> that may be passed when
-        /// recognizing PII entities. Options include entity domain filters, model version, and more.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of entities identified
-        /// for each of the documents, as well as scores indicating the confidence
-        /// that a given entity correctly matches the identified substring.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override Response<RecognizePiiEntitiesResultCollection> RecognizePiiEntitiesBatch(IEnumerable<TextDocumentInput> documents, RecognizePiiEntitiesOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -1082,29 +644,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
         #endregion
 
         #region Analyze Sentiment
-        /// <summary>
-        /// Runs a predictive model to identify the positive, negative, neutral
-        /// or mixed sentiment contained in the document, as well as a score
-        /// indicating the model's confidence in the predicted sentiment.
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="document">The document to analyze.</param>
-        /// <param name="language">The language that the document is written in.
-        /// If unspecified, this value will be set to the default language in
-        /// <see cref="TextAnalyticsClientOptions.DefaultLanguage"/> in the request sent to the
-        /// service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="options">The additional configurable <see cref="AnalyzeSentimentOptions"/> that may be passed when
-        /// analyzing sentiments. Options include Opinion mining, model version, and more.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing sentiment predictions for the document
-        /// and each of the sentences it contains.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
+
         public override async Task<Response<DocumentSentiment>> AnalyzeSentimentAsync(string document, string language = default, AnalyzeSentimentOptions options = null, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(document, nameof(document));
@@ -1145,29 +685,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify the positive, negative or neutral
-        /// sentiment contained in the document, as well as a score indicating the model's
-        /// confidence in the predicted sentiment.
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="document">The text to analyze.</param>
-        /// <param name="language">The language that the document is written in.
-        /// If unspecified, this value will be set to the default language in
-        /// <see cref="TextAnalyticsClientOptions.DefaultLanguage"/> in the request sent to the
-        /// service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="options">The additional configurable <see cref="AnalyzeSentimentOptions"/> that may be passed when
-        /// analyzing sentiments. Options include Opinion mining, model version, and more.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing sentiment predictions for the document
-        /// and each of the sentences it contains.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override Response<DocumentSentiment> AnalyzeSentiment(string document, string language = default, AnalyzeSentimentOptions options = null, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(document, nameof(document));
@@ -1207,29 +724,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify the positive, negative or neutral
-        /// sentiment contained in the documents, as well as scores indicating
-        /// the model's confidence in each of the predicted sentiments.
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="language">The language that all of the documents are written in.
-        /// If unspecified, this value will be set to the default language in
-        /// <see cref="TextAnalyticsClientOptions.DefaultLanguage"/> in the request sent to the
-        /// service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="options">The additional configurable <see cref="AnalyzeSentimentOptions"/> that may be passed when
-        /// analyzing sentiments. Options include Opinion mining, model version, and more.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing sentiment predictions for each of the documents
-        /// and predictions for each of the sentences each document contains.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<Response<AnalyzeSentimentResultCollection>> AnalyzeSentimentBatchAsync(IEnumerable<string> documents, string language = default, AnalyzeSentimentOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -1241,29 +735,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify the positive, negative or neutral
-        /// sentiment contained in the documents, as well as scores indicating
-        /// the model's confidence in each of the predicted sentiments.
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="language">The language that all of the documents are written in.
-        /// If unspecified, this value will be set to the default language in
-        /// <see cref="TextAnalyticsClientOptions.DefaultLanguage"/> in the request sent to the
-        /// service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="options">The additional configurable <see cref="AnalyzeSentimentOptions"/> that may be passed when
-        /// analyzing sentiments. Options include Opinion mining, model version, and more.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing sentiment predictions for each of the documents
-        /// and predictions for each of the sentences each document contains.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override Response<AnalyzeSentimentResultCollection> AnalyzeSentimentBatch(IEnumerable<string> documents, string language = default, AnalyzeSentimentOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -1274,24 +745,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify the positive, negative or neutral
-        /// sentiment contained in the documents, as well as scores indicating
-        /// the model's confidence in each of the predicted sentiments.
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="options">The additional configurable <see cref="AnalyzeSentimentOptions"/> that may be passed when
-        /// analyzing sentiments. Options include Opinion mining, model version, and more.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing sentiment predictions for each of the documents
-        /// and predictions for each of the sentences each document contains.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<Response<AnalyzeSentimentResultCollection>> AnalyzeSentimentBatchAsync(IEnumerable<TextDocumentInput> documents, AnalyzeSentimentOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -1303,24 +756,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify the positive, negative or neutral
-        /// sentiment contained in the documents, as well as scores indicating
-        /// the model's confidence in each of the predicted sentiments.
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="options">The additional configurable <see cref="AnalyzeSentimentOptions"/> that may be passed when
-        /// analyzing sentiments. Options include Opinion mining, model version, and more.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing sentiment predictions for each of the documents
-        /// and predictions for each of the sentences each document contains.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override Response<AnalyzeSentimentResultCollection> AnalyzeSentimentBatch(IEnumerable<TextDocumentInput> documents, AnalyzeSentimentOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -1330,33 +765,11 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             //return AnalyzeSentimentBatch(documentInputs, options, cancellationToken);
             throw new NotImplementedException();
         }
+
         #endregion
 
         #region Extract Key Phrases
 
-        /// <summary>
-        /// Runs a model to identify a collection of significant phrases
-        /// found in the passed-in document.
-        /// <para>For example, for the document "The food was delicious and there
-        /// were wonderful staff", the API returns the main talking points: "food"
-        /// and "wonderful staff".</para>
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="document">The document to analyze.</param>
-        /// <param name="language">The language that the document is written in.
-        /// If unspecified, this value will be set to the default language in
-        /// <see cref="TextAnalyticsClientOptions.DefaultLanguage"/> in the request sent to the
-        /// service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of key phrases identified
-        /// in the document.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<Response<KeyPhraseCollection>> ExtractKeyPhrasesAsync(string document, string language = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(document, nameof(document));
@@ -1389,29 +802,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a model to identify a collection of significant phrases
-        /// found in the passed-in document.
-        /// <para>For example, for the document "The food was delicious and there
-        /// were wonderful staff", the API returns the main talking points: "food"
-        /// and "wonderful staff".</para>
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="document">The document to analyze.</param>
-        /// <param name="language">The language that the document is written in.
-        /// If unspecified, this value will be set to the default language in
-        /// <see cref="TextAnalyticsClientOptions.DefaultLanguage"/> in the request sent to the
-        /// service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of key phrases identified
-        /// in the document.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override Response<KeyPhraseCollection> ExtractKeyPhrases(string document, string language = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(document, nameof(document));
@@ -1443,32 +833,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a model to identify a collection of significant phrases
-        /// found in the passed-in documents.
-        /// <para>For example, for the document "The food was delicious and there
-        /// were wonderful staff", the API returns the main talking points: "food"
-        /// and "wonderful staff".</para>
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="language">The language that all the documents are
-        /// written in. If unspecified, this value will be set to the default
-        /// language in <see cref="TextAnalyticsClientOptions.DefaultLanguage"/> in the request
-        /// sent to the service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="options"><see cref="TextAnalyticsRequestOptions"/> used to
-        /// select the version of the predictive model to run, and whether
-        /// statistics are returned in the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of key phrases identified
-        /// in each of the documents.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<Response<ExtractKeyPhrasesResultCollection>> ExtractKeyPhrasesBatchAsync(IEnumerable<string> documents, string language = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -1480,32 +844,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a model to identify a collection of significant phrases
-        /// found in the passed-in documents.
-        /// <para>For example, for the document "The food was delicious and there
-        /// were wonderful staff", the API returns the main talking points: "food"
-        /// and "wonderful staff".</para>
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="language">The language that all the documents are
-        /// written in. If unspecified, this value will be set to the default
-        /// language in <see cref="TextAnalyticsClientOptions"/> in the request
-        /// sent to the service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="options"><see cref="TextAnalyticsRequestOptions"/> used to
-        /// select the version of the predictive model to run, and whether
-        /// statistics are returned in the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of key phrases identified
-        /// in each of the documents.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override Response<ExtractKeyPhrasesResultCollection> ExtractKeyPhrasesBatch(IEnumerable<string> documents, string language = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -1516,27 +854,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a model to identify a collection of significant phrases
-        /// found in the passed-in documents.
-        /// <para>For example, for the document "The food was delicious and there
-        /// were wonderful staff", the API returns the main talking points: "food"
-        /// and "wonderful staff".</para>
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="options"><see cref="TextAnalyticsRequestOptions"/> used to
-        /// select the version of the predictive model to run, and whether
-        /// statistics are returned in the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of key phrases identified
-        /// in each of the documents.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<Response<ExtractKeyPhrasesResultCollection>> ExtractKeyPhrasesBatchAsync(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -1548,27 +865,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a model to identify a collection of significant phrases
-        /// found in the passed-in documents.
-        /// <para>For example, for the document "The food was delicious and there
-        /// were wonderful staff", the API returns the main talking points: "food"
-        /// and "wonderful staff".</para>
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="options"><see cref="TextAnalyticsRequestOptions"/> used to
-        /// select the version of the predictive model to run, and whether
-        /// statistics are returned in the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of key phrases identified
-        /// in each of the documents.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override Response<ExtractKeyPhrasesResultCollection> ExtractKeyPhrasesBatch(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -1578,32 +874,11 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             //return ExtractKeyPhrasesBatch(documentInputs, options, cancellationToken);
             throw new NotImplementedException();
         }
+
         #endregion
 
         #region Linked Entities
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of entities
-        /// found in the passed-in document, and include information linking the
-        /// entities to their corresponding entries in a well-known knowledge base.
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="document">The document to analyze.</param>
-        /// <param name="language">The language that the document is written in.
-        /// If unspecified, this value will be set to the default language in
-        /// <see cref="TextAnalyticsClientOptions.DefaultLanguage"/> in the request sent to the
-        /// service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of linked entities identified
-        /// in the document, as well as scores indicating the confidence
-        /// that the entity correctly matches the identified substring.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<Response<LinkedEntityCollection>> RecognizeLinkedEntitiesAsync(string document, string language = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(document, nameof(document));
@@ -1640,28 +915,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of entities
-        /// found in the passed-in document, and include information linking the
-        /// entities to their corresponding entries in a well-known knowledge base.
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="document">The document to analyze.</param>
-        /// <param name="language">The language that the document is written in.
-        /// If unspecified, this value will be set to the default language in
-        /// <see cref="TextAnalyticsClientOptions.DefaultLanguage"/> in the request sent to the
-        /// service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of linked entities identified
-        /// in the document, as well as scores indicating the confidence
-        /// that the entity correctly matches the identified substring.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override Response<LinkedEntityCollection> RecognizeLinkedEntities(string document, string language = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(document, nameof(document));
@@ -1697,31 +950,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of entities
-        /// found in the passed-in documents, and include information linking the
-        /// entities to their corresponding entries in a well-known knowledge base.
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="language">The language that the documents are written in.
-        /// If unspecified, this value will be set to the default language in
-        /// <see cref="TextAnalyticsClientOptions.DefaultLanguage"/> in the request sent to the
-        /// service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="options"><see cref="TextAnalyticsRequestOptions"/> used to
-        /// select the version of the predictive model to run, and whether
-        /// statistics are returned in the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of entities identified
-        /// for each of the documents, as well as scores indicating the confidence
-        /// that a given entity correctly matches the identified substring.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<Response<RecognizeLinkedEntitiesResultCollection>> RecognizeLinkedEntitiesBatchAsync(IEnumerable<string> documents, string language = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -1733,31 +961,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of entities
-        /// found in the passed-in documents, and include information linking the
-        /// entities to their corresponding entries in a well-known knowledge base.
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="language">The language that the documents are written in.
-        /// If unspecified, this value will be set to the default language in
-        /// <see cref="TextAnalyticsClientOptions.DefaultLanguage"/> in the request sent to the
-        /// service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="options"><see cref="TextAnalyticsRequestOptions"/> used to
-        /// select the version of the predictive model to run, and whether
-        /// statistics are returned in the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of entities identified
-        /// for each of the documents, as well as scores indicating the confidence
-        /// that a given entity correctly matches the identified substring.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override Response<RecognizeLinkedEntitiesResultCollection> RecognizeLinkedEntitiesBatch(IEnumerable<string> documents, string language = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -1768,26 +971,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of entities
-        /// found in the passed-in documents, and include information linking the
-        /// entities to their corresponding entries in a well-known knowledge base.
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="options"><see cref="TextAnalyticsRequestOptions"/> used to
-        /// select the version of the predictive model to run, and whether
-        /// statistics are returned in the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of entities identified
-        /// for each of the documents, as well as scores indicating the confidence
-        /// that a given entity correctly matches the identified substring.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<Response<RecognizeLinkedEntitiesResultCollection>> RecognizeLinkedEntitiesBatchAsync(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -1799,26 +982,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of entities
-        /// found in the passed-in documents, and include information linking the
-        /// entities to their corresponding entries in a well-known knowledge base.
-        /// <para>For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.</para>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.</para>
-        /// </summary>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="options"><see cref="TextAnalyticsRequestOptions"/> used to
-        /// select the version of the predictive model to run, and whether
-        /// statistics are returned in the response.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of entities identified
-        /// for each of the documents, as well as scores indicating the confidence
-        /// that a given entity correctly matches the identified substring.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override Response<RecognizeLinkedEntitiesResultCollection> RecognizeLinkedEntitiesBatch(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -1828,29 +991,11 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             //return RecognizeLinkedEntitiesBatch(documentInputs, options, cancellationToken);
             throw new NotImplementedException();
         }
+
         #endregion
 
         #region Healthcare
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of healthcare entities
-        /// found in the passed-in document, and include information linking the
-        /// entities to their corresponding entries in a well-known knowledge base.
-        /// For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.
-        /// For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.
-        /// </summary>
-        /// <remarks>
-        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1"/> and up.
-        /// </remarks>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="language">The language that the document is written in.</param>
-        /// <param name="options">The additional configurable <see cref="AnalyzeHealthcareEntitiesOptions"/> </param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<AnalyzeHealthcareEntitiesOperation> StartAnalyzeHealthcareEntitiesAsync(IEnumerable<string> documents, string language = default, AnalyzeHealthcareEntitiesOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -1862,32 +1007,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of healthcare entities
-        /// found in the passed-in document, and include information linking the
-        /// entities to their corresponding entries in a well-known knowledge base.
-        /// For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.
-        /// For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.
-        /// </summary>
-        /// <remarks>
-        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1"/> and up.
-        /// </remarks>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="language">The language that the document is written in.
-        /// If unspecified, this value will be set to the default language in
-        /// <see cref="TextAnalyticsClientOptions"/> in the request sent to the
-        /// service.  If set to an empty string, the service will apply a model
-        /// where the language is explicitly set to "None".</param>
-        /// <param name="options">The additional configurable options<see cref="AnalyzeHealthcareEntitiesOptions"/></param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>
-        /// controlling the request lifetime.</param>
-        /// <returns>A result containing the collection of entities identified
-        /// for each of the documents, as well as scores indicating the confidence
-        /// that a given entity correctly matches the identified substring.</returns>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override AnalyzeHealthcareEntitiesOperation StartAnalyzeHealthcareEntities(IEnumerable<string> documents, string language = default, AnalyzeHealthcareEntitiesOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -1898,23 +1017,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of healthcare entities
-        /// found in the passed-in document, and include information linking the
-        /// entities to their corresponding entries in a well-known knowledge base.
-        /// For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.
-        /// For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.
-        /// </summary>
-        /// <remarks>
-        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1"/> and up.
-        /// </remarks>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="options">The additional configurable options<see cref="AnalyzeHealthcareEntitiesOptions"/></param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        /// <returns>A <see cref="AnalyzeHealthcareEntitiesOperation"/> to wait on this long-running operation.  Its <see cref="AnalyzeHealthcareEntitiesOperation.Value"/> upon successful
-        /// completion will contain layout elements extracted from the form.</returns>
         public override AnalyzeHealthcareEntitiesOperation StartAnalyzeHealthcareEntities(IEnumerable<TextDocumentInput> documents, AnalyzeHealthcareEntitiesOptions options, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNull(documents, nameof(documents));
@@ -1927,23 +1029,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// Runs a predictive model to identify a collection of healthcare entities
-        /// found in the passed-in document, and include information linking the
-        /// entities to their corresponding entries in a well-known knowledge base.
-        /// For a list of languages supported by this operation, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/language-support"/>.
-        /// For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3"/>.
-        /// </summary>
-        /// <remarks>
-        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1"/> and up.
-        /// </remarks>
-        /// <param name="documents">The documents to analyze.</param>
-        /// <param name="options">The additional configurable options<see cref="AnalyzeHealthcareEntitiesOptions"/></param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        /// <returns>A <see cref="AnalyzeHealthcareEntitiesOperation"/> to wait on this long-running operation.  Its <see cref="AnalyzeHealthcareEntitiesOperation.Value"/> upon successful
-        /// completion will contain layout elements extracted from the form.</returns>
         public override async Task<AnalyzeHealthcareEntitiesOperation> StartAnalyzeHealthcareEntitiesAsync(IEnumerable<TextDocumentInput> documents, AnalyzeHealthcareEntitiesOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNull(documents, nameof(documents));
@@ -1956,35 +1041,11 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             await Task.Yield();
             throw new NotImplementedException();
         }
+
         #endregion
 
         #region Analyze Operation
 
-        /// <summary>
-        /// StartAnalyzeActionsAsync enables the application to execute multiple actions in a set of documents. It includes:
-        /// <list type="bullet">
-        /// <item><description>Entity Recognition (Named, Linked, and Personally Identifiable Information (PII) entities)</description></item>
-        /// <item><description>Key Phrases Extraction</description></item>
-        /// <item><description>Sentiment Analysis</description></item>
-        /// <item><description>Extractive Text Summarization</description></item>
-        /// <item><description>Custom Entity Recognition</description></item>
-        /// <item><description>Custom Single and Multi Category Classification</description></item>
-        /// </list>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see more information
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3">here</see>.
-        /// </para>
-        /// </summary>
-        /// <remarks>
-        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1"/> and up.
-        /// See the service <see href="https://aka.ms/azsdk/textanalytics/customfunctionalities">documentation</see> for regional support of custom action features.
-        /// </remarks>
-        /// <param name="documents">The list of documents to analyze.</param>
-        /// <param name="language">The language that the document is written in.</param>
-        /// <param name="actions"> The different <see cref="TextAnalyticsActions"/> to execute in the list of documents.</param>
-        /// <param name="options">Sets the IncludeStatistcs property on the analyze action operation. </param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<AnalyzeActionsOperation> StartAnalyzeActionsAsync(IEnumerable<string> documents, TextAnalyticsActions actions, string language = default, AnalyzeActionsOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -1996,31 +1057,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// StartAnalyzeActionsAsync enables the application to execute multiple actions in a set of documents. It includes:
-        /// <list type="bullet">
-        /// <item><description>Entity Recognition (Named, Linked, and Personally Identifiable Information (PII) entities)</description></item>
-        /// <item><description>Key Phrases Extraction</description></item>
-        /// <item><description>Sentiment Analysis</description></item>
-        /// <item><description>Extractive Text Summarization</description></item>
-        /// <item><description>Custom Entity Recognition</description></item>
-        /// <item><description>Custom Single and Multi Category Classification</description></item>
-        /// </list>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3">here</see>.
-        /// </para>
-        /// </summary>
-        /// <remarks>
-        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1"/> and up.
-        /// See the service <see href="https://aka.ms/azsdk/textanalytics/customfunctionalities">documentation</see> for regional support of custom action features.
-        /// </remarks>
-        /// <param name="documents">The list of documents to analyze.</param>
-        /// <param name="actions"> The different <see cref="TextAnalyticsActions"/> to execute in the list of documents.</param>
-        /// <param name="language">The language that the document is written in.</param>
-        /// <param name="options">Sets the IncludeStatistcs property on the analyze action operation. </param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override AnalyzeActionsOperation StartAnalyzeActions(IEnumerable<string> documents, TextAnalyticsActions actions, string language = default, AnalyzeActionsOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -2031,30 +1067,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// StartAnalyzeActionsAsync enables the application to execute multiple actions in a set of documents. It includes:
-        /// <list type="bullet">
-        /// <item><description>Entity Recognition (Named, Linked, and Personally Identifiable Information (PII) entities)</description></item>
-        /// <item><description>Key Phrases Extraction</description></item>
-        /// <item><description>Sentiment Analysis</description></item>
-        /// <item><description>Extractive Text Summarization</description></item>
-        /// <item><description>Custom Entity Recognition</description></item>
-        /// <item><description>Custom Single and Multi Category Classification</description></item>
-        /// </list>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3">here</see>.
-        /// </para>
-        /// </summary>
-        /// <remarks>
-        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1"/> and up.
-        /// See the service <see href="https://aka.ms/azsdk/textanalytics/customfunctionalities">documentation</see> for regional support of custom action features.
-        /// </remarks>
-        /// <param name="documents">The list of documents to analyze.</param>
-        /// <param name="actions"> The different <see cref="TextAnalyticsActions"/> to execute in the list of documents.</param>
-        /// <param name="options">Sets the IncludeStatistcs property on the analyze action operation. </param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override AnalyzeActionsOperation StartAnalyzeActions(IEnumerable<TextDocumentInput> documents, TextAnalyticsActions actions, AnalyzeActionsOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
@@ -2065,30 +1077,6 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// StartAnalyzeActionsAsync enables the application to execute multiple actions in a set of documents. It includes:
-        /// <list type="bullet">
-        /// <item><description>Entity Recognition (Named, Linked, and Personally Identifiable Information (PII) entities)</description></item>
-        /// <item><description>Key Phrases Extraction</description></item>
-        /// <item><description>Sentiment Analysis</description></item>
-        /// <item><description>Extractive Text Summarization</description></item>
-        /// <item><description>Custom Entity Recognition</description></item>
-        /// <item><description>Custom Single and Multi Category Classification</description></item>
-        /// </list>
-        /// <para>For document length limits, maximum batch size, and supported text encoding, see
-        /// <see href="https://docs.microsoft.com/azure/cognitive-services/text-analytics/concepts/data-limits?tabs=version-3">here</see>.
-        /// </para>
-        /// </summary>
-        /// <remarks>
-        /// Method is only available for <see cref="TextAnalyticsClientOptions.ServiceVersion.V3_1"/> and up.
-        /// See the service <see href="https://aka.ms/azsdk/textanalytics/customfunctionalities">documentation</see> for regional support of custom action features.
-        /// </remarks>
-        /// <param name="documents">The list of documents to analyze.</param>
-        /// <param name="actions"> The different <see cref="TextAnalyticsActions"/> to execute in the list of documents.</param>
-        /// <param name="options">Sets the IncludeStatistcs property on the analyze action operation. </param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        /// <exception cref="RequestFailedException">Service returned a non-success
-        /// status code.</exception>
         public override async Task<AnalyzeActionsOperation> StartAnalyzeActionsAsync(IEnumerable<TextDocumentInput> documents, TextAnalyticsActions actions, AnalyzeActionsOptions options = default, CancellationToken cancellationToken = default)
         {
             //Argument.AssertNotNullOrEmpty(documents, nameof(documents));

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LanguageServiceClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LanguageServiceClient.cs
@@ -23,14 +23,13 @@ namespace Azure.AI.TextAnalytics.ServiceClients
         private static readonly TextAnalyticsRequestOptions s_defaultRequestOptions = new TextAnalyticsRequestOptions();
 
         private readonly MicrosoftCognitiveLanguageServiceRestClient _languageRestClient;
+        private readonly TextAnalyticsClientOptions _options;
         private readonly ClientDiagnostics _clientDiagnostics;
         private readonly Uri _baseUri;
-        private readonly string _defaultLanguage;
-        private readonly string _defaultCountryHint;
 
         public override ClientDiagnostics Diagnostics => _clientDiagnostics;
 
-        public LanguageServiceClient(Uri endpoint, TokenCredential credential, string defaultLanguage, string defaultCountryHint, string authorizationScope, string serviceVersion, ClientOptions options)
+        public LanguageServiceClient(Uri endpoint, TokenCredential credential, string authorizationScope, string serviceVersion, TextAnalyticsClientOptions options)
         {
             Argument.AssertNotNull(endpoint, nameof(endpoint));
             Argument.AssertNotNull(credential, nameof(credential));
@@ -41,26 +40,23 @@ namespace Azure.AI.TextAnalytics.ServiceClients
 
             _baseUri = endpoint;
             _clientDiagnostics = new TextAnalyticsClientDiagnostics(options);
-            _defaultLanguage = defaultLanguage;
-            _defaultCountryHint = defaultCountryHint;
+            _options = options;
 
             var pipeline = HttpPipelineBuilder.Build(options, new BearerTokenAuthenticationPolicy(credential, authorizationScope));
             _languageRestClient = new MicrosoftCognitiveLanguageServiceRestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri, serviceVersion);
         }
 
-        public LanguageServiceClient(Uri endpoint, AzureKeyCredential credential, string defaultLanguage, string defaultCountryHint, string authorizationScope, string serviceVersion, ClientOptions options)
+        public LanguageServiceClient(Uri endpoint, AzureKeyCredential credential, string serviceVersion, TextAnalyticsClientOptions options)
         {
             Argument.AssertNotNull(endpoint, nameof(endpoint));
             Argument.AssertNotNull(credential, nameof(credential));
             Argument.AssertNotNull(options, nameof(options));
 
-            Argument.AssertNotNullOrEmpty(authorizationScope, nameof(authorizationScope));
             Argument.AssertNotNullOrEmpty(serviceVersion, nameof(serviceVersion));
 
             _baseUri = endpoint;
             _clientDiagnostics = new TextAnalyticsClientDiagnostics(options);
-            _defaultLanguage = defaultLanguage;
-            _defaultCountryHint = defaultCountryHint;
+            _options = options;
 
             var pipeline = HttpPipelineBuilder.Build(options, new AzureKeyCredentialPolicy(credential, Constants.AuthorizationHeader));
             _languageRestClient = new MicrosoftCognitiveLanguageServiceRestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri, serviceVersion);
@@ -2174,7 +2170,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
         }
 
         private MultiLanguageInput ConvertToMultiLanguageInput(string document, string language, int id = 0)
-            => new MultiLanguageInput($"{id}", document) { Language = language ?? _defaultLanguage };
+            => new MultiLanguageInput($"{id}", document) { Language = language ?? _options.DefaultLanguage };
 
         private MultiLanguageAnalysisInput ConvertToMultiLanguageInputs(IEnumerable<string> documents, string language)
         {
@@ -2191,13 +2187,13 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             MultiLanguageAnalysisInput input = new MultiLanguageAnalysisInput();
             foreach (var document in documents)
             {
-                input.Documents.Add(new MultiLanguageInput(document.Id, document.Text) { Language = document.Language ?? _defaultLanguage });
+                input.Documents.Add(new MultiLanguageInput(document.Id, document.Text) { Language = document.Language ?? _options.DefaultLanguage });
             }
             return input;
         }
 
         private LanguageInput ConvertToLanguageInput(string document, string countryHint, int id = 0)
-            => new LanguageInput($"{id}", document) { CountryHint = countryHint ?? _defaultCountryHint };
+            => new LanguageInput($"{id}", document) { CountryHint = countryHint ?? _options.DefaultCountryHint };
 
         private static IDictionary<string, string> CreateAdditionalInformation(TextAnalyticsError error) =>
             (string.IsNullOrEmpty(error.Target))

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LanguageServiceClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LanguageServiceClient.cs
@@ -36,10 +36,8 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             Argument.AssertNotNull(credential, nameof(credential));
             Argument.AssertNotNull(options, nameof(options));
 
-            Argument.AssertNotNullOrEmpty(defaultLanguage, nameof(defaultLanguage));
-            Argument.AssertNotNullOrEmpty(defaultCountryHint, nameof(defaultCountryHint));
-            Argument.AssertNotNull(authorizationScope, nameof(authorizationScope));
-            Argument.AssertNotNull(serviceVersion, nameof(serviceVersion));
+            Argument.AssertNotNullOrEmpty(authorizationScope, nameof(authorizationScope));
+            Argument.AssertNotNullOrEmpty(serviceVersion, nameof(serviceVersion));
 
             _baseUri = endpoint;
             _clientDiagnostics = new TextAnalyticsClientDiagnostics(options);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LegacyServiceClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LegacyServiceClient.cs
@@ -25,14 +25,13 @@ namespace Azure.AI.TextAnalytics.ServiceClients
         private static readonly AnalyzeSentimentOptions DefaultAnalyzeSentimentOptions = new();
 
         private readonly TextAnalyticsRestClient _serviceRestClient;
+        private readonly TextAnalyticsClientOptions _options;
         private readonly ClientDiagnostics _clientDiagnostics;
         private readonly Uri _baseUri;
-        private readonly string _defaultLanguage;
-        private readonly string _defaultCountryHint;
 
         public override ClientDiagnostics Diagnostics => _clientDiagnostics;
 
-        public LegacyServiceClient(Uri endpoint, TokenCredential credential, string defaultLanguage, string defaultCountryHint, string authorizationScope, string serviceVersion, ClientOptions options)
+        public LegacyServiceClient(Uri endpoint, TokenCredential credential, string authorizationScope, string serviceVersion, TextAnalyticsClientOptions options)
         {
             Argument.AssertNotNull(endpoint, nameof(endpoint));
             Argument.AssertNotNull(credential, nameof(credential));
@@ -43,26 +42,23 @@ namespace Azure.AI.TextAnalytics.ServiceClients
 
             _baseUri = endpoint;
             _clientDiagnostics = new TextAnalyticsClientDiagnostics(options);
-            _defaultLanguage = defaultLanguage;
-            _defaultCountryHint = defaultCountryHint;
+            _options = options;
 
             var pipeline = HttpPipelineBuilder.Build(options, new BearerTokenAuthenticationPolicy(credential, authorizationScope));
             _serviceRestClient = new TextAnalyticsRestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri, serviceVersion);
         }
 
-        public LegacyServiceClient(Uri endpoint, AzureKeyCredential credential, string defaultLanguage, string defaultCountryHint, string authorizationScope, string serviceVersion, ClientOptions options)
+        public LegacyServiceClient(Uri endpoint, AzureKeyCredential credential, string serviceVersion, TextAnalyticsClientOptions options)
         {
             Argument.AssertNotNull(endpoint, nameof(endpoint));
             Argument.AssertNotNull(credential, nameof(credential));
             Argument.AssertNotNull(options, nameof(options));
 
-            Argument.AssertNotNullOrEmpty(authorizationScope, nameof(authorizationScope));
             Argument.AssertNotNullOrEmpty(serviceVersion, nameof(serviceVersion));
 
             _baseUri = endpoint;
             _clientDiagnostics = new TextAnalyticsClientDiagnostics(options);
-            _defaultLanguage = defaultLanguage;
-            _defaultCountryHint = defaultCountryHint;
+            _options = options;
 
             var pipeline = HttpPipelineBuilder.Build(options, new AzureKeyCredentialPolicy(credential, Constants.AuthorizationHeader));
             _serviceRestClient = new TextAnalyticsRestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri, serviceVersion);
@@ -1302,7 +1298,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
         #region Common
 
         private MultiLanguageInput ConvertToMultiLanguageInput(string document, string language, int id = 0)
-            => new MultiLanguageInput($"{id}", document) { Language = language ?? _defaultLanguage };
+            => new MultiLanguageInput($"{id}", document) { Language = language ?? _options.DefaultLanguage };
 
         private MultiLanguageBatchInput ConvertToMultiLanguageInputs(IEnumerable<string> documents, string language)
         {
@@ -1324,14 +1320,14 @@ namespace Azure.AI.TextAnalytics.ServiceClients
 
             foreach (var document in documents)
             {
-                batchInput.Documents.Add(new MultiLanguageInput(document.Id, document.Text) { Language = document.Language ?? _defaultLanguage });;
+                batchInput.Documents.Add(new MultiLanguageInput(document.Id, document.Text) { Language = document.Language ?? _options.DefaultLanguage });;
             }
 
             return batchInput;
         }
 
         private LanguageInput ConvertToLanguageInput(string document, string countryHint, int id = 0)
-            => new LanguageInput($"{id}", document) { CountryHint = countryHint ?? _defaultCountryHint };
+            => new LanguageInput($"{id}", document) { CountryHint = countryHint ?? _options.DefaultCountryHint };
 
         private LanguageBatchInput ConvertToLanguageInputs(IEnumerable<string> documents, string countryHint)
         {
@@ -1353,7 +1349,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
 
             foreach (var document in documents)
             {
-                batchInput.Documents.Add(new LanguageInput(document.Id, document.Text) { CountryHint = document.CountryHint ?? _defaultCountryHint });
+                batchInput.Documents.Add(new LanguageInput(document.Id, document.Text) { CountryHint = document.CountryHint ?? _options.DefaultCountryHint });
             }
 
             return batchInput;

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LegacyServiceClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LegacyServiceClient.cs
@@ -56,10 +56,8 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             Argument.AssertNotNull(credential, nameof(credential));
             Argument.AssertNotNull(options, nameof(options));
 
-            Argument.AssertNotNullOrEmpty(defaultLanguage, nameof(defaultLanguage));
-            Argument.AssertNotNullOrEmpty(defaultCountryHint, nameof(defaultCountryHint));
-            Argument.AssertNotNull(authorizationScope, nameof(authorizationScope));
-            Argument.AssertNotNull(serviceVersion, nameof(serviceVersion));
+            Argument.AssertNotNullOrEmpty(authorizationScope, nameof(authorizationScope));
+            Argument.AssertNotNullOrEmpty(serviceVersion, nameof(serviceVersion));
 
             _baseUri = endpoint;
             _clientDiagnostics = new TextAnalyticsClientDiagnostics(options);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LegacyServiceClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LegacyServiceClient.cs
@@ -38,10 +38,8 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             Argument.AssertNotNull(credential, nameof(credential));
             Argument.AssertNotNull(options, nameof(options));
 
-            Argument.AssertNotNullOrEmpty(defaultLanguage, nameof(defaultLanguage));
-            Argument.AssertNotNullOrEmpty(defaultCountryHint, nameof(defaultCountryHint));
-            Argument.AssertNotNull(authorizationScope, nameof(authorizationScope));
-            Argument.AssertNotNull(serviceVersion, nameof(serviceVersion));
+            Argument.AssertNotNullOrEmpty(authorizationScope, nameof(authorizationScope));
+            Argument.AssertNotNullOrEmpty(serviceVersion, nameof(serviceVersion));
 
             _baseUri = endpoint;
             _clientDiagnostics = new TextAnalyticsClientDiagnostics(options);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LegacyServiceClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LegacyServiceClient.cs
@@ -24,12 +24,13 @@ namespace Azure.AI.TextAnalytics.ServiceClients
         private static readonly AnalyzeHealthcareEntitiesOptions DefaultHeathcareEntitiesOptions = new();
         private static readonly AnalyzeSentimentOptions DefaultAnalyzeSentimentOptions = new();
 
-        internal readonly TextAnalyticsRestClient _serviceRestClient;
-        internal readonly ClientDiagnostics _clientDiagnostics;
-
+        private readonly TextAnalyticsRestClient _serviceRestClient;
+        private readonly ClientDiagnostics _clientDiagnostics;
         private readonly Uri _baseUri;
         private readonly string _defaultLanguage;
         private readonly string _defaultCountryHint;
+
+        public override ClientDiagnostics Diagnostics => _clientDiagnostics;
 
         public LegacyServiceClient(Uri endpoint, TokenCredential credential, string defaultLanguage, string defaultCountryHint, string authorizationScope, string serviceVersion, ClientOptions options)
         {
@@ -591,6 +592,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
         #endregion
 
         #region Analyze Sentiment
+
         public override async Task<Response<DocumentSentiment>> AnalyzeSentimentAsync(string document, string language = default, AnalyzeSentimentOptions options = null, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(document, nameof(document));

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/ServiceClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/ServiceClient.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core.Pipeline;
 
 namespace Azure.AI.TextAnalytics.ServiceClients
 {
@@ -16,6 +17,8 @@ namespace Azure.AI.TextAnalytics.ServiceClients
     ///
     internal abstract class ServiceClient
     {
+        public abstract ClientDiagnostics Diagnostics { get; }
+
         #region Detect Language
 
         public abstract Task<Response<DetectedLanguage>> DetectLanguageAsync(string document, string countryHint = default, CancellationToken cancellationToken = default);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.AI.TextAnalytics.Models;
+using Azure.AI.TextAnalytics.ServiceClients;
 using Azure.Core;
 using Azure.Core.Pipeline;
 using System;
@@ -20,12 +21,14 @@ namespace Azure.AI.TextAnalytics
     /// </summary>
     public class TextAnalyticsClient
     {
-        internal readonly MicrosoftCognitiveLanguageServiceRestClient _languageRestClient;
-        internal readonly ClientDiagnostics _clientDiagnostics;
+        private static HashSet<TextAnalyticsClientOptions.ServiceVersion> s_legacyServiceVersions = new()
+        {
+            TextAnalyticsClientOptions.ServiceVersion.V3_0,
+            TextAnalyticsClientOptions.ServiceVersion.V3_1,
+            TextAnalyticsClientOptions.ServiceVersion.V3_2_Preview_2
+        };
 
-        private readonly Uri _baseUri;
-        private readonly TextAnalyticsClientOptions _options;
-        private readonly TextAnalyticsRequestOptions _requestOptions = new TextAnalyticsRequestOptions();
+        internal readonly ServiceClient _serviceClient;
 
         /// <summary>
         /// Protected constructor to allow mocking.
@@ -63,13 +66,29 @@ namespace Azure.AI.TextAnalytics
             Argument.AssertNotNull(credential, nameof(credential));
             Argument.AssertNotNull(options, nameof(options));
 
-            string defaultScope = $"{(string.IsNullOrEmpty(options.Audience?.ToString()) ? TextAnalyticsAudience.AzurePublicCloud : options.Audience)}/.default";
-            _baseUri = endpoint;
-            _clientDiagnostics = new TextAnalyticsClientDiagnostics(options);
-            _options = options;
+            var authorizationScope = $"{(string.IsNullOrEmpty(options.Audience?.ToString()) ? TextAnalyticsAudience.AzurePublicCloud : options.Audience)}/.default";
 
-            var pipeline = HttpPipelineBuilder.Build(options, new BearerTokenAuthenticationPolicy(credential, defaultScope));
-            _languageRestClient = new MicrosoftCognitiveLanguageServiceRestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri, TextAnalyticsClientOptions.GetVersionString(options.Version));
+            _serviceClient = options.Version switch
+            {
+                var version when s_legacyServiceVersions.Contains(version) =>
+                    new LegacyServiceClient(
+                        endpoint,
+                        credential,
+                        options.DefaultLanguage,
+                        options.DefaultCountryHint,
+                        authorizationScope,
+                        TextAnalyticsClientOptions.GetVersionString(options.Version), options),
+
+                _ =>
+                    new LanguageServiceClient(
+                        endpoint,
+                        credential,
+                        options.DefaultLanguage,
+                        options.DefaultCountryHint,
+                        authorizationScope,
+                        TextAnalyticsClientOptions.GetVersionString(options.Version),
+                        options)
+            };
         }
 
         /// <summary>
@@ -103,12 +122,29 @@ namespace Azure.AI.TextAnalytics
             Argument.AssertNotNull(credential, nameof(credential));
             Argument.AssertNotNull(options, nameof(options));
 
-            _baseUri = endpoint;
-            _clientDiagnostics = new TextAnalyticsClientDiagnostics(options);
-            _options = options;
+            var authorizationScope = $"{(string.IsNullOrEmpty(options.Audience?.ToString()) ? TextAnalyticsAudience.AzurePublicCloud : options.Audience)}/.default";
 
-            var pipeline = HttpPipelineBuilder.Build(options, new AzureKeyCredentialPolicy(credential, Constants.AuthorizationHeader));
-            _languageRestClient = new MicrosoftCognitiveLanguageServiceRestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri, TextAnalyticsClientOptions.GetVersionString(options.Version));
+            _serviceClient = options.Version switch
+            {
+                var version when s_legacyServiceVersions.Contains(version) =>
+                    new LegacyServiceClient(
+                        endpoint,
+                        credential,
+                        options.DefaultLanguage,
+                        options.DefaultCountryHint,
+                        authorizationScope,
+                        TextAnalyticsClientOptions.GetVersionString(options.Version), options),
+
+                _ =>
+                    new LanguageServiceClient(
+                        endpoint,
+                        credential,
+                        options.DefaultLanguage,
+                        options.DefaultCountryHint,
+                        authorizationScope,
+                        TextAnalyticsClientOptions.GetVersionString(options.Version),
+                        options)
+            };
         }
 
         #region Detect Language
@@ -135,42 +171,8 @@ namespace Azure.AI.TextAnalytics
         /// the model could not analyze the document.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<DetectedLanguage>> DetectLanguageAsync(string document, string countryHint = default, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNullOrEmpty(document, nameof(document));
-
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(DetectLanguage)}");
-            scope.AddAttribute("document", document);
-            scope.Start();
-
-            try
-            {
-                var documents = new List<LanguageInput>() { ConvertToLanguageInput(document, countryHint) };
-                var input = new LanguageDetectionAnalysisInput();
-                foreach (var doc in documents)
-                {
-                    input.Documents.Add(doc);
-                }
-                var analyzeLanguageDetection = new AnalyzeTextLanguageDetectionInput { AnalysisInput = input };
-                Response<AnalyzeTextTaskResult> result = await _languageRestClient.AnalyzeAsync(analyzeLanguageDetection, cancellationToken: cancellationToken).ConfigureAwait(false);
-
-                var languageDetection = (LanguageDetectionTaskResult)result.Value;
-                Response response = result.GetRawResponse();
-                if (languageDetection.Results.Errors.Count > 0)
-                {
-                    // only one document, so we can ignore the id and grab the first error message.
-                    var error = Transforms.ConvertToError(languageDetection.Results.Errors[0].Error);
-                    throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, new ResponseError(error.ErrorCode.ToString(), error.Message), CreateAdditionalInformation(error)).ConfigureAwait(false);
-                }
-
-                return Response.FromValue(Transforms.ConvertToDetectedLanguage(languageDetection.Results.Documents.FirstOrDefault()), response);
-            }
-            catch (Exception e)
-            {
-                scope.Failed(e);
-                throw;
-            }
-        }
+        public virtual async Task<Response<DetectedLanguage>> DetectLanguageAsync(string document, string countryHint = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.DetectLanguageAsync(document, countryHint, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a predictive model to determine the language the passed-in
@@ -194,43 +196,8 @@ namespace Azure.AI.TextAnalytics
         /// the model could not analyze the document.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<DetectedLanguage> DetectLanguage(string document, string countryHint = default, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNullOrEmpty(document, nameof(document));
-
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(DetectLanguage)}");
-            scope.AddAttribute("document", document);
-            scope.Start();
-
-            try
-            {
-                var documents = new List<LanguageInput>() { ConvertToLanguageInput(document, countryHint) };
-                var input = new LanguageDetectionAnalysisInput();
-                foreach (var doc in documents)
-                {
-                    input.Documents.Add(doc);
-                }
-                var analyzeLanguageDetection = new AnalyzeTextLanguageDetectionInput { AnalysisInput = input };
-                Response<AnalyzeTextTaskResult> result = _languageRestClient.Analyze(analyzeLanguageDetection, cancellationToken: cancellationToken);
-
-                var languageDetection = (LanguageDetectionTaskResult)result.Value;
-                Response response = result.GetRawResponse();
-                if (languageDetection.Results.Errors.Count > 0)
-                {
-                    // only one document, so we can ignore the id and grab the first error message.
-
-                    var error = Transforms.ConvertToError(languageDetection.Results.Errors[0].Error);
-                    throw _clientDiagnostics.CreateRequestFailedException(response, new ResponseError(error.ErrorCode.ToString(), error.Message), CreateAdditionalInformation(error));
-                }
-
-                return Response.FromValue(Transforms.ConvertToDetectedLanguage(languageDetection.Results.Documents.FirstOrDefault()), response);
-            }
-            catch (Exception e)
-            {
-                scope.Failed(e);
-                throw;
-            }
-        }
+        public virtual Response<DetectedLanguage> DetectLanguage(string document, string countryHint = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.DetectLanguage(document, countryHint, cancellationToken);
 
         /// <summary>
         /// Runs a predictive model to determine the language the passed-in
@@ -257,14 +224,8 @@ namespace Azure.AI.TextAnalytics
         /// the model could not analyze the documents.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<DetectLanguageResultCollection>> DetectLanguageBatchAsync(IEnumerable<string> documents, string countryHint = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            options ??= _requestOptions;
-            LanguageDetectionAnalysisInput detectLanguageInputs = DocumentsToLanguageDetection(documents, countryHint);
-
-            return await DetectLanguageBatchAsync(detectLanguageInputs, options, cancellationToken).ConfigureAwait(false);
-        }
+        public virtual async Task<Response<DetectLanguageResultCollection>> DetectLanguageBatchAsync(IEnumerable<string> documents, string countryHint = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.DetectLanguageBatchAsync(documents, countryHint, options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a predictive model to determine the language the passed-in
@@ -291,13 +252,8 @@ namespace Azure.AI.TextAnalytics
         /// the model could not analyze the documents.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<DetectLanguageResultCollection> DetectLanguageBatch(IEnumerable<string> documents, string countryHint = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            options ??= _requestOptions;
-            LanguageDetectionAnalysisInput detectLanguageInputs = DocumentsToLanguageDetection(documents, countryHint);
-            return DetectLanguageBatch(detectLanguageInputs, options, cancellationToken);
-        }
+        public virtual Response<DetectLanguageResultCollection> DetectLanguageBatch(IEnumerable<string> documents, string countryHint = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.DetectLanguageBatch(documents, countryHint, options, cancellationToken);
 
         /// <summary>
         /// Runs a predictive model to determine the language the passed-in
@@ -318,14 +274,8 @@ namespace Azure.AI.TextAnalytics
         /// the model could not analyze the documents.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<DetectLanguageResultCollection>> DetectLanguageBatchAsync(IEnumerable<DetectLanguageInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            options ??= _requestOptions;
-            LanguageDetectionAnalysisInput detectLanguageInputs = LanguageInputToLanguageDetection(documents);
-
-            return await DetectLanguageBatchAsync(detectLanguageInputs, options, cancellationToken).ConfigureAwait(false);
-        }
+        public virtual async Task<Response<DetectLanguageResultCollection>> DetectLanguageBatchAsync(IEnumerable<DetectLanguageInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.DetectLanguageBatchAsync(documents, options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a predictive model to determine the language the passed-in
@@ -346,93 +296,11 @@ namespace Azure.AI.TextAnalytics
         /// the model could not analyze the document.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<DetectLanguageResultCollection> DetectLanguageBatch(IEnumerable<DetectLanguageInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            options ??= _requestOptions;
-            LanguageDetectionAnalysisInput detectLanguageInputs = LanguageInputToLanguageDetection(documents);
-
-            return DetectLanguageBatch(detectLanguageInputs, options, cancellationToken);
-        }
-
-        private async Task<Response<DetectLanguageResultCollection>> DetectLanguageBatchAsync(LanguageDetectionAnalysisInput batchInput, TextAnalyticsRequestOptions options, CancellationToken cancellationToken)
-        {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(DetectLanguageBatch)}");
-            scope.Start();
-
-            try
-            {
-                var analyzeLanguageDetection = new AnalyzeTextLanguageDetectionInput {
-                    AnalysisInput = batchInput,
-                    Parameters = new LanguageDetectionTaskParameters(options.DisableServiceLogs, options.ModelVersion) };
-
-                Response<AnalyzeTextTaskResult> result = await _languageRestClient.AnalyzeAsync(analyzeLanguageDetection, options.IncludeStatistics, cancellationToken: cancellationToken).ConfigureAwait(false);
-                var languageDetection = result.Value as LanguageDetectionTaskResult;
-                var response = result.GetRawResponse();
-
-                IDictionary<string, int> map = CreateIdToIndexMap(batchInput.Documents);
-                DetectLanguageResultCollection results = Transforms.ConvertToDetectLanguageResultCollection(languageDetection.Results, map);
-                return Response.FromValue(results, response);
-            }
-            catch (Exception e)
-            {
-                scope.Failed(e);
-                throw;
-            }
-        }
-
-        private Response<DetectLanguageResultCollection> DetectLanguageBatch(LanguageDetectionAnalysisInput batchInput, TextAnalyticsRequestOptions options, CancellationToken cancellationToken)
-        {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(DetectLanguageBatch)}");
-            scope.Start();
-
-            try
-            {
-                var analyzeLanguageDetection = new AnalyzeTextLanguageDetectionInput {
-                    AnalysisInput = batchInput,
-                    Parameters = new LanguageDetectionTaskParameters(options.DisableServiceLogs, options.ModelVersion) };
-
-                Response<AnalyzeTextTaskResult> result = _languageRestClient.Analyze(analyzeLanguageDetection, options.IncludeStatistics, cancellationToken: cancellationToken);
-                var languageDetection = result.Value as LanguageDetectionTaskResult;
-                var response = result.GetRawResponse();
-
-                IDictionary<string, int> map = CreateIdToIndexMap(batchInput.Documents);
-                DetectLanguageResultCollection results = Transforms.ConvertToDetectLanguageResultCollection(languageDetection.Results, map);
-                return Response.FromValue(results, response);
-            }
-            catch (Exception e)
-            {
-                scope.Failed(e);
-                throw;
-            }
-        }
-
-        private LanguageDetectionAnalysisInput DocumentsToLanguageDetection(IEnumerable<string> documents, string countryHint = default)
-        {
-            LanguageDetectionAnalysisInput detectLanguageInputs = new LanguageDetectionAnalysisInput();
-            int id = 0;
-            foreach (var document in documents)
-            {
-                LanguageInput languageInput = ConvertToLanguageInput(document, countryHint, id);
-                id++;
-                detectLanguageInputs.Documents.Add(languageInput);
-            }
-            return detectLanguageInputs;
-        }
-
-        private static LanguageDetectionAnalysisInput LanguageInputToLanguageDetection(IEnumerable<DetectLanguageInput> documents)
-        {
-            LanguageDetectionAnalysisInput detectLanguageInputs = new LanguageDetectionAnalysisInput();
-            foreach (var document in documents)
-            {
-                LanguageInput languageInput = new LanguageInput (document.Id, document.Text);
-                languageInput.CountryHint = document.CountryHint;
-                detectLanguageInputs.Documents.Add(languageInput);
-            }
-            return detectLanguageInputs;
-        }
+        public virtual Response<DetectLanguageResultCollection> DetectLanguageBatch(IEnumerable<DetectLanguageInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.DetectLanguageBatch(documents, options, cancellationToken);
 
         #endregion
+
         #region Recognize Entities
 
         /// <summary>
@@ -459,44 +327,8 @@ namespace Azure.AI.TextAnalytics
         /// that the entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<CategorizedEntityCollection>> RecognizeEntitiesAsync(string document, string language = default, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNullOrEmpty(document, nameof(document));
-
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(RecognizeEntities)}");
-            scope.AddAttribute("document", document);
-            scope.Start();
-
-            try
-            {
-                var documents = new List<MultiLanguageInput>() { ConvertToMultiLanguageInput(document, language) };
-                var input = new MultiLanguageAnalysisInput();
-                foreach (var doc in documents)
-                {
-                    input.Documents.Add(doc);
-                }
-                var analyzeRecognizeEntities = new AnalyzeTextEntityRecognitionInput { AnalysisInput = input };
-                Response<AnalyzeTextTaskResult> result = await _languageRestClient.AnalyzeAsync(
-                    analyzeRecognizeEntities,
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
-
-                var entityRecognition = (EntitiesTaskResult)result.Value;
-                Response response = result.GetRawResponse();
-
-                if (entityRecognition.Results.Errors.Count > 0)
-                {
-                    // only one document, so we can ignore the id and grab the first error message.
-                    var error = Transforms.ConvertToError(entityRecognition.Results.Errors[0].Error);
-                    throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, new ResponseError(error.ErrorCode.ToString(), error.Message), CreateAdditionalInformation(error)).ConfigureAwait(false);
-                }
-                return Response.FromValue(Transforms.ConvertToCategorizedEntityCollection(entityRecognition.Results.Documents.FirstOrDefault()), response);
-            }
-            catch (Exception e)
-            {
-                scope.Failed(e);
-                throw;
-            }
-        }
+        public virtual async Task<Response<CategorizedEntityCollection>> RecognizeEntitiesAsync(string document, string language = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.RecognizeEntitiesAsync(document, language, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a predictive model to identify a collection of named entities
@@ -522,44 +354,8 @@ namespace Azure.AI.TextAnalytics
         /// that the entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<CategorizedEntityCollection> RecognizeEntities(string document, string language = default, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNullOrEmpty(document, nameof(document));
-
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(RecognizeEntities)}");
-            scope.AddAttribute("document", document);
-            scope.Start();
-
-            try
-            {
-                var documents = new List<MultiLanguageInput>() { ConvertToMultiLanguageInput(document, language) };
-                var input = new MultiLanguageAnalysisInput();
-                foreach (var doc in documents)
-                {
-                    input.Documents.Add(doc);
-                }
-                var analyzeRecognizeEntities = new AnalyzeTextEntityRecognitionInput { AnalysisInput = input };
-                Response<AnalyzeTextTaskResult> result = _languageRestClient.Analyze(
-                    analyzeRecognizeEntities,
-                    cancellationToken: cancellationToken);
-
-                var entityRecognition = (EntitiesTaskResult)result.Value;
-                Response response = result.GetRawResponse();
-
-                if (entityRecognition.Results.Errors.Count > 0)
-                {
-                    // only one document, so we can ignore the id and grab the first error message.
-                    var error = Transforms.ConvertToError(entityRecognition.Results.Errors[0].Error);
-                    throw _clientDiagnostics.CreateRequestFailedException(response, new ResponseError(error.ErrorCode.ToString(), error.Message), CreateAdditionalInformation(error));
-                }
-                return Response.FromValue(Transforms.ConvertToCategorizedEntityCollection(entityRecognition.Results.Documents.FirstOrDefault()), response);
-            }
-            catch (Exception e)
-            {
-                scope.Failed(e);
-                throw;
-            }
-        }
+        public virtual Response<CategorizedEntityCollection> RecognizeEntities(string document, string language = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.RecognizeEntities(document, language, cancellationToken);
 
         /// <summary>
         /// Runs a predictive model to identify a collection of named entities
@@ -588,14 +384,8 @@ namespace Azure.AI.TextAnalytics
         /// that a given entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<RecognizeEntitiesResultCollection>> RecognizeEntitiesBatchAsync(IEnumerable<string> documents, string language = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            options ??= _requestOptions;
-            AnalyzeTextEntityRecognitionInput input = DocumentsToEntityRecognition(documents, language);
-
-            return await RecognizeEntitiesBatchAsync(input, options, cancellationToken).ConfigureAwait(false);
-        }
+        public virtual async Task<Response<RecognizeEntitiesResultCollection>> RecognizeEntitiesBatchAsync(IEnumerable<string> documents, string language = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.RecognizeEntitiesBatchAsync(documents, language, options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a predictive model to identify a collection of named entities
@@ -624,14 +414,8 @@ namespace Azure.AI.TextAnalytics
         /// that a given entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<RecognizeEntitiesResultCollection> RecognizeEntitiesBatch(IEnumerable<string> documents, string language = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            options ??= _requestOptions;
-            AnalyzeTextEntityRecognitionInput input = DocumentsToEntityRecognition(documents, language);
-
-            return RecognizeEntitiesBatch(input, options, cancellationToken);
-        }
+        public virtual Response<RecognizeEntitiesResultCollection> RecognizeEntitiesBatch(IEnumerable<string> documents, string language = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.RecognizeEntitiesBatch(documents, language, options, cancellationToken);
 
         /// <summary>
         /// Runs a predictive model to identify a collection of named entities
@@ -655,14 +439,8 @@ namespace Azure.AI.TextAnalytics
         /// that a given entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<RecognizeEntitiesResultCollection>> RecognizeEntitiesBatchAsync(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            options ??= _requestOptions;
-            AnalyzeTextEntityRecognitionInput input = TextDocumentInputToEntityRecognition(documents);
-
-            return await RecognizeEntitiesBatchAsync(input, options, cancellationToken).ConfigureAwait(false);
-        }
+        public virtual async Task<Response<RecognizeEntitiesResultCollection>> RecognizeEntitiesBatchAsync(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.RecognizeEntitiesBatchAsync(documents, options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a predictive model to identify a collection of named entities
@@ -686,68 +464,8 @@ namespace Azure.AI.TextAnalytics
         /// that a given entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<RecognizeEntitiesResultCollection> RecognizeEntitiesBatch(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            options ??= _requestOptions;
-            AnalyzeTextEntityRecognitionInput input = TextDocumentInputToEntityRecognition(documents);
-
-            return RecognizeEntitiesBatch(input, options, cancellationToken);
-        }
-
-        private async Task<Response<RecognizeEntitiesResultCollection>> RecognizeEntitiesBatchAsync(AnalyzeTextEntityRecognitionInput entityRecognitionInput, TextAnalyticsRequestOptions options, CancellationToken cancellationToken)
-        {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(RecognizeEntitiesBatch)}");
-            scope.Start();
-
-            try
-            {
-                entityRecognitionInput.Parameters = new EntitiesTaskParameters(options.DisableServiceLogs, options.ModelVersion, Constants.DefaultStringIndexType);
-
-                Response<AnalyzeTextTaskResult> result = await _languageRestClient.AnalyzeAsync(
-                    entityRecognitionInput, options.IncludeStatistics,
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
-
-                var entityRecognition = (EntitiesTaskResult)result.Value;
-                Response response = result.GetRawResponse();
-
-                IDictionary<string, int> map = CreateIdToIndexMap(entityRecognitionInput.AnalysisInput.Documents);
-                RecognizeEntitiesResultCollection results = Transforms.ConvertToRecognizeEntitiesResultCollection(entityRecognition.Results, map);
-                return Response.FromValue(results, response);
-            }
-            catch (Exception e)
-            {
-                scope.Failed(e);
-                throw;
-            }
-        }
-
-        private Response<RecognizeEntitiesResultCollection> RecognizeEntitiesBatch(AnalyzeTextEntityRecognitionInput entityRecognitionInput, TextAnalyticsRequestOptions options, CancellationToken cancellationToken)
-        {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(RecognizeEntitiesBatch)}");
-            scope.Start();
-
-            try
-            {
-                entityRecognitionInput.Parameters = new EntitiesTaskParameters(options.DisableServiceLogs, options.ModelVersion, Constants.DefaultStringIndexType);
-
-                Response<AnalyzeTextTaskResult> result = _languageRestClient.Analyze(
-                    entityRecognitionInput, options.IncludeStatistics,
-                    cancellationToken: cancellationToken);
-
-                var entityRecognition = (EntitiesTaskResult)result.Value;
-                Response response = result.GetRawResponse();
-
-                IDictionary<string, int> map = CreateIdToIndexMap(entityRecognitionInput.AnalysisInput.Documents);
-                RecognizeEntitiesResultCollection results = Transforms.ConvertToRecognizeEntitiesResultCollection(entityRecognition.Results, map);
-                return Response.FromValue(results, response);
-            }
-            catch (Exception e)
-            {
-                scope.Failed(e);
-                throw;
-            }
-        }
+        public virtual Response<RecognizeEntitiesResultCollection> RecognizeEntitiesBatch(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.RecognizeEntitiesBatch(documents, options, cancellationToken);
 
         private static AnalyzeTextEntityRecognitionInput DocumentsToEntityRecognition(IEnumerable<string> documents, string language)
         {
@@ -811,45 +529,8 @@ namespace Azure.AI.TextAnalytics
         /// that the entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<PiiEntityCollection>> RecognizePiiEntitiesAsync(string document, string language = default, RecognizePiiEntitiesOptions options = default, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNullOrEmpty(document, nameof(document));
-            options ??= new RecognizePiiEntitiesOptions();
-
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(RecognizePiiEntities)}");
-            scope.AddAttribute("document", document);
-            scope.Start();
-
-            try
-            {
-                var documents = new List<MultiLanguageInput>() { ConvertToMultiLanguageInput(document, language) };
-                var input = new MultiLanguageAnalysisInput();
-                foreach (var doc in documents)
-                {
-                    input.Documents.Add(doc);
-                }
-                var analyzePiiEntites = new AnalyzeTextPiiEntitiesRecognitionInput { AnalysisInput = input };
-                Response<AnalyzeTextTaskResult> result = await _languageRestClient.AnalyzeAsync(analyzePiiEntites, cancellationToken: cancellationToken).ConfigureAwait(false);
-
-                var piiEntities = (PiiTaskResult)result.Value;
-                Response response = result.GetRawResponse();
-
-                if (piiEntities.Results.Errors.Count > 0)
-                {
-                    // only one document, so we can ignore the id and grab the first error message.
-
-                    var error = Transforms.ConvertToError(piiEntities.Results.Errors[0].Error);
-                    throw _clientDiagnostics.CreateRequestFailedException(response, new ResponseError(error.ErrorCode.ToString(), error.Message), CreateAdditionalInformation(error));
-                }
-
-                return Response.FromValue(Transforms.ConvertToPiiEntityCollection(piiEntities.Results.Documents.FirstOrDefault()), response);
-            }
-            catch (Exception e)
-            {
-                scope.Failed(e);
-                throw;
-            }
-        }
+        public virtual async Task<Response<PiiEntityCollection>> RecognizePiiEntitiesAsync(string document, string language = default, RecognizePiiEntitiesOptions options = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.RecognizePiiEntitiesAsync(document, language, options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a predictive model to identify a collection of entities containing
@@ -881,45 +562,8 @@ namespace Azure.AI.TextAnalytics
         /// that the entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<PiiEntityCollection> RecognizePiiEntities(string document, string language = default, RecognizePiiEntitiesOptions options = default, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNullOrEmpty(document, nameof(document));
-            options ??= new RecognizePiiEntitiesOptions();
-
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(RecognizePiiEntities)}");
-            scope.AddAttribute("document", document);
-            scope.Start();
-
-            try
-            {
-                var documents = new List<MultiLanguageInput>() { ConvertToMultiLanguageInput(document, language) };
-                var input = new MultiLanguageAnalysisInput();
-                foreach (var doc in documents)
-                {
-                    input.Documents.Add(doc);
-                }
-                var analyzePiiEntites = new AnalyzeTextPiiEntitiesRecognitionInput { AnalysisInput = input };
-                Response<AnalyzeTextTaskResult> result = _languageRestClient.Analyze(analyzePiiEntites, cancellationToken: cancellationToken);
-
-                var piiEntities = (PiiTaskResult)result.Value;
-                Response response = result.GetRawResponse();
-
-                if (piiEntities.Results.Errors.Count > 0)
-                {
-                    // only one document, so we can ignore the id and grab the first error message.
-
-                    var error = Transforms.ConvertToError(piiEntities.Results.Errors[0].Error);
-                    throw _clientDiagnostics.CreateRequestFailedException(response, new ResponseError(error.ErrorCode.ToString(), error.Message), CreateAdditionalInformation(error));
-                }
-
-                return Response.FromValue(Transforms.ConvertToPiiEntityCollection(piiEntities.Results.Documents.FirstOrDefault()), response);
-            }
-            catch (Exception e)
-            {
-                scope.Failed(e);
-                throw;
-            }
-        }
+        public virtual Response<PiiEntityCollection> RecognizePiiEntities(string document, string language = default, RecognizePiiEntitiesOptions options = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.RecognizePiiEntities(document, language, options, cancellationToken);
 
         /// <summary>
         /// Runs a predictive model to identify a collection of entities containing
@@ -951,15 +595,8 @@ namespace Azure.AI.TextAnalytics
         /// that a given entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<RecognizePiiEntitiesResultCollection>> RecognizePiiEntitiesBatchAsync(IEnumerable<string> documents, string language = default, RecognizePiiEntitiesOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new RecognizePiiEntitiesOptions();
-            //AnalyzeTextPiiEntitiesRecognitionInput input = ConvertToLanguageInputs(documents, language);
-            //return await RecognizePiiEntitiesBatchAsync(input, options, cancellationToken).ConfigureAwait(false);
-            await Task.Yield();
-            throw new NotImplementedException();
-        }
+        public virtual async Task<Response<RecognizePiiEntitiesResultCollection>> RecognizePiiEntitiesBatchAsync(IEnumerable<string> documents, string language = default, RecognizePiiEntitiesOptions options = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.RecognizePiiEntitiesBatchAsync(documents, language, options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a predictive model to identify a collection of entities containing
@@ -991,15 +628,8 @@ namespace Azure.AI.TextAnalytics
         /// that a given entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<RecognizePiiEntitiesResultCollection> RecognizePiiEntitiesBatch(IEnumerable<string> documents, string language = default, RecognizePiiEntitiesOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new RecognizePiiEntitiesOptions();
-            //AnalyzeTextPiiEntitiesRecognitionInput input = ConvertToLanguageInputs(documents, language);
-
-            //return RecognizePiiEntitiesBatch(input, options, cancellationToken);
-            throw new NotImplementedException();
-        }
+        public virtual Response<RecognizePiiEntitiesResultCollection> RecognizePiiEntitiesBatch(IEnumerable<string> documents, string language = default, RecognizePiiEntitiesOptions options = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.RecognizePiiEntitiesBatch(documents, language, options, cancellationToken);
 
         /// <summary>
         /// Runs a predictive model to identify a collection of entities containing
@@ -1026,16 +656,8 @@ namespace Azure.AI.TextAnalytics
         /// that a given entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<RecognizePiiEntitiesResultCollection>> RecognizePiiEntitiesBatchAsync(IEnumerable<TextDocumentInput> documents, RecognizePiiEntitiesOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new RecognizePiiEntitiesOptions();
-            //AnalyzeTextPiiEntitiesRecognitionInput input = ConvertToMultiLanguageInputs(documents);
-
-            //return await RecognizePiiEntitiesBatchAsync(input, options, cancellationToken).ConfigureAwait(false);
-            await Task.Yield();
-            throw new NotImplementedException();
-        }
+        public virtual async Task<Response<RecognizePiiEntitiesResultCollection>> RecognizePiiEntitiesBatchAsync(IEnumerable<TextDocumentInput> documents, RecognizePiiEntitiesOptions options = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.RecognizePiiEntitiesBatchAsync(documents.ToArray(), options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a predictive model to identify a collection of entities containing
@@ -1062,75 +684,8 @@ namespace Azure.AI.TextAnalytics
         /// that a given entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<RecognizePiiEntitiesResultCollection> RecognizePiiEntitiesBatch(IEnumerable<TextDocumentInput> documents, RecognizePiiEntitiesOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new RecognizePiiEntitiesOptions();
-            //AnalyzeTextPiiEntitiesRecognitionInput input = ConvertToMultiLanguageInputs(documents);
-
-            //return RecognizePiiEntitiesBatch(input, options, cancellationToken);
-            throw new NotImplementedException();
-        }
-
-        private async Task<Response<RecognizePiiEntitiesResultCollection>> RecognizePiiEntitiesBatchAsync(AnalyzeTextPiiEntitiesRecognitionInput piiEntitiesRecognitionInput, TextAnalyticsRequestOptions options, CancellationToken cancellationToken)
-        {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(RecognizePiiEntitiesBatch)}");
-            scope.Start();
-
-            try
-            {
-                var input = piiEntitiesRecognitionInput.AnalysisInput;
-                var analyzeRecognizeEntities = new AnalyzeTextPiiEntitiesRecognitionInput { AnalysisInput = input };
-                analyzeRecognizeEntities.Parameters.ModelVersion = options.ModelVersion;
-                analyzeRecognizeEntities.Parameters.LoggingOptOut = options.DisableServiceLogs;
-
-                Response<AnalyzeTextTaskResult> result = await _languageRestClient.AnalyzeAsync(
-                    analyzeRecognizeEntities, options.IncludeStatistics,
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
-
-                var entityRecognition = (PiiTaskResult)result.Value;
-                Response response = result.GetRawResponse();
-
-                IDictionary<string, int> map = CreateIdToIndexMap(input.Documents);
-                RecognizePiiEntitiesResultCollection results = Transforms.ConvertToRecognizePiiEntitiesResultCollection(entityRecognition.Results, map);
-                return Response.FromValue(results, response);
-            }
-            catch (Exception e)
-            {
-                scope.Failed(e);
-                throw;
-            }
-        }
-
-        private Response<RecognizePiiEntitiesResultCollection> RecognizePiiEntitiesBatch(AnalyzeTextPiiEntitiesRecognitionInput piiEntitiesRecognitionInput, TextAnalyticsRequestOptions options, CancellationToken cancellationToken)
-        {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(RecognizePiiEntitiesBatch)}");
-            scope.Start();
-
-            try
-            {
-                var input = piiEntitiesRecognitionInput.AnalysisInput;
-                var analyzeRecognizeEntities = new AnalyzeTextPiiEntitiesRecognitionInput { AnalysisInput = input };
-                analyzeRecognizeEntities.Parameters.ModelVersion = options.ModelVersion;
-                analyzeRecognizeEntities.Parameters.LoggingOptOut = options.DisableServiceLogs;
-
-                Response<AnalyzeTextTaskResult> result = _languageRestClient.Analyze(
-                    analyzeRecognizeEntities, options.IncludeStatistics,
-                    cancellationToken: cancellationToken);
-
-                var entityRecognition = (PiiTaskResult)result.Value;
-                Response response = result.GetRawResponse();
-
-                IDictionary<string, int> map = CreateIdToIndexMap(input.Documents);
-                RecognizePiiEntitiesResultCollection results = Transforms.ConvertToRecognizePiiEntitiesResultCollection(entityRecognition.Results, map);
-                return Response.FromValue(results, response);
-            }
-            catch (Exception e)
-            {
-                scope.Failed(e);
-                throw;
-            }
-        }
+        public virtual Response<RecognizePiiEntitiesResultCollection> RecognizePiiEntitiesBatch(IEnumerable<TextDocumentInput> documents, RecognizePiiEntitiesOptions options = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.RecognizePiiEntitiesBatch(documents, options, cancellationToken);
 
         #endregion
 
@@ -1158,10 +713,8 @@ namespace Azure.AI.TextAnalytics
         /// status code.</exception>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "AZC0002:DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.", Justification = "Hidden method we don't encourage people to use.")]
-        public virtual async Task<Response<DocumentSentiment>> AnalyzeSentimentAsync(string document, string language, CancellationToken cancellationToken)
-        {
-            return await AnalyzeSentimentAsync(document, language, new AnalyzeSentimentOptions(), cancellationToken).ConfigureAwait(false);
-        }
+        public virtual async Task<Response<DocumentSentiment>> AnalyzeSentimentAsync(string document, string language, CancellationToken cancellationToken) =>
+            await AnalyzeSentimentAsync(document, language, new AnalyzeSentimentOptions(), cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a predictive model to identify the positive, negative or neutral
@@ -1186,10 +739,8 @@ namespace Azure.AI.TextAnalytics
         /// status code.</exception>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "AZC0002:DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.", Justification = "Hidden method we don't encourage people to use.")]
-        public virtual Response<DocumentSentiment> AnalyzeSentiment(string document, string language, CancellationToken cancellationToken)
-        {
-            return AnalyzeSentiment(document, language, new AnalyzeSentimentOptions(), cancellationToken);
-        }
+        public virtual Response<DocumentSentiment> AnalyzeSentiment(string document, string language, CancellationToken cancellationToken) =>
+            AnalyzeSentiment(document, language, new AnalyzeSentimentOptions(), cancellationToken);
 
         /// <summary>
         /// Runs a predictive model to identify the positive, negative, neutral
@@ -1214,45 +765,8 @@ namespace Azure.AI.TextAnalytics
         /// and each of the sentences it contains.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<DocumentSentiment>> AnalyzeSentimentAsync(string document, string language = default, AnalyzeSentimentOptions options = null, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(document, nameof(document));
-            //options ??= new AnalyzeSentimentOptions();
-
-            //using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(AnalyzeSentiment)}");
-            //scope.AddAttribute("document", document);
-            //scope.Start();
-
-            //try
-            //{
-            //    var documents = new List<MultiLanguageInput>() { ConvertToMultiLanguageInput(document, language) };
-            //    Response<SentimentResponse> result = await _serviceRestClient.SentimentAsync(
-            //        new MultiLanguageBatchInput(documents),
-            //        options.ModelVersion,
-            //        options.IncludeStatistics,
-            //        options.DisableServiceLogs,
-            //        options.IncludeOpinionMining,
-            //        Constants.DefaultStringIndexType,
-            //        cancellationToken).ConfigureAwait(false);
-            //    Response response = result.GetRawResponse();
-
-            //    if (result.Value.Errors.Count > 0)
-            //    {
-            //        // only one document, so we can ignore the id and grab the first error message.
-            //        var error = Transforms.ConvertToError(result.Value.Errors[0].Error);
-            //        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, new ResponseError(error.ErrorCode.ToString(), error.Message), CreateAdditionalInformation(error)).ConfigureAwait(false);
-            //    }
-
-            //    return Response.FromValue(new DocumentSentiment(result.Value.Documents[0]), response);
-            //}
-            //catch (Exception e)
-            //{
-            //    scope.Failed(e);
-            //    throw;
-            //}
-            await Task.Yield();
-            throw new NotImplementedException();
-        }
+        public virtual async Task<Response<DocumentSentiment>> AnalyzeSentimentAsync(string document, string language = default, AnalyzeSentimentOptions options = null, CancellationToken cancellationToken = default) =>
+            await AnalyzeSentimentAsync(document, language, options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a predictive model to identify the positive, negative or neutral
@@ -1277,44 +791,8 @@ namespace Azure.AI.TextAnalytics
         /// and each of the sentences it contains.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<DocumentSentiment> AnalyzeSentiment(string document, string language = default, AnalyzeSentimentOptions options = null, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(document, nameof(document));
-            //options ??= new AnalyzeSentimentOptions();
-
-            //using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(AnalyzeSentiment)}");
-            //scope.AddAttribute("document", document);
-            //scope.Start();
-
-            //try
-            //{
-            //    var documents = new List<MultiLanguageInput>() { ConvertToMultiLanguageInput(document, language) };
-            //    Response<SentimentResponse> result = _serviceRestClient.Sentiment(
-            //        new MultiLanguageBatchInput(documents),
-            //        options.ModelVersion,
-            //        options.IncludeStatistics,
-            //        options.DisableServiceLogs,
-            //        options.IncludeOpinionMining,
-            //        Constants.DefaultStringIndexType,
-            //        cancellationToken);
-            //    Response response = result.GetRawResponse();
-
-            //    if (result.Value.Errors.Count > 0)
-            //    {
-            //        // only one document, so we can ignore the id and grab the first error message.
-            //        var error = Transforms.ConvertToError(result.Value.Errors[0].Error);
-            //        throw _clientDiagnostics.CreateRequestFailedException(response, new ResponseError(error.ErrorCode.ToString(), error.Message), CreateAdditionalInformation(error));
-            //    }
-
-            //    return Response.FromValue(new DocumentSentiment(result.Value.Documents[0]), response);
-            //}
-            //catch (Exception e)
-            //{
-            //    scope.Failed(e);
-            //    throw;
-            //}
-            throw new NotImplementedException();
-        }
+        public virtual Response<DocumentSentiment> AnalyzeSentiment(string document, string language = default, AnalyzeSentimentOptions options = null, CancellationToken cancellationToken = default) =>
+            _serviceClient.AnalyzeSentiment(document, language, options, cancellationToken);
 
         /// <summary>
         /// Runs a predictive model to identify the positive, negative or neutral
@@ -1341,16 +819,8 @@ namespace Azure.AI.TextAnalytics
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual async Task<Response<AnalyzeSentimentResultCollection>> AnalyzeSentimentBatchAsync(IEnumerable<string> documents, string language, TextAnalyticsRequestOptions options, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //var analyzeSentimentOptions = options != null ? new AnalyzeSentimentOptions(options) : new AnalyzeSentimentOptions();
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents, language);
-
-            //return await AnalyzeSentimentBatchAsync(documentInputs, analyzeSentimentOptions, cancellationToken).ConfigureAwait(false);
-            await Task.Yield();
-            throw new NotImplementedException();
-        }
+        public virtual async Task<Response<AnalyzeSentimentResultCollection>> AnalyzeSentimentBatchAsync(IEnumerable<string> documents, string language, TextAnalyticsRequestOptions options, CancellationToken cancellationToken = default) =>
+            await _serviceClient.AnalyzeSentimentBatchAsync(documents, language, (options != null ? new AnalyzeSentimentOptions(options) : null), cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a predictive model to identify the positive, negative or neutral
@@ -1377,15 +847,8 @@ namespace Azure.AI.TextAnalytics
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual Response<AnalyzeSentimentResultCollection> AnalyzeSentimentBatch(IEnumerable<string> documents, string language, TextAnalyticsRequestOptions options, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //var analyzeSentimentOptions = options != null ? new AnalyzeSentimentOptions(options) : new AnalyzeSentimentOptions();
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents, language);
-
-            //return AnalyzeSentimentBatch(documentInputs, analyzeSentimentOptions, cancellationToken);
-            throw new NotImplementedException();
-        }
+        public virtual Response<AnalyzeSentimentResultCollection> AnalyzeSentimentBatch(IEnumerable<string> documents, string language, TextAnalyticsRequestOptions options, CancellationToken cancellationToken = default) =>
+            _serviceClient.AnalyzeSentimentBatch(documents, language, (options != null ? new AnalyzeSentimentOptions() : null), cancellationToken);
 
         /// <summary>
         /// Runs a predictive model to identify the positive, negative or neutral
@@ -1410,16 +873,8 @@ namespace Azure.AI.TextAnalytics
         /// and predictions for each of the sentences each document contains.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<AnalyzeSentimentResultCollection>> AnalyzeSentimentBatchAsync(IEnumerable<string> documents, string language = default, AnalyzeSentimentOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new AnalyzeSentimentOptions();
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents, language);
-
-            //return await AnalyzeSentimentBatchAsync(documentInputs, options, cancellationToken).ConfigureAwait(false);
-            await Task.Yield();
-            throw new NotImplementedException();
-        }
+        public virtual async Task<Response<AnalyzeSentimentResultCollection>> AnalyzeSentimentBatchAsync(IEnumerable<string> documents, string language = default, AnalyzeSentimentOptions options = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.AnalyzeSentimentBatchAsync(documents, language,options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a predictive model to identify the positive, negative or neutral
@@ -1444,15 +899,8 @@ namespace Azure.AI.TextAnalytics
         /// and predictions for each of the sentences each document contains.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<AnalyzeSentimentResultCollection> AnalyzeSentimentBatch(IEnumerable<string> documents, string language = default, AnalyzeSentimentOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new AnalyzeSentimentOptions();
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents, language);
-
-            //return AnalyzeSentimentBatch(documentInputs, options, cancellationToken);
-            throw new NotImplementedException();
-        }
+        public virtual Response<AnalyzeSentimentResultCollection> AnalyzeSentimentBatch(IEnumerable<string> documents, string language = default, AnalyzeSentimentOptions options = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.AnalyzeSentimentBatch(documents, language, options, cancellationToken);
 
         /// <summary>
         /// Runs a predictive model to identify the positive, negative or neutral
@@ -1474,16 +922,8 @@ namespace Azure.AI.TextAnalytics
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual async Task<Response<AnalyzeSentimentResultCollection>> AnalyzeSentimentBatchAsync(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //var analyzeSentimentOptions = options != null ? new AnalyzeSentimentOptions(options) : new AnalyzeSentimentOptions();
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents);
-
-            //return await AnalyzeSentimentBatchAsync(documentInputs, analyzeSentimentOptions, cancellationToken).ConfigureAwait(false);
-            await Task.Yield();
-            throw new NotImplementedException();
-        }
+        public virtual async Task<Response<AnalyzeSentimentResultCollection>> AnalyzeSentimentBatchAsync(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options, CancellationToken cancellationToken = default) =>
+            await _serviceClient.AnalyzeSentimentBatchAsync(documents, (options != null ? new AnalyzeSentimentOptions(options) : null), cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a predictive model to identify the positive, negative or neutral
@@ -1505,15 +945,8 @@ namespace Azure.AI.TextAnalytics
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual Response<AnalyzeSentimentResultCollection> AnalyzeSentimentBatch(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //var analyzeSentimentOptions = options != null ? new AnalyzeSentimentOptions(options) : new AnalyzeSentimentOptions();
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents);
-
-            //return AnalyzeSentimentBatch(documentInputs, analyzeSentimentOptions, cancellationToken);
-            throw new NotImplementedException();
-        }
+        public virtual Response<AnalyzeSentimentResultCollection> AnalyzeSentimentBatch(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options, CancellationToken cancellationToken = default) =>
+            _serviceClient?.AnalyzeSentimentBatch(documents, (options != null ? new AnalyzeSentimentOptions() : null), cancellationToken);
 
         /// <summary>
         /// Runs a predictive model to identify the positive, negative or neutral
@@ -1533,16 +966,8 @@ namespace Azure.AI.TextAnalytics
         /// and predictions for each of the sentences each document contains.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<AnalyzeSentimentResultCollection>> AnalyzeSentimentBatchAsync(IEnumerable<TextDocumentInput> documents, AnalyzeSentimentOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new AnalyzeSentimentOptions();
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents);
-
-            //return await AnalyzeSentimentBatchAsync(documentInputs, options, cancellationToken).ConfigureAwait(false);
-            await Task.Yield();
-            throw new NotImplementedException();
-        }
+        public virtual async Task<Response<AnalyzeSentimentResultCollection>> AnalyzeSentimentBatchAsync(IEnumerable<TextDocumentInput> documents, AnalyzeSentimentOptions options = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.AnalyzeSentimentBatchAsync(documents, options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a predictive model to identify the positive, negative or neutral
@@ -1562,15 +987,9 @@ namespace Azure.AI.TextAnalytics
         /// and predictions for each of the sentences each document contains.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<AnalyzeSentimentResultCollection> AnalyzeSentimentBatch(IEnumerable<TextDocumentInput> documents, AnalyzeSentimentOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new AnalyzeSentimentOptions();
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents);
+        public virtual Response<AnalyzeSentimentResultCollection> AnalyzeSentimentBatch(IEnumerable<TextDocumentInput> documents, AnalyzeSentimentOptions options = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.AnalyzeSentimentBatch(documents, options, cancellationToken);
 
-            //return AnalyzeSentimentBatch(documentInputs, options, cancellationToken);
-            throw new NotImplementedException();
-        }
         #endregion
 
         #region Extract Key Phrases
@@ -1598,37 +1017,8 @@ namespace Azure.AI.TextAnalytics
         /// in the document.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<KeyPhraseCollection>> ExtractKeyPhrasesAsync(string document, string language = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(document, nameof(document));
-
-            //using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(ExtractKeyPhrases)}");
-            //scope.AddAttribute("document", document);
-            //scope.Start();
-
-            //try
-            //{
-            //    var documents = new List<MultiLanguageInput>() { ConvertToMultiLanguageInput(document, language) };
-            //    Response<KeyPhraseResult> result = await _serviceRestClient.KeyPhrasesAsync(new MultiLanguageBatchInput(documents), cancellationToken: cancellationToken).ConfigureAwait(false);
-            //    Response response = result.GetRawResponse();
-
-            //    if (result.Value.Errors.Count > 0)
-            //    {
-            //        // only one document, so we can ignore the id and grab the first error message.
-            //        var error = Transforms.ConvertToError(result.Value.Errors[0].Error);
-            //        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, new ResponseError(error.ErrorCode.ToString(), error.Message), CreateAdditionalInformation(error)).ConfigureAwait(false);
-            //    }
-
-            //    return Response.FromValue(Transforms.ConvertToKeyPhraseCollection(result.Value.Documents[0]), response);
-            //}
-            //catch (Exception e)
-            //{
-            //    scope.Failed(e);
-            //    throw;
-            //}
-            await Task.Yield();
-            throw new NotImplementedException();
-        }
+        public virtual async Task<Response<KeyPhraseCollection>> ExtractKeyPhrasesAsync(string document, string language = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.ExtractKeyPhrasesAsync(document, language, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a model to identify a collection of significant phrases
@@ -1653,36 +1043,8 @@ namespace Azure.AI.TextAnalytics
         /// in the document.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<KeyPhraseCollection> ExtractKeyPhrases(string document, string language = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(document, nameof(document));
-
-            //using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(ExtractKeyPhrases)}");
-            //scope.AddAttribute("document", document);
-            //scope.Start();
-
-            //try
-            //{
-            //    var documents = new List<MultiLanguageInput>() { ConvertToMultiLanguageInput(document, language) };
-            //    Response<KeyPhraseResult> result = _serviceRestClient.KeyPhrases(new MultiLanguageBatchInput(documents), cancellationToken: cancellationToken);
-            //    Response response = result.GetRawResponse();
-
-            //    if (result.Value.Errors.Count > 0)
-            //    {
-            //        // only one document, so we can ignore the id and grab the first error message.
-            //        var error = Transforms.ConvertToError(result.Value.Errors[0].Error);
-            //        throw _clientDiagnostics.CreateRequestFailedException(response, new ResponseError(error.ErrorCode.ToString(), error.Message), CreateAdditionalInformation(error));
-            //    }
-
-            //    return Response.FromValue(Transforms.ConvertToKeyPhraseCollection(result.Value.Documents[0]), response);
-            //}
-            //catch (Exception e)
-            //{
-            //    scope.Failed(e);
-            //    throw;
-            //}
-            throw new NotImplementedException();
-        }
+        public virtual Response<KeyPhraseCollection> ExtractKeyPhrases(string document, string language = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.ExtractKeyPhrases(document, language, cancellationToken);
 
         /// <summary>
         /// Runs a model to identify a collection of significant phrases
@@ -1710,16 +1072,8 @@ namespace Azure.AI.TextAnalytics
         /// in each of the documents.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<ExtractKeyPhrasesResultCollection>> ExtractKeyPhrasesBatchAsync(IEnumerable<string> documents, string language = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new TextAnalyticsRequestOptions();
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents, language);
-
-            //return await ExtractKeyPhrasesBatchAsync(documentInputs, options, cancellationToken).ConfigureAwait(false);
-            await Task.Yield();
-            throw new NotImplementedException();
-        }
+        public virtual async Task<Response<ExtractKeyPhrasesResultCollection>> ExtractKeyPhrasesBatchAsync(IEnumerable<string> documents, string language = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.ExtractKeyPhrasesBatchAsync(documents, language, options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a model to identify a collection of significant phrases
@@ -1747,15 +1101,8 @@ namespace Azure.AI.TextAnalytics
         /// in each of the documents.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<ExtractKeyPhrasesResultCollection> ExtractKeyPhrasesBatch(IEnumerable<string> documents, string language = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new TextAnalyticsRequestOptions();
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents, language);
-
-            //return ExtractKeyPhrasesBatch(documentInputs, options, cancellationToken);
-            throw new NotImplementedException();
-        }
+        public virtual Response<ExtractKeyPhrasesResultCollection> ExtractKeyPhrasesBatch(IEnumerable<string> documents, string language = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.ExtractKeyPhrasesBatch(documents, language, options, cancellationToken);
 
         /// <summary>
         /// Runs a model to identify a collection of significant phrases
@@ -1778,16 +1125,8 @@ namespace Azure.AI.TextAnalytics
         /// in each of the documents.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<ExtractKeyPhrasesResultCollection>> ExtractKeyPhrasesBatchAsync(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new TextAnalyticsRequestOptions();
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents);
-
-            //return await ExtractKeyPhrasesBatchAsync(documentInputs, options, cancellationToken).ConfigureAwait(false);
-            await Task.Yield();
-            throw new NotImplementedException();
-        }
+        public virtual async Task<Response<ExtractKeyPhrasesResultCollection>> ExtractKeyPhrasesBatchAsync(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.ExtractKeyPhrasesBatchAsync(documents, options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a model to identify a collection of significant phrases
@@ -1810,15 +1149,9 @@ namespace Azure.AI.TextAnalytics
         /// in each of the documents.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<ExtractKeyPhrasesResultCollection> ExtractKeyPhrasesBatch(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new TextAnalyticsRequestOptions();
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents);
+        public virtual Response<ExtractKeyPhrasesResultCollection> ExtractKeyPhrasesBatch(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.ExtractKeyPhrasesBatch(documents, options, cancellationToken);
 
-            //return ExtractKeyPhrasesBatch(documentInputs, options, cancellationToken);
-            throw new NotImplementedException();
-        }
         #endregion
 
         #region Linked Entities
@@ -1845,41 +1178,8 @@ namespace Azure.AI.TextAnalytics
         /// that the entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<LinkedEntityCollection>> RecognizeLinkedEntitiesAsync(string document, string language = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(document, nameof(document));
-
-            //using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(RecognizeLinkedEntities)}");
-            //scope.AddAttribute("document", document);
-            //scope.Start();
-
-            //try
-            //{
-            //    var documents = new List<MultiLanguageInput>() { ConvertToMultiLanguageInput(document, language) };
-
-            //    Response<EntityLinkingResult> result = await _serviceRestClient.EntitiesLinkingAsync(
-            //        new MultiLanguageBatchInput(documents),
-            //        stringIndexType: Constants.DefaultStringIndexType,
-            //        cancellationToken: cancellationToken).ConfigureAwait(false);
-            //    Response response = result.GetRawResponse();
-
-            //    if (result.Value.Errors.Count > 0)
-            //    {
-            //        // only one document, so we can ignore the id and grab the first error message.
-            //        var error = Transforms.ConvertToError(result.Value.Errors[0].Error);
-            //        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, new ResponseError(error.ErrorCode.ToString(), error.Message), CreateAdditionalInformation(error)).ConfigureAwait(false);
-            //    }
-
-            //    return Response.FromValue(Transforms.ConvertToLinkedEntityCollection(result.Value.Documents[0]), response);
-            //}
-            //catch (Exception e)
-            //{
-            //    scope.Failed(e);
-            //    throw;
-            //}
-            await Task.Yield();
-            throw new NotImplementedException();
-        }
+        public virtual async Task<Response<LinkedEntityCollection>> RecognizeLinkedEntitiesAsync(string document, string language = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.RecognizeLinkedEntitiesAsync(document, language, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a predictive model to identify a collection of entities
@@ -1903,40 +1203,8 @@ namespace Azure.AI.TextAnalytics
         /// that the entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<LinkedEntityCollection> RecognizeLinkedEntities(string document, string language = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(document, nameof(document));
-
-            //using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(TextAnalyticsClient)}.{nameof(RecognizeLinkedEntities)}");
-            //scope.AddAttribute("document", document);
-            //scope.Start();
-
-            //try
-            //{
-            //    var documents = new List<MultiLanguageInput>() { ConvertToMultiLanguageInput(document, language) };
-
-            //    Response<EntityLinkingResult> result = _serviceRestClient.EntitiesLinking(
-            //        new MultiLanguageBatchInput(documents),
-            //        stringIndexType: Constants.DefaultStringIndexType,
-            //        cancellationToken: cancellationToken);
-            //    Response response = result.GetRawResponse();
-
-            //    if (result.Value.Errors.Count > 0)
-            //    {
-            //        // only one document, so we can ignore the id and grab the first error message.
-            //        var error = Transforms.ConvertToError(result.Value.Errors[0].Error);
-            //        throw _clientDiagnostics.CreateRequestFailedException(response, new ResponseError(error.ErrorCode.ToString(), error.Message), CreateAdditionalInformation(error));
-            //    }
-
-            //    return Response.FromValue(Transforms.ConvertToLinkedEntityCollection(result.Value.Documents[0]), response);
-            //}
-            //catch (Exception e)
-            //{
-            //    scope.Failed(e);
-            //    throw;
-            //}
-            throw new NotImplementedException();
-        }
+        public virtual Response<LinkedEntityCollection> RecognizeLinkedEntities(string document, string language = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.RecognizeLinkedEntities(document, language, cancellationToken);
 
         /// <summary>
         /// Runs a predictive model to identify a collection of entities
@@ -1963,16 +1231,8 @@ namespace Azure.AI.TextAnalytics
         /// that a given entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<RecognizeLinkedEntitiesResultCollection>> RecognizeLinkedEntitiesBatchAsync(IEnumerable<string> documents, string language = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new TextAnalyticsRequestOptions();
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents, language);
-
-            //return await RecognizeLinkedEntitiesBatchAsync(documentInputs, options, cancellationToken).ConfigureAwait(false);
-            await Task.Yield();
-            throw new NotImplementedException();
-        }
+        public virtual async Task<Response<RecognizeLinkedEntitiesResultCollection>> RecognizeLinkedEntitiesBatchAsync(IEnumerable<string> documents, string language = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.RecognizeLinkedEntitiesBatchAsync(documents, language, options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a predictive model to identify a collection of entities
@@ -1999,15 +1259,8 @@ namespace Azure.AI.TextAnalytics
         /// that a given entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<RecognizeLinkedEntitiesResultCollection> RecognizeLinkedEntitiesBatch(IEnumerable<string> documents, string language = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new TextAnalyticsRequestOptions();
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents, language);
-
-            //return RecognizeLinkedEntitiesBatch(documentInputs, options, cancellationToken);
-            throw new NotImplementedException();
-        }
+        public virtual Response<RecognizeLinkedEntitiesResultCollection> RecognizeLinkedEntitiesBatch(IEnumerable<string> documents, string language = default, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.RecognizeLinkedEntitiesBatch(documents, language, options, cancellationToken);
 
         /// <summary>
         /// Runs a predictive model to identify a collection of entities
@@ -2029,16 +1282,8 @@ namespace Azure.AI.TextAnalytics
         /// that a given entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<RecognizeLinkedEntitiesResultCollection>> RecognizeLinkedEntitiesBatchAsync(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new TextAnalyticsRequestOptions();
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents);
-
-            //return await RecognizeLinkedEntitiesBatchAsync(documentInputs, options, cancellationToken).ConfigureAwait(false);
-            await Task.Yield();
-            throw new NotImplementedException();
-        }
+        public virtual async Task<Response<RecognizeLinkedEntitiesResultCollection>> RecognizeLinkedEntitiesBatchAsync(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.RecognizeLinkedEntitiesBatchAsync(documents, options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a predictive model to identify a collection of entities
@@ -2060,15 +1305,9 @@ namespace Azure.AI.TextAnalytics
         /// that a given entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<RecognizeLinkedEntitiesResultCollection> RecognizeLinkedEntitiesBatch(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new TextAnalyticsRequestOptions();
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents);
+        public virtual Response<RecognizeLinkedEntitiesResultCollection> RecognizeLinkedEntitiesBatch(IEnumerable<TextDocumentInput> documents, TextAnalyticsRequestOptions options = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.RecognizeLinkedEntitiesBatch(documents, options, cancellationToken);
 
-            //return RecognizeLinkedEntitiesBatch(documentInputs, options, cancellationToken);
-            throw new NotImplementedException();
-        }
         #endregion
 
         #region Healthcare
@@ -2092,16 +1331,8 @@ namespace Azure.AI.TextAnalytics
         /// controlling the request lifetime.</param>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<AnalyzeHealthcareEntitiesOperation> StartAnalyzeHealthcareEntitiesAsync(IEnumerable<string> documents, string language = default, AnalyzeHealthcareEntitiesOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new AnalyzeHealthcareEntitiesOptions();
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents, language);
-
-            //return await StartAnalyzeHealthcareEntitiesAsync(documentInputs, options, cancellationToken).ConfigureAwait(false);
-            await Task.Yield();
-            throw new NotImplementedException();
-        }
+        public virtual async Task<AnalyzeHealthcareEntitiesOperation> StartAnalyzeHealthcareEntitiesAsync(IEnumerable<string> documents, string language = default, AnalyzeHealthcareEntitiesOptions options = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.StartAnalyzeHealthcareEntitiesAsync(documents, language, options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Runs a predictive model to identify a collection of healthcare entities
@@ -2129,15 +1360,8 @@ namespace Azure.AI.TextAnalytics
         /// that a given entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual AnalyzeHealthcareEntitiesOperation StartAnalyzeHealthcareEntities(IEnumerable<string> documents, string language = default, AnalyzeHealthcareEntitiesOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //options ??= new AnalyzeHealthcareEntitiesOptions();
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents, language);
-
-            //return StartAnalyzeHealthcareEntities(documentInputs, options, cancellationToken);
-            throw new NotImplementedException();
-        }
+        public virtual AnalyzeHealthcareEntitiesOperation StartAnalyzeHealthcareEntities(IEnumerable<string> documents, string language = default, AnalyzeHealthcareEntitiesOptions options = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.StartAnalyzeHealthcareEntities(documents, language, options, cancellationToken);
 
         /// <summary>
         /// Runs a predictive model to identify a collection of healthcare entities
@@ -2156,17 +1380,8 @@ namespace Azure.AI.TextAnalytics
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="AnalyzeHealthcareEntitiesOperation"/> to wait on this long-running operation.  Its <see cref="AnalyzeHealthcareEntitiesOperation.Value"/> upon successful
         /// completion will contain layout elements extracted from the form.</returns>
-        public virtual AnalyzeHealthcareEntitiesOperation StartAnalyzeHealthcareEntities(IEnumerable<TextDocumentInput> documents, AnalyzeHealthcareEntitiesOptions options, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNull(documents, nameof(documents));
-
-            //options ??= new AnalyzeHealthcareEntitiesOptions();
-
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents);
-
-            //return StartAnalyzeHealthcareEntities(documentInputs, options, cancellationToken);
-            throw new NotImplementedException();
-        }
+        public virtual AnalyzeHealthcareEntitiesOperation StartAnalyzeHealthcareEntities(IEnumerable<TextDocumentInput> documents, AnalyzeHealthcareEntitiesOptions options, CancellationToken cancellationToken = default) =>
+            _serviceClient.StartAnalyzeHealthcareEntities(documents, options, cancellationToken);
 
         /// <summary>
         /// Runs a predictive model to identify a collection of healthcare entities
@@ -2185,18 +1400,9 @@ namespace Azure.AI.TextAnalytics
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="AnalyzeHealthcareEntitiesOperation"/> to wait on this long-running operation.  Its <see cref="AnalyzeHealthcareEntitiesOperation.Value"/> upon successful
         /// completion will contain layout elements extracted from the form.</returns>
-        public virtual async Task<AnalyzeHealthcareEntitiesOperation> StartAnalyzeHealthcareEntitiesAsync(IEnumerable<TextDocumentInput> documents, AnalyzeHealthcareEntitiesOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNull(documents, nameof(documents));
+        public virtual async Task<AnalyzeHealthcareEntitiesOperation> StartAnalyzeHealthcareEntitiesAsync(IEnumerable<TextDocumentInput> documents, AnalyzeHealthcareEntitiesOptions options = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.StartAnalyzeHealthcareEntitiesAsync(documents, options, cancellationToken).ConfigureAwait(false);
 
-            //options ??= new AnalyzeHealthcareEntitiesOptions();
-
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents);
-
-            //return await StartAnalyzeHealthcareEntitiesAsync(documentInputs, options, cancellationToken).ConfigureAwait(false);
-            await Task.Yield();
-            throw new NotImplementedException();
-        }
         #endregion
 
         #region Analyze Operation
@@ -2226,16 +1432,8 @@ namespace Azure.AI.TextAnalytics
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<AnalyzeActionsOperation> StartAnalyzeActionsAsync(IEnumerable<string> documents, TextAnalyticsActions actions, string language = default, AnalyzeActionsOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //Argument.AssertNotNull(actions, nameof(actions));
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents, language);
-
-            //return await StartAnalyzeActionsAsync(documentInputs, actions, options, cancellationToken).ConfigureAwait(false);
-            await Task.Yield();
-            throw new NotImplementedException();
-        }
+        public virtual async Task<AnalyzeActionsOperation> StartAnalyzeActionsAsync(IEnumerable<string> documents, TextAnalyticsActions actions, string language = default, AnalyzeActionsOptions options = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.StartAnalyzeActionsAsync(documents, actions, language, options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// StartAnalyzeActionsAsync enables the application to execute multiple actions in a set of documents. It includes:
@@ -2262,15 +1460,8 @@ namespace Azure.AI.TextAnalytics
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual AnalyzeActionsOperation StartAnalyzeActions(IEnumerable<string> documents, TextAnalyticsActions actions, string language = default, AnalyzeActionsOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //Argument.AssertNotNull(actions, nameof(actions));
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents, language);
-
-            //return StartAnalyzeActions(documentInputs, actions, options, cancellationToken);
-            throw new NotImplementedException();
-        }
+        public virtual AnalyzeActionsOperation StartAnalyzeActions(IEnumerable<string> documents, TextAnalyticsActions actions, string language = default, AnalyzeActionsOptions options = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.StartAnalyzeActions(documents, actions, language, options, cancellationToken);
 
         /// <summary>
         /// StartAnalyzeActionsAsync enables the application to execute multiple actions in a set of documents. It includes:
@@ -2296,15 +1487,8 @@ namespace Azure.AI.TextAnalytics
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual AnalyzeActionsOperation StartAnalyzeActions(IEnumerable<TextDocumentInput> documents, TextAnalyticsActions actions, AnalyzeActionsOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //Argument.AssertNotNull(actions, nameof(actions));
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents);
-
-            //return StartAnalyzeActions(documentInputs, actions, options, cancellationToken);
-            throw new NotImplementedException();
-        }
+        public virtual AnalyzeActionsOperation StartAnalyzeActions(IEnumerable<TextDocumentInput> documents, TextAnalyticsActions actions, AnalyzeActionsOptions options = default, CancellationToken cancellationToken = default) =>
+            _serviceClient.StartAnalyzeActions(documents, actions, options, cancellationToken);
 
         /// <summary>
         /// StartAnalyzeActionsAsync enables the application to execute multiple actions in a set of documents. It includes:
@@ -2330,116 +1514,8 @@ namespace Azure.AI.TextAnalytics
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<AnalyzeActionsOperation> StartAnalyzeActionsAsync(IEnumerable<TextDocumentInput> documents, TextAnalyticsActions actions, AnalyzeActionsOptions options = default, CancellationToken cancellationToken = default)
-        {
-            //Argument.AssertNotNullOrEmpty(documents, nameof(documents));
-            //Argument.AssertNotNull(actions, nameof(actions));
-            //MultiLanguageBatchInput documentInputs = ConvertToMultiLanguageInputs(documents);
-
-            //return await StartAnalyzeActionsAsync(documentInputs, actions, options, cancellationToken).ConfigureAwait(false);
-            await Task.Yield();
-            throw new NotImplementedException();
-        }
-
-        private static JobManifestTasks CreateTasks(TextAnalyticsActions actions)
-        {
-            //JobManifestTasks tasks = new();
-
-            //if (actions.RecognizePiiEntitiesActions != null)
-            //{
-            //    tasks.EntityRecognitionPiiTasks = Transforms.ConvertFromRecognizePiiEntitiesActionsToTasks(actions.RecognizePiiEntitiesActions);
-            //}
-            //if (actions.RecognizeEntitiesActions != null)
-            //{
-            //    tasks.EntityRecognitionTasks = Transforms.ConvertFromRecognizeEntitiesActionsToTasks(actions.RecognizeEntitiesActions);
-            //}
-            //if (actions.RecognizeCustomEntitiesActions != null)
-            //{
-            //    tasks.CustomEntityRecognitionTasks = Transforms.ConvertFromRecognizeCustomEntitiesActionsToTasks(actions.RecognizeCustomEntitiesActions);
-            //}
-            //if (actions.ExtractKeyPhrasesActions != null)
-            //{
-            //    tasks.KeyPhraseExtractionTasks = Transforms.ConvertFromExtractKeyPhrasesActionsToTasks(actions.ExtractKeyPhrasesActions);
-            //}
-            //if (actions.RecognizeLinkedEntitiesActions != null)
-            //{
-            //    tasks.EntityLinkingTasks = Transforms.ConvertFromRecognizeLinkedEntitiesActionsToTasks(actions.RecognizeLinkedEntitiesActions);
-            //}
-            //if (actions.AnalyzeSentimentActions != null)
-            //{
-            //    tasks.SentimentAnalysisTasks = Transforms.ConvertFromAnalyzeSentimentActionsToTasks(actions.AnalyzeSentimentActions);
-            //}
-            //if (actions.ExtractSummaryActions != null)
-            //{
-            //    tasks.ExtractiveSummarizationTasks = Transforms.ConvertFromExtractSummaryActionsToTasks(actions.ExtractSummaryActions);
-            //}
-            //if (actions.SingleCategoryClassifyActions != null)
-            //{
-            //    tasks.CustomSingleClassificationTasks = Transforms.ConvertFromSingleCategoryClassifyActionsToTasks(actions.SingleCategoryClassifyActions);
-            //}
-            //if (actions.MultiCategoryClassifyActions != null)
-            //{
-            //    tasks.CustomMultiClassificationTasks = Transforms.ConvertFromMultiCategoryClassifyActionsToTasks(actions.MultiCategoryClassifyActions);
-            //}
-            //return tasks;
-
-            throw new NotImplementedException();
-        }
-
-        #endregion
-
-        #region Common
-
-        private static IDictionary<string, int> CreateIdToIndexMap<T>(IEnumerable<T> documents)
-        {
-            var map = new Dictionary<string, int>(documents.Count());
-
-            int i = 0;
-            foreach (T item in documents)
-            {
-                string id = item switch
-                {
-                    LanguageInput li => li.Id,
-                    MultiLanguageInput mli => mli.Id,
-                    _ => throw new NotSupportedException(),
-                };
-
-                map[id] = i++;
-            }
-
-            return map;
-        }
-
-        private MultiLanguageInput ConvertToMultiLanguageInput(string document, string language, int id = 0)
-            => new MultiLanguageInput($"{id}", document) { Language = language ?? _options.DefaultLanguage };
-
-        private MultiLanguageAnalysisInput ConvertToMultiLanguageInputs(IEnumerable<string> documents, string language)
-        {
-            MultiLanguageAnalysisInput input = new MultiLanguageAnalysisInput();
-            foreach (var document in documents)
-            {
-                input.Documents.Add(ConvertToMultiLanguageInput(document, language));
-            }
-            return input;
-        }
-
-        private MultiLanguageAnalysisInput ConvertToMultiLanguageInputs(IEnumerable<TextDocumentInput> documents)
-        {
-            MultiLanguageAnalysisInput input = new MultiLanguageAnalysisInput();
-            foreach (var document in documents)
-            {
-                input.Documents.Add(new MultiLanguageInput(document.Id, document.Text) { Language = document.Language ?? _options.DefaultLanguage });
-            }
-            return input;
-        }
-
-        private LanguageInput ConvertToLanguageInput(string document, string countryHint, int id = 0)
-            => new LanguageInput($"{id}", document) { CountryHint = countryHint ?? _options.DefaultCountryHint };
-
-        private static IDictionary<string, string> CreateAdditionalInformation(TextAnalyticsError error) =>
-            (string.IsNullOrEmpty(error.Target))
-                ? null
-                : new Dictionary<string, string> { { "Target", error.Target } };
+        public virtual async Task<AnalyzeActionsOperation> StartAnalyzeActionsAsync(IEnumerable<TextDocumentInput> documents, TextAnalyticsActions actions, AnalyzeActionsOptions options = default, CancellationToken cancellationToken = default) =>
+            await _serviceClient.StartAnalyzeActionsAsync(documents, actions, options, cancellationToken).ConfigureAwait(false);
 
         #endregion
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -74,17 +74,14 @@ namespace Azure.AI.TextAnalytics
                     new LegacyServiceClient(
                         endpoint,
                         credential,
-                        options.DefaultLanguage,
-                        options.DefaultCountryHint,
                         authorizationScope,
-                        TextAnalyticsClientOptions.GetVersionString(options.Version), options),
+                        TextAnalyticsClientOptions.GetVersionString(options.Version),
+                        options),
 
                 _ =>
                     new LanguageServiceClient(
                         endpoint,
                         credential,
-                        options.DefaultLanguage,
-                        options.DefaultCountryHint,
                         authorizationScope,
                         TextAnalyticsClientOptions.GetVersionString(options.Version),
                         options)
@@ -122,26 +119,18 @@ namespace Azure.AI.TextAnalytics
             Argument.AssertNotNull(credential, nameof(credential));
             Argument.AssertNotNull(options, nameof(options));
 
-            var authorizationScope = $"{(string.IsNullOrEmpty(options.Audience?.ToString()) ? TextAnalyticsAudience.AzurePublicCloud : options.Audience)}/.default";
-
             _serviceClient = options.Version switch
             {
                 var version when s_legacyServiceVersions.Contains(version) =>
                     new LegacyServiceClient(
                         endpoint,
                         credential,
-                        options.DefaultLanguage,
-                        options.DefaultCountryHint,
-                        authorizationScope,
                         TextAnalyticsClientOptions.GetVersionString(options.Version), options),
 
                 _ =>
                     new LanguageServiceClient(
                         endpoint,
                         credential,
-                        options.DefaultLanguage,
-                        options.DefaultCountryHint,
-                        authorizationScope,
                         TextAnalyticsClientOptions.GetVersionString(options.Version),
                         options)
             };

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientTests.cs
@@ -5,6 +5,7 @@ using System;
 using Azure.Core;
 using Azure.Core.TestFramework;
 using Azure.Identity;
+using Moq;
 using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Tests
@@ -34,6 +35,30 @@ namespace Azure.AI.TextAnalytics.Tests
             Assert.Throws<ArgumentNullException>(() => new TextAnalyticsClient(uri, (AzureKeyCredential)null));
             Assert.Throws<ArgumentNullException>(() => new TextAnalyticsClient(uri, (TokenCredential)null));
             Assert.Throws<ArgumentNullException>(() => new TextAnalyticsClient(null, new DefaultAzureCredential()));
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void CreateClientAllowsMissingDefaultLanguage(string defaultLanguage)
+        {
+            var uri = new Uri("http://localhost");
+            var options = new TextAnalyticsClientOptions { DefaultLanguage = defaultLanguage };
+
+            Assert.DoesNotThrow(() => new TextAnalyticsClient(uri, new AzureKeyCredential("apiKey"), options));
+            Assert.DoesNotThrow(() => new TextAnalyticsClient(uri, Mock.Of<TokenCredential>(), options));
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void CreateClientAllowsMissingDefaultCountryHint(string defaultCountryHint)
+        {
+            var uri = new Uri("http://localhost");
+            var options = new TextAnalyticsClientOptions { DefaultCountryHint = defaultCountryHint };
+
+            Assert.DoesNotThrow(() => new TextAnalyticsClient(uri, new AzureKeyCredential("apiKey"), options));
+            Assert.DoesNotThrow(() => new TextAnalyticsClient(uri, Mock.Of<TokenCredential>(), options));
         }
 
         [Test]


### PR DESCRIPTION
# Summary

The focus of these changes is to shift functionality for the Language REST API integration into the `LanguageServiceClient` and update the `TextAnalyticsClient` to delegate all operations to the service client.

## Next steps (BEFORE MERGE)

- Integrate the recent work for the language service integration via rebase.
- Coordinate with language service integration efforts to move work into the LanguageServiceClient