### PR TITLE
Smoke Tests:  Fix dangling parenthesis

### DIFF
--- a/common/SmokeTests/SmokeTest/Program.cs
+++ b/common/SmokeTests/SmokeTest/Program.cs
@@ -131,7 +131,7 @@ void LogInformation(string message, ConsoleColor? color = default)
 {
     if (IsDevOpsHost)
     {
-        Console.WriteLine($"[debug]{ message })");
+        Console.WriteLine($"[debug]{ message }");
     }
     else
     {


### PR DESCRIPTION
The focus of these changes is to fix a dangling parenthesis emitted as part of information log messages when running in CI.    This is specific to the CI formatting and does not occur for local runs.