### PR TITLE
[TA] Add missing mock tests plus enable missing mocks

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/MockTests/AnalyzeOperationMockTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/MockTests/AnalyzeOperationMockTests.cs
@@ -1,0 +1,793 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.AI.TextAnalytics.Tests
+{
+    public class AnalyzeOperationMockTests : ClientTestBase
+    {
+        private static readonly string s_endpoint = "https://contoso-textanalytics.cognitiveservices.azure.com/";
+        private static readonly string s_apiKey = "FakeapiKey";
+        private static readonly string FakeProjectName = "FakeProjectName";
+        private static readonly string FakeDeploymentName = "FakeDeploymentName";
+
+        public AnalyzeOperationMockTests(bool isAsync) : base(isAsync)
+        {
+        }
+
+        private TextAnalyticsClient CreateTestClient(HttpPipelineTransport transport)
+        {
+            var options = new TextAnalyticsClientOptions()
+            {
+                Transport = transport
+            };
+
+            var client = new TextAnalyticsClient(new Uri(s_endpoint), new AzureKeyCredential(s_apiKey), options);
+
+            return client;
+        }
+
+        #region Key phrases
+
+        [Test]
+        public async Task AnalyzeOperationKeyPhrasesWithDisableServiceLogs()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            var actions = new ExtractKeyPhrasesAction()
+            {
+                DisableServiceLogs = true
+            };
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { actions },
+            };
+
+            await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            var contentString = GetString(mockTransport.Requests.Single().Content);
+            string logging = contentString.Substring(contentString.IndexOf("loggingOptOut"), 19);
+
+            var expectedContent = "loggingOptOut\":true";
+            Assert.AreEqual(expectedContent, logging);
+        }
+
+        [Test]
+        public async Task AnalyzeOperationKeyPhrasesFromRequestOptions()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            var options = new TextAnalyticsRequestOptions();
+
+            var actions = new ExtractKeyPhrasesAction(options);
+
+            TextAnalyticsActions batchActions = new()
+            {
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { actions },
+            };
+
+            await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            var contentString = GetString(mockTransport.Requests.Single().Content);
+            ValidateRequestOptions(contentString);
+        }
+
+        [Test]
+        public async Task AnalyzeOperationKeyPhrasesFromRequestOptionsFull()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            var options = new TextAnalyticsRequestOptions()
+            {
+                ModelVersion = "latest",
+                DisableServiceLogs = true,
+                IncludeStatistics = false
+            };
+
+            var actions = new ExtractKeyPhrasesAction(options);
+
+            TextAnalyticsActions batchActions = new()
+            {
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { actions },
+            };
+
+            await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            var contentString = GetString(mockTransport.Requests.Single().Content);
+            ValidateRequestOptions(contentString, true);
+        }
+
+        #endregion Key phrases
+
+        #region entities
+
+        [Test]
+        public async Task AnalyzeOperationRecognizeEntitiesWithDisableServiceLogs()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            var actions = new RecognizeEntitiesAction()
+            {
+                DisableServiceLogs = true
+            };
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { actions },
+            };
+
+            await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            var contentString = GetString(mockTransport.Requests.Single().Content);
+            string logging = contentString.Substring(contentString.IndexOf("loggingOptOut"), 19);
+
+            var expectedContent = "loggingOptOut\":true";
+            Assert.AreEqual(expectedContent, logging);
+        }
+
+        [Test]
+        public async Task AnalyzeOperationRecognizeEntitiesWithRequestOptions()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            var options = new TextAnalyticsRequestOptions();
+
+            var actions = new RecognizeEntitiesAction(options);
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { actions },
+            };
+
+            await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            var contentString = GetString(mockTransport.Requests.Single().Content);
+            ValidateRequestOptions(contentString);
+        }
+
+        [Test]
+        public async Task AnalyzeOperationRecognizeEntitiesWithRequestOptionsFull()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            var options = new TextAnalyticsRequestOptions()
+            {
+                ModelVersion = "latest",
+                DisableServiceLogs = true,
+                IncludeStatistics = false
+            };
+
+            var actions = new RecognizeEntitiesAction(options);
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { actions },
+            };
+
+            await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            var contentString = GetString(mockTransport.Requests.Single().Content);
+            ValidateRequestOptions(contentString, true);
+        }
+
+        #endregion entities
+
+        #region Custom Entities
+
+        [Test]
+        public async Task AnalyzeOperationRecognizeCustomEntitiesWithDisableServiceLogs()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            var actions = new RecognizeCustomEntitiesAction(FakeProjectName, FakeDeploymentName)
+            {
+                DisableServiceLogs = true
+            };
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                RecognizeCustomEntitiesActions = new List<RecognizeCustomEntitiesAction>() { actions },
+            };
+
+            await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            var contentString = GetString(mockTransport.Requests.Single().Content);
+            string logging = contentString.Substring(contentString.IndexOf("loggingOptOut"), 19);
+
+            var expectedContent = "loggingOptOut\":true";
+            Assert.AreEqual(expectedContent, logging);
+        }
+        #endregion
+
+        #region linked entities
+
+        [Test]
+        public async Task AnalyzeOperationRecognizeLinkedEntitiesWithDisableServiceLogs()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            var actions = new RecognizeLinkedEntitiesAction()
+            {
+                DisableServiceLogs = true
+            };
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { actions },
+            };
+
+            await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            var contentString = GetString(mockTransport.Requests.Single().Content);
+            string logging = contentString.Substring(contentString.IndexOf("loggingOptOut"), 19);
+
+            var expectedContent = "loggingOptOut\":true";
+            Assert.AreEqual(expectedContent, logging);
+        }
+
+        [Test]
+        public async Task AnalyzeOperationRecognizeLinkedEntitiesWithRequestOptions()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            var options = new TextAnalyticsRequestOptions();
+
+            var actions = new RecognizeLinkedEntitiesAction(options);
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { actions },
+            };
+
+            await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            var contentString = GetString(mockTransport.Requests.Single().Content);
+            ValidateRequestOptions(contentString);
+        }
+
+        [Test]
+        public async Task AnalyzeOperationRecognizeLinkedEntitiesWithRequestOptionsFull()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            var options = new TextAnalyticsRequestOptions()
+            {
+                ModelVersion = "latest",
+                DisableServiceLogs = true,
+                IncludeStatistics = false
+            };
+
+            var actions = new RecognizeLinkedEntitiesAction(options);
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { actions },
+            };
+
+            await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            var contentString = GetString(mockTransport.Requests.Single().Content);
+            ValidateRequestOptions(contentString, true);
+        }
+
+        #endregion linked entities
+
+        #region Pii entities
+
+        [Test]
+        public async Task AnalyzeOperationRecognizePiiEntitiesWithDisableServiceLogs()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            var actions = new RecognizePiiEntitiesAction()
+            {
+                DisableServiceLogs = true
+            };
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { actions },
+            };
+
+            await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            var contentString = GetString(mockTransport.Requests.Single().Content);
+            string logging = contentString.Substring(contentString.IndexOf("loggingOptOut"), 19);
+
+            var expectedContent = "loggingOptOut\":true";
+            Assert.AreEqual(expectedContent, logging);
+        }
+
+        [Test]
+        public async Task AnalyzeOperationRecognizePiiEntitiesWithPiiOptions()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            var options = new RecognizePiiEntitiesOptions();
+
+            var actions = new RecognizePiiEntitiesAction(options);
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { actions },
+            };
+
+            await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            var contentString = GetString(mockTransport.Requests.Single().Content);
+            ValidateRequestOptions(contentString);
+            Assert.AreEqual(-1, contentString.IndexOf("domain"));
+            Assert.AreEqual(-1, contentString.IndexOf("piiCategories"));
+        }
+
+        [Test]
+        public async Task AnalyzeOperationRecognizePiiEntitiesWithPiiOptionsFull()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            var options = new RecognizePiiEntitiesOptions()
+            {
+                ModelVersion = "latest",
+                DisableServiceLogs = true,
+                IncludeStatistics = true,
+                DomainFilter = (TextAnalytics.PiiEntityDomain)PiiEntityDomain.ProtectedHealthInformation,
+                CategoriesFilter = { PiiEntityCategory.USSocialSecurityNumber }
+            };
+
+            var actions = new RecognizePiiEntitiesAction(options);
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { actions },
+            };
+
+            await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            var contentString = GetString(mockTransport.Requests.Single().Content);
+            ValidateRequestOptions(contentString, true);
+
+            string domaintFilter = contentString.Substring(contentString.IndexOf("domain"), 13);
+
+            var expectedDomainFilterContent = "domain\":\"phi\"";
+            Assert.AreEqual(expectedDomainFilterContent, domaintFilter);
+
+            string piiCategories = contentString.Substring(contentString.IndexOf("piiCategories"), 41);
+
+            var expectedPiiCategoriesContent = "piiCategories\":[\"USSocialSecurityNumber\"]";
+            Assert.AreEqual(expectedPiiCategoriesContent, piiCategories);
+        }
+
+        #endregion Pii entities
+
+        #region Analyze sentiment
+
+        [Test]
+        public async Task AnalyzeOperationAnalyzeSentimentWithDisableServiceLogs()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            var actions = new AnalyzeSentimentAction()
+            {
+                DisableServiceLogs = true
+            };
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { actions },
+            };
+
+            await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            var contentString = GetString(mockTransport.Requests.Single().Content);
+            string logging = contentString.Substring(contentString.IndexOf("loggingOptOut"), 19);
+
+            var expectedContent = "loggingOptOut\":true";
+            Assert.AreEqual(expectedContent, logging);
+        }
+
+        [Test]
+        public async Task AnalyzeOperationAnalyzeSentimentWithAnalyzeSentimentOptions()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            var options = new AnalyzeSentimentOptions();
+
+            var actions = new AnalyzeSentimentAction(options);
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { actions },
+            };
+
+            await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            var contentString = GetString(mockTransport.Requests.Single().Content);
+            ValidateRequestOptions(contentString);
+            Assert.AreEqual(-1, contentString.IndexOf("opinionMining"));
+        }
+
+        [Test]
+        public async Task AnalyzeOperationAnalyzeSentimentWithAnalyzeSentimentOptionsFull()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            var options = new AnalyzeSentimentOptions()
+            {
+                ModelVersion = "latest",
+                DisableServiceLogs = true,
+                IncludeStatistics = true,
+                IncludeOpinionMining = true
+            };
+
+            var actions = new AnalyzeSentimentAction(options);
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { actions },
+            };
+
+            await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            var contentString = GetString(mockTransport.Requests.Single().Content);
+            ValidateRequestOptions(contentString, true);
+
+            string opinionMining = contentString.Substring(contentString.IndexOf("opinionMining"), 19);
+
+            var expectedOpinionMiningContent = "opinionMining\":true";
+            Assert.AreEqual(expectedOpinionMiningContent, opinionMining);
+        }
+
+        #endregion Analyze sentiment
+
+        #region Extract summary
+
+        [Test]
+        public async Task AnalyzeOperationExtractSummaryWithDisableServiceLogs()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            var actions = new ExtractSummaryAction()
+            {
+                DisableServiceLogs = true
+            };
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                ExtractSummaryActions = new List<ExtractSummaryAction>() { actions },
+            };
+
+            await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            var contentString = GetString(mockTransport.Requests.Single().Content);
+            string logging = contentString.Substring(contentString.IndexOf("loggingOptOut"), 19);
+
+            var expectedContent = "loggingOptOut\":true";
+            Assert.AreEqual(expectedContent, logging);
+        }
+
+        #endregion Extract summary
+
+        #region Multi Category Classify
+
+        [Test]
+        public async Task AnalyzeOperationMultiCategoryClassifyWithDisableServiceLogs()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            var actions = new MultiCategoryClassifyAction(FakeProjectName, FakeDeploymentName)
+            {
+                DisableServiceLogs = true
+            };
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                MultiCategoryClassifyActions = new List<MultiCategoryClassifyAction>() { actions },
+            };
+
+            await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            var contentString = GetString(mockTransport.Requests.Single().Content);
+            string logging = contentString.Substring(contentString.IndexOf("loggingOptOut"), 19);
+
+            var expectedContent = "loggingOptOut\":true";
+            Assert.AreEqual(expectedContent, logging);
+        }
+        #endregion
+
+        #region Single Category Classify
+
+        [Test]
+        public async Task AnalyzeOperationSingleCategoryClassifyWithDisableServiceLogs()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla."
+            };
+
+            var actions = new SingleCategoryClassifyAction(FakeProjectName, FakeDeploymentName)
+            {
+                DisableServiceLogs = true
+            };
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                SingleCategoryClassifyActions = new List<SingleCategoryClassifyAction>() { actions },
+            };
+
+            await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            var contentString = GetString(mockTransport.Requests.Single().Content);
+            string logging = contentString.Substring(contentString.IndexOf("loggingOptOut"), 19);
+
+            var expectedContent = "loggingOptOut\":true";
+            Assert.AreEqual(expectedContent, logging);
+        }
+        #endregion
+
+        [Test]
+        public void AnalyzeOperationWithGenericError()
+        {
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(@"
+                {
+                    ""displayName"": ""AnalyzeOperationBatchWithErrorTest"",
+                    ""jobId"": ""75d521bc-c2aa-4d8a-aabe-713e72d53a2d"",
+                    ""lastUpdateDateTime"": ""2021-03-03T22:39:37Z"",
+                    ""createdDateTime"": ""2021-03-03T22:39:36Z"",
+                    ""expirationDateTime"": ""2021-03-04T22:39:36Z"",
+                    ""status"": ""failed"",
+                    ""errors"": [
+                      {
+                        ""code"": ""InternalServerError"",
+                        ""message"": ""Some error""
+                      }
+                    ],
+                    ""tasks"": {
+                      ""details"": {
+                        ""name"": ""AnalyzeOperationBatchWithErrorTest"",
+                        ""lastUpdateDateTime"": ""2021-03-03T22:39:37Z""
+                      },
+                      ""completed"": 0,
+                      ""failed"": 1,
+                      ""inProgress"": 0,
+                      ""total"": 1,
+                      ""entityRecognitionTasks"": [
+                        {
+                          ""lastUpdateDateTime"": ""2021-03-03T22:39:37.1716697Z"",
+                          ""taskName"": ""something"",
+                          ""state"": ""failed""
+                        }
+                      ]
+                    }
+                }"));
+
+            var mockResponse = new MockResponse(200);
+            mockResponse.ContentStream = stream;
+
+            var mockTransport = new MockTransport(new[] { mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var operation = CreateOperation(client);
+
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.UpdateStatusAsync());
+            Assert.AreEqual("InternalServerError", ex.ErrorCode);
+            Assert.IsTrue(ex.Message.Contains("Some error"));
+        }
+
+        private static string GetString(RequestContent content)
+        {
+            using var stream = new MemoryStream();
+            content.WriteTo(stream, CancellationToken.None);
+
+            return Encoding.UTF8.GetString(stream.ToArray());
+        }
+
+        private static void ValidateRequestOptions(string contentString, bool full = false)
+        {
+            if (!full)
+            {
+                Assert.AreEqual(-1, contentString.IndexOf("loggingOptOut"));
+                Assert.AreEqual(-1, contentString.IndexOf("modelVersion"));
+            }
+            else
+            {
+                string logging = contentString.Substring(contentString.IndexOf("loggingOptOut"), 19);
+
+                var expectedContent = "loggingOptOut\":true";
+                Assert.AreEqual(expectedContent, logging);
+
+                string modelVersion = contentString.Substring(contentString.IndexOf("modelVersion"), 22);
+
+                var expectedModelVersionContent = "modelVersion\":\"latest\"";
+                Assert.AreEqual(expectedModelVersionContent, modelVersion);
+            }
+        }
+
+        private AnalyzeActionsOperation CreateOperation(TextAnalyticsClient client)
+        {
+            var inputOrder = new Dictionary<string, int>(1) { { "0", 0 } };
+            var operationId = OperationContinuationToken.Serialize("75d521bc-c2aa-4d8a-aabe-713e72d53a2d", inputOrder, null);
+
+            return new AnalyzeActionsOperation(operationId, client);
+        }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/MockTests/OperationsMockTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/MockTests/OperationsMockTests.cs
@@ -1,0 +1,304 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.AI.TextAnalytics.Tests
+{
+    public class OperationsMockTests : ClientTestBase
+    {
+        private static readonly string s_endpoint = "https://contoso-textanalytics.cognitiveservices.azure.com/";
+        private static readonly string s_apiKey = "FakeapiKey";
+
+        public OperationsMockTests(bool isAsync) : base(isAsync)
+        {
+        }
+
+        private TextAnalyticsClient CreateTestClient(HttpPipelineTransport transport)
+        {
+            var options = new TextAnalyticsClientOptions()
+            {
+                Transport = transport
+            };
+
+            return new TextAnalyticsClient(new Uri(s_endpoint), new AzureKeyCredential(s_apiKey), options);
+        }
+
+        #region Analyze
+
+        [Test]
+        public async Task CreateAnalyzeOperationConvenienceSetsOperationId()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla.",
+                "Microsoft was founded by Bill Gates and Paul Allen.",
+                "My cat and my dog might need to see a veterinarian."
+            };
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
+            };
+
+            AnalyzeActionsOperation operation = await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            OperationContinuationToken continuationToken = OperationContinuationToken.Deserialize(operation.Id);
+
+            Assert.IsNull(continuationToken.ShowStats);
+            Assert.AreEqual("2a96a91f-7edf-4931-a880-3fdee1d56f15", continuationToken.JobId);
+            Assert.AreEqual(3, continuationToken.InputDocumentOrder.Count);
+            Assert.AreEqual(0, continuationToken.InputDocumentOrder["0"]);
+            Assert.AreEqual(1, continuationToken.InputDocumentOrder["1"]);
+            Assert.AreEqual(2, continuationToken.InputDocumentOrder["2"]);
+        }
+
+        [Test]
+        public async Task CreateAnalyzeOperationSetsOperationId()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<TextDocumentInput>
+            {
+                new TextDocumentInput("134234", "Elon Musk is the CEO of SpaceX and Tesla.")
+                {
+                     Language = "en",
+                },
+                new TextDocumentInput("324232", "Tesla stock is up by 400% this year.")
+                {
+                     Language = "en",
+                }
+            };
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
+            };
+
+            AnalyzeActionsOperation operation = await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            OperationContinuationToken continuationToken = OperationContinuationToken.Deserialize(operation.Id);
+
+            Assert.IsNull(continuationToken.ShowStats);
+            Assert.AreEqual("2a96a91f-7edf-4931-a880-3fdee1d56f15", continuationToken.JobId);
+            Assert.AreEqual(2, continuationToken.InputDocumentOrder.Count);
+            Assert.AreEqual(0, continuationToken.InputDocumentOrder["134234"]);
+            Assert.AreEqual(1, continuationToken.InputDocumentOrder["324232"]);
+        }
+
+        [Test]
+        public void CreateAnalyzeOperationFromFakeValidOperationId()
+        {
+            var jobId = "2a96a91f-7edf-4931-a880-3fdee1d56f15";
+
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", $"something/jobs/{jobId}?api-version=myVersion"));
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var inputOrder = new Dictionary<string, int>(1) { { "0", 0 } };
+            string operationId = OperationContinuationToken.Serialize(jobId, inputOrder, true);
+
+            var operation = new AnalyzeActionsOperation(operationId, client);
+            Assert.AreEqual(operationId, operation.Id);
+        }
+
+        [Test]
+        public void CreateAnalyzeOperationWrongOperationId()
+        {
+            var client = CreateTestClient(new MockTransport());
+
+            var ex = Assert.Throws<ArgumentException>(() => new AnalyzeActionsOperation("2a96a91f-7edf-4931-a880-3fdee1d56f15", client));
+            Assert.IsInstanceOf<FormatException>(ex.InnerException);
+        }
+
+        [Test]
+        public void CreateAnalyzeOperationWrongTokenVersion()
+        {
+            var client = CreateTestClient(new MockTransport());
+            var order = new Dictionary<string, int>() { { "0", 0 } };
+
+            var token = new OperationContinuationToken("2a96a91f-7edf-4931-a880-3fdee1d56f15", order, null);
+            token.Version = "wrong-version";
+
+            string operationId = token.Serialize();
+
+            var ex = Assert.Throws<ArgumentException>(() => new AnalyzeActionsOperation(operationId, client));
+            Assert.IsInstanceOf<ArgumentException>(ex.InnerException);
+        }
+
+        [Test]
+        public void CreateAnalyzeOperationMissingJobId()
+        {
+            var client = CreateTestClient(new MockTransport());
+            var order = new Dictionary<string, int>() { { "0", 0 } };
+
+            string operationId = OperationContinuationToken.Serialize(null, order, null);
+
+            var ex = Assert.Throws<ArgumentException>(() => new AnalyzeActionsOperation(operationId, client));
+            Assert.IsInstanceOf<ArgumentNullException>(ex.InnerException);
+        }
+
+        [Test]
+        public void CreateAnalyzeOperationMissingDocumentOrder()
+        {
+            var client = CreateTestClient(new MockTransport());
+            var order = new Dictionary<string, int>();
+
+            var token = new OperationContinuationToken("2a96a91f-7edf-4931-a880-3fdee1d56f15", order, null);
+            token.InputDocumentOrder = null;
+
+            string operationId = token.Serialize();
+
+            var ex = Assert.Throws<ArgumentException>(() => new AnalyzeActionsOperation(operationId, client));
+            Assert.IsInstanceOf<ArgumentNullException>(ex.InnerException);
+        }
+
+        #endregion Analyze
+
+        #region Healthcare
+        [Test]
+        public async Task CreateHealthcareOperationConvenienceSetsOperationId()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Subject is taking 100mg of ibuprofen twice daily",
+                "Can cause rapid or irregular heartbeat, delirium, panic, psychosis, and heart failure."
+            };
+
+            AnalyzeHealthcareEntitiesOperation operation = await client.StartAnalyzeHealthcareEntitiesAsync(documents);
+
+            OperationContinuationToken continuationToken = OperationContinuationToken.Deserialize(operation.Id);
+
+            Assert.IsFalse(continuationToken.ShowStats);
+            Assert.AreEqual("2a96a91f-7edf-4931-a880-3fdee1d56f15", continuationToken.JobId);
+            Assert.AreEqual(2, continuationToken.InputDocumentOrder.Count);
+            Assert.AreEqual(0, continuationToken.InputDocumentOrder["0"]);
+            Assert.AreEqual(1, continuationToken.InputDocumentOrder["1"]);
+        }
+
+        [Test]
+        public async Task CreateHealthcareOperationSetsOperationId()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15?api-version=myVersion"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<TextDocumentInput>
+            {
+                new TextDocumentInput("134234", "Subject is taking 100mg of ibuprofen twice daily")
+                {
+                     Language = "en",
+                },
+                new TextDocumentInput("324232", "Can cause rapid or irregular heartbeat, delirium, panic, psychosis, and heart failure.")
+                {
+                     Language = "en",
+                }
+            };
+
+            AnalyzeHealthcareEntitiesOperation operation = await client.StartAnalyzeHealthcareEntitiesAsync(documents);
+
+            OperationContinuationToken continuationToken = OperationContinuationToken.Deserialize(operation.Id);
+
+            Assert.IsFalse(continuationToken.ShowStats);
+            Assert.AreEqual("2a96a91f-7edf-4931-a880-3fdee1d56f15", continuationToken.JobId);
+            Assert.AreEqual(2, continuationToken.InputDocumentOrder.Count);
+            Assert.AreEqual(0, continuationToken.InputDocumentOrder["134234"]);
+            Assert.AreEqual(1, continuationToken.InputDocumentOrder["324232"]);
+        }
+
+        [Test]
+        public void CreateHealthcareOperationFromFakeValidOperationId()
+        {
+            var jobId = "2a96a91f-7edf-4931-a880-3fdee1d56f15";
+
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", $"something/jobs/{jobId}?api-version=myVersion"));
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var inputOrder = new Dictionary<string, int>(1) { { "0", 0 } };
+            string operationId = OperationContinuationToken.Serialize(jobId, inputOrder, true);
+
+            var operation = new AnalyzeHealthcareEntitiesOperation(operationId, client);
+            Assert.AreEqual(operationId, operation.Id);
+        }
+
+        [Test]
+        public void CreateHealthcareOperationWrongOperationId()
+        {
+            var client = CreateTestClient(new MockTransport());
+
+            var ex = Assert.Throws<ArgumentException>(() => new AnalyzeHealthcareEntitiesOperation("2a96a91f-7edf-4931-a880-3fdee1d56f15", client));
+            Assert.IsInstanceOf<FormatException>(ex.InnerException);
+        }
+
+        [Test]
+        public void CreateHealthcareOperationWrongTokenVersion()
+        {
+            var client = CreateTestClient(new MockTransport());
+            var order = new Dictionary<string, int>() { { "0", 0 } };
+
+            var token = new OperationContinuationToken("2a96a91f-7edf-4931-a880-3fdee1d56f15", order, null);
+            token.Version = "wrong-version";
+
+            string operationId = token.Serialize();
+
+            var ex = Assert.Throws<ArgumentException>(() => new AnalyzeHealthcareEntitiesOperation(operationId, client));
+            Assert.IsInstanceOf<ArgumentException>(ex.InnerException);
+        }
+
+        [Test]
+        public void CreateHealthcareOperationMissingJobId()
+        {
+            var client = CreateTestClient(new MockTransport());
+            var order = new Dictionary<string, int>() { { "0", 0 } };
+
+            string operationId = OperationContinuationToken.Serialize(null, order, null);
+
+            var ex = Assert.Throws<ArgumentException>(() => new AnalyzeHealthcareEntitiesOperation(operationId, client));
+            Assert.IsInstanceOf<ArgumentNullException>(ex.InnerException);
+        }
+
+        [Test]
+        public void CreateHealthcareOperationMissingDocumentOrder()
+        {
+            var client = CreateTestClient(new MockTransport());
+            var order = new Dictionary<string, int>();
+
+            var token = new OperationContinuationToken("2a96a91f-7edf-4931-a880-3fdee1d56f15", order, null);
+            token.InputDocumentOrder = null;
+
+            string operationId = token.Serialize();
+
+            var ex = Assert.Throws<ArgumentException>(() => new AnalyzeHealthcareEntitiesOperation(operationId, client));
+            Assert.IsInstanceOf<ArgumentNullException>(ex.InnerException);
+        }
+
+        #endregion Healthcare
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/MockTests/TextAnalyticsClientMockTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/MockTests/TextAnalyticsClientMockTests.cs
@@ -645,32 +645,34 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [Test]
-        [Ignore("Not implemented yet")]
         public async Task DeserializeTextAnalyticsError()
         {
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(@"
                 {
-                    ""documents"": [
-                        {
-                            ""id"": ""0"",
-                            ""keyPhrases"": [],
-                            ""warnings"": []
-                        }
-                    ],
-                    ""errors"": [
-                        {
-                            ""id"": ""1"",
-                            ""error"": {
-                                ""code"": ""InvalidArgument"",
-                                ""message"": ""Invalid document in request."",
-                                ""innererror"": {
-                                    ""code"": ""InvalidDocument"",
-                                    ""message"": ""Document text is empty.""
+                    ""kind"": ""KeyPhraseExtractionResults"",
+                    ""results"": {  
+                        ""documents"": [
+                            {
+                                ""id"": ""0"",
+                                ""keyPhrases"": [],
+                                ""warnings"": []
+                            }
+                        ],
+                        ""errors"": [
+                            {
+                                ""id"": ""1"",
+                                ""error"": {
+                                    ""code"": ""InvalidArgument"",
+                                    ""message"": ""Invalid document in request."",
+                                    ""innererror"": {
+                                        ""code"": ""InvalidDocument"",
+                                        ""message"": ""Document text is empty.""
+                                    }
                                 }
                             }
-                        }
-                    ],
-                    ""modelVersion"": ""2020-07-01""
+                        ],
+                        ""modelVersion"": ""2020-07-01""
+                    }
                 }"));
 
             var mockResponse = new MockResponse(200);


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/28780
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/28781

We had mock tests for the operations on the [Legacy client](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/MockTests/Legacy). I ported the tests and adjusted them to the new format/parameters of the Language client