### PR TITLE
Event Hubs: Buffered Producer Improvements

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -2501,6 +2501,32 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has encountered persistent service
+        ///   throttling during attempts to publish a batch and is backing off.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the buffered producer.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="partitionId">The identifier of the partition that the handler was invoked for.</param>
+        /// <param name="operationId">An artificial identifier for the publishing operation.</param>
+        /// <param name="backoffSeconds">The number of seconds that the back-off will delay.</param>
+        /// <param name="backoffCount">The message for the exception that occurred.</param>
+        ///
+        [Event(122, Level = EventLevel.Warning, Message = "The Event Hubs service is throttling the buffered producer instance with identifier '{0}' for Event Hub: {1}, Partition Id: '{2}', Operation Id: '{3}'.  To avoid overloading the service, publishing of this batch will delay for {4} seconds.  This batch has attempted a delay to avoid throttling {5} times.  This is non-fatal and publishing will continue to retry.")]
+        public virtual void BufferedProducerThrottleDelay(string identifier,
+                                                          string eventHubName,
+                                                          string partitionId,
+                                                          string operationId,
+                                                          double backoffSeconds,
+                                                          int backoffCount)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(122, identifier ?? string.Empty, eventHubName ?? string.Empty, partitionId ?? string.Empty, operationId ?? string.Empty, backoffSeconds, backoffCount);
+            }
+        }
+
+        /// <summary>
         ///   Indicates that the publishing of events has completed, writing into a stack allocated
         ///   <see cref="EventSource.EventData"/> struct to avoid the parameter array allocation on the WriteEvent methods.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
@@ -58,6 +58,15 @@ namespace Azure.Messaging.EventHubs.Producer
         /// <summary>The maximum amount of time, in milliseconds, to allow for acquiring the semaphore guarding a partition's publishing eligibility.</summary>
         private const int PartitionPublishingGuardAcquireLimitMilliseconds = 100;
 
+        /// <summary>The maximum number of seconds to delay between checks when no events are available in the buffers for any partition.</summary>
+        private const double MaximumEmptyBufferDelaySeconds = 1;
+
+        /// <summary>The number of seconds to use as the starting delay between checks when no events are available in the buffers for any partition.</summary>
+        private static readonly double StartingEmptyBufferDelaySeconds = TimeSpan.FromMilliseconds(25).TotalSeconds;
+
+        /// <summary>The base interval to delay when publishing is throttled and an operation needs to back-off before retrying.  Four seconds is recommended by the service.</summary>
+        private static readonly TimeSpan ThrottleBackoffInterval = TimeSpan.FromSeconds(4);
+
         /// <summary>The minimum interval to allow for waiting when building a batch to publish.</summary>
         private static readonly TimeSpan MinimumPublishingWaitInterval = TimeSpan.FromMilliseconds(5);
 
@@ -65,11 +74,13 @@ namespace Azure.Messaging.EventHubs.Producer
         private static readonly TimeSpan DefaultPublishingDelayInterval = TimeSpan.FromMilliseconds(25);
 
         /// <summary>The set of client options to use when options were not passed when the producer was instantiated.</summary>
-        private static readonly EventHubBufferedProducerClientOptions DefaultOptions =
-            new EventHubBufferedProducerClientOptions
-            {
-                RetryOptions = new EventHubsRetryOptions { MaximumRetries = 15, TryTimeout = TimeSpan.FromMinutes(3) }
-            };
+        private static readonly EventHubBufferedProducerClientOptions DefaultOptions = new();
+
+        /// <summary>The random number generator to use for a specific thread.</summary>
+        private static readonly ThreadLocal<Random> RandomNumberGenerator = new ThreadLocal<Random>(() => new Random(Interlocked.Increment(ref s_randomSeed)), false);
+
+        /// <summary>The seed to use for initializing random number generated for a given thread-specific instance.</summary>
+        private static int s_randomSeed = Environment.TickCount;
 
         /// <summary>The set of currently active partition publishing tasks.  Partition identifiers are used as keys.</summary>
         private readonly ConcurrentDictionary<string, PartitionPublishingState> _activePartitionStateMap = new();
@@ -1377,7 +1388,7 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 var totalWaitTime = _options.MaximumWaitTime ?? Timeout.InfiniteTimeSpan;
                 var remainingWaitTime = totalWaitTime;
-                var delayInterval = CalculateDelay(totalWaitTime, DefaultPublishingDelayInterval);
+                var delayInterval = CalculateBatchingDelay(totalWaitTime, DefaultPublishingDelayInterval);
 
                 // The wait time constraint should not consider creating the batch; start tracking after the batch is available to build.
 
@@ -1412,8 +1423,8 @@ namespace Azure.Messaging.EventHubs.Producer
 
                                 Logger.BufferedProducerEventBatchPublishError(Identifier, EventHubName, partitionId, operationId, message);
 
-                                // Handler invocation is performed in the background as a fire-and-forget operation.  Exceptions in the handler
-                                // are logged as part of the invocation.
+                                // Handler invocation is performed with a guarantee not to throw; exceptions in the handler are logged
+                                // as part of the invocation.
 
                                 await SafeInvokeOnSendFailedAsync(new List<EventData>(1) { currentEvent }, exception, partitionId, cancellationToken).ConfigureAwait(false);
                                 return;
@@ -1434,7 +1445,7 @@ namespace Azure.Messaging.EventHubs.Producer
                         // this point, the remaining time has not been updated, but the attempt to read was a quick synchronous operation,
                         // so the lack of precision is not a concern.
 
-                        delayInterval = CalculateDelay(remainingWaitTime, delayInterval);
+                        delayInterval = CalculateBatchingDelay(remainingWaitTime, delayInterval);
                         Logger.BufferedProducerEventBatchPublishNoEventRead(Identifier, EventHubName, partitionId, operationId, delayInterval.TotalSeconds, publishWatch.GetElapsedTime().TotalSeconds);
 
                         if (ShouldWait(remainingWaitTime, MinimumPublishingWaitInterval))
@@ -1454,10 +1465,10 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 if (batch.Count > 0)
                 {
-                    // Handler invocation is performed in the background as a fire-and-forget operation.  Exceptions in the handler
-                    // are logged as part of the invocation.
+                    // Handler invocation is performed with a guarantee not to throw; exceptions in the handler are logged
+                    // as part of the invocation.
 
-                    await _producer.SendAsync(batch, cancellationToken).ConfigureAwait(false);
+                    await SendBatchAsync(batch, partitionId, operationId, cancellationToken).ConfigureAwait(false);
                     await SafeInvokeOnSendSucceededAsync(batchEvents, partitionId, cancellationToken).ConfigureAwait(false);
                 }
             }
@@ -1465,8 +1476,8 @@ namespace Azure.Messaging.EventHubs.Producer
             {
                 Logger.BufferedProducerEventBatchPublishError(Identifier, EventHubName, partitionId, operationId, ex.Message);
 
-                // Handler invocation is performed in the background as a fire-and-forget operation.  Exceptions in the handler
-                // are logged as part of the invocation.
+                // Handler invocation is performed with a guarantee not to throw; exceptions in the handler are logged
+                // as part of the invocation.
 
                 if (batch?.Count > 0)
                 {
@@ -1923,6 +1934,53 @@ namespace Azure.Messaging.EventHubs.Producer
         }
 
         /// <summary>
+        ///   Performs the actions need to publish a batch of events, applying any needed
+        ///   logic for handling special error cases and recovery.
+        /// </summary>
+        ///
+        /// <param name="batch">The batch of events to publish.</param>
+        /// <param name="partitionId">The identifier of the partition associated with this publishing operation.</param>
+        /// <param name="operationId">The identifier of the publishing operation that this invocation is associated with.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the stop operation.</param>
+        ///
+        /// <remarks>
+        ///   Callers are assumed to retain ownership over the <paramref name="batch" /> and are responsible for its disposal.
+        /// </remarks>
+        ///
+        private async Task SendBatchAsync(EventDataBatch batch,
+                                          string partitionId,
+                                          string operationId,
+                                          CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var throttleBackoffs = 0;
+
+                try
+                {
+                    await _producer.SendAsync(batch, cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+                catch (EventHubsException ex) when (ex.Reason == EventHubsException.FailureReason.ServiceBusy)
+                {
+                    // The service is throttling requests.  Because this is not a scenario under control
+                    // of callers, the operation should continue to be retried until cancellation takes
+                    // place or the operation succeeds/fails. Retry policy limits should not be applied.
+
+                    ++throttleBackoffs;
+
+                    var randomJitter = TimeSpan.FromSeconds(RandomNumberGenerator.Value.NextDouble());
+                    var backoffInterval = ThrottleBackoffInterval.Add(randomJitter);
+
+                    Logger.BufferedProducerThrottleDelay(Identifier, EventHubName, partitionId, operationId, backoffInterval.TotalSeconds, throttleBackoffs);
+                    await Task.Delay(backoffInterval, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            throw new TaskCanceledException();
+        }
+
+        /// <summary>
         ///   Responsible for invoking <see cref="OnSendSucceededAsync" /> and ensuring that no exceptions
         ///   are surfaced.  This is necessary because the method may be overridden and non-throwing behavior
         ///   cannot be guaranteed.
@@ -2092,6 +2150,7 @@ namespace Azure.Messaging.EventHubs.Producer
                     existingSource?.Dispose();
 
                     var partitionIndex = 0u;
+                    var consecutiveEmptyBufferCount = 0;
                     var partitions = default(string[]);
                     var activeTasks = new List<Task>(_options.MaximumConcurrentSends);
 
@@ -2145,14 +2204,21 @@ namespace Azure.Messaging.EventHubs.Producer
                                 // Responsibility for releasing the guard semaphore is passed to the task.
 
                                 activeTasks.Add(PublishBatchToPartition(partitionState, releaseGuard: true, activeOperationCancellationSource.Token));
+                                consecutiveEmptyBufferCount = 0;
                             }
 
-                            // If there are no publishing tasks active, introduce a small
-                            // delay to avoid a tight loop.
+                            // If there are no publishing tasks active, introduce a small delay to avoid a tight loop.  If no events are
+                            // available in the buffers, use an increasing delay to avoid wasting resources during periods of low activity.
 
                             if (activeTasks.Count == 0)
                             {
-                                 await Task.Delay(DefaultPublishingDelayInterval, cancellationToken).ConfigureAwait(false);
+                                var delay = _totalBufferedEventCount switch
+                                {
+                                    0 => CalculateEmptyBufferDelay(++consecutiveEmptyBufferCount, StartingEmptyBufferDelaySeconds, MaximumEmptyBufferDelaySeconds),
+                                    _ => DefaultPublishingDelayInterval
+                                };
+
+                                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
                             }
                         }
                         catch (OperationCanceledException)
@@ -2314,16 +2380,36 @@ namespace Azure.Messaging.EventHubs.Producer
           ((waitTime == Timeout.InfiniteTimeSpan) || (waitTime > minimumAllowedWaitTime));
 
         /// <summary>
-        ///   Calculates the amount of delay to apply, ensuring that the remaining time allotted
-        ///   supersedes the delay amount, if not enough time remains for the full delay.
+        ///   Calculates the amount of delay to apply when building a batch, ensuring that the remaining time
+        ///   allotted supersedes the delay amount, if not enough time remains for the full delay.
         /// </summary>
         /// <param name="remainingTime">The amount of allotted time remaining.</param>
         /// <param name="delayInterval">The desired delay interval.</param>
         ///
         /// <returns>The amount of delay to apply.</returns>
         ///
-        private static TimeSpan CalculateDelay(TimeSpan remainingTime,
-                                               TimeSpan delayInterval) => ((remainingTime != Timeout.InfiniteTimeSpan) && (remainingTime < delayInterval)) ? remainingTime : delayInterval;
+        private static TimeSpan CalculateBatchingDelay(TimeSpan remainingTime,
+                                                       TimeSpan delayInterval) => ((remainingTime != Timeout.InfiniteTimeSpan) && (remainingTime < delayInterval)) ? remainingTime : delayInterval;
+
+        /// <summary>
+        ///   Calculates the amount of delay to apply between checks when no events are available
+        ///   in the buffers for any partition, gradually increasing for each empty check until it
+        ///   reaches the maximum limit.
+        /// </summary>
+        ///
+        /// <param name="consecutiveEmptyBufferCount">The consecutive number of times that the buffers have been empty when checked.</param>
+        /// <param name="startingEmptyBufferDelaySeconds">The number of seconds to use as the starting point for the delay.</param>
+        /// <param name="maximumBufferDelaySeconds">The maximum number of seconds to allow as a delay.</param>
+        ///
+        /// <returns>The amount of delay to apply before checking the buffers for available events.</returns>
+        ///
+        private static TimeSpan CalculateEmptyBufferDelay(int consecutiveEmptyBufferCount,
+                                                          double startingEmptyBufferDelaySeconds,
+                                                          double maximumBufferDelaySeconds)
+        {
+            var delay = (Math.Pow(1.4, consecutiveEmptyBufferCount) * startingEmptyBufferDelaySeconds);
+            return delay > maximumBufferDelaySeconds ? TimeSpan.FromSeconds(1) : TimeSpan.FromSeconds(delay);
+        }
 
         /// <summary>
         ///   The set of information needed to track and manage the active publishing

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
@@ -2408,7 +2408,7 @@ namespace Azure.Messaging.EventHubs.Producer
                                                           double maximumBufferDelaySeconds)
         {
             var delay = (Math.Pow(1.4, consecutiveEmptyBufferCount) * startingEmptyBufferDelaySeconds);
-            return delay > maximumBufferDelaySeconds ? TimeSpan.FromSeconds(1) : TimeSpan.FromSeconds(delay);
+            return TimeSpan.FromSeconds(delay > maximumBufferDelaySeconds ? maximumBufferDelaySeconds : delay);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClientOptions.cs
@@ -32,7 +32,7 @@ namespace Azure.Messaging.EventHubs.Producer
         private EventHubConnectionOptions _connectionOptions = new EventHubConnectionOptions();
 
         /// <summary>The set of options to govern retry behavior and try timeouts.</summary>
-        private EventHubsRetryOptions _retryOptions = new EventHubsRetryOptions();
+        private EventHubsRetryOptions _retryOptions = new EventHubBufferedProducerClientRetryOptions();
 
         /// <summary>
         ///   Indicates whether or not events should be published using idempotent semantics for retries. If enabled, retries during publishing
@@ -272,6 +272,26 @@ namespace Azure.Messaging.EventHubs.Producer
                 RetryOptions = RetryOptions
             };
             return translatedOptions;
+        }
+
+        /// <summary>
+        ///   Provides a set of retry options with defaults optimized for use with the
+        ///   <see cref="EventHubBufferedProducerClient" />.
+        /// </summary>
+        ///
+        /// <seealso cref="EventHubsRetryOptions" />
+        ///
+        private class EventHubBufferedProducerClientRetryOptions : EventHubsRetryOptions
+        {
+            /// <summary>
+            ///   Initializes a new instance of the <see cref="EventHubBufferedProducerClientRetryOptions"/> class.
+            /// </summary>
+            ///
+            public EventHubBufferedProducerClientRetryOptions() : base()
+            {
+                MaximumRetries = 15;
+                TryTimeout = TimeSpan.FromMinutes(3);
+            }
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClientOptions.cs
@@ -32,7 +32,7 @@ namespace Azure.Messaging.EventHubs.Producer
         private EventHubConnectionOptions _connectionOptions = new EventHubConnectionOptions();
 
         /// <summary>The set of options to govern retry behavior and try timeouts.</summary>
-        private EventHubsRetryOptions _retryOptions = new EventHubBufferedProducerClientRetryOptions();
+        private EventHubsRetryOptions _retryOptions;
 
         /// <summary>
         ///   Indicates whether or not events should be published using idempotent semantics for retries. If enabled, retries during publishing
@@ -200,6 +200,19 @@ namespace Azure.Messaging.EventHubs.Producer
         }
 
         /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubBufferedProducerClientOptions"/> class.
+        /// </summary>
+        ///
+        public EventHubBufferedProducerClientOptions()
+        {
+            _retryOptions = new EventHubsRetryOptions
+            {
+                MaximumRetries = 15,
+                TryTimeout = TimeSpan.FromMinutes(3),
+            };
+        }
+
+        /// <summary>
         ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.
         /// </summary>
         ///
@@ -272,26 +285,6 @@ namespace Azure.Messaging.EventHubs.Producer
                 RetryOptions = RetryOptions
             };
             return translatedOptions;
-        }
-
-        /// <summary>
-        ///   Provides a set of retry options with defaults optimized for use with the
-        ///   <see cref="EventHubBufferedProducerClient" />.
-        /// </summary>
-        ///
-        /// <seealso cref="EventHubsRetryOptions" />
-        ///
-        private class EventHubBufferedProducerClientRetryOptions : EventHubsRetryOptions
-        {
-            /// <summary>
-            ///   Initializes a new instance of the <see cref="EventHubBufferedProducerClientRetryOptions"/> class.
-            /// </summary>
-            ///
-            public EventHubBufferedProducerClientRetryOptions() : base()
-            {
-                MaximumRetries = 15;
-                TryTimeout = TimeSpan.FromMinutes(3);
-            }
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientOptionsTests.cs
@@ -24,6 +24,23 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        public void RetryOptionsAreOptimizedForBufferedPublishing()
+        {
+            var standardRetryOptions = new EventHubsRetryOptions();
+            var options = new EventHubBufferedProducerClientOptions();
+
+            Assert.That(options.RetryOptions, Is.Not.Null, "The retry options should not be null.");
+            Assert.That(options.RetryOptions.GetType().Name, Is.Not.EqualTo(typeof(EventHubsRetryOptions).Name), "The buffered retry options should be a custom type.");
+            Assert.That(options.RetryOptions.MaximumRetries, Is.GreaterThan(standardRetryOptions.MaximumRetries), "The buffered retry options should allow for more retries than the standard.");
+            Assert.That(options.RetryOptions.TryTimeout, Is.GreaterThan(standardRetryOptions.TryTimeout), "The buffered retry options should allow for a longer try timeout than the standard.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClientOptions.Clone" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
         public void CloneProducesACopy()
         {
             var options = new EventHubBufferedProducerClientOptions
@@ -34,9 +51,13 @@ namespace Azure.Messaging.EventHubs.Tests
                 MaximumConcurrentSends = 9,
                 MaximumConcurrentSendsPerPartition = 5,
                 Identifier = "Test-Options",
-                ConnectionOptions = new EventHubConnectionOptions { TransportType = EventHubsTransportType.AmqpWebSockets },
-                RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(36) }
+                ConnectionOptions = new EventHubConnectionOptions { TransportType = EventHubsTransportType.AmqpWebSockets }
             };
+
+            // Update the options without assigning a new instance.  This will ensure that the default custom type
+            // that defines buffered publishing defaults is maintained.
+
+            options.RetryOptions.TryTimeout = TimeSpan.FromMinutes(26);
 
             var clone = options.Clone();
             Assert.That(clone, Is.Not.Null, "The clone should not be null.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientOptionsTests.cs
@@ -30,7 +30,6 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new EventHubBufferedProducerClientOptions();
 
             Assert.That(options.RetryOptions, Is.Not.Null, "The retry options should not be null.");
-            Assert.That(options.RetryOptions.GetType().Name, Is.Not.EqualTo(typeof(EventHubsRetryOptions).Name), "The buffered retry options should be a custom type.");
             Assert.That(options.RetryOptions.MaximumRetries, Is.GreaterThan(standardRetryOptions.MaximumRetries), "The buffered retry options should allow for more retries than the standard.");
             Assert.That(options.RetryOptions.TryTimeout, Is.GreaterThan(standardRetryOptions.TryTimeout), "The buffered retry options should allow for a longer try timeout than the standard.");
         }


### PR DESCRIPTION
# Summary 

The focus of these changes is to enhance the buffered producer with some minor improvements based on stress and performance test findings.

- When the service is throttling, logic has been added to allow for retrying with an additional back-off until the operation completes or has been cancelled. Because callers do not directly influence when publishing takes place, they should not be exposed to failures for throttling; doing so would require that they take extreme steps, such as manually publishing the throttled events or recreating their producer to reset buffers if the ordering of events needed to be restored.

- When events are not available in the buffer, an expanding back-off is now applied to the publishing loop.  This is intended to avoid wasting resources in a spin-wait scenario during periods of low activity.  In the current implementation, consecutive empty buffer checks will result in a delay pattern that looks like:

    - 25 ms
    - 35 ms
    - 48 ms
    - 68 ms
    - 96 ms
    - 134 ms
    - 188 ms
    - 263 ms
    - 368 ms
    - 516 ms
    - 723 ms
    - 1 second

  Once the back-off reaches one second, it will continue to use that value until an event is available in the buffer.

- The approach to setting buffered producer-specific retry defaults is now more robust and will be applied when options are passed rather than only in the case when they were not.  Customization of retry values will continue to be appropriately respected.
