### PR TITLE
Change [Test] to [RecordedTest] for Key Vault

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
@@ -68,7 +68,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         public void StartCreateCertificateError()
         {
             string certName = Recording.GenerateId();
@@ -85,7 +85,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             Assert.AreEqual(400, ex.Status);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyGetCertificateOperation()
         {
             string certName = Recording.GenerateId();
@@ -103,7 +103,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             Assert.IsNotNull(getOperation);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyCancelCertificateOperation()
         {
             string certName = Recording.GenerateId();
@@ -145,7 +145,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             Assert.AreEqual(200, operation.GetRawResponse().Status);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyUnexpectedCancelCertificateOperation()
         {
             string certName = Recording.GenerateId();
@@ -189,7 +189,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             Assert.AreEqual(200, operation.GetRawResponse().Status);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyDeleteCertificateOperation()
         {
             string certName = Recording.GenerateId();
@@ -212,7 +212,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             Assert.AreEqual(404, operation.GetRawResponse().Status);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyUnexpectedDeleteCertificateOperation()
         {
             string certName = Recording.GenerateId();
@@ -243,7 +243,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             Assert.AreEqual(404, operation.GetRawResponse().Status);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyCertificateOperationError()
         {
             string issuerName = Recording.GenerateId();
@@ -294,7 +294,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyCertificateGetWithPolicyInProgress()
         {
             string certName = Recording.GenerateId();
@@ -321,7 +321,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             Assert.AreEqual(certificate.Name, certName);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyGetCertificateCompleted()
         {
             string certName = Recording.GenerateId();
@@ -347,7 +347,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             Assert.AreEqual(certificate.Name, certName);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyGetCertificateCompletedSubsequently()
         {
             string certName = Recording.GenerateId();
@@ -374,7 +374,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             Assert.NotNull(certificateWithPolicy.Properties.Version);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyUpdateCertificate()
         {
             string certName = Recording.GenerateId();
@@ -402,7 +402,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             CollectionAssert.AreEqual(expTags, updated.Properties.Tags);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyDeleteRecoverPurge()
         {
             string certName = Recording.GenerateId();
@@ -442,7 +442,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             await WaitForPurgedCertificate(certName);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyImportCertificatePem()
         {
             string certificateName = Recording.GenerateId();
@@ -465,7 +465,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             Assert.AreEqual("azuresdk@microsoft.com", cert.Policy.SubjectAlternativeNames?.Emails?[0]);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyImportCertificatePemWithoutIssuer()
         {
             string certificateName = Recording.GenerateId();
@@ -495,7 +495,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             Assert.AreEqual("azuresdk@microsoft.com", cert.Policy.SubjectAlternativeNames?.Emails?[0]);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyImportCertificatePfx()
         {
             string caCertificateName = Recording.GenerateId();
@@ -516,7 +516,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             CollectionAssert.AreEqual(pubBytes, cert.Cer);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task ValidateMergeCertificate()
         {
             string serverCertificateName = Recording.GenerateId();
@@ -583,7 +583,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             CollectionAssert.AreEqual(mergedServerCertificate.Cer, completedServerCertificate.Cer);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyGetIssuer()
         {
             string issuerName = Recording.GenerateId();
@@ -618,7 +618,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             // Assert.AreEqual(issuer.Name, getIssuer.Name);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyUpdateIssuer()
         {
             string issuerName = Recording.GenerateId();
@@ -642,7 +642,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             Assert.AreEqual(updateProvider, updateIssuer.Provider);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyGetPropertiesOfIssuersAsync()
         {
             string issuerName = Recording.GenerateId();
@@ -673,7 +673,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyGetContacts()
         {
             IList<CertificateContact> contacts = new List<CertificateContact>();
@@ -710,7 +710,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyGetCertificatePolicy()
         {
             string certName = Recording.GenerateId();
@@ -733,7 +733,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             Assert.AreEqual(DefaultPolicy.ReuseKey, policy.ReuseKey);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task VerifyUpdateCertificatePolicy()
         {
             string certName = Recording.GenerateId();
@@ -901,7 +901,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             Assert.IsFalse(x509certificate.HasPrivateKey);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task DownloadECDsaCertificateSignRemoteVerifyLocal([EnumValues] CertificateContentType contentType, [EnumValues] CertificateKeyCurveName keyCurveName)
         {
 #if NET461
@@ -958,7 +958,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task DownloadECDsaCertificateSignLocalVerifyRemote([EnumValues] CertificateContentType contentType, [EnumValues] CertificateKeyCurveName keyCurveName)
         {
 #if NET461

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/CryptographyClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/CryptographyClientLiveTests.cs
@@ -30,7 +30,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             CompareBodies = false;
         }
 
-        [Test]
+        [RecordedTest]
         public async Task EncryptDecryptRoundTrip([EnumValues(nameof(EncryptionAlgorithm.Rsa15), nameof(EncryptionAlgorithm.RsaOaep), nameof(EncryptionAlgorithm.RsaOaep256))]EncryptionAlgorithm algorithm)
         {
             KeyVaultKey key = await CreateTestKey(algorithm);
@@ -56,7 +56,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             CollectionAssert.AreEqual(data, decResult.Plaintext);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task WrapUnwrapRoundTrip([EnumValues(Exclude = new[] { nameof(KeyWrapAlgorithm.A128KW), nameof(KeyWrapAlgorithm.A192KW), nameof(KeyWrapAlgorithm.A256KW) })]KeyWrapAlgorithm algorithm)
         {
             KeyVaultKey key = await CreateTestKey(algorithm);
@@ -82,7 +82,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             CollectionAssert.AreEqual(data, decResult.Key);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task SignVerifyDataRoundTrip([EnumValues]SignatureAlgorithm algorithm)
         {
             KeyVaultKey key = await CreateTestKey(algorithm);
@@ -124,7 +124,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.True(verifyResult.IsValid);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task SignVerifyDataStreamRoundTrip([EnumValues]SignatureAlgorithm algorithm)
         {
             KeyVaultKey key = await CreateTestKey(algorithm);
@@ -174,7 +174,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
 
         // We do not test using ES256K below since macOS doesn't support it; various ideas to work around that adversely affect runtime code too much.
 
-        [Test]
+        [RecordedTest]
         public async Task LocalSignVerifyRoundTrip([EnumValues(Exclude = new[] { nameof(SignatureAlgorithm.ES256K) })]SignatureAlgorithm algorithm)
         {
 #if NET461
@@ -217,7 +217,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.IsTrue(verifyResult.IsValid);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task LocalSignVerifyRoundTripOnFramework([EnumValues(nameof(SignatureAlgorithm.PS256), nameof(SignatureAlgorithm.PS384), nameof(SignatureAlgorithm.PS512))]SignatureAlgorithm algorithm)
         {
 #if !NETFRAMEWORK
@@ -251,7 +251,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.IsTrue(verifyResult.IsValid);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task SignLocalVerifyRoundTrip([EnumValues(Exclude = new[] { nameof(SignatureAlgorithm.ES256K) })]SignatureAlgorithm algorithm)
         {
 #if NET461
@@ -294,7 +294,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.IsTrue(verifyResult.IsValid);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task SignLocalVerifyRoundTripFramework([EnumValues(nameof(SignatureAlgorithm.PS256), nameof(SignatureAlgorithm.PS384), nameof(SignatureAlgorithm.PS512))]SignatureAlgorithm algorithm)
         {
 #if !NETFRAMEWORK
@@ -328,7 +328,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.IsTrue(verifyResult.IsValid);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task EncryptLocalDecryptOnKeyVault([EnumValues(nameof(EncryptionAlgorithm.Rsa15), nameof(EncryptionAlgorithm.RsaOaep), nameof(EncryptionAlgorithm.RsaOaep256))] EncryptionAlgorithm algorithm)
         {
             KeyVaultKey key = await CreateTestKey(algorithm);
@@ -355,7 +355,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             CollectionAssert.AreEqual(plaintext, decrypted.Plaintext);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task EncryptDecryptFromKeyClient()
         {
             KeyVaultKey key = await CreateTestKey(EncryptionAlgorithm.RsaOaep);
@@ -371,7 +371,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.AreEqual(plaintext, decryptResult.Plaintext);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task EncryptWithKeyNameReturnsFullKeyId()
         {
             KeyVaultKey key = await CreateTestKey(EncryptionAlgorithm.RsaOaep);

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.KeyRotation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.KeyRotation.cs
@@ -11,7 +11,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
 {
     public partial class KeyClientLiveTests
     {
-        [Test]
+        [RecordedTest]
         [KeyVaultOnly]
         [ServiceVersion(Min = KeyClientOptions.ServiceVersion.V7_3)]
         public async Task GetKeyRotationPolicyReturnsDefault()
@@ -25,7 +25,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.That(policy.LifetimeActions, Has.One.Matches<KeyRotationLifetimeAction>(action => action.Action == KeyRotationPolicyAction.Notify));
         }
 
-        [Test]
+        [RecordedTest]
         [KeyVaultOnly]
         [ServiceVersion(Min = KeyClientOptions.ServiceVersion.V7_3)]
         public void GetKeyRotationPolicyThrowsForMissingKey()
@@ -38,7 +38,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.AreEqual("KeyNotFound", ex.ErrorCode);
         }
 
-        [Test]
+        [RecordedTest]
         [KeyVaultOnly]
         [ServiceVersion(Min = KeyClientOptions.ServiceVersion.V7_3)]
         public async Task RotateKeyCreatesNewVersion()
@@ -55,7 +55,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.AreNotEqual(key.Key.N, rotatedKey.Key.N);
         }
 
-        [Test]
+        [RecordedTest]
         [KeyVaultOnly]
         [ServiceVersion(Min = KeyClientOptions.ServiceVersion.V7_3)]
         public async Task UpdateKeyRotationPolicy()
@@ -90,7 +90,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.AreEqual(policy.LifetimeActions[0].TimeBeforeExpiry, rotateAction.TimeBeforeExpiry);
         }
 
-        [Test]
+        [RecordedTest]
         [KeyVaultOnly]
         [ServiceVersion(Min = KeyClientOptions.ServiceVersion.V7_3)]
         public void UpdateKeyRotationPolicyThrowsForMissingKey()

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.SecureKeyRelease.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.SecureKeyRelease.cs
@@ -13,7 +13,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
 {
     public partial class KeyClientLiveTests
     {
-        [Test]
+        [RecordedTest]
         [IgnoreServiceError(403, "Forbidden", Message = "Target environment attestation statement cannot be verified.")] // TODO: Remove once the attestation issue is resolved: https://github.com/Azure/azure-sdk-for-net/issues/27957
         [IgnoreServiceError(400, "BadParameter")] // TODO: Remove once SKR is deployed to sovereign clouds.
         [PremiumOnly]
@@ -41,7 +41,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.AreEqual(JsonValueKind.String, keyElement.GetProperty("key_hsm").ValueKind);
         }
 
-        [Test]
+        [RecordedTest]
         [IgnoreServiceError(403, "Forbidden", Message = "Target environment attestation statement cannot be verified.")] // TODO: Remove once the attestation issue is resolved: https://github.com/Azure/azure-sdk-for-net/issues/27957
         [IgnoreServiceError(400, "BadParameter")] // TODO: Remove once SKR is deployed to sovereign clouds.
         [PremiumOnly]
@@ -79,7 +79,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.AreEqual("BadParameter", ex.ErrorCode);
         }
 
-        [Test]
+        [RecordedTest]
         [IgnoreServiceError(403, "Forbidden", Message = "Target environment attestation statement cannot be verified.")] // TODO: Remove once the attestation issue is resolved: https://github.com/Azure/azure-sdk-for-net/issues/27957
         [IgnoreServiceError(400, "BadParameter")] // TODO: Remove once SKR is deployed to sovereign clouds.
         [PremiumOnly]

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.cs
@@ -35,7 +35,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             CompareBodies = false;
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CreateKey()
         {
             string keyName = Recording.GenerateId();
@@ -47,7 +47,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(key, keyReturned);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CreateKeyWithOptions()
         {
             var exp = new DateTimeOffset(new DateTime(637027248120000000, DateTimeKind.Utc));
@@ -69,7 +69,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(key, keyReturned);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task CreateEcHsmKey()
         {
@@ -92,7 +92,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             StringAssert.Contains(@"""crv"":""P-256""", json);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task CreateEcKey()
         {
@@ -106,7 +106,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(keyNoHsm, keyReturned);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task CreateEcWithCurveKey([EnumValues]KeyCurveName curveName)
         {
@@ -131,7 +131,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(keyNoHsmCurve, keyReturned);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task CreateRsaHsmKey()
         {
@@ -153,7 +153,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             StringAssert.Contains(@"""kty"":""RSA-HSM""", json);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task CreateRsaKey()
         {
@@ -165,7 +165,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(key, keyReturned);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task CreateRsaWithSizeKey()
         {
@@ -181,7 +181,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(key, keyReturned);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task UpdateKey()
         {
             string keyName = Recording.GenerateId();
@@ -195,7 +195,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(key, updateResult);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task UpdateEcHsmKey()
         {
@@ -211,7 +211,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(ecHsmKey, updateResult);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task UpdateRsaHsmKey()
         {
@@ -227,7 +227,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(rsaHsmKey, updateResult);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task UpdateEnabled()
         {
             string keyName = Recording.GenerateId();
@@ -242,7 +242,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(keyReturned, updateResult);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task UpdateEcHsmKeyEnabled()
         {
@@ -259,7 +259,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(keyReturned, updateResult);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task UpdateRsaHsmKeyEnabled()
         {
@@ -276,7 +276,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(keyReturned, updateResult);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task UpdateOps()
         {
             string keyName = Recording.GenerateId();
@@ -303,7 +303,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertAreEqual(new[] { KeyOperation.Sign, KeyOperation.Verify }, key.KeyOperations);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task UpdateEcHsmKeyOps()
         {
@@ -331,7 +331,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertAreEqual(new[] { KeyOperation.Sign, KeyOperation.Verify }, ecHsmKey.KeyOperations);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task UpdateRsaHsmKeyOps()
         {
@@ -359,7 +359,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertAreEqual(new[] { KeyOperation.Sign, KeyOperation.Verify }, rsaHsmKey.KeyOperations);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task UpdateTags()
         {
             string keyName = Recording.GenerateId();
@@ -411,7 +411,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertAreEqual(expectedTags, key.Properties.Tags);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task UpdateEcHsmKeyTags()
         {
@@ -464,7 +464,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertAreEqual(expectedTags, ecHsmKey.Properties.Tags);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task UpdateRsaHsmKeyTags()
         {
@@ -517,7 +517,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertAreEqual(expectedTags, rsaHsmKey.Properties.Tags);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task GetKey()
         {
             string keyName = Recording.GenerateId();
@@ -529,7 +529,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(key, keyReturned);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task GetEcHsmKey()
         {
@@ -544,7 +544,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(ecHsmKey, keyReturned);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task GetRsaHsmKey()
         {
@@ -559,13 +559,13 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(rsaHsmKey, keyReturned);
         }
 
-        [Test]
+        [RecordedTest]
         public void GetKeyNonExisting()
         {
             Assert.ThrowsAsync<RequestFailedException>(() => Client.GetKeyAsync(Recording.GenerateId()));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task GetKeyWithVersion()
         {
             string keyName = Recording.GenerateId();
@@ -577,7 +577,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(key, keyReturned);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task DeleteKey()
         {
             string keyName = Recording.GenerateId();
@@ -597,7 +597,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.ThrowsAsync<RequestFailedException>(() => Client.GetKeyAsync(keyName));
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task DeleteEcHsmKey()
         {
@@ -619,7 +619,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.ThrowsAsync<RequestFailedException>(() => Client.GetKeyAsync(keyName));
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task DeleteRsaHsmKey()
         {
@@ -641,13 +641,13 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.ThrowsAsync<RequestFailedException>(() => Client.GetKeyAsync(keyName));
         }
 
-        [Test]
+        [RecordedTest]
         public void DeleteKeyNonExisting()
         {
             Assert.ThrowsAsync<RequestFailedException>(() => Client.StartDeleteKeyAsync(Recording.GenerateId()));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task GetDeletedKey()
         {
             string keyName = Recording.GenerateId();
@@ -671,7 +671,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(key, polledSecret);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task GetDeletedEcHsmKey()
         {
@@ -697,7 +697,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(ecHsmKey, polledSecret);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task GetDeletedRsaHsmKey()
         {
@@ -723,13 +723,13 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(rsaHsmKey, polledSecret);
         }
 
-        [Test]
+        [RecordedTest]
         public void GetDeletedKeyNonExisting()
         {
             Assert.ThrowsAsync<RequestFailedException>(() => Client.GetDeletedKeyAsync(Recording.GenerateId()));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task RecoverDeletedKey()
         {
             string keyName = Recording.GenerateId();
@@ -757,7 +757,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(key, recoveredKey);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task RecoverDeletedEcHsmKey()
         {
@@ -789,7 +789,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(ecHsmKey, recoveredKey);
         }
 
-        [Test]
+        [RecordedTest]
         [PremiumOnly]
         public async Task RecoverDeletedRsaHsmKey()
         {
@@ -821,13 +821,13 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(rsaHsmKey, recoveredKey);
         }
 
-        [Test]
+        [RecordedTest]
         public void RecoverDeletedKeyNonExisting()
         {
             Assert.ThrowsAsync<RequestFailedException>(() => Client.StartRecoverDeletedKeyAsync(Recording.GenerateId()));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task BackupKey()
         {
             string keyName = Recording.GenerateId();
@@ -841,13 +841,13 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.NotNull(backup);
         }
 
-        [Test]
+        [RecordedTest]
         public void BackupKeyNonExisting()
         {
             Assert.ThrowsAsync<RequestFailedException>(() => Client.BackupKeyAsync(Recording.GenerateId()));
         }
 
-        [Test]
+        [RecordedTest]
         [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/6514")]
         public async Task RestoreKeyBackup()
         {
@@ -871,14 +871,14 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(key, restoredResult);
         }
 
-        [Test]
+        [RecordedTest]
         public void RestoreKeyNonExisting()
         {
             byte[] backupMalformed = Encoding.ASCII.GetBytes("non-existing");
             Assert.ThrowsAsync<RequestFailedException>(() => Client.RestoreKeyBackupAsync(backupMalformed));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task GetPropertiesOfKeys()
         {
             string keyName = Recording.GenerateId();
@@ -900,7 +900,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task GetDeletedKeys()
         {
             string keyName = Recording.GenerateId();
@@ -932,7 +932,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task GetPropertiesOfKeyVersions()
         {
             string keyName = Recording.GenerateId();
@@ -954,7 +954,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task GetPropertiesOfKeyVersionsNonExisting()
         {
             List<KeyProperties> allKeys = await Client.GetPropertiesOfKeyVersionsAsync(Recording.GenerateId()).ToEnumerableAsync();

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyResolverLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyResolverLiveTests.cs
@@ -38,7 +38,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             return InstrumentClient(new SecretClient(Uri, TestEnvironment.Credential, InstrumentClientOptions(new SecretClientOptions())));
         }
 
-        [Test]
+        [RecordedTest]
         public void ResolveNonExistantKeyId()
         {
             var uriBuilder = new RequestUriBuilder();
@@ -52,7 +52,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.ThrowsAsync<RequestFailedException>(() => Resolver.ResolveAsync(uriBuilder.ToUri()));
         }
 
-        [Test]
+        [RecordedTest]
         public void ResolveNonExistantSecretId()
         {
             var uriBuilder = new RequestUriBuilder();
@@ -66,7 +66,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.ThrowsAsync<RequestFailedException>(() => Resolver.ResolveAsync(uriBuilder.ToUri()));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task ResolveKeyId()
         {
             string keyName = Recording.GenerateId();
@@ -92,7 +92,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             CollectionAssert.AreEqual(toWrap, unwrapResult.Key);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task ResolveSecretId()
         {
             SecretClient secretClient = GetSecretClient();
@@ -130,7 +130,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             CollectionAssert.AreEqual(toWrap, unwrapResult.Key);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task ResolveAsInterface()
         {
             string keyName = Recording.GenerateId();

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeysTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeysTestBase.cs
@@ -17,6 +17,11 @@ namespace Azure.Security.KeyVault.Keys.Tests
         KeyClientOptions.ServiceVersion.V7_1,
         KeyClientOptions.ServiceVersion.V7_2,
         KeyClientOptions.ServiceVersion.V7_3)]
+    [IgnoreServiceError(
+        409,
+        "Conflict",
+        Message = "User triggered Restore operation is in progress",
+        Reason = "Test assemblies run in parallel so a restore operation triggered by the Administration package may be in progress.")]
     public abstract class KeysTestBase : RecordedTestBase<KeyVaultTestEnvironment>
     {
         protected TimeSpan PollingInterval => Recording.Mode == RecordedTestMode.Playback

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/ManagedHsmCryptographyClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/ManagedHsmCryptographyClientLiveTests.cs
@@ -38,7 +38,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
                 // To provision Managed HSM: New-TestResources.ps1 -AdditionalParameters @{enableHsm=$true}
                 : throw new IgnoreException($"Required variable 'AZURE_MANAGEDHSM_URL' is not defined");
 
-        [Test]
+        [RecordedTest]
         public async Task EncryptLocalDecryptOnManagedHsm([EnumValues(
             nameof(EncryptionAlgorithm.A128Cbc),
             nameof(EncryptionAlgorithm.A192Cbc),
@@ -102,7 +102,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             CollectionAssert.AreEqual(plaintext, decrypted.Plaintext);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task AesGcmEncryptDecrypt([EnumValues(
             nameof(EncryptionAlgorithm.A128Gcm),
             nameof(EncryptionAlgorithm.A192Gcm),
@@ -165,7 +165,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             CollectionAssert.AreEqual(plaintext, decrypted.Plaintext);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task AesKwWrapUnwrapRoundTrip([EnumValues(
             nameof(KeyWrapAlgorithm.A128KW),
             nameof(KeyWrapAlgorithm.A192KW),

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/ManagedHsmLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/ManagedHsmLiveTests.cs
@@ -31,7 +31,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
 
         protected internal override bool IsManagedHSM => true;
 
-        [Test]
+        [RecordedTest]
         public async Task CreateRsaWithPublicExponent()
         {
             CreateRsaKeyOptions options = new CreateRsaKeyOptions(Recording.GenerateId())
@@ -51,7 +51,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.AreEqual(3, publicExponent);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CreateOctHsmKey()
         {
             string keyName = Recording.GenerateId();
@@ -65,7 +65,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             AssertKeyVaultKeysEqual(ecHsmkey, keyReturned);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task CreateOctKey()
         {
             string keyName = Recording.GenerateId();
@@ -88,7 +88,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.AreEqual(count, rand.Length);
         }
 
-        [Test]
+        [RecordedTest]
         [ServiceVersion(Min = KeyClientOptions.ServiceVersion.V7_3)]
         public async Task ReleaseImportedKey()
         {

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretClientLiveTests.cs
@@ -35,7 +35,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task SetSecret()
         {
             string secretName = Recording.GenerateId();
@@ -50,7 +50,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             Assert.AreEqual("value2", secret.Value);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task SetSecretWithExtendedProps()
         {
             string secretName = Recording.GenerateId();
@@ -116,7 +116,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task UpdateEnabled()
         {
             string secretName = Recording.GenerateId();
@@ -138,7 +138,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             await Client.UpdateSecretPropertiesAsync(secret.Properties);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task UpdateSecret()
         {
             string secretName = Recording.GenerateId();
@@ -154,7 +154,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             AssertSecretPropertiesEqual(secret.Properties, updateResult);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task UpdateTags()
         {
             string secretName = Recording.GenerateId();
@@ -209,7 +209,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             AssertAreEqual(expectedTags, updateResult.Tags);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task GetSecret()
         {
             string secretName = Recording.GenerateId();
@@ -222,7 +222,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             AssertSecretsEqual(setSecret, secret);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task GetSecretWithVersion()
         {
             string secretName = Recording.GenerateId();
@@ -237,7 +237,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             Assert.AreEqual("value2", secret.Value);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task GetSecretVersionsNonExisting()
         {
             List<SecretProperties> allSecrets = await Client.GetPropertiesOfSecretVersionsAsync(Recording.GenerateId()).ToEnumerableAsync();
@@ -245,7 +245,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             Assert.AreEqual(0, allSecrets.Count);
         }
 
-        [Test]
+        [RecordedTest]
         public async Task BackupSecret()
         {
             string secretName = Recording.GenerateId();
@@ -259,13 +259,13 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             Assert.NotNull(backup);
         }
 
-        [Test]
+        [RecordedTest]
         public void BackupSecretNonExisting()
         {
             Assert.ThrowsAsync<RequestFailedException>(() => Client.BackupSecretAsync(Recording.GenerateId()));
         }
 
-        [Test]
+        [RecordedTest]
         [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/6514")]
         public async Task RestoreSecretBackup()
         {
@@ -291,14 +291,14 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             AssertSecretPropertiesEqual(secret.Properties, restoreResult);
         }
 
-        [Test]
+        [RecordedTest]
         public void RestoreMalformedBackup()
         {
             byte[] backupMalformed = Encoding.ASCII.GetBytes("non-existing");
             Assert.ThrowsAsync<RequestFailedException>(() => Client.RestoreSecretBackupAsync(backupMalformed));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartDeleteSecret()
         {
             string secretName = Recording.GenerateId();
@@ -317,13 +317,13 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             Assert.ThrowsAsync<RequestFailedException>(() => Client.GetSecretAsync(secretName));
         }
 
-        [Test]
+        [RecordedTest]
         public void StartDeleteSecretNonExisting()
         {
             Assert.ThrowsAsync<RequestFailedException>(() => Client.StartDeleteSecretAsync(Recording.GenerateId()));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task GetDeletedSecret()
         {
             string secretName = Recording.GenerateId();
@@ -347,13 +347,13 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             AssertSecretPropertiesEqual(secret.Properties, polledSecret.Properties);
         }
 
-        [Test]
+        [RecordedTest]
         public void GetDeletedSecretNonExisting()
         {
             Assert.ThrowsAsync<RequestFailedException>(() => Client.GetDeletedSecretAsync(Recording.GenerateId()));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task StartRecoverDeletedSecret()
         {
             string secretName = Recording.GenerateId();
@@ -379,13 +379,13 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             AssertSecretsEqual(secret, recoveredSecret);
         }
 
-        [Test]
+        [RecordedTest]
         public void StartRecoverDeletedSecretNonExisting()
         {
             Assert.ThrowsAsync<RequestFailedException>(() => Client.StartRecoverDeletedSecretAsync(Recording.GenerateId()));
         }
 
-        [Test]
+        [RecordedTest]
         public async Task GetPropertiesOfSecrets()
         {
             string secretName = Recording.GenerateId();
@@ -407,7 +407,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task GetPropertiesOfSecretVersions()
         {
             string secretName = Recording.GenerateId();
@@ -430,7 +430,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task GetDeletedSecrets()
         {
             string secretName = Recording.GenerateId();
@@ -466,7 +466,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task AuthenticateCrossTenant()
         {
             TokenCredential credential = GetCredential(Recording.Random.NewGuid().ToString());


### PR DESCRIPTION
Also ignores 409 errors for user-triggered restore operations still in progress.
