### PR TITLE
Keep the SuppressClientNestedActivities flag private for now

### DIFF
--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -399,7 +399,6 @@ namespace Azure.Core
         public int LoggedContentSizeLimit { get { throw null; } set { } }
         public System.Collections.Generic.IList<string> LoggedHeaderNames { get { throw null; } }
         public System.Collections.Generic.IList<string> LoggedQueryParameters { get { throw null; } }
-        public bool SuppressNestedClientSpans { get { throw null; } set { } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct HttpHeader : System.IEquatable<Azure.Core.HttpHeader>

--- a/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
@@ -399,7 +399,6 @@ namespace Azure.Core
         public int LoggedContentSizeLimit { get { throw null; } set { } }
         public System.Collections.Generic.IList<string> LoggedHeaderNames { get { throw null; } }
         public System.Collections.Generic.IList<string> LoggedQueryParameters { get { throw null; } }
-        public bool SuppressNestedClientSpans { get { throw null; } set { } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct HttpHeader : System.IEquatable<Azure.Core.HttpHeader>

--- a/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
@@ -399,7 +399,6 @@ namespace Azure.Core
         public int LoggedContentSizeLimit { get { throw null; } set { } }
         public System.Collections.Generic.IList<string> LoggedHeaderNames { get { throw null; } }
         public System.Collections.Generic.IList<string> LoggedQueryParameters { get { throw null; } }
-        public bool SuppressNestedClientSpans { get { throw null; } set { } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct HttpHeader : System.IEquatable<Azure.Core.HttpHeader>

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -399,7 +399,6 @@ namespace Azure.Core
         public int LoggedContentSizeLimit { get { throw null; } set { } }
         public System.Collections.Generic.IList<string> LoggedHeaderNames { get { throw null; } }
         public System.Collections.Generic.IList<string> LoggedQueryParameters { get { throw null; } }
-        public bool SuppressNestedClientSpans { get { throw null; } set { } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct HttpHeader : System.IEquatable<Azure.Core.HttpHeader>

--- a/sdk/core/Azure.Core/src/DiagnosticsOptions.cs
+++ b/sdk/core/Azure.Core/src/DiagnosticsOptions.cs
@@ -81,7 +81,7 @@ namespace Azure.Core
         public bool IsLoggingEnabled { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets value indicating whether distributed tracing spans are going to be created for the clients methods calls and HTTP calls.
+        /// Gets or sets value indicating whether distributed tracing activities (<see cref="System.Diagnostics.Activity"/>) are going to be created for the clients methods calls and HTTP calls.
         /// </summary>
         public bool IsDistributedTracingEnabled { get; set; } = true;
 

--- a/sdk/core/Azure.Core/src/DiagnosticsOptions.cs
+++ b/sdk/core/Azure.Core/src/DiagnosticsOptions.cs
@@ -38,7 +38,6 @@ namespace Azure.Core
                 LoggedContentSizeLimit = diagnosticsOptions.LoggedContentSizeLimit;
                 IsDistributedTracingEnabled = diagnosticsOptions.IsDistributedTracingEnabled;
                 IsLoggingContentEnabled = diagnosticsOptions.IsLoggingContentEnabled;
-                SuppressNestedClientSpans  = diagnosticsOptions.SuppressNestedClientSpans;
             }
             else
             {
@@ -85,11 +84,6 @@ namespace Azure.Core
         /// Gets or sets value indicating whether distributed tracing spans are going to be created for the clients methods calls and HTTP calls.
         /// </summary>
         public bool IsDistributedTracingEnabled { get; set; } = true;
-
-        /// <summary>
-        /// Gets or sets value indicating whether distributed tracing spans are going to be created when this client's methods are called by other instrumented client methods.
-        /// </summary>
-        public bool SuppressNestedClientSpans  { get; set; }
 
         /// <summary>
         /// Gets or sets value indicating whether the "User-Agent" header containing <see cref="ApplicationId"/>, client library package name and version, <see cref="RuntimeInformation.FrameworkDescription"/>

--- a/sdk/core/Azure.Core/src/Shared/ClientDiagnostics.cs
+++ b/sdk/core/Azure.Core/src/Shared/ClientDiagnostics.cs
@@ -31,7 +31,7 @@ namespace Azure.Core.Pipeline
         }
 
         public ClientDiagnostics(string optionsNamespace, string? providerNamespace, DiagnosticsOptions diagnosticsOptions, bool? suppressNestedClientActivities = null)
-            : base(optionsNamespace, providerNamespace, diagnosticsOptions.IsDistributedTracingEnabled, suppressNestedClientActivities)
+            : base(optionsNamespace, providerNamespace, diagnosticsOptions.IsDistributedTracingEnabled, suppressNestedClientActivities.GetValueOrDefault(false))
         {
             // TODO: use DiagnosticsOptions.SuppressNestedClientSpans  here after new Azure.Core ships:
             // ClientDiagnostics class is shared as a source code and used in client libraries.

--- a/sdk/core/Azure.Core/src/Shared/ClientDiagnostics.cs
+++ b/sdk/core/Azure.Core/src/Shared/ClientDiagnostics.cs
@@ -22,15 +22,16 @@ namespace Azure.Core.Pipeline
 
         private readonly HttpMessageSanitizer _sanitizer;
 
-        public ClientDiagnostics(ClientOptions options)
+        public ClientDiagnostics(ClientOptions options, bool? suppressNestedClientActivities = null)
                     : this(options.GetType().Namespace!,
                     GetResourceProviderNamespace(options.GetType().Assembly),
-                    options.Diagnostics)
+                    options.Diagnostics,
+                    suppressNestedClientActivities)
         {
         }
 
-        public ClientDiagnostics(string optionsNamespace, string? providerNamespace, DiagnosticsOptions diagnosticsOptions)
-            : base(optionsNamespace, providerNamespace, diagnosticsOptions.IsDistributedTracingEnabled, false)
+        public ClientDiagnostics(string optionsNamespace, string? providerNamespace, DiagnosticsOptions diagnosticsOptions, bool? suppressNestedClientActivities = null)
+            : base(optionsNamespace, providerNamespace, diagnosticsOptions.IsDistributedTracingEnabled, suppressNestedClientActivities)
         {
             // TODO: use DiagnosticsOptions.SuppressNestedClientSpans  here after new Azure.Core ships:
             // ClientDiagnostics class is shared as a source code and used in client libraries.

--- a/sdk/core/Azure.Core/src/Shared/ClientDiagnostics.cs
+++ b/sdk/core/Azure.Core/src/Shared/ClientDiagnostics.cs
@@ -28,7 +28,7 @@ namespace Azure.Core.Pipeline
         /// <param name="options">The customer provided client options object.</param>
         /// <param name="suppressNestedClientActivities">Flag controlling if <see cref="System.Diagnostics.Activity"/>
         ///  created by this <see cref="ClientDiagnostics"/> for client method calls should be suppressed when called
-        ///  by other Azure SDK client methods.  It's recommended to set it to true for new clients; use default (null) for
+        ///  by other Azure SDK client methods.  It's recommended to set it to true for new clients; use default (null)
         ///  for backward compatibility reasons, or set it to false to explicitly disable suppression for specific cases.
         ///  The default value could change in the future, the flag should be only set to false if suppression for the client
         ///  should never be enabled.</param>

--- a/sdk/core/Azure.Core/src/Shared/ClientDiagnostics.cs
+++ b/sdk/core/Azure.Core/src/Shared/ClientDiagnostics.cs
@@ -33,8 +33,6 @@ namespace Azure.Core.Pipeline
         public ClientDiagnostics(string optionsNamespace, string? providerNamespace, DiagnosticsOptions diagnosticsOptions, bool? suppressNestedClientActivities = null)
             : base(optionsNamespace, providerNamespace, diagnosticsOptions.IsDistributedTracingEnabled, suppressNestedClientActivities.GetValueOrDefault(false))
         {
-            // TODO: use DiagnosticsOptions.SuppressNestedClientSpans  here after new Azure.Core ships:
-            // ClientDiagnostics class is shared as a source code and used in client libraries.
             _sanitizer = CreateMessageSanitizer(diagnosticsOptions);
         }
 

--- a/sdk/core/Azure.Core/src/Shared/ClientDiagnostics.cs
+++ b/sdk/core/Azure.Core/src/Shared/ClientDiagnostics.cs
@@ -22,6 +22,16 @@ namespace Azure.Core.Pipeline
 
         private readonly HttpMessageSanitizer _sanitizer;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClientDiagnostics"/> class.
+        /// </summary>
+        /// <param name="options">The customer provided client options object.</param>
+        /// <param name="suppressNestedClientActivities">Flag controlling if <see cref="System.Diagnostics.Activity"/>
+        ///  created by this <see cref="ClientDiagnostics"/> for client method calls should be suppressed when called
+        ///  by other Azure SDK client methods.  It's recommended to set it to true for new clients; use default (null) for
+        ///  for backward compatibility reasons, or set it to false to explicitly disable suppression for specific cases.
+        ///  The default value could change in the future, the flag should be only set to false if suppression for the client
+        ///  should never be enabled.</param>
         public ClientDiagnostics(ClientOptions options, bool? suppressNestedClientActivities = null)
                     : this(options.GetType().Namespace!,
                     GetResourceProviderNamespace(options.GetType().Assembly),
@@ -30,6 +40,18 @@ namespace Azure.Core.Pipeline
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClientDiagnostics"/> class.
+        /// </summary>
+        /// <param name="optionsNamespace">Namespace of the client class, such as Azure.Storage or Azure.AppConfiguration.</param>
+        /// <param name="providerNamespace">Azure Resource Provider namespace of the Azure service SDK is primarily used for.</param>
+        /// <param name="diagnosticsOptions">The customer provided client diagnostics options.</param>
+        /// <param name="suppressNestedClientActivities">Flag controlling if <see cref="System.Diagnostics.Activity"/>
+        ///  created by this <see cref="ClientDiagnostics"/> for client method calls should be suppressed when called
+        ///  by other Azure SDK client methods.  It's recommended to set it to true for new clients, use default (null) for old clients
+        ///  for backward compatibility reasons, or set it to false to explicitly disable suppression for specific cases.
+        ///  The default value could change in the future, the flag should be only set to false if suppression for the client
+        ///  should never be enabled.</param>
         public ClientDiagnostics(string optionsNamespace, string? providerNamespace, DiagnosticsOptions diagnosticsOptions, bool? suppressNestedClientActivities = null)
             : base(optionsNamespace, providerNamespace, diagnosticsOptions.IsDistributedTracingEnabled, suppressNestedClientActivities.GetValueOrDefault(false))
         {

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -22,22 +22,22 @@ namespace Azure.Core.Pipeline
         private static readonly ConcurrentDictionary<string, object?> ActivitySources = new();
 
         private readonly ActivityAdapter? _activityAdapter;
-        private readonly bool _suppressNestedClientScopes;
+        private readonly bool _suppressNestedClientActivities;
 
-        internal DiagnosticScope(string ns, string scopeName, DiagnosticListener source, ActivityKind kind, bool suppressNestedClientScopes = true) :
-            this(scopeName, source, null, GetActivitySource(ns, scopeName), kind, suppressNestedClientScopes)
+        internal DiagnosticScope(string ns, string scopeName, DiagnosticListener source, ActivityKind kind, bool suppressNestedClientActivities) :
+            this(scopeName, source, null, GetActivitySource(ns, scopeName), kind, suppressNestedClientActivities)
         {
         }
 
-        internal DiagnosticScope(string scopeName, DiagnosticListener source, object? diagnosticSourceArgs, object? activitySource, ActivityKind kind, bool suppressNestedClientScopes = true)
+        internal DiagnosticScope(string scopeName, DiagnosticListener source, object? diagnosticSourceArgs, object? activitySource, ActivityKind kind, bool suppressNestedClientActivities)
         {
             // ActivityKind.Internal and Client both can represent public API calls depending on the SDK
-            _suppressNestedClientScopes = (kind == ActivityKind.Client || kind == ActivityKind.Internal) ? suppressNestedClientScopes : false;
+            _suppressNestedClientActivities = (kind == ActivityKind.Client || kind == ActivityKind.Internal) ? suppressNestedClientActivities : false;
 
             // outer scope presence is enough to suppress any inner scope, regardless of inner scope configuation.
             IsEnabled = source.IsEnabled() || ActivityExtensions.ActivitySourceHasListeners(activitySource);
 
-            if (_suppressNestedClientScopes)
+            if (_suppressNestedClientActivities)
             {
                 IsEnabled &= !AzureSdkScopeValue.Equals(Activity.Current?.GetCustomProperty(AzureSdkScopeLabel));
             }

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScopeFactory.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScopeFactory.cs
@@ -23,7 +23,7 @@ namespace Azure.Core.Pipeline
             _resourceProviderNamespace = resourceProviderNamespace;
             IsActivityEnabled = isActivityEnabled;
             _suppressNestedClientActivities = suppressNestedClientActivities;
-            ;
+
             if (IsActivityEnabled)
             {
                 var listeners = LazyInitializer.EnsureInitialized(ref _listeners);

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScopeFactory.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScopeFactory.cs
@@ -18,11 +18,12 @@ namespace Azure.Core.Pipeline
         private readonly DiagnosticListener? _source;
         private readonly bool _suppressNestedClientActivities;
 
-        public DiagnosticScopeFactory(string clientNamespace, string? resourceProviderNamespace, bool isActivityEnabled, bool? suppressNestedClientActivities = null)
+        public DiagnosticScopeFactory(string clientNamespace, string? resourceProviderNamespace, bool isActivityEnabled, bool suppressNestedClientActivities)
         {
             _resourceProviderNamespace = resourceProviderNamespace;
             IsActivityEnabled = isActivityEnabled;
-            _suppressNestedClientActivities = suppressNestedClientActivities.GetValueOrDefault(false);
+            _suppressNestedClientActivities = suppressNestedClientActivities;
+            ;
             if (IsActivityEnabled)
             {
                 var listeners = LazyInitializer.EnsureInitialized(ref _listeners);

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScopeFactory.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScopeFactory.cs
@@ -16,13 +16,13 @@ namespace Azure.Core.Pipeline
         private static Dictionary<string, DiagnosticListener>? _listeners;
         private readonly string? _resourceProviderNamespace;
         private readonly DiagnosticListener? _source;
-        private readonly bool _suppressNestedClientScopes;
+        private readonly bool _suppressNestedClientActivities;
 
-        public DiagnosticScopeFactory(string clientNamespace, string? resourceProviderNamespace, bool isActivityEnabled, bool suppressNestedClientScopes = true)
+        public DiagnosticScopeFactory(string clientNamespace, string? resourceProviderNamespace, bool isActivityEnabled, bool? suppressNestedClientActivities = null)
         {
             _resourceProviderNamespace = resourceProviderNamespace;
             IsActivityEnabled = isActivityEnabled;
-            _suppressNestedClientScopes = suppressNestedClientScopes;
+            _suppressNestedClientActivities = suppressNestedClientActivities.GetValueOrDefault(false);
             if (IsActivityEnabled)
             {
                 var listeners = LazyInitializer.EnsureInitialized(ref _listeners);
@@ -46,7 +46,7 @@ namespace Azure.Core.Pipeline
             {
                 return default;
             }
-            var scope = new DiagnosticScope(_source.Name, name, _source, kind, _suppressNestedClientScopes);
+            var scope = new DiagnosticScope(_source.Name, name, _source, kind, _suppressNestedClientActivities);
 
             if (_resourceProviderNamespace != null)
             {

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
@@ -104,9 +104,6 @@ namespace Azure.Core.Tests
         [NonParallelizable]
         public void NestedClientActivitiesConfigurationClientOptions(bool? suppressNestedScopes)
         {
-            // TODO: ClientDiagnostics need new Azure.Core to ship before using
-            // DiagnosticsOptions.AreNestedClientSpansEnabled flag so we can't check it yet.
-
             using var testListener = new TestDiagnosticListener("Azure.Clients");
             DiagnosticsOptions testOptions = new DiagnosticsOptions();
 

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
@@ -33,7 +33,7 @@ namespace Azure.Core.Tests
         {
             using var activityListener = new TestActivitySourceListener("Azure.Clients.ClientName");
 
-            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true);
+            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true, false);
 
             DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName");
 
@@ -59,7 +59,7 @@ namespace Azure.Core.Tests
             {
                 using var activityListener = new TestActivitySourceListener("Azure.Clients.ClientName");
 
-                DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true);
+                DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true, false);
 
                 DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName");
                 scope.AddAttribute("Attribute1", "Value1");
@@ -162,24 +162,6 @@ namespace Azure.Core.Tests
             Assert.AreEqual("ClientName.ActivityName", Activity.Current.OperationName);
         }
 
-        [Test]
-        [NonParallelizable]
-        public void NestedClientActivitiesNotSuppressedDefaultDiagnosticScopeFactory()
-        {
-            using var testListener = new TestDiagnosticListener("Azure.Clients");
-            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true);
-
-            using DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName");
-            scope.Start();
-
-            DiagnosticScope nestedScope = clientDiagnostics.CreateScope("ClientName.NestedActivityName");
-            nestedScope.Start();
-            Assert.IsTrue(nestedScope.IsEnabled);
-            Assert.AreEqual("ClientName.NestedActivityName", Activity.Current.OperationName);
-            nestedScope.Dispose();
-            Assert.AreEqual("ClientName.ActivityName", Activity.Current.OperationName);
-        }
-
         [TestCase(DiagnosticScope.ActivityKind.Internal, true)]
         [TestCase(DiagnosticScope.ActivityKind.Server, false)]
         [TestCase(DiagnosticScope.ActivityKind.Client, true)]
@@ -208,26 +190,6 @@ namespace Azure.Core.Tests
                 Assert.IsTrue(nestedScope.IsEnabled);
                 Assert.AreEqual("ClientName.NestedActivityName", Activity.Current.OperationName);
             }
-            nestedScope.Dispose();
-            Assert.AreEqual("ClientName.ActivityName", Activity.Current.OperationName);
-        }
-
-        [Test]
-        [NonParallelizable]
-        public void NestedClientActivitiesNoSuppressionByDefault()
-        {
-            using var _ = SetAppConfigSwitch();
-            using var activityListener = new TestActivitySourceListener("Azure.Clients.ClientName");
-
-            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true);
-
-            using DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName", DiagnosticScope.ActivityKind.Client);
-            scope.Start();
-
-            DiagnosticScope nestedScope = clientDiagnostics.CreateScope("ClientName.NestedActivityName", DiagnosticScope.ActivityKind.Internal);
-            nestedScope.Start();
-            Assert.IsTrue(nestedScope.IsEnabled);
-            Assert.AreEqual("ClientName.NestedActivityName", Activity.Current.OperationName);
             nestedScope.Dispose();
             Assert.AreEqual("ClientName.ActivityName", Activity.Current.OperationName);
         }
@@ -297,7 +259,7 @@ namespace Azure.Core.Tests
             using var testListener = new TestDiagnosticListener("Azure.Clients");
             using var activityListener = new TestActivitySourceListener("Azure.Clients.ClientName");
 
-            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true);
+            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true, false);
 
             DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName");
             scope.Start();
@@ -340,7 +302,7 @@ namespace Azure.Core.Tests
 
             using var activityListener = new TestActivitySourceListener("Azure.Clients.ClientName");
 
-            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true);
+            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true, false);
 
             DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName");
             scope.Start();
@@ -360,7 +322,7 @@ namespace Azure.Core.Tests
 
             using var activityListener = new TestActivitySourceListener("Azure.Clients.ClientName");
 
-            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true);
+            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true, false);
 
             DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName");
 

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.cs
@@ -21,7 +21,7 @@ namespace Azure.Core.Tests
         public void CreatesActivityWithNameAndTags()
         {
             using var testListener = new TestDiagnosticListener("Azure.Clients");
-            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true);
+            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true, false);
 
             DiagnosticScope scope = clientDiagnostics.CreateScope("ActivityName");
 
@@ -57,7 +57,7 @@ namespace Azure.Core.Tests
             using var testListener = new TestDiagnosticListener("Azure.Clients");
             testListener.EventCallback = _ => { duration = Activity.Current?.Duration; };
 
-            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true);
+            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true, false);
 
             DiagnosticScope scope = clientDiagnostics.CreateScope("ActivityName");
 
@@ -74,7 +74,7 @@ namespace Azure.Core.Tests
         public void ResourceNameIsOptional()
         {
             using var testListener = new TestDiagnosticListener("Azure.Clients");
-            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", null, true);
+            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", null, true, false);
 
             DiagnosticScope scope = clientDiagnostics.CreateScope("ActivityName");
             scope.Start();
@@ -98,7 +98,7 @@ namespace Azure.Core.Tests
         public void AddLinkCallsPassesLinksAsPartOfStartPayload()
         {
             using var testListener = new TestDiagnosticListener("Azure.Clients");
-            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients",  "Microsoft.Azure.Core.Cool.Tests",true);
+            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients",  "Microsoft.Azure.Core.Cool.Tests", true, false);
 
             DiagnosticScope scope = clientDiagnostics.CreateScope("ActivityName");
 
@@ -144,7 +144,7 @@ namespace Azure.Core.Tests
         public void AddLinkCreatesLinkedActivityWithTags()
         {
             using var testListener = new TestDiagnosticListener("Azure.Clients");
-            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true);
+            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true, false);
 
             DiagnosticScope scope = clientDiagnostics.CreateScope("ActivityName");
 
@@ -180,7 +180,7 @@ namespace Azure.Core.Tests
         public void FailedStopsActivityAndWritesExceptionEvent()
         {
             using var testListener = new TestDiagnosticListener("Azure.Clients");
-            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients",  "Microsoft.Azure.Core.Cool.Tests", true);
+            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients",  "Microsoft.Azure.Core.Cool.Tests", true, false);
 
             DiagnosticScope scope = clientDiagnostics.CreateScope("ActivityName");
 
@@ -215,7 +215,7 @@ namespace Azure.Core.Tests
         [Test]
         public void NoOpsWhenDisabled()
         {
-            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients",  "Microsoft.Azure.Core.Cool.Tests", false);
+            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients",  "Microsoft.Azure.Core.Cool.Tests", false, false);
             DiagnosticScope scope = clientDiagnostics.CreateScope("");
 
             Assert.IsFalse(scope.IsEnabled);
@@ -237,9 +237,9 @@ namespace Azure.Core.Tests
         {
             using var testListener = new TestDiagnosticListener(l => l.Name.StartsWith("Azure.Clients."));
 
-            _ = new DiagnosticScopeFactory("Azure.Clients.1",  "Microsoft.Azure.Core.Cool.Tests", true);
-            _ = new DiagnosticScopeFactory("Azure.Clients.1",  "Microsoft.Azure.Core.Cool.Tests", true);
-            _ = new DiagnosticScopeFactory("Azure.Clients.2",  "Microsoft.Azure.Core.Cool.Tests", true);
+            _ = new DiagnosticScopeFactory("Azure.Clients.1",  "Microsoft.Azure.Core.Cool.Tests", true, false);
+            _ = new DiagnosticScopeFactory("Azure.Clients.1",  "Microsoft.Azure.Core.Cool.Tests", true, false);
+            _ = new DiagnosticScopeFactory("Azure.Clients.2",  "Microsoft.Azure.Core.Cool.Tests", true, false);
 
             Assert.AreEqual(2, testListener.Sources.Count);
         }

--- a/sdk/core/Azure.Core/tests/ClientOptionsTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientOptionsTests.cs
@@ -200,7 +200,6 @@ namespace Azure.Core.Tests
             yield return M(o => o.Diagnostics.IsLoggingContentEnabled = true, o => o.Diagnostics.IsLoggingContentEnabled);
             yield return M(o => o.Diagnostics.LoggedContentSizeLimit = 100, o => o.Diagnostics.LoggedContentSizeLimit);
             yield return M(o => o.Diagnostics.IsDistributedTracingEnabled = false, o => o.Diagnostics.IsDistributedTracingEnabled);
-            yield return M(o => o.Diagnostics.SuppressNestedClientSpans = true, o => o.Diagnostics.SuppressNestedClientSpans);
 
             yield return M(o =>
             {

--- a/sdk/core/Azure.Core/tests/TestClients/TestResource.cs
+++ b/sdk/core/Azure.Core/tests/TestClients/TestResource.cs
@@ -14,7 +14,7 @@ namespace Azure.Core.Tests
 {
     internal class TestResource : ArmResource
     {
-        private DiagnosticScopeFactory _diagnostic = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true);
+        private DiagnosticScopeFactory _diagnostic = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true, false);
         private static MockResponse mockResponse = new(200);
         private Func<MockResponse> mockResponseFactory = () => mockResponse;
 

--- a/sdk/core/Azure.Core/tests/TestClients/TestResourceCollection.cs
+++ b/sdk/core/Azure.Core/tests/TestClients/TestResourceCollection.cs
@@ -17,7 +17,7 @@ namespace Azure.Core.Tests
 {
     internal class TestResourceCollection : ArmCollection, IEnumerable<TestResource>, IAsyncEnumerable<TestResource>
     {
-        private DiagnosticScopeFactory _diagnostic = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true);
+        private DiagnosticScopeFactory _diagnostic = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true, false);
 
         public virtual Pageable<TestResource> GetAll(int pages = 1, CancellationToken cancellation = default)
         {

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/EventGridExtensionConfigProvider.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/EventGridExtensionConfigProvider.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
             _converter = converter;
             _httpRequestProcessor = httpRequestProcessor;
             _loggerFactory = loggerFactory;
-            _diagnosticScopeFactory = new DiagnosticScopeFactory(DiagnosticScopeNamespace, ResourceProviderNamespace, true);
+            _diagnosticScopeFactory = new DiagnosticScopeFactory(DiagnosticScopeNamespace, ResourceProviderNamespace, true, false);
         }
 
         // default constructor
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
             _converter = (attr => new EventGridAsyncCollector(new EventGridPublisherClient(new Uri(attr.TopicEndpointUri), new AzureKeyCredential(attr.TopicKeySetting))));
             _httpRequestProcessor = httpRequestProcessor;
             _loggerFactory = loggerFactory;
-            _diagnosticScopeFactory = new DiagnosticScopeFactory(DiagnosticScopeNamespace, ResourceProviderNamespace, true);
+            _diagnosticScopeFactory = new DiagnosticScopeFactory(DiagnosticScopeNamespace, ResourceProviderNamespace, true, false);
         }
 
         public void Initialize(ExtensionConfigContext context)

--- a/sdk/storage/Azure.Storage.Common/tests/PartitionedUploaderTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/PartitionedUploaderTests.cs
@@ -37,7 +37,7 @@ namespace Azure.Storage.Tests
         {
             var mock = new Mock<PartitionedUploader<object, object>.CreateScope>(MockBehavior.Strict);
             mock.Setup(del => del(s_operationName))
-                .Returns(new Core.Pipeline.DiagnosticScope("Azure.Storage.Tests", s_operationName, new DiagnosticListener("Azure.Storage.Tests"), DiagnosticScope.ActivityKind.Client));
+                .Returns(new Core.Pipeline.DiagnosticScope("Azure.Storage.Tests", s_operationName, new DiagnosticListener("Azure.Storage.Tests"), DiagnosticScope.ActivityKind.Client, false));
             return mock;
         }
 


### PR DESCRIPTION
Addressing [Review feedback](https://apiview.dev/Assemblies/Review/77bdbcef49a3465fa96fac3fb745bf57/cb4a44f8dda24ee49d5410d986524c6e?diffRevisionId=532c07579b3146faad925857b4d5353d&doc=False&diffOnly=True)

Related: https://github.com/Azure/azure-sdk/issues/4222

1. Do not  expose `SuppressNestedClientSpans` until we have some clear request, make it an explicit parameter on `ClientDiagnsotics`
2. Use `Activity` terminology instead of `span` similar to OpenTelemetry in .NET and BCL