### PR TITLE
[Text Analytics] Fixing CodeGen Capitalization

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/CustomEntitiesResult.Serialization.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/CustomEntitiesResult.Serialization.cs
@@ -45,7 +45,7 @@ namespace Azure.AI.TextAnalytics.Models
 
         internal static CustomEntitiesResult DeserializeCustomEntitiesResult(JsonElement element)
         {
-            IList<CustomEntitiesResultDocumentsitem> documents = default;
+            IList<CustomEntitiesResultDocumentsItem> documents = default;
             IList<DocumentError> errors = default;
             Optional<TextDocumentBatchStatistics> statistics = default;
             string projectName = default;
@@ -54,10 +54,10 @@ namespace Azure.AI.TextAnalytics.Models
             {
                 if (property.NameEquals("documents"))
                 {
-                    List<CustomEntitiesResultDocumentsitem> array = new List<CustomEntitiesResultDocumentsitem>();
+                    List<CustomEntitiesResultDocumentsItem> array = new List<CustomEntitiesResultDocumentsItem>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(CustomEntitiesResultDocumentsitem.DeserializeCustomEntitiesResultDocumentsitem(item));
+                        array.Add(CustomEntitiesResultDocumentsItem.DeserializeCustomEntitiesResultDocumentsItem(item));
                     }
                     documents = array;
                     continue;

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/CustomEntitiesResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/CustomEntitiesResult.cs
@@ -21,7 +21,7 @@ namespace Azure.AI.TextAnalytics.Models
         /// <param name="deploymentName"> This field indicates the deployment name for the model. </param>
         /// <param name="documents"> Response by document. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="errors"/>, <paramref name="projectName"/>, <paramref name="deploymentName"/> or <paramref name="documents"/> is null. </exception>
-        public CustomEntitiesResult(IEnumerable<DocumentError> errors, string projectName, string deploymentName, IEnumerable<CustomEntitiesResultDocumentsitem> documents) : base(errors, projectName, deploymentName)
+        public CustomEntitiesResult(IEnumerable<DocumentError> errors, string projectName, string deploymentName, IEnumerable<CustomEntitiesResultDocumentsItem> documents) : base(errors, projectName, deploymentName)
         {
             if (errors == null)
             {
@@ -49,12 +49,12 @@ namespace Azure.AI.TextAnalytics.Models
         /// <param name="projectName"> This field indicates the project name for the model. </param>
         /// <param name="deploymentName"> This field indicates the deployment name for the model. </param>
         /// <param name="documents"> Response by document. </param>
-        internal CustomEntitiesResult(IList<DocumentError> errors, TextDocumentBatchStatistics statistics, string projectName, string deploymentName, IList<CustomEntitiesResultDocumentsitem> documents) : base(errors, statistics, projectName, deploymentName)
+        internal CustomEntitiesResult(IList<DocumentError> errors, TextDocumentBatchStatistics statistics, string projectName, string deploymentName, IList<CustomEntitiesResultDocumentsItem> documents) : base(errors, statistics, projectName, deploymentName)
         {
             Documents = documents;
         }
 
         /// <summary> Response by document. </summary>
-        public IList<CustomEntitiesResultDocumentsitem> Documents { get; }
+        public IList<CustomEntitiesResultDocumentsItem> Documents { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/CustomEntitiesResultDocumentsItem.Serialization.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/CustomEntitiesResultDocumentsItem.Serialization.cs
@@ -12,7 +12,7 @@ using Azure.Core;
 
 namespace Azure.AI.TextAnalytics.Models
 {
-    internal partial class CustomEntitiesResultDocumentsitem : IUtf8JsonSerializable
+    internal partial class CustomEntitiesResultDocumentsItem : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
@@ -41,7 +41,7 @@ namespace Azure.AI.TextAnalytics.Models
             writer.WriteEndObject();
         }
 
-        internal static CustomEntitiesResultDocumentsitem DeserializeCustomEntitiesResultDocumentsitem(JsonElement element)
+        internal static CustomEntitiesResultDocumentsItem DeserializeCustomEntitiesResultDocumentsItem(JsonElement element)
         {
             IList<Entity> entities = default;
             string id = default;
@@ -85,7 +85,7 @@ namespace Azure.AI.TextAnalytics.Models
                     continue;
                 }
             }
-            return new CustomEntitiesResultDocumentsitem(id, warnings, Optional.ToNullable(statistics), entities);
+            return new CustomEntitiesResultDocumentsItem(id, warnings, Optional.ToNullable(statistics), entities);
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/CustomEntitiesResultDocumentsItem.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/CustomEntitiesResultDocumentsItem.cs
@@ -12,14 +12,14 @@ using Azure.AI.TextAnalytics;
 namespace Azure.AI.TextAnalytics.Models
 {
     /// <summary> The CustomEntitiesResultDocumentsItem. </summary>
-    internal partial class CustomEntitiesResultDocumentsitem : EntitiesDocumentResult
+    internal partial class CustomEntitiesResultDocumentsItem : EntitiesDocumentResult
     {
-        /// <summary> Initializes a new instance of CustomEntitiesResultDocumentsitem. </summary>
+        /// <summary> Initializes a new instance of CustomEntitiesResultDocumentsItem. </summary>
         /// <param name="id"> Unique, non-empty document identifier. </param>
         /// <param name="warnings"> Warnings encountered while processing document. </param>
         /// <param name="entities"> Recognized entities in the document. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="id"/>, <paramref name="warnings"/> or <paramref name="entities"/> is null. </exception>
-        public CustomEntitiesResultDocumentsitem(string id, IEnumerable<DocumentWarning> warnings, IEnumerable<Entity> entities) : base(id, warnings, entities)
+        public CustomEntitiesResultDocumentsItem(string id, IEnumerable<DocumentWarning> warnings, IEnumerable<Entity> entities) : base(id, warnings, entities)
         {
             if (id == null)
             {
@@ -35,12 +35,12 @@ namespace Azure.AI.TextAnalytics.Models
             }
         }
 
-        /// <summary> Initializes a new instance of CustomEntitiesResultDocumentsitem. </summary>
+        /// <summary> Initializes a new instance of CustomEntitiesResultDocumentsItem. </summary>
         /// <param name="id"> Unique, non-empty document identifier. </param>
         /// <param name="warnings"> Warnings encountered while processing document. </param>
         /// <param name="statistics"> if showStats=true was specified in the request this field will contain information about the document payload. </param>
         /// <param name="entities"> Recognized entities in the document. </param>
-        internal CustomEntitiesResultDocumentsitem(string id, IList<DocumentWarning> warnings, TextDocumentStatistics? statistics, IList<Entity> entities) : base(id, warnings, statistics, entities)
+        internal CustomEntitiesResultDocumentsItem(string id, IList<DocumentWarning> warnings, TextDocumentStatistics? statistics, IList<Entity> entities) : base(id, warnings, statistics, entities)
         {
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/GeneratorStubs/InternalTypes.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/GeneratorStubs/InternalTypes.cs
@@ -7,8 +7,8 @@ namespace Azure.AI.TextAnalytics.Models
 {
 #pragma warning disable SA1402 // File may only contain a single type
 
-    [CodeGenModel("CustomEntitiesResultDocumentsitem")]
-    internal partial class CustomEntitiesResultDocumentsitem { }
+    [CodeGenModel("CustomEntitiesResultDocumentsItem")]
+    internal partial class CustomEntitiesResultDocumentsItem { }
 
     [CodeGenModel("CustomMultiLabelClassificationResultDocumentsItem")]
     internal partial class CustomMultiLabelClassificationResultDocumentsItem { }


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a typo in the `CustomEntitiesResultDocumentsItem` stub which was causing "item" to be generated as lower-case. This differs from the capitalization of the file committed to the repository and was causing issues with case-sensitive file systems in CI when the "Analyze" step was run during API diff checks.