### PR TITLE
fix(dpg): issues in GenerateAndBuildLib.ps1

### DIFF
--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -187,12 +187,13 @@ function New-DataPlanePackageFolder() {
         $dotnetNewCmd = $dotnetNewCmd + " --includeCI false"
     }
     # dotnet new azsdkdpg --name $namespace --clientName $clientName --groupName $groupName --serviceDirectory $service --swagger $inputfile --securityScopes $securityScope --securityHeaderName $securityHeaderName --includeCI true --force
-    Write-Host "Invote dotnet new command: $dotnetNewCmd"
+    Write-Host "Invoke dotnet new command: $dotnetNewCmd"
     Invoke-Expression $dotnetNewCmd
+    Pop-Location
 
     $file = (Join-Path $projectFolder "src" $AUTOREST_CONFIG_FILE)
+    Write-Host "Generating configuration file: $file"
     Update-AutorestConfigFile -autorestFilePath $file -readme $readme
-    Pop-Location
     # dotnet sln
     Push-Location $projectFolder
     dotnet sln remove src\$namespace.csproj

--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -189,11 +189,11 @@ function New-DataPlanePackageFolder() {
     # dotnet new azsdkdpg --name $namespace --clientName $clientName --groupName $groupName --serviceDirectory $service --swagger $inputfile --securityScopes $securityScope --securityHeaderName $securityHeaderName --includeCI true --force
     Write-Host "Invoke dotnet new command: $dotnetNewCmd"
     Invoke-Expression $dotnetNewCmd
-    Pop-Location
 
     $file = (Join-Path $projectFolder "src" $AUTOREST_CONFIG_FILE)
     Write-Host "Generating configuration file: $file"
     Update-AutorestConfigFile -autorestFilePath $file -readme $readme
+    Pop-Location
     # dotnet sln
     Push-Location $projectFolder
     dotnet sln remove src\$namespace.csproj

--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -191,7 +191,7 @@ function New-DataPlanePackageFolder() {
     Invoke-Expression $dotnetNewCmd
 
     $file = (Join-Path $projectFolder "src" $AUTOREST_CONFIG_FILE)
-    Write-Host "Generating configuration file: $file"
+    Write-Host "Updating configuration file: $file"
     Update-AutorestConfigFile -autorestFilePath $file -readme $readme
     Pop-Location
     # dotnet sln


### PR DESCRIPTION
- fix a typo
- fix a relative location problem;
  - uplift `Pop-Location` right after the work under `sdkPath` is done
  - So when composing `$file` from a relative path, it's not under `sdkPath`.

fix #28626 #28627

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
