### PR TITLE
{AzureQueueStorage} Include return null for PeekMessage

### DIFF
--- a/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
@@ -2364,7 +2364,7 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Response{T}"/> where T is a <see cref="PeekedMessage"/>
+        /// <see cref="Response{T}"/> where T is a <see cref="PeekedMessage"/>. Returns null if there are no messages in the queue.
         /// </returns>
         public virtual Response<PeekedMessage> PeekMessage(
             CancellationToken cancellationToken = default) =>
@@ -2384,7 +2384,7 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Response{T}"/> where T is a <see cref="PeekedMessage"/>
+        /// <see cref="Response{T}"/> where T is a <see cref="PeekedMessage"/>. Returns null if there are no messages in the queue.
         /// </returns>
         public virtual async Task<Response<PeekedMessage>> PeekMessageAsync(
             CancellationToken cancellationToken = default) =>


### PR DESCRIPTION
The documentation for the Peek family of methods is unclear. This PR mentions about null being returned if there are no messages in the queue. 

Fixes Azure/azure-sdk-for-net#28839

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
