### PR TITLE
Asset file type case and null handling

### DIFF
--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/CHANGELOG.md
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 ## 0.3.0-beta.3 (Unreleased)
 
+### Bugs Fixed
+
+- Fixed a regression from `0.2.0-beta.1` to validate file extensions case insensitively.
+
 ### Features Added
+
 - Added `ScaledAssetDimensions` to `AssetConversionProperties`.
 
 ### Breaking Changes
+
 - `OutputModelUri` now returns a `Uri` to a `.zip` file containing the `.ou` file instead of the `.ou` file itself when using the new default service version: `V0_3_preview_0`.
+- The value specified when creating an `AssetFileType` is now validated and must begin with a '.' character.
 
 ### Bugs Fixed
 

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetFileType.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetFileType.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel;
 using System.IO;
+using Azure.Core;
 
 namespace Azure.MixedReality.ObjectAnchors.Conversion
 {
@@ -19,13 +20,22 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         internal const string ObjValue = ".obj";
         internal const string PlyValue = ".ply";
 
+        internal string Value => _value ?? string.Empty;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AssetFileType"/> struct.
         /// </summary>
         /// <param name="value">The asset file type.</param>
         public AssetFileType(string value)
         {
-            _value = value ?? throw new ArgumentNullException(nameof(value));
+            Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
+
+            if (!value.StartsWith(".", StringComparison.Ordinal))
+            {
+                throw new ArgumentException("The value must start with a '.' character.", nameof(value));
+            }
+
+            _value = value.ToLowerInvariant();
         }
 
         /// <summary>
@@ -35,7 +45,9 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// <returns>The AssetFileType derived from the extension of a provided file name.</returns>
         public static AssetFileType FromFilePath(string assetFilePath)
         {
-            return new AssetFileType(Path.GetExtension(assetFilePath));
+            Argument.AssertNotNullOrWhiteSpace(assetFilePath, nameof(assetFilePath));
+
+            return new AssetFileType(Path.GetExtension(assetFilePath).ToLowerInvariant());
         }
 
         /// <summary>
@@ -85,24 +97,29 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// <inheritdoc/>
         public bool Equals(AssetFileType other)
         {
-            return this._value == other._value;
+            return Value.Equals(other._value, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj)
         {
-            return obj is AssetFileType && Equals((AssetFileType)obj);
+            if (obj is AssetFileType otherFileType)
+            {
+                return Equals(otherFileType);
+            }
+
+            return false;
         }
 
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()
         {
-            return _value.GetHashCode();
+            return Value.GetHashCode();
         }
 
         /// <inheritdoc/>
-        public override string ToString() => _value;
+        public override string ToString() => Value;
     }
 }

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/AssetFileTypeTests.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/AssetFileTypeTests.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using NUnit.Framework;
+
+namespace Azure.MixedReality.ObjectAnchors.Conversion.Tests
+{
+    public class AssetFileTypeTests
+    {
+        [Test]
+        public void ConstructorParameters()
+        {
+            _ = new AssetFileType(".foo");
+            Assert.Throws<ArgumentNullException>(() => new AssetFileType(null));
+            Assert.Throws<ArgumentException>(() => new AssetFileType(string.Empty));
+            Assert.Throws<ArgumentException>(() => new AssetFileType(" "));
+            Assert.Throws<ArgumentException>(() => new AssetFileType("foo"));
+        }
+
+        [Test]
+        public void Equality()
+        {
+            Assert.True(new AssetFileType(".foo").Equals(new AssetFileType(".FOO")));
+            Assert.False(new AssetFileType(".foo").Equals(new AssetFileType(".bar")));
+            Assert.False(new AssetFileType(".foo").Equals(".bar"));
+        }
+
+        [Test]
+        public void GetHashCodeFromDefault()
+        {
+            // Arrange
+            AssetFileType assetFileType = default;
+
+            // Act
+            int actualHashCode = assetFileType.GetHashCode();
+
+            // Assert
+            Assert.AreEqual(string.Empty.GetHashCode(), actualHashCode);
+        }
+    }
+}


### PR DESCRIPTION
  - Make asset file type comparisons case insensitive
    - This change enables the `AssetFileType` to handle file extensions with case insensitivity.
    - I've also hardened the `AssetFileType` type to better handle `null` values in the case of the default value and other cases as well as to perform parameter validate to ensure we are creating values that will be useful.
