### PR TITLE
AOA Conversion SDK casing and null handling

### DIFF
--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/Azure.MixedReality.ObjectAnchors.Conversion.sln
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/Azure.MixedReality.ObjectAnchors.Conversion.sln
@@ -1,7 +1,7 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30907.101
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32228.430
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.MixedReality.ObjectAnchors.Conversion", "src\Azure.MixedReality.ObjectAnchors.Conversion.csproj", "{F2DECE5E-D006-41CC-A4F2-2ACE91D18E16}"
 EndProject

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/CHANGELOG.md
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/CHANGELOG.md
@@ -2,11 +2,24 @@
 
 ## 0.3.0-beta.3 (Unreleased)
 
+### Bugs Fixed
+
+- Fixed a regression from `0.2.0-beta.1` to validate file extensions case insensitively.
+- We now properly set the `AccountDomain` property when creating an `ObjectAnchorsConversionClient`.
+- Better handling of `null` values in many parts of the code.
+
 ### Features Added
+
 - Added `ScaledAssetDimensions` to `AssetConversionProperties`.
+- Enabled the nullable context to surface nullable reference information.
 
 ### Breaking Changes
-- `OutputModelUri` now returns a `Uri` to a `.zip` file containing the `.ou` file instead of the `.ou` file itself when using the new default service version: `V0_3_preview_0`.
+
+- `OutputModelUri` now returns a `Uri` to a `.zip` file containing the `.ou` file instead of the `.ou` file itself when
+  using the new default service version: `V0_3_preview_0`.
+- Simplified the `ObjectAnchorsConversionClient` constructors and removed the `SupportedAssetFileTypes` property as it
+  shouldn't have been exposed.
+- The value specified when creating a `AssetFileType` is now validated and must begin with a '.' character.
 
 ### Bugs Fixed
 

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetConversionOperation.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetConversionOperation.cs
@@ -2,12 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
-using Azure.Core.Pipeline;
 
 namespace Azure.MixedReality.ObjectAnchors.Conversion
 {
@@ -19,10 +16,10 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         private static readonly TimeSpan defaultPollingInterval = TimeSpan.FromSeconds(15);
         private readonly ObjectAnchorsConversionClient _objectAnchorsConversionClient;
         private readonly Guid _jobId;
-        private Response<AssetConversionProperties> _lastConversionResponse;
-        private Response<AssetConversionProperties> _conclusiveConversionResponse;
+        private Response<AssetConversionProperties>? _lastConversionResponse;
+        private Response<AssetConversionProperties>? _conclusiveConversionResponse;
         private bool _conversionEnded;
-        private object _updateStatusLock = new object();
+        private readonly object _updateStatusLock = new object();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AssetConversionOperation"/> class.
@@ -37,7 +34,9 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         }
 
         /// <summary> Initializes a new instance of <see cref="AssetConversionOperation" /> for mocking. </summary>
-        protected AssetConversionOperation() {}
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        protected AssetConversionOperation() { }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         /// <inheritdoc/>
         public override string Id => _jobId.ToString();
@@ -63,10 +62,11 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// <summary>
         /// Whether the operation has completed and has a successful final status.
         /// </summary>
-        public bool HasCompletedSuccessfully => HasCompleted && HasValue && (this.Value.ConversionStatus == AssetConversionStatus.Succeeded);
+        public bool HasCompletedSuccessfully => HasCompleted && HasValue && (Value.ConversionStatus == AssetConversionStatus.Succeeded);
 
         /// <inheritdoc/>
-        public override Response GetRawResponse() => _lastConversionResponse.GetRawResponse();
+        public override Response GetRawResponse() => _lastConversionResponse?.GetRawResponse()
+            ?? throw new InvalidOperationException("No response was available.");
 
         /// <inheritdoc/>
         public override Response UpdateStatus(CancellationToken cancellationToken = default)

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetConversionOptions.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetConversionOptions.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using Azure.Core;
+
 namespace Azure.MixedReality.ObjectAnchors.Conversion
 {
-    using Azure.Core;
-    using System;
-
     /// <summary>
     /// Represents an Object Anchors asset conversion job request's options.
     /// </summary>
@@ -32,10 +32,10 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         public Guid JobId { get; set; } = Guid.NewGuid();
 
         /// <summary> Gravity vector with respect to object's nominal position. </summary>
-        public System.Numerics.Vector3 Gravity { get => ConversionConfiguration.Gravity; }
+        public System.Numerics.Vector3 Gravity => ConversionConfiguration.Gravity;
 
         /// <summary> Scale of transformation of asset units into meter space. </summary>
-        public float Scale { get => ConversionConfiguration.Scale; }
+        public float Scale => ConversionConfiguration.Scale;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AssetConversionOptions"/> class.
@@ -77,9 +77,9 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
                 throw new ArgumentException(assetConfigurationInvalidMessage, nameof(conversionConfiguration));
             }
 
-            this.InputAssetUri = inputAssetUri;
-            this.InputAssetFileType = inputAssetFileType;
-            this.ConversionConfiguration = conversionConfiguration;
+            InputAssetUri = inputAssetUri;
+            InputAssetFileType = inputAssetFileType;
+            ConversionConfiguration = conversionConfiguration;
         }
     }
 }

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetFileType.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetFileType.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel;
 using System.IO;
+using Azure.Core;
 
 namespace Azure.MixedReality.ObjectAnchors.Conversion
 {
@@ -19,13 +20,23 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         internal const string ObjValue = ".obj";
         internal const string PlyValue = ".ply";
 
+        internal string Value => _value ?? string.Empty;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AssetFileType"/> struct.
         /// </summary>
         /// <param name="value">The asset file type.</param>
         public AssetFileType(string value)
         {
-            _value = value ?? throw new ArgumentNullException(nameof(value));
+            Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
+
+            if (!value.StartsWith(".", StringComparison.Ordinal))
+            {
+                throw new ArgumentException("The value must start with a '.' character.", nameof(value));
+            }
+
+            _value = value.ToLowerInvariant()
+                ?? throw new ArgumentNullException(nameof(value));
         }
 
         /// <summary>
@@ -35,7 +46,9 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// <returns>The AssetFileType derived from the extension of a provided file name.</returns>
         public static AssetFileType FromFilePath(string assetFilePath)
         {
-            return new AssetFileType(Path.GetExtension(assetFilePath));
+            Argument.AssertNotNullOrWhiteSpace(assetFilePath, nameof(assetFilePath));
+
+            return new AssetFileType(Path.GetExtension(assetFilePath).ToLowerInvariant());
         }
 
         /// <summary>
@@ -85,24 +98,29 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// <inheritdoc/>
         public bool Equals(AssetFileType other)
         {
-            return this._value == other._value;
+            return Value.Equals(other._value, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj)
         {
-            return obj is AssetFileType && Equals((AssetFileType)obj);
+            if (obj is AssetFileType otherFileType)
+            {
+                return Equals(otherFileType);
+            }
+
+            return false;
         }
 
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()
         {
-            return _value.GetHashCode();
+            return Value.GetHashCode();
         }
 
         /// <inheritdoc/>
-        public override string ToString() => _value;
+        public override string ToString() => Value;
     }
 }

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetFileType.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetFileType.cs
@@ -13,7 +13,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
     /// </summary>
     public readonly struct AssetFileType : IEquatable<AssetFileType>
     {
-        private readonly string _value;
+        private readonly string? _value;
         internal const string FbxValue = ".fbx";
         internal const string GlbValue = ".glb";
         internal const string GltfValue = ".gltf";
@@ -103,7 +103,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
 
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (obj is AssetFileType otherFileType)
             {

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetFileTypeNotSupportedException.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetFileTypeNotSupportedException.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Serialization;
 using Azure.Core;
 
@@ -51,11 +52,11 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
             base.GetObjectData(info, context);
         }
 
-        internal AssetFileTypeNotSupportedException(AssetFileType assetFileType, IReadOnlyList<AssetFileType> supportedAssetFileTypes)
+        internal AssetFileTypeNotSupportedException(AssetFileType assetFileType, IReadOnlyCollection<AssetFileType> supportedAssetFileTypes)
             : base($"The provided asset file type of \"{assetFileType}\" is unsupported by Azure Object Anchors for conversion. Supported file types: {string.Join(", ", supportedAssetFileTypes)}")
         {
             AttemptedFileType = assetFileType;
-            SupportedAssetFileTypes = supportedAssetFileTypes;
+            SupportedAssetFileTypes = supportedAssetFileTypes.ToArray();
         }
 
         /// <summary>

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetFileTypeNotSupportedException.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetFileTypeNotSupportedException.cs
@@ -74,11 +74,11 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// <summary>
         /// The unsupported filetype provided for asset conversion.
         /// </summary>
-        public AssetFileType AttemptedFileType { get; }
+        public AssetFileType? AttemptedFileType { get; }
 
         /// <summary>
         /// The list of file types supported by Azure Object Anchors Conversion.
         /// </summary>
-        public IReadOnlyList<AssetFileType> SupportedAssetFileTypes { get; }
+        public IReadOnlyList<AssetFileType>? SupportedAssetFileTypes { get; }
     }
 }

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Azure.MixedReality.ObjectAnchors.Conversion.csproj
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Azure.MixedReality.ObjectAnchors.Conversion.csproj
@@ -8,6 +8,7 @@
     <PackageProjectUrl>https://azure.microsoft.com/topic/mixed-reality/</PackageProjectUrl>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/AssetConversionConfiguration.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/AssetConversionConfiguration.cs
@@ -50,7 +50,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// <summary>
         /// Scale of transformation of asset units into meter space.
         /// </summary>
-        public float Scale { get; internal set; }
+        public float Scale { get; }
 
         /// <summary>
         /// Ground truth trajectory.
@@ -61,27 +61,32 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// <summary>
         /// Dimensions of the asset.
         /// </summary>
-        public System.Numerics.Vector3? AssetDimensions { get => AssetDimensionsWrapper == null ? null : (System.Numerics.Vector3)AssetDimensionsWrapper; }
+        public System.Numerics.Vector3? AssetDimensions
+            => AssetDimensionsWrapper is null ? null : (System.Numerics.Vector3)AssetDimensionsWrapper;
 
         /// <summary>
         /// BoundingBoxCenter of the asset.
         /// </summary>
-        public System.Numerics.Vector3? BoundingBoxCenter { get => BoundingBoxCenterWrapper == null ? null : (System.Numerics.Vector3)BoundingBoxCenterWrapper; }
+        public System.Numerics.Vector3? BoundingBoxCenter
+            => BoundingBoxCenterWrapper is null ? null : (System.Numerics.Vector3)BoundingBoxCenterWrapper;
 
         /// <summary>
         /// Gravity vector with respect to object's nominal position.
         /// </summary>
-        public System.Numerics.Vector3 Gravity { get => (System.Numerics.Vector3)GravityWrapper; internal set => GravityWrapper = (Vector3)value; }
+        public System.Numerics.Vector3 Gravity
+            => GravityWrapper is null ? default : (System.Numerics.Vector3)GravityWrapper;
 
         /// <summary>
         /// Orientation of model's bounding box.
         /// </summary>
-        public System.Numerics.Quaternion? PrincipalAxis { get => PrincipalAxisWrapper == null ? null : PrincipalAxisWrapper; }
+        public System.Numerics.Quaternion? PrincipalAxis
+            => PrincipalAxisWrapper is null ? null : (System.Numerics.Quaternion)PrincipalAxisWrapper;
 
         /// <summary>
         /// Definition of supporting plane.
         /// </summary>
-        public System.Numerics.Vector4? SupportingPlane { get => SupportingPlaneWrapper == null ? null : SupportingPlaneWrapper; }
+        public System.Numerics.Vector4? SupportingPlane
+            => SupportingPlaneWrapper is null ? null : (System.Numerics.Vector4)SupportingPlaneWrapper;
 
         /// <summary>
         /// Indices of Key Frames.
@@ -95,20 +100,20 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         public IReadOnlyList<TrajectoryPose> TestTrajectoryCameraPoses { get; }
 
         [CodeGenMember("Dimensions")]
-        internal Vector3 AssetDimensionsWrapper { get; set; }
+        internal Vector3? AssetDimensionsWrapper { get; set; }
 
         [CodeGenMember("BoundingBoxCenter")]
-        internal Vector3 BoundingBoxCenterWrapper { get; set; }
+        internal Vector3? BoundingBoxCenterWrapper { get; set; }
 
         [CodeGenMember("Gravity")]
-        internal Vector3 GravityWrapper { get; set; }
+        internal Vector3? GravityWrapper { get; set; }
 
         [CodeGenMember("PrincipalAxis")]
-        internal Quaternion PrincipalAxisWrapper { get; set; }
+        internal Quaternion? PrincipalAxisWrapper { get; set; }
 
         /// <summary> Scale of transformation of asset units into meter space. </summary>
         [CodeGenMember("SupportingPlane")]
-        internal Vector4 SupportingPlaneWrapper { get; set; }
+        internal Vector4? SupportingPlaneWrapper { get; set; }
 
         /// <summary>
         /// Returns true if the values of the object contain valid data.
@@ -119,7 +124,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         {
             invalidMessage = string.Empty;
 
-            if (!this.Gravity.IsNormalized())
+            if (!Gravity.IsNormalized())
             {
                 invalidMessage = $"The value for {nameof(AssetConversionConfiguration.Gravity)} must be normalized.";
             }

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/AssetConversionProperties.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/AssetConversionProperties.cs
@@ -16,32 +16,44 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// <summary>
         /// Represents the properties of an AOA asset conversion job.
         /// </summary>
-        internal AssetConversionProperties()
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        internal AssetConversionProperties() { }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+        /// <summary>
+        /// Represents the properties of an AOA asset conversion job.
+        /// </summary>
+        /// <param name="conversionConfiguration">The conversion configuration.</param>
+        /// <param name="inputAssetFileType">The input asset file type.</param>
+        /// <param name="inputAssetUri">The input asset URI.</param>
+        internal AssetConversionProperties(
+            AssetConversionConfiguration conversionConfiguration,
+            AssetFileType inputAssetFileType,
+            Uri inputAssetUri)
         {
+            InputAssetFileType = inputAssetFileType;
+            InputAssetUri = inputAssetUri;
+            ConversionConfiguration = conversionConfiguration;
         }
 
         /// <summary>
         /// The URI for downloading the generated AOA Model.
         /// </summary>
-        public Uri OutputModelUri
-        {
-            get
-            {
-                return OutputModelUriString == null ? null : new Uri(OutputModelUriString);
-            }
-        }
+        public Uri? OutputModelUri
+            => OutputModelUriString is null ? null : new Uri(OutputModelUriString);
+
         /// <summary>
         /// The Uri to the Asset to be ingested by the AOA Asset Conversion Service. This asset needs to have been uploaded to the service using an endpoint provided from a call to the GetUploadUri API.
         /// </summary>
-        public Uri InputAssetUri
+        public Uri? InputAssetUri
         {
             get
             {
-                return InputAssetUriString == null ? null : new Uri(InputAssetUriString);
+                return InputAssetUriString is null ? null : new Uri(InputAssetUriString);
             }
             internal set
             {
-                InputAssetUriString = value.AbsoluteUri;
+                InputAssetUriString = value?.AbsoluteUri ?? null;
             }
         }
 
@@ -55,7 +67,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// The configuration of the AOA asset conversion job.
         /// </summary>
         [CodeGenMember("IngestionConfiguration")]
-        public AssetConversionConfiguration ConversionConfiguration { get; internal set; }
+        public AssetConversionConfiguration ConversionConfiguration { get; }
 
         /// <summary>
         /// The error code of the AOA asset conversion job.
@@ -78,16 +90,21 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// <summary>
         /// The scaled dimensions of the asset.
         /// </summary>
-        public System.Numerics.Vector3? ScaledAssetDimensions { get => ScaledAssetDimensionsWrapper == null ? null : (System.Numerics.Vector3)ScaledAssetDimensionsWrapper; }
+        public System.Numerics.Vector3? ScaledAssetDimensions
+            => ScaledAssetDimensionsWrapper is null ? null : (System.Numerics.Vector3)ScaledAssetDimensionsWrapper;
 
         [CodeGenMember("OutputModelUri")]
-        internal string OutputModelUriString { get; }
+        internal string? OutputModelUriString { get; }
 
         [CodeGenMember("InputAssetUri")]
-        internal string InputAssetUriString { get; set; }
+        internal string? InputAssetUriString { get; set; }
 
         [CodeGenMember("AssetFileType")]
-        internal string AssetFileTypeString { get => this.InputAssetFileType.ToString(); set => this.InputAssetFileType = new AssetFileType(value); }
+        internal string AssetFileTypeString
+        {
+            get => InputAssetFileType.ToString();
+            set => InputAssetFileType = new AssetFileType(value);
+        }
 
         [CodeGenMember("JobId")]
         internal Guid? JobIdInternal { get; set; }
@@ -96,6 +113,6 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         internal Guid? AccountIdInternal { get; set; }
 
         [CodeGenMember("ScaledAssetDimensions")]
-        internal Vector3 ScaledAssetDimensionsWrapper { get; set; }
+        internal Vector3? ScaledAssetDimensionsWrapper { get; set; }
     }
 }

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/AssetUploadUriResult.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/AssetUploadUriResult.cs
@@ -33,6 +33,6 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         public Uri UploadUri { get; }
 
         [CodeGenMember("InputAssetUri")]
-        internal string UploadUriString { get => UploadUri.AbsoluteUri; }
+        internal string UploadUriString => UploadUri.AbsoluteUri;
     }
 }

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/Quaternion.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/Quaternion.cs
@@ -51,42 +51,68 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Models
         /// <summary>
         /// X component.
         /// </summary>
-        public float X { get { return data.X; } set { data.X = value; } }
+        public float X
+        {
+            get => data.X;
+            set { data.X = value; }
+        }
 
         /// <summary>
         /// Y component.
         /// </summary>
-        public float Y { get { return data.Y; } set { data.Y = value; } }
+        public float Y
+        {
+            get => data.Y;
+            set { data.Y = value; }
+        }
 
         /// <summary>
         /// Z component.
         /// </summary>
-        public float Z { get { return data.Z; } set { data.Z = value; } }
+        public float Z
+        {
+            get => data.Z;
+            set { data.Z = value; }
+        }
 
         /// <summary>
         /// W component.
         /// </summary>
-        public float W { get { return data.W; } set { data.W = value; } }
+        public float W
+        {
+            get => data.W;
+            set { data.W = value; }
+        }
 
         /// <summary>
         /// Gets a value that indicates whether the current instance is the identity quaternion.
         /// </summary>
-        public bool IsIdentity { get => data.IsIdentity; }
+        public bool IsIdentity  => data.IsIdentity;
 
         /// <summary>
         /// Assesses equality with another quaternion.
         /// </summary>
         /// <param name="other">The other quaternion being compared to.</param>
         /// <returns>Whether the two are equal.</returns>
-        public bool Equals(Quaternion other)
+        public bool Equals(Quaternion? other)
         {
-            return this.data.Equals(other.data);
+            if (other is null)
+            {
+                return false;
+            }
+
+            return data.Equals(other.data);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            return obj is Quaternion && this.Equals(obj as Quaternion);
+            if (obj is Quaternion quaternion)
+            {
+                return Equals(quaternion);
+            }
+
+            return false;
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -96,6 +122,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Models
         }
 
         public static implicit operator System.Numerics.Quaternion(Quaternion q) => q.data;
+
         public static implicit operator Quaternion(System.Numerics.Quaternion q) => new Quaternion(q);
     }
 }

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/TrajectoryPose.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/TrajectoryPose.cs
@@ -56,15 +56,20 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// </summary>
         public bool Equals(TrajectoryPose other)
         {
-            return this.Rotation.Equals(other.Rotation)
-                && this.Translation.Equals(other.Translation);
+            return Rotation.Equals(other.Rotation)
+                && Translation.Equals(other.Translation);
         }
 
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            return obj is TrajectoryPose && this.Equals(obj as Vector4);
+            if (obj is TrajectoryPose pose)
+            {
+                return Equals(pose);
+            }
+
+            return false;
         }
 
         /// <inheritdoc/>

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/Vector3.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/Vector3.cs
@@ -36,32 +36,54 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Models
         /// <summary>
         /// X component.
         /// </summary>
-        public float X { get { return data.X; } set { data.X = value; } }
+        public float X
+        {
+            get => data.X;
+            set { data.X = value; }
+        }
 
         /// <summary>
         /// Y component.
         /// </summary>
-        public float Y { get { return data.Y; } set { data.Y = value; } }
+        public float Y
+        {
+            get => data.Y;
+            set { data.Y = value; }
+        }
 
         /// <summary>
         /// Z component.
         /// </summary>
-        public float Z { get { return data.Z; } set { data.Z = value; } }
+        public float Z
+        {
+            get => data.Z;
+            set { data.Z = value; }
+        }
 
         /// <summary>
         /// Assesses equality with another vector.
         /// </summary>
         /// <param name="other">The other vector being compared to.</param>
         /// <returns>Whether the two are equal.</returns>
-        public bool Equals(Vector3 other)
+        public bool Equals(Vector3? other)
         {
-            return this.data.Equals(other.data);
+            if (other is null)
+            {
+                return false;
+            }
+
+            return data.Equals(other.data);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            return obj is Vector3 && this.Equals(obj as Quaternion);
+            if (obj is Vector3 vector3)
+            {
+                return Equals(vector3);
+            }
+
+            return false;
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -76,6 +98,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Models
         }
 
         public static explicit operator System.Numerics.Vector3(Vector3 v) => v.data;
+
         public static explicit operator Vector3(System.Numerics.Vector3 v) => new Vector3(v);
     }
 }

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/Vector4.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/Vector4.cs
@@ -37,37 +37,63 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Models
         /// <summary>
         /// X component.
         /// </summary>
-        public float X { get { return data.X; } set { data.X = value; } }
+        public float X
+        {
+            get => data.X;
+            set { data.X = value; }
+        }
 
         /// <summary>
         /// Y component.
         /// </summary>
-        public float Y { get { return data.Y; } set { data.Y = value; } }
+        public float Y
+        {
+            get => data.Y;
+            set { data.Y = value; }
+        }
 
         /// <summary>
         /// Z component.
         /// </summary>
-        public float Z { get { return data.Z; } set { data.Z = value; } }
+        public float Z
+        {
+            get => data.Z;
+            set { data.Z = value; }
+        }
 
         /// <summary>
         /// W component.
         /// </summary>
-        public float W { get { return data.W; } set { data.W = value; } }
+        public float W
+        {
+            get => data.W;
+            set { data.W = value; }
+        }
 
         /// <summary>
         /// Assesses equality with another vector.
         /// </summary>
         /// <param name="other">The other vector being compared to.</param>
         /// <returns>Whether the two are equal.</returns>
-        public bool Equals(Vector4 other)
+        public bool Equals(Vector4? other)
         {
-            return this.data.Equals(other.data);
+            if (other is null)
+            {
+                return false;
+            }
+
+            return data.Equals(other.data);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            return obj is Vector4 && this.Equals(obj as Vector4);
+            if (obj is Vector4 vector4)
+            {
+                return Equals(vector4);
+            }
+
+            return false;
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -77,6 +103,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Models
         }
 
         public static implicit operator System.Numerics.Vector4(Vector4 v) => v.data;
+
         public static implicit operator Vector4(System.Numerics.Vector4 v) => new Vector4(v);
     }
 }

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/ObjectAnchorsConversionClient.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/ObjectAnchorsConversionClient.cs
@@ -42,7 +42,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// <param name="accountDomain">The Azure Object Anchors account domain.</param>
         /// <param name="keyCredential">The Azure Object Anchors account primary or secondary key credential.</param>
         /// <param name="options">The options.</param>
-        public ObjectAnchorsConversionClient(Guid accountId, string accountDomain, AzureKeyCredential keyCredential, ObjectAnchorsConversionClientOptions options = null)
+        public ObjectAnchorsConversionClient(Guid accountId, string accountDomain, AzureKeyCredential keyCredential, ObjectAnchorsConversionClientOptions? options = null)
             : this(accountId, accountDomain, new MixedRealityAccountKeyCredential(accountId, keyCredential), options) { }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// <param name="accountDomain">The Azure Object Anchors account domain.</param>
         /// <param name="token">An access token used to access the specified Azure Object Anchors account.</param>
         /// <param name="options">The options.</param>
-        public ObjectAnchorsConversionClient(Guid accountId, string accountDomain, AccessToken token, ObjectAnchorsConversionClientOptions options = null)
+        public ObjectAnchorsConversionClient(Guid accountId, string accountDomain, AccessToken token, ObjectAnchorsConversionClientOptions? options = null)
             : this(accountId, accountDomain, new StaticAccessTokenCredential(token), options) { }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// <param name="accountDomain">The Azure Object Anchors account domain.</param>
         /// <param name="credential">The credential used to access the Mixed Reality service.</param>
         /// <param name="options">The options.</param>
-        public ObjectAnchorsConversionClient(Guid accountId, string accountDomain, TokenCredential credential, ObjectAnchorsConversionClientOptions options = null)
+        public ObjectAnchorsConversionClient(Guid accountId, string accountDomain, TokenCredential credential, ObjectAnchorsConversionClientOptions? options = null)
         {
             Argument.AssertNotDefault(ref accountId, nameof(accountId));
             Argument.AssertNotNullOrWhiteSpace(accountDomain, nameof(accountDomain));
@@ -74,6 +74,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
             Uri serviceEndpoint = options.ServiceEndpoint ?? ConstructObjectAnchorsEndpointUrl(accountDomain);
 
             AccountId = accountId;
+            AccountDomain = accountDomain;
             _clientOptions = options;
             _clientDiagnostics = new ClientDiagnostics(options);
             _pipeline = HttpPipelineBuilder.Build(options, new BearerTokenAuthenticationPolicy(mrTokenCredential, GetDefaultScope(serviceEndpoint)));
@@ -87,7 +88,9 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// <remarks>
         /// Required for mocking.
         /// </remarks>
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         protected ObjectAnchorsConversionClient()
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
         }
 
@@ -108,12 +111,10 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
                     throw new AssetFileTypeNotSupportedException(options.InputAssetFileType, _clientOptions.SupportedAssetFileTypes);
                 }
 
-                AssetConversionProperties properties = new AssetConversionProperties
-                {
-                    InputAssetFileType = options.InputAssetFileType,
-                    ConversionConfiguration = options.ConversionConfiguration,
-                    InputAssetUri = options.InputAssetUri
-                };
+                AssetConversionProperties properties = new(
+                    options.ConversionConfiguration,
+                    options.InputAssetFileType,
+                    options.InputAssetUri);
 
                 _ingestionJobRestClient.Create(AccountId, options.JobId, body: properties, cancellationToken: cancellationToken);
                 return new AssetConversionOperation(options.JobId, this);
@@ -142,12 +143,10 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
                     throw new AssetFileTypeNotSupportedException(options.InputAssetFileType, _clientOptions.SupportedAssetFileTypes);
                 }
 
-                AssetConversionProperties properties = new AssetConversionProperties
-                {
-                    InputAssetFileType = options.InputAssetFileType,
-                    ConversionConfiguration = options.ConversionConfiguration,
-                    InputAssetUri = options.InputAssetUri
-                };
+                AssetConversionProperties properties = new(
+                    options.ConversionConfiguration,
+                    options.InputAssetFileType,
+                    options.InputAssetUri);
 
                 await _ingestionJobRestClient.CreateAsync(AccountId, options.JobId, body: properties, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return new AssetConversionOperation(options.JobId, this);

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/ObjectAnchorsConversionClientOptions.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/ObjectAnchorsConversionClientOptions.cs
@@ -21,17 +21,17 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// <summary>
         /// Gets the authentication endpoint.
         /// </summary>
-        public Uri MixedRealityAuthenticationEndpoint { get; set; }
+        public Uri? MixedRealityAuthenticationEndpoint { get; set; }
 
         /// <summary>
         /// Gets the authentication options.
         /// </summary>
-        public MixedRealityStsClientOptions MixedRealityAuthenticationOptions { get; set; }
+        public MixedRealityStsClientOptions? MixedRealityAuthenticationOptions { get; set; }
 
         /// <summary>
         /// Gets the service endpoint.
         /// </summary>
-        public Uri ServiceEndpoint { get; set; }
+        public Uri? ServiceEndpoint { get; set; }
 
         /// <summary>
         /// Gets the list of supported asset file types.

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/ObjectAnchorsConversionClientOptions.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/ObjectAnchorsConversionClientOptions.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Azure.Core;
 using Azure.MixedReality.Authentication;
 
@@ -16,12 +16,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
     /// <seealso cref="Azure.Core.ClientOptions" />
     public class ObjectAnchorsConversionClientOptions : ClientOptions
     {
-        internal string Version { get; }
-
-        /// <summary>
-        /// Gets the list of supported asset file types.
-        /// </summary>
-        internal HashSet<AssetFileType> SupportedAssetFileTypes { get; }
+        private readonly HashSet<AssetFileType> _supportedAssetFileTypes;
 
         /// <summary>
         /// Gets the authentication endpoint.
@@ -29,14 +24,24 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         public Uri MixedRealityAuthenticationEndpoint { get; set; }
 
         /// <summary>
+        /// Gets the authentication options.
+        /// </summary>
+        public MixedRealityStsClientOptions MixedRealityAuthenticationOptions { get; set; }
+
+        /// <summary>
         /// Gets the service endpoint.
         /// </summary>
         public Uri ServiceEndpoint { get; set; }
 
         /// <summary>
-        /// Gets the authentication options.
+        /// Gets the list of supported asset file types.
         /// </summary>
-        public MixedRealityStsClientOptions MixedRealityAuthenticationOptions { get; set; }
+        internal IReadOnlyCollection<AssetFileType> SupportedAssetFileTypes => _supportedAssetFileTypes;
+
+        /// <summary>
+        /// Gets the version.
+        /// </summary>
+        internal string Version { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectAnchorsConversionClientOptions"/> class.
@@ -51,7 +56,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
                 _ => throw new ArgumentException($"The service version {version} is not supported by this library.", nameof(version))
             };
 
-            SupportedAssetFileTypes = version switch
+            _supportedAssetFileTypes = version switch
             {
                 ServiceVersion.V0_2_preview_0 or ServiceVersion.V0_3_preview_0 => new HashSet<AssetFileType>
                 {
@@ -67,21 +72,27 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// <summary>
         /// The Azure Spatial Anchors service version.
         /// </summary>
+        [SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores")]
+        [SuppressMessage("Usage", "AZC0016:Invalid ServiceVersion member name.")]
         public enum ServiceVersion
         {
             /// <summary>
             /// Version 0.2-preview.0 of the Azure Object Anchors service.
             /// </summary>
-#pragma warning disable CA1707 // Identifiers should not contain underscores
-#pragma warning disable AZC0016 // Invalid ServiceVersion member name.
             V0_2_preview_0 = 1,
 
             /// <summary>
             /// Version 0.3-preview.0 of the Azure Object Anchors service.
             /// </summary>
             V0_3_preview_0 = 2,
-#pragma warning restore AZC0016 // Invalid ServiceVersion member name.
-#pragma warning restore CA1707 // Identifiers should not contain underscores
         }
+
+        /// <summary>
+        /// Gets a value indicating if the specified asset file type is supported.
+        /// </summary>
+        /// <param name="assertFileType">Type of the assert file.</param>
+        /// <returns><c>true</c> if the asset file type is supported, <c>false</c> otherwise.</returns>
+        internal bool IsFileTypeSupported(AssetFileType assertFileType)
+            => _supportedAssetFileTypes.Contains(assertFileType);
     }
 }

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/AssetConversionOptionsTests.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/AssetConversionOptionsTests.cs
@@ -3,10 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
-using System.Text;
-using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -37,7 +34,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Tests
             {
                 new object[] { new Vector3(1, 0, 0), new Uri(anyWorkingUriString), true },
                 new object[] { default(Vector3), new Uri(anyWorkingUriString), false },
-                new object[] { new Vector3(1, 0, 0), default(Uri), false }
+                new object[] { new Vector3(1, 0, 0), default(Uri)!, false }
             };
 
         [Test]
@@ -80,7 +77,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Tests
             float x = 0.2672612f;
             float y = 0.5345224f;
             float z = 0.8017837f;
-            var config = ObjectAnchorsConversionModelFactory.AssetConversionConfiguration(default, default, new Vector3(x, y, z), default, default, default, 1, default, default);
+            var config = ObjectAnchorsConversionModelFactory.AssetConversionConfiguration(default, default, new Vector3(x, y, z), default!, default!, default, 1, default, default!);
             Assert.AreEqual(x, config.Gravity.X);
             Assert.AreEqual(y, config.Gravity.Y);
             Assert.AreEqual(z, config.Gravity.Z);
@@ -94,8 +91,9 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Tests
             float y = 2;
             float z = 3;
             float w = 4;
-            var config = ObjectAnchorsConversionModelFactory.AssetConversionConfiguration(default, default, gravity, default, default, default, 1, new Vector4(x, y, z, w), default);
-            Assert.AreEqual(x, config.SupportingPlane.Value.X);
+            var config = ObjectAnchorsConversionModelFactory.AssetConversionConfiguration(default, default, gravity, default!, default!, default, 1, new Vector4(x, y, z, w), default!);
+            Assert.NotNull(config.SupportingPlane);
+            Assert.AreEqual(x, config.SupportingPlane!.Value.X);
             Assert.AreEqual(y, config.SupportingPlane.Value.Y);
             Assert.AreEqual(z, config.SupportingPlane.Value.Z);
             Assert.AreEqual(w, config.SupportingPlane.Value.W);
@@ -109,8 +107,9 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Tests
             float y = 2;
             float z = 3;
             float w = 4;
-            var config = ObjectAnchorsConversionModelFactory.AssetConversionConfiguration(default, default, gravity, default, default, new Quaternion(x, y, z, w), 1, default, default);
-            Assert.AreEqual(x, config.PrincipalAxis.Value.X);
+            var config = ObjectAnchorsConversionModelFactory.AssetConversionConfiguration(default, default, gravity, default!, default!, new Quaternion(x, y, z, w), 1, default, default!);
+            Assert.NotNull(config.PrincipalAxis);
+            Assert.AreEqual(x, config.PrincipalAxis!.Value.X);
             Assert.AreEqual(y, config.PrincipalAxis.Value.Y);
             Assert.AreEqual(z, config.PrincipalAxis.Value.Z);
             Assert.AreEqual(w, config.PrincipalAxis.Value.W);

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/AssetFileTypeTests.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/AssetFileTypeTests.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using NUnit.Framework;
+
+namespace Azure.MixedReality.ObjectAnchors.Conversion.Tests
+{
+    public class AssetFileTypeTests
+    {
+        [Test]
+        public void ConstructorParameters()
+        {
+            _ = new AssetFileType(".foo");
+            Assert.Throws<ArgumentNullException>(() => new AssetFileType(null));
+            Assert.Throws<ArgumentException>(() => new AssetFileType(string.Empty));
+            Assert.Throws<ArgumentException>(() => new AssetFileType(" "));
+            Assert.Throws<ArgumentException>(() => new AssetFileType("foo"));
+        }
+
+        [Test]
+        public void Equality()
+        {
+            Assert.True(new AssetFileType(".foo").Equals(new AssetFileType(".FOO")));
+            Assert.False(new AssetFileType(".foo").Equals(new AssetFileType(".bar")));
+            Assert.False(new AssetFileType(".foo").Equals(".bar"));
+        }
+
+        [Test]
+        public void GetHashCodeFromDefault()
+        {
+            // Arrange
+            AssetFileType assetFileType = default;
+
+            // Act
+            int actualHashCode = assetFileType.GetHashCode();
+
+            // Assert
+            Assert.AreEqual(string.Empty.GetHashCode(), actualHashCode);
+        }
+    }
+}

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/AssetFileTypeTests.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/AssetFileTypeTests.cs
@@ -12,7 +12,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Tests
         public void ConstructorParameters()
         {
             _ = new AssetFileType(".foo");
-            Assert.Throws<ArgumentNullException>(() => new AssetFileType(null));
+            Assert.Throws<ArgumentNullException>(() => new AssetFileType(null!));
             Assert.Throws<ArgumentException>(() => new AssetFileType(string.Empty));
             Assert.Throws<ArgumentException>(() => new AssetFileType(" "));
             Assert.Throws<ArgumentException>(() => new AssetFileType("foo"));

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/Azure.MixedReality.ObjectAnchors.Conversion.Tests.csproj
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/Azure.MixedReality.ObjectAnchors.Conversion.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/ObjectAnchorsConversionClientLiveTests.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/ObjectAnchorsConversionClientLiveTests.cs
@@ -27,7 +27,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Tests
         private const float assetScale = 0.001f;
         private const string ClientCorrelationVectorHeaderName = "X-MRC-CV";
 
-        private static string currentWorkingDirectory => Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        private static string currentWorkingDirectory => Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
         private static readonly string assetLocalFilePath = Path.Combine(currentWorkingDirectory, assetsFolderName, assetsFileName);
         private static readonly string fakeAssetLocalFilePath = Path.Combine(currentWorkingDirectory, assetsFolderName, fakeAssetFileName);
         public string modelDownloadLocalFilePath => Path.Combine(currentWorkingDirectory, modelDownloadFileName);

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/ObjectAnchorsConversionClientOptionsTests.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/ObjectAnchorsConversionClientOptionsTests.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Azure.MixedReality.ObjectAnchors.Conversion.Tests
+{
+    public class ObjectAnchorsConversionClientOptionsTests
+    {
+        public static IEnumerable<object[]> FileTypeTestCases =>
+            new object[][]
+            {
+                new object[] { ".fbx", true },
+                new object[] { ".FBX", true },
+                new object[] { ".glb", true },
+                new object[] { ".GLB", true },
+                new object[] { ".obj", true },
+                new object[] { ".OBJ", true },
+                new object[] { ".ply", true },
+                new object[] { ".PLY", true },
+                new object[] { ".gltf", false },
+                new object[] { ".GLTF", false },
+                new object[] { ".exe", false },
+                new object[] { ".EXE", false },
+            };
+
+        [Test]
+        [TestCaseSource(nameof(FileTypeTestCases))]
+        public void IsFileTypeSupported_V0_2_preview_0(string fileExtension, bool expectedIsSupported)
+        {
+            // Arrange
+            AssetFileType assetFileType = new(fileExtension);
+            ObjectAnchorsConversionClientOptions clientOptions = new(ObjectAnchorsConversionClientOptions.ServiceVersion.V0_2_preview_0);
+
+            // Act
+            bool actualIsSupported = clientOptions.IsFileTypeSupported(assetFileType);
+
+            // Assert
+            Assert.AreEqual(expectedIsSupported, actualIsSupported);
+        }
+
+        [Test]
+        [TestCaseSource(nameof(FileTypeTestCases))]
+        public void IsFileTypeSupported_V0_3_preview_0(string fileExtension, bool expectedIsSupported)
+        {
+            // Arrange
+            AssetFileType assetFileType = new(fileExtension);
+            ObjectAnchorsConversionClientOptions clientOptions = new(ObjectAnchorsConversionClientOptions.ServiceVersion.V0_3_preview_0);
+
+            // Act
+            bool actualIsSupported = clientOptions.IsFileTypeSupported(assetFileType);
+
+            // Assert
+            Assert.AreEqual(expectedIsSupported, actualIsSupported);
+        }
+    }
+}

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/ObjectAnchorsConversionClientTests.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/ObjectAnchorsConversionClientTests.cs
@@ -42,12 +42,12 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Tests
             Assert.Throws<ArgumentException>(() => new ObjectAnchorsConversionClient(default, accountDomain, azureCredential, options));
             Assert.Throws<ArgumentException>(() => new ObjectAnchorsConversionClient(default, accountDomain, tokenCredential));
             Assert.Throws<ArgumentException>(() => new ObjectAnchorsConversionClient(default, accountDomain, tokenCredential, options));
-            Assert.Throws<ArgumentNullException>(() => new ObjectAnchorsConversionClient(accountId, null, accessToken));
-            Assert.Throws<ArgumentNullException>(() => new ObjectAnchorsConversionClient(accountId, null, accessToken, options));
-            Assert.Throws<ArgumentNullException>(() => new ObjectAnchorsConversionClient(accountId, null, azureCredential));
-            Assert.Throws<ArgumentNullException>(() => new ObjectAnchorsConversionClient(accountId, null, azureCredential, options));
-            Assert.Throws<ArgumentNullException>(() => new ObjectAnchorsConversionClient(accountId, null, tokenCredential));
-            Assert.Throws<ArgumentNullException>(() => new ObjectAnchorsConversionClient(accountId, null, tokenCredential, options));
+            Assert.Throws<ArgumentNullException>(() => new ObjectAnchorsConversionClient(accountId, null!, accessToken));
+            Assert.Throws<ArgumentNullException>(() => new ObjectAnchorsConversionClient(accountId, null!, accessToken, options));
+            Assert.Throws<ArgumentNullException>(() => new ObjectAnchorsConversionClient(accountId, null!, azureCredential));
+            Assert.Throws<ArgumentNullException>(() => new ObjectAnchorsConversionClient(accountId, null!, azureCredential, options));
+            Assert.Throws<ArgumentNullException>(() => new ObjectAnchorsConversionClient(accountId, null!, tokenCredential));
+            Assert.Throws<ArgumentNullException>(() => new ObjectAnchorsConversionClient(accountId, null!, tokenCredential, options));
             Assert.Throws<ArgumentException>(() => new ObjectAnchorsConversionClient(accountId, string.Empty, accessToken));
             Assert.Throws<ArgumentException>(() => new ObjectAnchorsConversionClient(accountId, string.Empty, accessToken, options));
             Assert.Throws<ArgumentException>(() => new ObjectAnchorsConversionClient(accountId, string.Empty, azureCredential));
@@ -60,9 +60,9 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Tests
             Assert.Throws<ArgumentException>(() => new ObjectAnchorsConversionClient(accountId, " ", azureCredential, options));
             Assert.Throws<ArgumentException>(() => new ObjectAnchorsConversionClient(accountId, " ", tokenCredential));
             Assert.Throws<ArgumentException>(() => new ObjectAnchorsConversionClient(accountId, " ", tokenCredential, options));
-            Assert.Throws<ArgumentNullException>(() => new ObjectAnchorsConversionClient(accountId, accountDomain, (AzureKeyCredential)null));
-            Assert.Throws<ArgumentNullException>(() => new ObjectAnchorsConversionClient(accountId, accountDomain, (AzureKeyCredential)null, options));
-            Assert.Throws<ArgumentNullException>(() => new ObjectAnchorsConversionClient(accountId, accountDomain, (TokenCredential)null));
+            Assert.Throws<ArgumentNullException>(() => new ObjectAnchorsConversionClient(accountId, accountDomain, (AzureKeyCredential)null!));
+            Assert.Throws<ArgumentNullException>(() => new ObjectAnchorsConversionClient(accountId, accountDomain, (AzureKeyCredential)null!, options));
+            Assert.Throws<ArgumentNullException>(() => new ObjectAnchorsConversionClient(accountId, accountDomain, (TokenCredential)null!));
         }
 
         [Test]

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/Samples/AssetConversionProcessSample.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/Samples/AssetConversionProcessSample.cs
@@ -22,7 +22,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Tests.Samples
         private const float assetGravityZ = 0;
         private const float assetScale = 0.001f;
 
-        private static string currentWorkingDirectory => Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        private static string currentWorkingDirectory => Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
         private static readonly string assetLocalFilePath = Path.Combine(currentWorkingDirectory, assetsFolderName, assetsFileName);
         public string modelDownloadLocalFilePath => Path.Combine(currentWorkingDirectory, modelDownloadFileName);
 


### PR DESCRIPTION
This change addresses some big issues in the Object Anchors Conversion SDK related to case sensitive file extensions and handling of null references along with several other more minor enhancements.

  - Make solution file target VS 2022 since we now include a .NET 6 target.
  - Fix ObjectAnchorsConversionClientTests to properly test what we intend to test.
    - Note: We can't currently mock parts of the client, so we can't perform positive tests with it.
  - Make asset file type comparisons case insensitive
    - This change enables the `AssetFileType` to handle file extensions with case insensitivity and enabling it to be testable by centralizing that logic in the client options.
    - I've also hardened the `AssetFileType` type to better handle null values in the case of the default value and other cases as well as to perform parameter validate to ensure we are creating values that will be useful.
  - Enabled null reference types
    - This change enables the nullable context handling to help me catch and handle more nullable references properly. This also allowed me to remove some unused and unnecessary internal setters and things.
    - This led me to an issue in the `ObjectAnchorsConversionClient` where we weren't setting the AccountDomain property at all.