### PR TITLE
Adding configurable process timeout to AzurePowershellCredentials

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/AzurePowerShellCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzurePowerShellCredential.cs
@@ -24,7 +24,7 @@ namespace Azure.Identity
     {
         private readonly CredentialPipeline _pipeline;
         private readonly IProcessService _processService;
-        private const int PowerShellProcessTimeoutMs = 10000;
+        internal int PowerShellProcessTimeoutMs { get; private set; }
         internal bool UseLegacyPowerShell { get; set; }
 
         private const string Troubleshooting = "See the troubleshooting guide for more information. https://aka.ms/azsdk/net/identity/powershellcredential/troubleshoot";
@@ -67,6 +67,7 @@ namespace Azure.Identity
             _tenantId = options?.TenantId;
             _pipeline = pipeline ?? CredentialPipeline.GetInstance(options);
             _processService = processService ?? ProcessService.Default;
+            PowerShellProcessTimeoutMs = options?.PowerShellProcessTimeoutMs ?? (int)TimeSpan.FromSeconds(10).TotalMilliseconds;
         }
 
         /// <summary>

--- a/sdk/identity/Azure.Identity/src/Credentials/AzurePowerShellCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzurePowerShellCredentialOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Azure.Identity
 {
     /// <summary>
@@ -12,5 +14,10 @@ namespace Azure.Identity
         /// The Azure Active Directory tenant (directory) Id of the service principal
         /// </summary>
         public string TenantId { get; set; }
+
+        /// <summary>
+        /// The Powershell process timeout miliseconds.
+        /// </summary>
+        public int PowerShellProcessTimeoutMs { get; set; } = (int)TimeSpan.FromSeconds(10).TotalMilliseconds;
     }
 }

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredential.cs
@@ -225,7 +225,7 @@ namespace Azure.Identity
 
             if (!options.ExcludeAzurePowerShellCredential)
             {
-                chain[i++] = factory.CreateAzurePowerShellCredential();
+                chain[i++] = factory.CreateAzurePowerShellCredential(options.PowerShellProcessTimeoutMs);
             }
 
             if (!options.ExcludeInteractiveBrowserCredential)

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -68,6 +68,11 @@ namespace Azure.Identity
         public ResourceIdentifier ManagedIdentityResourceId { get; set; }
 
         /// <summary>
+        /// Specifies Powershell process timeout in milliseconds.
+        /// </summary>
+        public int PowerShellProcessTimeoutMs { get; set; } = (int)TimeSpan.FromSeconds(10).TotalMilliseconds;
+
+        /// <summary>
         /// Specifies whether the <see cref="EnvironmentCredential"/> will be excluded from the authentication flow. Setting to true disables reading
         /// authentication details from the process' environment variables.
         /// </summary>

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -67,9 +67,9 @@ namespace Azure.Identity
             return new VisualStudioCodeCredential(new VisualStudioCodeCredentialOptions { TenantId = tenantId }, Pipeline, default, default, default);
         }
 
-        public virtual TokenCredential CreateAzurePowerShellCredential()
+        public virtual TokenCredential CreateAzurePowerShellCredential(int powerShellProcessTimeoutMs)
         {
-            return new AzurePowerShellCredential(new AzurePowerShellCredentialOptions(), Pipeline, default);
+            return new AzurePowerShellCredential(new AzurePowerShellCredentialOptions() { PowerShellProcessTimeoutMs = powerShellProcessTimeoutMs }, Pipeline, default);
         }
     }
 }

--- a/sdk/identity/Azure.Identity/tests/AzurePowerShellCredentialsTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzurePowerShellCredentialsTests.cs
@@ -144,6 +144,16 @@ namespace Azure.Identity.Tests
         }
 
         [Test]
+        public void ConfigurePowershellProcessTimeout()
+        {
+            int powershellProcessTimeout = 42;
+
+            AzurePowerShellCredential credential = new AzurePowerShellCredential(
+                      new AzurePowerShellCredentialOptions() { PowerShellProcessTimeoutMs = powershellProcessTimeout });
+            Assert.AreEqual(powershellProcessTimeout, credential.PowerShellProcessTimeoutMs);
+        }
+
+        [Test]
         [RunOnlyOnPlatforms(Windows = true)]
         public void AuthenticateWithAzurePowerShellCredential_PowerShellNotInstalled(
             [Values("'powershell' is not recognized", "powershell: command not found", "powershell: not found")]

--- a/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialTests.cs
@@ -83,6 +83,7 @@ namespace Azure.Identity.Tests
             string expVsTenantId = Guid.NewGuid().ToString();
             string expCodeTenantId = Guid.NewGuid().ToString();
             string expResourceId =  $"/subscriptions/{Guid.NewGuid().ToString()}/locations/MyLocation";
+            int expPowershellProcessTimeoutMs = 42;
             string actClientId_ManagedIdentity = null;
             string actResiurceId_ManagedIdentity = null;
             string actClientId_InteractiveBrowser = null;
@@ -91,6 +92,7 @@ namespace Azure.Identity.Tests
             string actBrowserTenantId = null;
             string actVsTenantId = null;
             string actCodeTenantId = null;
+            int actPowershellProcessTimeoutMs = 0;
 
             var credFactory = new MockDefaultAzureCredentialFactory(CredentialPipeline.GetInstance(null));
 
@@ -103,7 +105,7 @@ namespace Azure.Identity.Tests
             credFactory.OnCreateInteractiveBrowserCredential = (tenantId, clientId,  _) => { actBrowserTenantId = tenantId; actClientId_InteractiveBrowser = clientId; };
             credFactory.OnCreateVisualStudioCredential = (tenantId, _) => { actVsTenantId = tenantId; };
             credFactory.OnCreateVisualStudioCodeCredential = (tenantId, _) => { actCodeTenantId = tenantId; };
-            credFactory.OnCreateAzurePowerShellCredential = _ => {};
+            credFactory.OnCreateAzurePowerShellCredential = (powershellProcessTimeoutMs, _) => { actPowershellProcessTimeoutMs = powershellProcessTimeoutMs; };
 
             var options = new DefaultAzureCredentialOptions
             {
@@ -115,6 +117,7 @@ namespace Azure.Identity.Tests
                 VisualStudioCodeTenantId = expCodeTenantId,
                 InteractiveBrowserTenantId = expBrowserTenantId,
                 ExcludeInteractiveBrowserCredential = false,
+                PowerShellProcessTimeoutMs = expPowershellProcessTimeoutMs
             };
 
             switch (managedIdentityIdType)
@@ -135,6 +138,7 @@ namespace Azure.Identity.Tests
             Assert.AreEqual(expBrowserTenantId, actBrowserTenantId);
             Assert.AreEqual(expVsTenantId, actVsTenantId);
             Assert.AreEqual(expCodeTenantId, actCodeTenantId);
+            Assert.AreEqual(expPowershellProcessTimeoutMs, actPowershellProcessTimeoutMs);
             switch (managedIdentityIdType)
             {
                 case ManagedIdentityIdType.ClientId:
@@ -322,7 +326,7 @@ namespace Azure.Identity.Tests
             credFactory.OnCreateInteractiveBrowserCredential = (tenantId, _, _) => interactiveBrowserCredentialIncluded = true;
             credFactory.OnCreateVisualStudioCredential = (tenantId, _) => visualStudioCredentialIncluded = true;
             credFactory.OnCreateVisualStudioCodeCredential = (tenantId, _) => visualStudioCodeCredentialIncluded = true;
-            credFactory.OnCreateAzurePowerShellCredential = _ => powerShellCredentialsIncluded = true;
+            credFactory.OnCreateAzurePowerShellCredential = (_, _) => powerShellCredentialsIncluded = true;
             credFactory.OnCreateManagedIdentityCredential = (clientId, _) =>
             {
                 managedIdentityCredentialIncluded = true;
@@ -394,7 +398,7 @@ namespace Azure.Identity.Tests
                 SetupMockForException(c);
             credFactory.OnCreateAzureCliCredential = c =>
                 SetupMockForException(c);
-            credFactory.OnCreateAzurePowerShellCredential = c =>
+            credFactory.OnCreateAzurePowerShellCredential = (_, c) =>
                 SetupMockForException(c);
             credFactory.OnCreateVisualStudioCredential = (_, c) =>
                 SetupMockForException(c);
@@ -484,7 +488,7 @@ namespace Azure.Identity.Tests
                 SetupMockForException(c);
             credFactory.OnCreateAzureCliCredential = c =>
                 SetupMockForException(c);
-            credFactory.OnCreateAzurePowerShellCredential = c =>
+            credFactory.OnCreateAzurePowerShellCredential = (_, c) =>
                 SetupMockForException(c);
 
             credFactory.OnCreateInteractiveBrowserCredential = (_, _, c) =>
@@ -616,7 +620,7 @@ namespace Azure.Identity.Tests
                 SetupMockForException(c);
             credFactory.OnCreateVisualStudioCodeCredential = (_, c) =>
                 SetupMockForException(c);
-            credFactory.OnCreateAzurePowerShellCredential = c =>
+            credFactory.OnCreateAzurePowerShellCredential = (_, c) =>
                 SetupMockForException(c);
 
             return credFactory;

--- a/sdk/identity/Azure.Identity/tests/Mock/MockDefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/tests/Mock/MockDefaultAzureCredentialFactory.cs
@@ -25,7 +25,7 @@ namespace Azure.Identity.Tests.Mock
         private Mock<VisualStudioCredential> mockVisualStudioCredential = new();
         public Action<string, Mock<VisualStudioCodeCredential>> OnCreateVisualStudioCodeCredential { get; set; }
         private Mock<VisualStudioCodeCredential> mockVisualStudioCodeCredential = new();
-        public Action<Mock<AzurePowerShellCredential>> OnCreateAzurePowerShellCredential { get; set; }
+        public Action<int, Mock<AzurePowerShellCredential>> OnCreateAzurePowerShellCredential { get; set; }
         private Mock<AzurePowerShellCredential> mockAzurePowershellCredential = new();
 
         public override TokenCredential CreateEnvironmentCredential()
@@ -52,9 +52,9 @@ namespace Azure.Identity.Tests.Mock
             return mockAzureCliCredential.Object;
         }
 
-        public override TokenCredential CreateAzurePowerShellCredential()
+        public override TokenCredential CreateAzurePowerShellCredential(int powershellProcesTimeoutMs)
         {
-            OnCreateAzurePowerShellCredential?.Invoke(mockAzurePowershellCredential);
+            OnCreateAzurePowerShellCredential?.Invoke(powershellProcesTimeoutMs, mockAzurePowershellCredential);
             return mockAzurePowershellCredential.Object;
         }
 

--- a/sdk/identity/Azure.Identity/tests/Mock/TestDefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/tests/Mock/TestDefaultAzureCredentialFactory.cs
@@ -41,7 +41,7 @@ namespace Azure.Identity.Tests.Mock
         public override TokenCredential CreateVisualStudioCodeCredential(string tenantId)
             => new VisualStudioCodeCredential(new VisualStudioCodeCredentialOptions { TenantId = tenantId }, Pipeline, default, _fileSystem, _vscAdapter);
 
-        public override TokenCredential CreateAzurePowerShellCredential()
+        public override TokenCredential CreateAzurePowerShellCredential(int powershellProcessTimeoutMs)
             => new AzurePowerShellCredential(new AzurePowerShellCredentialOptions(), Pipeline, _processService);
     }
 }


### PR DESCRIPTION
Adding configurable process timeout for AzurePowershellCrendentials. 

Proposed solution for [FEATURE REQ]
#23135
#28734