### PR TITLE
[Event Hubs] Remove Project References

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Experimental/src/Azure.Messaging.EventHubs.Experimental.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Experimental/src/Azure.Messaging.EventHubs.Experimental.csproj
@@ -12,15 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--
-        TEMP:
-            Version override is needed until the 5.7.x line reaches a stable release.
-
     <PackageReference Include="Azure.Messaging.EventHubs" />
-    -->
-    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.7.0-beta.5" />
-    <!-- END TEMP -->
-    
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.Reflection.TypeExtensions" />

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
@@ -12,18 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--
-        TEMP:
-            Project reference is needed until the CheckpointStore is included in a release.  Revert when
-            the 5.7.x line is released for GA.
-
-    <PackageReference Include="Azure.Messaging.EventHubs" />
-    -->
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" />
-    <!-- END TEMP -->
+   <PackageReference Include="Azure.Messaging.EventHubs" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.WebJobs" />
-
     <PackageReference Include="Microsoft.Extensions.Azure" />
   </ItemGroup>
 
@@ -36,6 +27,7 @@
     <Compile Include="../../Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/*.cs" LinkBase="SharedSource" />
     <Compile Include="../../../extensions/Microsoft.Azure.WebJobs.Extensions.Clients/src/Shared/WebJobsConfigurationExtensions.cs" LinkBase="SharedSource" />
     <Compile Include="../../../extensions/Microsoft.Azure.WebJobs.Extensions.Clients/src/Shared/StorageClientProvider.cs" LinkBase="SharedSource" />
+    
     <Compile Update="Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-   <PackageReference Include="Azure.Messaging.EventHubs" />
+    <PackageReference Include="Azure.Messaging.EventHubs" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Extensions.Azure" />


### PR DESCRIPTION
# Summary

The focus of these changes is to remove the project references to the Azure.Messaging.EventHubs library.  Now that the 5.7.x line has reached a stable release, the package references can be restored.