### PR TITLE
Azure Extensions: GUID Parameter Recognition

### DIFF
--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
@@ -319,6 +319,11 @@ namespace Microsoft.Extensions.Azure
                 return TryConvertFromString(configuration, parameterName, s => new Uri(s), out value);
             }
 
+            if (parameterType == typeof(Guid))
+            {
+                return TryConvertFromString(configuration, parameterName, s => Guid.Parse(s), out value);
+            }
+
             return TryCreateObject(parameterType, configuration.GetSection(parameterName), out value);
         }
 

--- a/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
@@ -52,6 +52,24 @@ namespace Azure.Core.Extensions.Tests
         }
 
         [Test]
+        public void FailsToConvertInvalidUriConfiguration()
+        {
+            IConfiguration configuration = GetConfiguration(new KeyValuePair<string, string>("uri", "no it its not"));
+
+            var clientOptions = new TestClientOptions();
+            Assert.Throws<UriFormatException>(() => ClientFactory.CreateClient(typeof(TestClient), typeof(TestClientOptions), clientOptions, configuration, null));
+        }
+
+        [Test]
+        public void FailsToConvertInvalidGuidConfiguration()
+        {
+            IConfiguration configuration = GetConfiguration(new KeyValuePair<string, string>("guid", "no it its not"));
+
+            var clientOptions = new TestClientOptions();
+            Assert.Throws<FormatException>(() => ClientFactory.CreateClient(typeof(TestClient), typeof(TestClientOptions), clientOptions, configuration, null));
+        }
+
+        [Test]
         public void ConvertsCompositeObjectsConstructorParameters()
         {
             IConfiguration configuration = GetConfiguration(new KeyValuePair<string, string>("composite:c", "http://localhost"));

--- a/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
@@ -39,6 +39,19 @@ namespace Azure.Core.Extensions.Tests
         }
 
         [Test]
+        public void ConvertsGuidConstructorParameters()
+        {
+            var guidValue = Guid.NewGuid().ToString();
+            IConfiguration configuration = GetConfiguration(new KeyValuePair<string, string>("guid", guidValue));
+
+            var clientOptions = new TestClientOptions();
+            var client = (TestClient)ClientFactory.CreateClient(typeof(TestClient), typeof(TestClientOptions), clientOptions, configuration, null);
+
+            Assert.AreEqual(guidValue, client.Guid.ToString());
+            Assert.AreSame(clientOptions, client.Options);
+        }
+
+        [Test]
         public void ConvertsCompositeObjectsConstructorParameters()
         {
             IConfiguration configuration = GetConfiguration(new KeyValuePair<string, string>("composite:c", "http://localhost"));

--- a/sdk/extensions/Microsoft.Extensions.Azure/tests/TestClient.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/tests/TestClient.cs
@@ -8,6 +8,7 @@ namespace Azure.Core.Extensions.Tests
     internal class TestClient
     {
         public Uri Uri { get; }
+        public Guid Guid { get; }
         public string ConnectionString { get; }
         public CompositeObject Composite { get; }
         public TestClientOptions Options { get; }
@@ -31,6 +32,12 @@ namespace Azure.Core.Extensions.Tests
         public TestClient(Uri uri, TestClientOptions options)
         {
             Uri = uri;
+            Options = options;
+        }
+
+        public TestClient(Guid guid, TestClientOptions options)
+        {
+            Guid = guid;
             Options = options;
         }
 


### PR DESCRIPTION
# Summary

The focus of these changes is to add recognition for GUID parameter types in client constructors when creating from configuration.  This is intended to unblock scenarios needed by the AnomalyDetector client library.