### PR TITLE
(AzureCXP) Typo fixes Azure/azure-sdk-for-net#28684

### DIFF
--- a/sdk/storage/Azure.Storage.Files.Shares/src/Models/ShareFileItemProperties.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Models/ShareFileItemProperties.cs
@@ -26,7 +26,7 @@ namespace Azure.Storage.Files.Shares.Models
         public DateTimeOffset? LastWrittenOn { get; }
 
         /// <summary>
-        /// The time this time was changed.
+        /// The time this item was changed.
         /// </summary>
         public DateTimeOffset? ChangedOn { get; }
 


### PR DESCRIPTION
The "ChangedOn" property description says : "The time this time was changed." I think it should say "The time this item was changed."

Fixes Azure/azure-sdk-for-net#28684

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
