### PR TITLE
Add support for long metric types

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/MetricData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/MetricData.cs
@@ -39,12 +39,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                     };
                     break;
                 case MetricType.LongSum:
+                    // potential for minor precision loss implicitly going from long->double
+                    // see: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/numeric-conversions#implicit-numeric-conversions
                     metricDataPoint = new MetricDataPoint(metric.Name, metricPoint.GetSumLong())
                     {
                         DataPointType = DataPointType.Aggregation
                     };
                     break;
                 case MetricType.LongGauge:
+                    // potential for minor precision loss implicitly going from long->double
+                    // see: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/numeric-conversions#implicit-numeric-conversions
                     metricDataPoint = new MetricDataPoint(metric.Name, metricPoint.GetGaugeLastValueLong())
                     {
                         DataPointType = DataPointType.Measurement

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/MetricData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/MetricData.cs
@@ -27,12 +27,28 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             switch (metric.MetricType)
             {
                 case MetricType.DoubleSum:
-                    metricDataPoint = new MetricDataPoint(metric.Name, metricPoint.GetSumDouble());
-                    metricDataPoint.DataPointType = DataPointType.Aggregation;
+                    metricDataPoint = new MetricDataPoint(metric.Name, metricPoint.GetSumDouble())
+                    {
+                        DataPointType = DataPointType.Aggregation
+                    };
                     break;
                 case MetricType.DoubleGauge:
-                    metricDataPoint = new MetricDataPoint(metric.Name, metricPoint.GetGaugeLastValueDouble());
-                    metricDataPoint.DataPointType = DataPointType.Measurement;
+                    metricDataPoint = new MetricDataPoint(metric.Name, metricPoint.GetGaugeLastValueDouble())
+                    {
+                        DataPointType = DataPointType.Measurement
+                    };
+                    break;
+                case MetricType.LongSum:
+                    metricDataPoint = new MetricDataPoint(metric.Name, metricPoint.GetSumLong())
+                    {
+                        DataPointType = DataPointType.Aggregation
+                    };
+                    break;
+                case MetricType.LongGauge:
+                    metricDataPoint = new MetricDataPoint(metric.Name, metricPoint.GetGaugeLastValueLong())
+                    {
+                        DataPointType = DataPointType.Measurement
+                    };
                     break;
             }
 
@@ -45,5 +61,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             }
             Properties.Add(AggregationIntervalMsKey, DefaultExportIntervalMilliseconds);
         }
+
+        internal static bool IsSupportedType(MetricType metricType) =>
+            metricType switch
+            {
+                MetricType.DoubleGauge => true,
+                MetricType.DoubleSum => true,
+                MetricType.LongGauge => true,
+                MetricType.LongSum => true,
+                _ => false
+            };
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/MetricHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/MetricHelper.cs
@@ -14,22 +14,21 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
         internal static List<TelemetryItem> OtelToAzureMonitorMetrics(Batch<Metric> batch, string roleName, string roleInstance, string instrumentationKey)
         {
-            List<TelemetryItem> telemetryItems = new List<TelemetryItem>();
-            TelemetryItem telemetryItem;
-
+            List<TelemetryItem> telemetryItems = new();
             foreach (var metric in batch)
             {
-                if (metric.MetricType == MetricType.DoubleSum || metric.MetricType == MetricType.DoubleGauge)
+                if (MetricsData.IsSupportedType(metric.MetricType))
                 {
                     foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                     {
-                        telemetryItem = new TelemetryItem(metricPoint.EndTime.UtcDateTime, roleName, roleInstance, instrumentationKey);
-                        telemetryItem.Data = new MonitorBase
+                        telemetryItems.Add(new TelemetryItem(metricPoint.EndTime.UtcDateTime, roleName, roleInstance, instrumentationKey)
                         {
-                            BaseType = "MetricData",
-                            BaseData = new MetricsData(Version, metric, metricPoint)
-                        };
-                        telemetryItems.Add(telemetryItem);
+                            Data = new MonitorBase
+                            {
+                                BaseType = "MetricData",
+                                BaseData = new MetricsData(Version, metric, metricPoint)
+                            }
+                        });
                     }
                 }
                 else


### PR DESCRIPTION
Currently, the metric exporter only reads double-based metrics. This adds support for long-based metrics. 