### PR TITLE
Fixing CodeGen Capitalization

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/GeneratorStubs/InternalTypes.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/GeneratorStubs/InternalTypes.cs
@@ -7,8 +7,8 @@ namespace Azure.AI.TextAnalytics.Models
 {
 #pragma warning disable SA1402 // File may only contain a single type
 
-    [CodeGenModel("CustomEntitiesResultDocumentsitem")]
-    internal partial class CustomEntitiesResultDocumentsitem { }
+    [CodeGenModel("CustomEntitiesResultDocumentsItem")]
+    internal partial class CustomEntitiesResultDocumentsItem { }
 
     [CodeGenModel("CustomMultiLabelClassificationResultDocumentsItem")]
     internal partial class CustomMultiLabelClassificationResultDocumentsItem { }


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a typo in the `CustomEntitiesResultDocumentsItem` stub which was causing "item" to be generated as lower-case.  This differs from the capitalization of the file committed to the repository and was causing issues with case-sensitive file systems in CI when the "Analyze" step was run during API diff checks.