### PR TITLE
Abandon messages when an exception occurs in batch function regardless of autocomplete setting

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -7,8 +7,6 @@
 - Fixed issue that could result in the message lock renewal not being cancelled if the user message handler threw an exception.
 - Abandon messages that are received from the `ProcessorReceiveActions` in the event of the user message handler throwing an exception.
 
-### Other Changes
-
 ## 7.8.0 (2022-05-09)
 
 ### Features Added

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -1,12 +1,11 @@
 # Release History
 
-## 7.9.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 7.8.1 (2022-05-16)
 
 ### Bugs Fixed
+
+- Fixed issue that could result in the message lock renewal not being cancelled if the user message handler threw an exception.
+- Abandon messages that are received from the `ProcessorReceiveActions` in the event of the user message handler throwing an exception.
 
 ### Other Changes
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Service Bus is a fully managed enterprise integration message broker. Service Bus can decouple applications and services. Service Bus offers a reliable and secure platform for asynchronous transfer of data and state. This client library allows for both sending and receiving messages using Azure Service Bus. For more information about Service Bus, see https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview</Description>
-    <Version>7.9.0-beta.1</Version>
+    <Version>7.8.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>7.8.0</ApiCompatVersion>
     <PackageTags>Azure;Service Bus;ServiceBus;.NET;AMQP;$(PackageCommonTags)</PackageTags>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
@@ -140,39 +140,32 @@ namespace Azure.Messaging.ServiceBus
             CancellationToken cancellationToken)
         {
             ServiceBusErrorSource errorSource = ServiceBusErrorSource.Receive;
-            EventArgs args = null;
+            EventArgs args = ConstructEventArgs(triggerMessage, cancellationToken);
 
             try
             {
                 errorSource = ServiceBusErrorSource.ProcessMessageCallback;
                 try
                 {
-                    ServiceBusEventSource.Log.ProcessorMessageHandlerStart(Processor.Identifier, triggerMessage.SequenceNumber,
-                        triggerMessage.LockTokenGuid);
-                    args = await OnMessageHandler(triggerMessage, cancellationToken).ConfigureAwait(false);
-                    ServiceBusEventSource.Log.ProcessorMessageHandlerComplete(Processor.Identifier, triggerMessage.SequenceNumber,
-                        triggerMessage.LockTokenGuid);
+                    ServiceBusEventSource.Log.ProcessorMessageHandlerStart(Processor.Identifier, triggerMessage.SequenceNumber, triggerMessage.LockTokenGuid);
+                    await OnMessageHandler(args).ConfigureAwait(false);
+                    ServiceBusEventSource.Log.ProcessorMessageHandlerComplete(Processor.Identifier, triggerMessage.SequenceNumber, triggerMessage.LockTokenGuid);
                 }
                 catch (Exception ex)
                 {
-                    ServiceBusEventSource.Log.ProcessorMessageHandlerException(Processor.Identifier, triggerMessage.SequenceNumber,
-                        ex.ToString(), triggerMessage.LockTokenGuid);
+                    ServiceBusEventSource.Log.ProcessorMessageHandlerException(Processor.Identifier, triggerMessage.SequenceNumber, ex.ToString(), triggerMessage.LockTokenGuid);
                     throw;
                 }
 
                 if (Receiver.ReceiveMode == ServiceBusReceiveMode.PeekLock && ProcessorOptions.AutoCompleteMessages)
                 {
-                    var messages = (args is ProcessMessageEventArgs processMessageEventArgs)
-                        ? processMessageEventArgs.Messages.Keys
-                        : ((ProcessSessionMessageEventArgs)args).Messages.Keys;
-                    foreach (ServiceBusReceivedMessage message in messages)
+                    foreach (ServiceBusReceivedMessage message in GetProcessedMessages(args))
                     {
                         if (!message.IsSettled)
                         {
                             errorSource = ServiceBusErrorSource.Complete;
-                            // don't pass the processor cancellation token
-                            // as we want in flight auto-completion to be able
-                            // to finish
+                            // Don't pass the processor cancellation token as we want in flight auto-completion to be able
+                            // to finish.
                             await Receiver.CompleteMessageAsync(
                                     message,
                                     CancellationToken.None)
@@ -198,35 +191,38 @@ namespace Azure.Messaging.ServiceBus
                             cancellationToken))
                     .ConfigureAwait(false);
 
-                // if the user settled the message, or if the message or session lock was lost,
-                // do not attempt to abandon the message
+                // If we got a message or session lock lost error, do not attempt to abandon the message, or any of the additional received
+                // messages in the handler, as we have no way of knowing which message caused the error.
                 ServiceBusFailureReason? failureReason = (ex as ServiceBusException)?.Reason;
-                if (!triggerMessage.IsSettled &&
-                    _receiverOptions.ReceiveMode == ServiceBusReceiveMode.PeekLock &&
+                if (_receiverOptions.ReceiveMode == ServiceBusReceiveMode.PeekLock &&
                     failureReason != ServiceBusFailureReason.SessionLockLost &&
                     failureReason != ServiceBusFailureReason.MessageLockLost)
                 {
-                    try
+                    foreach (ServiceBusReceivedMessage message in GetProcessedMessages(args))
                     {
-                        // don't pass the processor cancellation token
-                        // as we want in flight abandon to be able
-                        // to finish even if user stopped processing
-                        await Receiver.AbandonMessageAsync(
-                                triggerMessage.LockTokenGuid,
-                                cancellationToken: CancellationToken.None)
-                            .ConfigureAwait(false);
-                    }
-                    catch (Exception exception)
-                    {
-                        ThrowIfSessionLockLost(exception, ServiceBusErrorSource.Abandon);
-                        await RaiseExceptionReceived(
-                                new ProcessErrorEventArgs(
-                                    exception,
-                                    ServiceBusErrorSource.Abandon,
-                                    Processor.FullyQualifiedNamespace,
-                                    Processor.EntityPath,
-                                    cancellationToken))
-                            .ConfigureAwait(false);
+                        // If the user already settled the message, do not abandon.
+                        if (message.IsSettled)
+                        {
+                            continue;
+                        }
+                        try
+                        {
+                            // Don't pass the processor cancellation token as we want in flight abandon to be able
+                            // to finish even if user stopped processing.
+                            await Receiver.AbandonMessageAsync(message, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+                        }
+                        catch (Exception exception)
+                        {
+                            ThrowIfSessionLockLost(exception, ServiceBusErrorSource.Abandon);
+                            await RaiseExceptionReceived(
+                                    new ProcessErrorEventArgs(
+                                        exception,
+                                        ServiceBusErrorSource.Abandon,
+                                        Processor.FullyQualifiedNamespace,
+                                        Processor.EntityPath,
+                                        cancellationToken))
+                                .ConfigureAwait(false);
+                        }
                     }
                 }
             }
@@ -239,6 +235,10 @@ namespace Azure.Messaging.ServiceBus
             }
         }
 
+        private static ICollection<ServiceBusReceivedMessage> GetProcessedMessages(EventArgs args) =>
+            args is ProcessMessageEventArgs processMessageEventArgs ? processMessageEventArgs.Messages.Keys
+                : ((ProcessSessionMessageEventArgs)args).Messages.Keys;
+
         internal bool ShouldAutoRenewMessageLock()
         {
             return !Receiver.IsSessionReceiver &&
@@ -246,17 +246,14 @@ namespace Azure.Messaging.ServiceBus
                    AutoRenewLock;
         }
 
-        protected virtual async Task<EventArgs> OnMessageHandler(
-            ServiceBusReceivedMessage message,
-            CancellationToken processorCancellationToken)
-        {
-            var args = new ProcessMessageEventArgs(
-                message,
-                this,
-                processorCancellationToken);
-            await Processor.OnProcessMessageAsync(args).ConfigureAwait(false);
-            return args;
-        }
+        protected virtual EventArgs ConstructEventArgs(ServiceBusReceivedMessage message, CancellationToken cancellationToken) =>
+            new ProcessMessageEventArgs(
+            message,
+            this,
+            cancellationToken);
+
+        protected virtual async Task OnMessageHandler(EventArgs args) =>
+            await Processor.OnProcessMessageAsync((ProcessMessageEventArgs) args).ConfigureAwait(false);
 
         internal async Task RenewMessageLockAsync(
             ServiceBusReceivedMessage message,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
@@ -389,18 +389,14 @@ namespace Azure.Messaging.ServiceBus
             }
         }
 
-        protected override async Task<EventArgs> OnMessageHandler(
-            ServiceBusReceivedMessage message,
-            CancellationToken cancellationToken)
-        {
-            var args = new ProcessSessionMessageEventArgs(
+        protected override EventArgs ConstructEventArgs(ServiceBusReceivedMessage message, CancellationToken cancellationToken) =>
+            new ProcessSessionMessageEventArgs(
                 message,
                 this,
                 cancellationToken);
 
-            await _sessionProcessor.OnProcessSessionMessageAsync(args).ConfigureAwait(false);
-            return args;
-        }
+        protected override async Task OnMessageHandler(EventArgs args) =>
+            await _sessionProcessor.OnProcessSessionMessageAsync((ProcessSessionMessageEventArgs) args).ConfigureAwait(false);
 
         protected override async Task RaiseExceptionReceived(ProcessErrorEventArgs eventArgs)
         {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
@@ -1217,5 +1217,96 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                         .EqualTo(ServiceBusFailureReason.MessageNotFound));
             }
         }
+
+        [Test]
+        public async Task MessagesReceivedFromCallbackAbandonedWhenException()
+        {
+            var lockDuration = ShortLockDuration;
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false, lockDuration: lockDuration))
+            {
+                await using var client = CreateClient();
+                var sender = client.CreateSender(scope.QueueName);
+                int messageCount = 10;
+                ConcurrentDictionary<long, byte> sequenceNumbers = new();
+
+                await sender.SendMessagesAsync(ServiceBusTestUtilities.GetMessages(messageCount));
+
+                await using var processor = client.CreateProcessor(scope.QueueName, new ServiceBusProcessorOptions
+                {
+                    MaxConcurrentCalls = 1
+                });
+
+                int receivedCount = 0;
+                var tcs = new TaskCompletionSource<bool>();
+
+                async Task ProcessMessage(ProcessMessageEventArgs args)
+                {
+                    var count = Interlocked.Increment(ref receivedCount);
+
+                    // defer first two messages
+                    if (count <= 2)
+                    {
+                        await args.DeferMessageAsync(args.Message);
+                        sequenceNumbers[args.Message.SequenceNumber] = default;
+                    }
+
+                    if (count == 2)
+                    {
+                        var additionalMessages = await args.GetReceiveActions().ReceiveMessagesAsync(2);
+                        Interlocked.Add(ref receivedCount, additionalMessages.Count);
+                    }
+
+                    if (count == messageCount)
+                    {
+                        tcs.TrySetResult(true);
+                    }
+
+                    throw new Exception("User exception message");
+                }
+
+                Task ProcessError(ProcessErrorEventArgs eventArgs)
+                {
+                    if (!eventArgs.Exception.Message.Contains("User exception message"))
+                    {
+                        Assert.Fail(eventArgs.Exception.ToString());
+                    }
+                    return Task.CompletedTask;
+                }
+
+                processor.ProcessMessageAsync += ProcessMessage;
+                processor.ProcessErrorAsync += ProcessError;
+
+                await processor.StartProcessingAsync();
+                await tcs.Task;
+                await processor.CloseAsync();
+
+                var receiver = client.CreateReceiver(scope.QueueName, new ServiceBusReceiverOptions {ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete});
+                int remaining = messageCount;
+
+                // all messages should have been abandoned, so we should be able to receive them right away
+                CancellationTokenSource tokenSource = new CancellationTokenSource();
+                tokenSource.CancelAfter(TimeSpan.FromSeconds(5));
+
+                while (!tokenSource.IsCancellationRequested && remaining > 0)
+                {
+                    try
+                    {
+                        var receivedMessages = await receiver.ReceiveMessagesAsync(remaining, TimeSpan.FromSeconds(5), tokenSource.Token);
+                        remaining -= receivedMessages.Count;
+
+                        if (sequenceNumbers.Keys.Count > 0)
+                        {
+                            receivedMessages = await receiver.ReceiveDeferredMessagesAsync(sequenceNumbers.Keys, tokenSource.Token);
+                            sequenceNumbers.Clear();
+                            remaining -= receivedMessages.Count;
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+                }
+                Assert.AreEqual(0, remaining);
+            }
+        }
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/README.md
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/README.md
@@ -274,7 +274,7 @@ public static async Task Run(
 
 ## Troubleshooting
 
-If your function triggers an unhandled exception, and you haven't already settled the message, the extension will attempt to abandon the message so that it becomes available for receiving again immediately.
+If your function triggers an unhandled exception and you haven't already settled the message, the extension will attempt to abandon the message so that it becomes available for receiving again immediately.
 
 Please refer to [Monitor Azure Functions](https://docs.microsoft.com/azure/azure-functions/functions-monitoring) for more troubleshooting guidance.
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/README.md
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/README.md
@@ -274,7 +274,9 @@ public static async Task Run(
 
 ## Troubleshooting
 
-Please refer to [Monitor Azure Functions](https://docs.microsoft.com/azure/azure-functions/functions-monitoring) for troubleshooting guidance.
+If your function triggers an unhandled exception, and you haven't already settled the message, the extension will attempt to abandon the message so that it becomes available for receiving again immediately.
+
+Please refer to [Monitor Azure Functions](https://docs.microsoft.com/azure/azure-functions/functions-monitoring) for more troubleshooting guidance.
 
 ## Next steps
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -402,11 +402,12 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                         FunctionResult result = await _triggerExecutor.TryExecuteAsync(input.GetTriggerFunctionData(), cancellationToken).ConfigureAwait(false);
                         receiveActions.EndExecutionScope();
 
+                        var processedMessages = messagesArray.Concat(receiveActions.Messages.Keys);
                         // Complete batch of messages only if the execution was successful
                         if (_autoCompleteMessages && result.Succeeded)
                         {
                             List<Task> completeTasks = new List<Task>();
-                            foreach (ServiceBusReceivedMessage message in messagesArray.Concat(receiveActions.Messages.Keys))
+                            foreach (ServiceBusReceivedMessage message in processedMessages)
                             {
                                 // skip messages that were settled in the user's function
                                 if (input.MessageActions.SettledMessages.ContainsKey(message))
@@ -427,7 +428,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                             // in the Service Bus SDK.
 
                             List<Task> abandonTasks = new List<Task>();
-                            foreach (ServiceBusReceivedMessage message in messagesArray)
+                            foreach (ServiceBusReceivedMessage message in processedMessages)
                             {
                                 // skip messages that were settled in the user's function
                                 if (input.MessageActions.SettledMessages.ContainsKey(message))

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
         private readonly ITriggeredFunctionExecutor _triggerExecutor;
         private readonly string _entityPath;
         private readonly bool _isSessionsEnabled;
-        private readonly bool _autoCompleteMessagesOptionEvaluatedValue;
+        private readonly bool _autoCompleteMessages;
         private readonly CancellationTokenSource _cancellationTokenSource;
         private readonly ServiceBusOptions _serviceBusOptions;
         private readonly bool _singleDispatch;
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             ServiceBusEntityType entityType,
             string entityPath,
             bool isSessionsEnabled,
-            bool autoCompleteMessagesOptionEvaluatedValue,
+            bool autoCompleteMessages,
             ITriggeredFunctionExecutor triggerExecutor,
             ServiceBusOptions options,
             string connection,
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
         {
             _entityPath = entityPath;
             _isSessionsEnabled = isSessionsEnabled;
-            _autoCompleteMessagesOptionEvaluatedValue = autoCompleteMessagesOptionEvaluatedValue;
+            _autoCompleteMessages = autoCompleteMessages;
             _triggerExecutor = triggerExecutor;
             _cancellationTokenSource = new CancellationTokenSource();
             _logger = loggerFactory.CreateLogger<ServiceBusListener>();
@@ -82,14 +82,14 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             _messageProcessor = new Lazy<MessageProcessor>(
                 () =>
                 {
-                    var processorOptions = options.ToProcessorOptions(_autoCompleteMessagesOptionEvaluatedValue, concurrencyManager.Enabled);
+                    var processorOptions = options.ToProcessorOptions(_autoCompleteMessages, concurrencyManager.Enabled);
                     return messagingProvider.CreateMessageProcessor(_client.Value, _entityPath, processorOptions);
                 });
 
             _sessionMessageProcessor = new Lazy<SessionMessageProcessor>(
                 () =>
                 {
-                    var sessionProcessorOptions = options.ToSessionProcessorOptions(_autoCompleteMessagesOptionEvaluatedValue, concurrencyManager.Enabled);
+                    var sessionProcessorOptions = options.ToSessionProcessorOptions(_autoCompleteMessages, concurrencyManager.Enabled);
                     return messagingProvider.CreateSessionMessageProcessor(_client.Value,_entityPath, sessionProcessorOptions);
                 });
 
@@ -403,42 +403,43 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                         receiveActions.EndExecutionScope();
 
                         // Complete batch of messages only if the execution was successful
-                        if (_autoCompleteMessagesOptionEvaluatedValue)
+                        if (_autoCompleteMessages && result.Succeeded)
                         {
-                            if (result.Succeeded)
+                            List<Task> completeTasks = new List<Task>();
+                            foreach (ServiceBusReceivedMessage message in messagesArray.Concat(receiveActions.Messages.Keys))
                             {
-                                List<Task> completeTasks = new List<Task>();
-                                foreach (ServiceBusReceivedMessage message in messagesArray.Concat(receiveActions.Messages.Keys))
+                                // skip messages that were settled in the user's function
+                                if (input.MessageActions.SettledMessages.ContainsKey(message))
                                 {
-                                    // skip messages that were settled in the user's function
-                                    if (input.MessageActions.SettledMessages.ContainsKey(message))
-                                    {
-                                        continue;
-                                    }
-
-                                    // Pass CancellationToken.None to allow autocompletion to finish even when shutting down
-                                    completeTasks.Add(receiver.CompleteMessageAsync(message, CancellationToken.None));
+                                    continue;
                                 }
 
-                                await Task.WhenAll(completeTasks).ConfigureAwait(false);
+                                // Pass CancellationToken.None to allow autocompletion to finish even when shutting down
+                                completeTasks.Add(receiver.CompleteMessageAsync(message, CancellationToken.None));
                             }
-                            else
-                            {
-                                List<Task> abandonTasks = new List<Task>();
-                                foreach (ServiceBusReceivedMessage message in messagesArray)
-                                {
-                                    // skip messages that were settled in the user's function
-                                    if (input.MessageActions.SettledMessages.ContainsKey(message))
-                                    {
-                                        continue;
-                                    }
 
-                                    // Pass CancellationToken.None to allow abandon to finish even when shutting down
-                                    abandonTasks.Add(receiver.AbandonMessageAsync(message, cancellationToken: CancellationToken.None));
+                            await Task.WhenAll(completeTasks).ConfigureAwait(false);
+                        }
+                        else if (!result.Succeeded)
+                        {
+                            // For failed executions, we abandon the messages regardless of the autoCompleteMessages configuration.
+                            // This matches the behavior that happens for single dispatch functions as the processor does the same thing
+                            // in the Service Bus SDK.
+
+                            List<Task> abandonTasks = new List<Task>();
+                            foreach (ServiceBusReceivedMessage message in messagesArray)
+                            {
+                                // skip messages that were settled in the user's function
+                                if (input.MessageActions.SettledMessages.ContainsKey(message))
+                                {
+                                    continue;
                                 }
 
-                                await Task.WhenAll(abandonTasks).ConfigureAwait(false);
+                                // Pass CancellationToken.None to allow abandon to finish even when shutting down
+                                abandonTasks.Add(receiver.AbandonMessageAsync(message, cancellationToken: CancellationToken.None));
                             }
+
+                            await Task.WhenAll(abandonTasks).ConfigureAwait(false);
                         }
 
                         if (_isSessionsEnabled)

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Sources" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
-    <PackageReference Include="Azure.Messaging.ServiceBus" />
+<!--    <PackageReference Include="Azure.Messaging.ServiceBus" />-->
   </ItemGroup>
 
   <ItemGroup>
@@ -28,6 +28,10 @@
     <Compile Include="..\..\Azure.Messaging.ServiceBus\src\EntityNameFormatter.cs" LinkBase="Shared" />
     <Compile Include="..\..\Azure.Messaging.ServiceBus\src\Resources.Designer.cs" LinkBase="Shared" />
     <Compile Include="..\..\..\extensions\Microsoft.Azure.WebJobs.Extensions.Clients\src\Shared\WebJobsConfigurationExtensions.cs" LinkBase="Shared" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Azure.Messaging.ServiceBus\src\Azure.Messaging.ServiceBus.csproj" />
   </ItemGroup>
 
 </Project>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Bindings/ServiceBusTriggerAttributeBindingProviderTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Bindings/ServiceBusTriggerAttributeBindingProviderTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
             var createListenerTask = binding.GetType().GetMethod("CreateListenerAsync");
             var listener = await (Task<IListener>)createListenerTask.Invoke(binding, parameters);
             var listenerOptions = (ServiceBusOptions)listener.GetType().GetField("_serviceBusOptions", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(listener);
-            var autoCompleteMessagesFlagSentToListener = (bool)listener.GetType().GetField("_autoCompleteMessagesOptionEvaluatedValue", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(listener);
+            var autoCompleteMessagesFlagSentToListener = (bool)listener.GetType().GetField("_autoCompleteMessages", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(listener);
 
             Assert.NotNull(listenerOptions);
             Assert.True(listenerOptions.AutoCompleteMessages);

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 await jobHost.CallAsync(nameof(BinderTestJobsAsyncCollector.ServiceBusBinderTest), args);
                 await jobHost.CallAsync(nameof(BinderTestJobsAsyncCollector.ServiceBusBinderTest), args);
 
-                var count = await CleanUpEntity(_firstQueueScope.QueueName);
+                var count = await CleanUpEntity(FirstQueueScope.QueueName);
 
                 Assert.AreEqual(numMessages * 3, count);
                 await host.StopAsync();
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 await jobHost.CallAsync(nameof(BinderTestJobsSyncCollector.ServiceBusBinderTest), args);
                 await jobHost.CallAsync(nameof(BinderTestJobsSyncCollector.ServiceBusBinderTest), args);
 
-                var count = await CleanUpEntity(_firstQueueScope.QueueName);
+                var count = await CleanUpEntity(FirstQueueScope.QueueName);
 
                 Assert.AreEqual(numMessages * 3, count);
                 await host.StopAsync();
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 await WriteQueueMessage(
                     "Test",
                     connectionString: ServiceBusTestEnvironment.Instance.ServiceBusSecondaryNamespaceConnectionString,
-                    queueName: _secondaryNamespaceQueueScope.QueueName);
+                    queueName: SecondaryNamespaceQueueScope.QueueName);
 
                 _topicSubscriptionCalled1.WaitOne(SBTimeoutMills);
                 _topicSubscriptionCalled2.WaitOne(SBTimeoutMills);
@@ -226,6 +226,40 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         }
 
         [Test]
+        public async Task TestSingle_AutoCompleteDisabledOnTrigger_AbandonsWhenException()
+        {
+            await TestAutoCompleteDisabledOnTrigger_AbandonsWhenException<TestSingleAutoCompleteMessagesEnabledOnTriggerException>();
+        }
+
+        [Test]
+        public async Task TestBatch_AutoCompleteDisabledOnTrigger_AbandonsWhenException()
+        {
+            await TestAutoCompleteDisabledOnTrigger_AbandonsWhenException<TestBatchAutoCompleteMessagesEnabledOnTriggerException>();
+        }
+
+        private async Task TestAutoCompleteDisabledOnTrigger_AbandonsWhenException<T>()
+        {
+            await WriteQueueMessage("{'Name': 'Test1', 'Value': 'Value'}");
+
+            // Intentionally skipping validation as we are expecting errors in the error log
+            // for this test, so we accept that the stop will not be graceful.
+            using (var host = BuildHost<T>(
+                host => host.ConfigureWebJobs(b => b.AddServiceBus(options => options.MaxConcurrentCalls = 1)),
+                skipValidation: true))
+            {
+                bool result = _waitHandle1.WaitOne(SBTimeoutMills);
+                Assert.True(result);
+                await host.StopAsync();
+            }
+            await using ServiceBusClient client = new ServiceBusClient(ServiceBusTestEnvironment.Instance.ServiceBusConnectionString);
+            await using ServiceBusReceiver receiver = client.CreateReceiver(FirstQueueScope.QueueName);
+
+            // The message should have been abandoned, so it should be available to be received again prior to the lock duration elapsing.
+            var message = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
+            Assert.NotNull(message);
+            await receiver.CompleteMessageAsync(message);
+        }
+        [Test]
         public async Task TestSingle_CrossEntityTransaction()
         {
             await WriteQueueMessage("{'Name': 'Test1', 'Value': 'Value'}");
@@ -255,13 +289,15 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         public async Task TestSingle_CustomErrorHandler()
         {
             await WriteQueueMessage("{'Name': 'Test1', 'Value': 'Value'}");
-            var host = BuildHost<TestCustomErrorHandler>(SetCustomErrorHandler);
+
+            // Intentionally skipping validation as we are expecting errors in the error log
+            // for this test, so we accept that the stop will not be graceful.
+            var host = BuildHost<TestCustomErrorHandler>(SetCustomErrorHandler, skipValidation: true);
             using (host)
             {
                 bool result = _waitHandle1.WaitOne(SBTimeoutMills);
                 Assert.True(result);
-                // intentionally not calling host.StopAsync as we are expecting errors in the error log
-                // for this test, so we accept that the stop will not be graceful
+                await host.StopAsync();
             }
         }
 
@@ -531,7 +567,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 var message = new ServiceBusMessage();
                 message.GetRawAmqpMessage().Body = AmqpMessageBody.FromValue("foobar");
                 await using ServiceBusClient client = new ServiceBusClient(ServiceBusTestEnvironment.Instance.ServiceBusConnectionString);
-                var sender = client.CreateSender(_firstQueueScope.QueueName);
+                var sender = client.CreateSender(FirstQueueScope.QueueName);
                 await sender.SendMessageAsync(message);
 
                 bool result = _waitHandle1.WaitOne(SBTimeoutMills);
@@ -548,7 +584,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 var message = new ServiceBusMessage();
                 message.GetRawAmqpMessage().Body = AmqpMessageBody.FromValue("foobar");
                 await using ServiceBusClient client = new ServiceBusClient(ServiceBusTestEnvironment.Instance.ServiceBusConnectionString);
-                var sender = client.CreateSender(_firstQueueScope.QueueName);
+                var sender = client.CreateSender(FirstQueueScope.QueueName);
                 await sender.SendMessageAsync(message);
 
                 bool result = _waitHandle1.WaitOne(SBTimeoutMills);
@@ -1020,7 +1056,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 int numMessages,
                 Binder binder)
             {
-                var attribute = new ServiceBusAttribute(_firstQueueScope.QueueName)
+                var attribute = new ServiceBusAttribute(FirstQueueScope.QueueName)
                 {
                     EntityType = ServiceBusEntityType.Queue
                 };
@@ -1044,7 +1080,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 int numMessages,
                 Binder binder)
             {
-                var attribute = new ServiceBusAttribute(_firstQueueScope.QueueName)
+                var attribute = new ServiceBusAttribute(FirstQueueScope.QueueName)
                 {
                     EntityType = ServiceBusEntityType.Queue
                 };
@@ -1294,6 +1330,28 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             }
         }
 
+        public class TestSingleAutoCompleteMessagesEnabledOnTriggerException
+        {
+            public static void Run(
+                [ServiceBusTrigger(FirstQueueNameKey, AutoCompleteMessages = false)]
+                ServiceBusReceivedMessage message)
+            {
+                _waitHandle1.Set();
+                throw new Exception("Exception from user function");
+            }
+        }
+
+        public class TestBatchAutoCompleteMessagesEnabledOnTriggerException
+        {
+            public static void Run(
+                [ServiceBusTrigger(FirstQueueNameKey, AutoCompleteMessages = false)]
+                ServiceBusReceivedMessage[] messages)
+            {
+                _waitHandle1.Set();
+                throw new Exception("Exception from user function");
+            }
+        }
+
         public class TestSingleAutoCompleteMessagesEnabledOnTrigger_CompleteInFunction
         {
             public static async Task RunAsync(
@@ -1318,7 +1376,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                 {
                     await messageActions.CompleteMessageAsync(message);
-                    var sender = client.CreateSender(_secondQueueScope.QueueName);
+                    var sender = client.CreateSender(SecondQueueScope.QueueName);
                     await sender.SendMessageAsync(new ServiceBusMessage());
                     ts.Complete();
                 }
@@ -1328,7 +1386,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 // Assert.IsNull(received);
                 // need to use a separate client here to do the assertions
                 var noTxClient = new ServiceBusClient(ServiceBusTestEnvironment.Instance.ServiceBusConnectionString);
-                ServiceBusReceiver receiver2 = noTxClient.CreateReceiver(_secondQueueScope.QueueName);
+                ServiceBusReceiver receiver2 = noTxClient.CreateReceiver(SecondQueueScope.QueueName);
                 var received = await receiver2.ReceiveMessageAsync();
                 Assert.IsNotNull(received);
                 _waitHandle1.Set();
@@ -1346,7 +1404,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                 {
                     await messageActions.CompleteMessageAsync(messages.First());
-                    var sender = client.CreateSender(_secondQueueScope.QueueName);
+                    var sender = client.CreateSender(SecondQueueScope.QueueName);
                     await sender.SendMessageAsync(new ServiceBusMessage());
                     ts.Complete();
                 }
@@ -1356,7 +1414,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 // Assert.IsNull(received);
                 // need to use a separate client here to do the assertions
                 var noTxClient = new ServiceBusClient(ServiceBusTestEnvironment.Instance.ServiceBusConnectionString);
-                ServiceBusReceiver receiver2 = noTxClient.CreateReceiver(_secondQueueScope.QueueName);
+                ServiceBusReceiver receiver2 = noTxClient.CreateReceiver(SecondQueueScope.QueueName);
                 var received = await receiver2.ReceiveMessageAsync();
                 Assert.IsNotNull(received);
                 _waitHandle1.Set();

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
@@ -905,7 +905,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                 {
                     await sessionActions.CompleteMessageAsync(message);
-                    var sender = client.CreateSender(_secondQueueScope.QueueName);
+                    var sender = client.CreateSender(SecondQueueScope.QueueName);
                     await sender.SendMessageAsync(new ServiceBusMessage() { SessionId = "sessionId" });
                     ts.Complete();
                 }
@@ -914,7 +914,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 // Assert.IsNull(receiver1);
                 // need to use a separate client here to do the assertions
                 var noTxClient = new ServiceBusClient(ServiceBusTestEnvironment.Instance.ServiceBusConnectionString);
-                ServiceBusReceiver receiver2 = await noTxClient.AcceptNextSessionAsync(_secondQueueScope.QueueName);
+                ServiceBusReceiver receiver2 = await noTxClient.AcceptNextSessionAsync(SecondQueueScope.QueueName);
                 Assert.IsNotNull(receiver2);
                 _waitHandle1.Set();
             }
@@ -931,7 +931,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                 {
                     await sessionActions.CompleteMessageAsync(messages.First());
-                    var sender = client.CreateSender(_secondQueueScope.QueueName);
+                    var sender = client.CreateSender(SecondQueueScope.QueueName);
                     await sender.SendMessageAsync(new ServiceBusMessage() { SessionId = "sessionId" });
                     ts.Complete();
                 }
@@ -940,7 +940,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 // Assert.IsNull(receiver1);
                 // need to use a separate client here to do the assertions
                 var noTxClient = new ServiceBusClient(ServiceBusTestEnvironment.Instance.ServiceBusConnectionString);
-                ServiceBusReceiver receiver2 = await noTxClient.AcceptNextSessionAsync(_secondQueueScope.QueueName);
+                ServiceBusReceiver receiver2 = await noTxClient.AcceptNextSessionAsync(SecondQueueScope.QueueName);
                 Assert.IsNotNull(receiver2);
                 _waitHandle1.Set();
             }
@@ -1025,7 +1025,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 // override the options computed from ServiceBusOptions
                 options.SessionIdleTimeout = TimeSpan.FromSeconds(90);
                 options.MaxConcurrentSessions = 1;
-                if (entityPath == _firstQueueScope.QueueName)
+                if (entityPath == FirstQueueScope.QueueName)
                 {
                     processor = client.CreateSessionProcessor(entityPath, options);
                 }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/WebJobsServiceBusTestBase.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/WebJobsServiceBusTestBase.cs
@@ -57,13 +57,13 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         protected const int DrainWaitTimeoutMills = 120 * 1000;
         protected const int DrainSleepMills = 5 * 1000;
         internal const int MaxAutoRenewDurationMin = 5;
-        internal static TimeSpan HostShutdownTimeout = TimeSpan.FromSeconds(120);
+        protected static TimeSpan HostShutdownTimeout = TimeSpan.FromSeconds(120);
 
-        internal static QueueScope _firstQueueScope;
-        protected static QueueScope _secondaryNamespaceQueueScope;
-        protected static QueueScope _secondQueueScope;
+        protected static QueueScope FirstQueueScope { get; private set; }
+        protected static QueueScope SecondaryNamespaceQueueScope { get; private set; }
+        protected static QueueScope SecondQueueScope { get; private set; }
         private QueueScope _thirdQueueScope;
-        protected static TopicScope _topicScope;
+        protected static TopicScope TopicScope { get; private set; }
 
         private readonly bool _isSession;
         protected static EventWaitHandle _topicSubscriptionCalled1;
@@ -86,14 +86,14 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [SetUp]
         public async Task FixtureSetUp()
         {
-            _firstQueueScope = await CreateWithQueue(enablePartitioning: false, enableSession: _isSession, lockDuration: TimeSpan.FromSeconds(15));
-            _secondQueueScope = await CreateWithQueue(enablePartitioning: false, enableSession: _isSession, lockDuration: TimeSpan.FromSeconds(15));
+            FirstQueueScope = await CreateWithQueue(enablePartitioning: false, enableSession: _isSession, lockDuration: TimeSpan.FromSeconds(15));
+            SecondQueueScope = await CreateWithQueue(enablePartitioning: false, enableSession: _isSession, lockDuration: TimeSpan.FromSeconds(15));
             _thirdQueueScope = await CreateWithQueue(enablePartitioning: false, enableSession: _isSession, lockDuration: TimeSpan.FromSeconds(15));
-            _topicScope = await CreateWithTopic(
+            TopicScope = await CreateWithTopic(
                 enablePartitioning: false,
                 enableSession: _isSession,
                 topicSubscriptions: new string[] { "sub1", "sub2" });
-            _secondaryNamespaceQueueScope = await CreateWithQueue(
+            SecondaryNamespaceQueueScope = await CreateWithQueue(
                 enablePartitioning: false,
                 enableSession: _isSession,
                 overrideNamespace: ServiceBusTestEnvironment.Instance.ServiceBusSecondaryNamespace,
@@ -114,27 +114,28 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [TearDown]
         public async Task FixtureTearDown()
         {
-            await _firstQueueScope.DisposeAsync();
-            await _secondQueueScope.DisposeAsync();
+            await FirstQueueScope.DisposeAsync();
+            await SecondQueueScope.DisposeAsync();
             await _thirdQueueScope.DisposeAsync();
-            await _secondaryNamespaceQueueScope.DisposeAsync();
-            await _topicScope.DisposeAsync();
+            await SecondaryNamespaceQueueScope.DisposeAsync();
+            await TopicScope.DisposeAsync();
         }
 
         protected IHost BuildHost<TJobClass>(
             Action<IHostBuilder> configurationDelegate = null,
             bool startHost = true,
-            bool useTokenCredential = false)
+            bool useTokenCredential = false,
+            bool skipValidation = false)
         {
             var settings = new Dictionary<string, string>
             {
-                {_firstQueueNameKey, _firstQueueScope.QueueName},
-                {_secondQueueNameKey, _secondQueueScope.QueueName},
+                {_firstQueueNameKey, FirstQueueScope.QueueName},
+                {_secondQueueNameKey, SecondQueueScope.QueueName},
                 {_thirdQueueNameKey, _thirdQueueScope.QueueName},
-                {_topicNameKey, _topicScope.TopicName},
-                {_firstSubscriptionNameKey, _topicScope.SubscriptionNames[0]},
-                {_secondSubscriptionNameKey, _topicScope.SubscriptionNames[1]},
-                {_secondaryNamespaceQueueKey, _secondaryNamespaceQueueScope.QueueName},
+                {_topicNameKey, TopicScope.TopicName},
+                {_firstSubscriptionNameKey, TopicScope.SubscriptionNames[0]},
+                {_secondSubscriptionNameKey, TopicScope.SubscriptionNames[1]},
+                {_secondaryNamespaceQueueKey, SecondaryNamespaceQueueScope.QueueName},
                 {SecondaryConnectionStringKey, ServiceBusTestEnvironment.Instance.ServiceBusSecondaryNamespaceConnectionString}
             };
             if (useTokenCredential)
@@ -156,7 +157,10 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     // Configure ServiceBusEndToEndTestService before WebJobs stuff so that the ServiceBusEndToEndTestService.StopAsync will be called after
                     // the WebJobsHost.StopAsync (service that is started first will be stopped last by the IHost).
                     // This will allow the logs captured in StopAsync to include everything from WebJobs.
-                    s.AddHostedService<ServiceBusEndToEndTestService>();
+                    if (!skipValidation)
+                    {
+                        s.AddHostedService<ServiceBusEndToEndTestService>();
+                    }
                 })
                 .ConfigureAppConfiguration(builder =>
                 {
@@ -180,7 +184,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         internal async Task WriteQueueMessage(string message, string sessionId = null, string connectionString = default, string queueName = default)
         {
             await using ServiceBusClient client = new ServiceBusClient(connectionString ?? ServiceBusTestEnvironment.Instance.ServiceBusConnectionString);
-            var sender = client.CreateSender(queueName ?? _firstQueueScope.QueueName);
+            var sender = client.CreateSender(queueName ?? FirstQueueScope.QueueName);
             ServiceBusMessage messageObj = new ServiceBusMessage(message)
             {
                 ContentType = "application/json",
@@ -200,7 +204,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         internal async Task WriteQueueMessages(string[] messages, string[] sessionIds = null, string connectionString = default, string queueName = default)
         {
             await using ServiceBusClient client = new ServiceBusClient(connectionString ?? ServiceBusTestEnvironment.Instance.ServiceBusConnectionString);
-            var sender = client.CreateSender(queueName ?? _firstQueueScope.QueueName);
+            var sender = client.CreateSender(queueName ?? FirstQueueScope.QueueName);
 
             ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
             int sessionCounter = 0;
@@ -239,7 +243,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             }
 
             await using ServiceBusClient client = new ServiceBusClient(ServiceBusTestEnvironment.Instance.ServiceBusConnectionString);
-            var sender = client.CreateSender(_firstQueueScope.QueueName);
+            var sender = client.CreateSender(FirstQueueScope.QueueName);
             ServiceBusMessage messageObj = new ServiceBusMessage(payload);
             if (!string.IsNullOrEmpty(sessionId))
             {
@@ -251,7 +255,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         internal async Task WriteTopicMessage(string message, string sessionId = null)
         {
             await using ServiceBusClient client = new ServiceBusClient(ServiceBusTestEnvironment.Instance.ServiceBusConnectionString);
-            var sender = client.CreateSender(_topicScope.TopicName);
+            var sender = client.CreateSender(TopicScope.TopicName);
             ServiceBusMessage messageObj = new ServiceBusMessage(message);
             if (!string.IsNullOrEmpty(sessionId))
             {
@@ -275,40 +279,38 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     sbOptions.MaxAutoLockRenewalDuration = TimeSpan.Zero;
                     sbOptions.MaxConcurrentCalls = 1;
                 }));
-    }
-
-#pragma warning disable SA1402 // File may only contain a single type
-    public class ServiceBusEndToEndTestService : IHostedService
-#pragma warning restore SA1402 // File may only contain a single type
-    {
-        private readonly IHost _host;
-
-        public ServiceBusEndToEndTestService(IHost host)
+        private class ServiceBusEndToEndTestService : IHostedService
         {
-            _host = host;
-        }
+            private readonly IHost _host;
 
-        public Task StartAsync(CancellationToken cancellationToken)
-        {
-            return Task.CompletedTask;
-        }
+            public ServiceBusEndToEndTestService(IHost host)
+            {
+                _host = host;
+            }
 
-        public async Task StopAsync(CancellationToken cancellationToken)
-        {
-            var logs = _host.GetTestLoggerProvider().GetAllLogMessages();
-            var errors = logs.Where(
-                p => p.Level == LogLevel.Error &&
-                // Ignore this error that the SDK logs when cancelling batch receive
-                !p.FormattedMessage.Contains("ReceiveBatchAsync Exception: System.Threading.Tasks.TaskCanceledException"));
-            Assert.IsEmpty(errors, string.Join(",", errors.Select(e => e.FormattedMessage)));
+            public Task StartAsync(CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
 
-            var client = new ServiceBusAdministrationClient(ServiceBusTestEnvironment.Instance.ServiceBusConnectionString);
+            public async Task StopAsync(CancellationToken cancellationToken)
+            {
+                var logs = _host.GetTestLoggerProvider().GetAllLogMessages();
+                var errors = logs.Where(
+                    p => p.Level == LogLevel.Error &&
+                         (p.FormattedMessage == null ||
+                         // Ignore this error that the SDK logs when cancelling batch receive
+                         !p.FormattedMessage.Contains("ReceiveBatchAsync Exception: System.Threading.Tasks.TaskCanceledException")));
+                Assert.IsEmpty(errors, string.Join(",", errors.Select(e => e.FormattedMessage)));
 
-            // wait for a few seconds to allow updated counts to propagate
-            await Task.Delay(TimeSpan.FromSeconds(2));
+                var client = new ServiceBusAdministrationClient(ServiceBusTestEnvironment.Instance.ServiceBusConnectionString);
 
-            QueueRuntimeProperties properties = await client.GetQueueRuntimePropertiesAsync(WebJobsServiceBusTestBase._firstQueueScope.QueueName, CancellationToken.None);
-            Assert.AreEqual(0, properties.TotalMessageCount);
+                // wait for a few seconds to allow updated counts to propagate
+                await Task.Delay(TimeSpan.FromSeconds(2));
+
+                QueueRuntimeProperties properties = await client.GetQueueRuntimePropertiesAsync(FirstQueueScope.QueueName, CancellationToken.None);
+                Assert.AreEqual(0, properties.TotalMessageCount);
+            }
         }
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/WebJobsServiceBusTestBase.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/WebJobsServiceBusTestBase.cs
@@ -301,7 +301,9 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                          (p.FormattedMessage == null ||
                          // Ignore this error that the SDK logs when cancelling batch receive
                          !p.FormattedMessage.Contains("ReceiveBatchAsync Exception: System.Threading.Tasks.TaskCanceledException")));
-                Assert.IsEmpty(errors, string.Join(",", errors.Select(e => e.FormattedMessage)));
+                Assert.IsEmpty(errors, string.Join(
+                    ",",
+                    errors.Select(e => e.Exception != null ? e.Exception.StackTrace : e.FormattedMessage)));
 
                 var client = new ServiceBusAdministrationClient(ServiceBusTestEnvironment.Instance.ServiceBusConnectionString);
 


### PR DESCRIPTION
Previously, we were only abandoning messages in batch functions if an error occurred _and_ AutoCompleteMessages was true. This was inconsistent with the behavior for single-dispatch functions, and with the behavior of the SDK when using the processor directly. The correct behavior is for abandoning to be independent of AutoCompleteMessages.

While working on this fix, an additional two issues were found and fixed:
- Messages received from ReceiveActions were not being abandoned when there was an exception
- Message lock renewal was not being stopped when user handler throws