### PR TITLE
Fix OTEL metrics provider to support IDeferredMeterProviderBuilder

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
@@ -10,11 +10,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     }
     public static partial class AzureMonitorExporterMetricExtensions
     {
-        public static OpenTelemetry.Metrics.MeterProviderBuilder AddAzureMonitorMetricExporter(this OpenTelemetry.Metrics.MeterProviderBuilder builder, System.Action<Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions> configure = null) { throw null; }
+        public static OpenTelemetry.Metrics.MeterProviderBuilder AddAzureMonitorMetricExporter(this OpenTelemetry.Metrics.MeterProviderBuilder builder, System.Action<Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions, OpenTelemetry.Metrics.MetricReaderOptions> configureExporterAndMetricReader) { throw null; }
+        public static OpenTelemetry.Metrics.MeterProviderBuilder AddAzureMonitorMetricExporter(this OpenTelemetry.Metrics.MeterProviderBuilder builder, System.Action<Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions> configureExporter) { throw null; }
     }
     public partial class AzureMonitorExporterOptions : Azure.Core.ClientOptions
     {
-        public AzureMonitorExporterOptions(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion version = Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion.V2020_09_15_Preview) { }
+        public AzureMonitorExporterOptions() { }
+        public AzureMonitorExporterOptions(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion version) { }
         public string ConnectionString { get { throw null; } set { } }
         public bool DisableOfflineStorage { get { throw null; } set { } }
         public string StorageDirectory { get { throw null; } set { } }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterMetricExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterMetricExtensions.cs
@@ -3,6 +3,7 @@
 
 using OpenTelemetry.Metrics;
 using System;
+using Microsoft.Extensions.Options;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter
 {
@@ -11,28 +12,107 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     /// </summary>
     public static class AzureMonitorExporterMetricExtensions
     {
+        private const int DefaultExportIntervalMilliseconds = 60000;
+        private const int DefaultExportTimeoutMilliseconds = 30000;
+
         /// <summary>
-        /// Adds Azure Monitor Metric exporter.
+        /// Adds <see cref="AzureMonitorMetricExporter"/> to the <see cref="MeterProviderBuilder"/>.
         /// </summary>
         /// <param name="builder"><see cref="MeterProviderBuilder"/> builder to use.</param>
-        /// <param name="configure">Exporter configuration options.</param>
+        /// <param name="configureExporter">Exporter configuration options.</param>
         /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The objects should not be disposed.")]
-        public static MeterProviderBuilder AddAzureMonitorMetricExporter(this MeterProviderBuilder builder, Action<AzureMonitorExporterOptions> configure = null)
+        public static MeterProviderBuilder AddAzureMonitorMetricExporter(this MeterProviderBuilder builder, Action<AzureMonitorExporterOptions> configureExporter)
         {
-            var options = new AzureMonitorExporterOptions();
-            configure?.Invoke(options);
-
-            // TODO: Fallback to default location if location provided via options does not work.
-            if (!options.DisableOfflineStorage && options.StorageDirectory == null)
+            if (builder is IDeferredMeterProviderBuilder deferredMeterProviderBuilder)
             {
-                options.StorageDirectory = StorageHelper.GetDefaultStorageDirectory();
+                return deferredMeterProviderBuilder.Configure((sp, innerBuilder) =>
+                {
+                    AddAzureMonitorMetricExporter(innerBuilder, sp.GetOptions(GetDefaultExportOptions), sp.GetOptions(GetDefaultReaderOptions), configureExporter, null);
+                });
             }
 
-            var exporter = new AzureMonitorMetricExporter(options);
+            return AddAzureMonitorMetricExporter(builder, GetDefaultExportOptions(), GetDefaultReaderOptions(), configureExporter, null);
+        }
 
-            return builder.AddReader(new PeriodicExportingMetricReader(new AzureMonitorMetricExporter(options))
-            { TemporalityPreference = MetricReaderTemporalityPreference.Delta });
+        /// <summary>
+        /// Adds <see cref="AzureMonitorMetricExporter"/> to the <see cref="MeterProviderBuilder"/>.
+        /// </summary>
+        /// <param name="builder"><see cref="MeterProviderBuilder"/> builder to use.</param>
+        /// <param name="configureExporterAndMetricReader">Exporter and <see cref="MetricReader"/> configuration options.</param>
+        /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The objects should not be disposed.")]
+        public static MeterProviderBuilder AddAzureMonitorMetricExporter(
+            this MeterProviderBuilder builder,
+            Action<AzureMonitorExporterOptions, MetricReaderOptions> configureExporterAndMetricReader)
+        {
+            if (builder is IDeferredMeterProviderBuilder deferredMeterProviderBuilder)
+            {
+                return deferredMeterProviderBuilder.Configure((sp, innerBuilder) =>
+                {
+                    AddAzureMonitorMetricExporter(innerBuilder, sp.GetOptions(GetDefaultExportOptions), sp.GetOptions(GetDefaultReaderOptions), null, configureExporterAndMetricReader);
+                });
+            }
+
+            return AddAzureMonitorMetricExporter(builder, GetDefaultExportOptions(), GetDefaultReaderOptions(), null, configureExporterAndMetricReader);
+        }
+
+        private static MeterProviderBuilder AddAzureMonitorMetricExporter(
+            MeterProviderBuilder builder,
+            AzureMonitorExporterOptions exporterOptions,
+            MetricReaderOptions metricReaderOptions,
+            Action<AzureMonitorExporterOptions> configureExporter,
+            Action<AzureMonitorExporterOptions, MetricReaderOptions> configureExporterAndMetricReader)
+        {
+            if (configureExporterAndMetricReader != null)
+            {
+                configureExporterAndMetricReader.Invoke(exporterOptions, metricReaderOptions);
+            }
+            else
+            {
+                configureExporter?.Invoke(exporterOptions);
+            }
+
+            if (!exporterOptions.DisableOfflineStorage && exporterOptions.StorageDirectory == null)
+            {
+                exporterOptions.StorageDirectory = StorageHelper.GetDefaultStorageDirectory();
+            }
+
+            var metricExporter = new AzureMonitorMetricExporter(exporterOptions);
+
+            var exportInterval = metricReaderOptions.PeriodicExportingMetricReaderOptions?.ExportIntervalMilliseconds
+                ?? DefaultExportIntervalMilliseconds;
+
+            var exportTimeout = metricReaderOptions.PeriodicExportingMetricReaderOptions?.ExportTimeoutMilliseconds
+                ?? DefaultExportTimeoutMilliseconds;
+
+            var metricReader = new PeriodicExportingMetricReader(metricExporter, exportInterval, exportTimeout)
+            {
+                TemporalityPreference = metricReaderOptions.TemporalityPreference,
+            };
+
+            return builder.AddReader(metricReader);
+        }
+
+        private static T GetOptions<T>(this IServiceProvider serviceProvider, Func<T> createDefaultOptions)
+            where T : class, new()
+        {
+            IOptions<T> options = (IOptions<T>)serviceProvider.GetService(typeof(IOptions<T>));
+            // Note: options could be null if user never invoked services.AddOptions().
+            return options?.Value ?? createDefaultOptions();
+        }
+
+        private static AzureMonitorExporterOptions GetDefaultExportOptions()
+        {
+            return new AzureMonitorExporterOptions();
+        }
+
+        private static MetricReaderOptions GetDefaultReaderOptions()
+        {
+            return new MetricReaderOptions
+            {
+                TemporalityPreference = MetricReaderTemporalityPreference.Delta
+            };
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
@@ -28,15 +28,22 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         /// <summary>
         /// The <see cref="ServiceVersion"/> of the Azure Monitor ingestion API.
         /// </summary>
-        public ServiceVersion Version { get; set; } = ServiceVersion.V2020_09_15_Preview;
+        public ServiceVersion Version { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureMonitorExporterOptions"/>.
+        /// </summary>
+        public AzureMonitorExporterOptions() : this(LatestVersion)
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureMonitorExporterOptions"/>.
         /// </summary>
         /// <param name="version">The <see cref="ServiceVersion"/> of the Azure Monitor ingestion API.</param>
-        public AzureMonitorExporterOptions(ServiceVersion version = LatestVersion)
+        public AzureMonitorExporterOptions(ServiceVersion version)
         {
-            this.Version = version;
+            Version = version;
         }
 
         [SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "This naming format is defined in the Azure SDK Design Guidelines.")]


### PR DESCRIPTION
This PR fixes an issue when using the OpenTelemetry Hosting Extensions (i.e. `AddOpenTelemetryMetrics`) where metrics are not getting published. The metrics exporter is not looking for `IDeferredMeterProviderBuilder`, so the inner handler was never getting configured with the exporter.
