### PR TITLE
[FormRecognizer] Applying the IgnoreServiceError property

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentAnalysisClient/DocumentAnalysisClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentAnalysisClient/DocumentAnalysisClientLiveTests.cs
@@ -20,7 +20,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
     /// These tests have a dependency on live Azure services and may incur costs for the associated
     /// Azure subscription.
     /// </remarks>
-    [IgnoreServiceError(400, "ContentSourceNotAccessible", Message = "Content is not accessible: Invalid data URL", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28923")]
+    [IgnoreServiceError(400, "InvalidRequest", Message = "Content is not accessible: Invalid data URL", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28923")]
     [ClientTestFixture(
      DocumentAnalysisClientOptions.ServiceVersion.V2022_01_30_preview)]
     public class DocumentAnalysisClientLiveTests : DocumentAnalysisLiveTestBase

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentAnalysisClient/DocumentAnalysisClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentAnalysisClient/DocumentAnalysisClientLiveTests.cs
@@ -20,6 +20,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
     /// These tests have a dependency on live Azure services and may incur costs for the associated
     /// Azure subscription.
     /// </remarks>
+    [IgnoreServiceError(400, "ContentSourceNotAccessible", Message = "Content is not accessible: Invalid data URL", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28923")]
     [ClientTestFixture(
      DocumentAnalysisClientOptions.ServiceVersion.V2022_01_30_preview)]
     public class DocumentAnalysisClientLiveTests : DocumentAnalysisLiveTestBase

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentAnalysisModels/OperationsLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentAnalysisModels/OperationsLiveTests.cs
@@ -17,6 +17,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
     /// These tests have a dependency on live Azure services and may incur costs for the associated
     /// Azure subscription.
     /// </remarks>
+    [IgnoreServiceError(400, "InvalidRequest", Message = "Content is not accessible: Invalid data URL", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28923")]
     public class OperationsLiveTests : DocumentAnalysisLiveTestBase
     {
         /// <summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationClientLiveTests.cs
@@ -202,6 +202,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
         [RecordedTest]
         [TestCase(true)]
         [TestCase(false)]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/28705")]
         public async Task AdminOps(bool useTokenCredential)
         {
             var client = CreateDocumentModelAdministrationClient(useTokenCredential);
@@ -236,8 +237,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
 
             await client.DeleteModelAsync(modelId);
 
-            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(() => client.GetModelAsync(modelId));
-            Console.WriteLine(ex.ErrorCode);
+            Assert.ThrowsAsync<RequestFailedException>(() => client.GetModelAsync(modelId));
         }
 
         [RecordedTest]

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationClientLiveTests.cs
@@ -17,7 +17,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
     /// These tests have a dependency on live Azure services and may incur costs for the associated
     /// Azure subscription.
     /// </remarks>
-    [IgnoreServiceError(400, "ContentSourceNotAccessible", Message = "Content is not accessible: Invalid data URL", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28923")]
+    [IgnoreServiceError(400, "InvalidRequest", Message = "Content is not accessible: Invalid data URL", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28923")]
     public class DocumentModelAdministrationClientLiveTests : DocumentAnalysisLiveTestBase
     {
         private readonly IReadOnlyDictionary<string, string> TestingTags = new Dictionary<string, string>()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationClientLiveTests.cs
@@ -17,6 +17,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
     /// These tests have a dependency on live Azure services and may incur costs for the associated
     /// Azure subscription.
     /// </remarks>
+    [IgnoreServiceError(400, "ContentSourceNotAccessible", Message = "Content is not accessible: Invalid data URL", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28923")]
     public class DocumentModelAdministrationClientLiveTests : DocumentAnalysisLiveTestBase
     {
         private readonly IReadOnlyDictionary<string, string> TestingTags = new Dictionary<string, string>()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/RecognizeCustomFormsLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/RecognizeCustomFormsLiveTests.cs
@@ -21,6 +21,7 @@ namespace Azure.AI.FormRecognizer.Tests
     [ClientTestFixture(
     FormRecognizerClientOptions.ServiceVersion.V2_0,
     FormRecognizerClientOptions.ServiceVersion.V2_1)]
+    [IgnoreServiceError(200, "3014", Message = "Generic error during training.")]
     public class RecognizeCustomFormsLiveTests : FormRecognizerLiveTestBase
     {
         public RecognizeCustomFormsLiveTests(bool isAsync, FormRecognizerClientOptions.ServiceVersion serviceVersion)
@@ -231,6 +232,7 @@ namespace Azure.AI.FormRecognizer.Tests
         }
 
         [RecordedTest]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/28556")]
         public async Task StartRecognizeCustomFormsWithLabelsCanParseBlankPage()
         {
             var client = CreateFormRecognizerClient();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/RecognizeCustomFormsLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/RecognizeCustomFormsLiveTests.cs
@@ -21,7 +21,7 @@ namespace Azure.AI.FormRecognizer.Tests
     [ClientTestFixture(
     FormRecognizerClientOptions.ServiceVersion.V2_0,
     FormRecognizerClientOptions.ServiceVersion.V2_1)]
-    [IgnoreServiceError(200, "3014", Message = "Generic error during training.")]
+    [IgnoreServiceError(200, "3014", Message = "Generic error during training.", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28913")]
     public class RecognizeCustomFormsLiveTests : FormRecognizerLiveTestBase
     {
         public RecognizeCustomFormsLiveTests(bool isAsync, FormRecognizerClientOptions.ServiceVersion serviceVersion)

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
@@ -19,6 +19,7 @@ namespace Azure.AI.FormRecognizer.Tests
     /// These tests have a dependency on live Azure services and may incur costs for the associated
     /// Azure subscription.
     /// </remarks>
+    [IgnoreServiceError(200, "3014", Message = "Generic error during training.", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28913")]
     public class FormTrainingClientLiveTests : FormRecognizerLiveTestBase
     {
         /// <summary>


### PR DESCRIPTION
This PR makes our tests ignore a couple of service-side errors we have been facing for months. GitHub issues have been created to track those.

Fixes #26956.
Fixes #27498.