### PR TITLE
Don't use internal method of Azure SignalR SDK

### DIFF
--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/IConfigurationExtensions.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/IConfigurationExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         {
             foreach (var child in config.GetChildren())
             {
-                if (child.TryGetNamedEndpointFromIdentity(azureComponentFactory, out var endpoint))
+                if (child.TryGetEndpointFromIdentity(azureComponentFactory, out var endpoint))
                 {
                     yield return endpoint;
                     continue;
@@ -54,17 +54,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             }
         }
 
-        public static bool TryGetNamedEndpointFromIdentity(this IConfigurationSection section, AzureComponentFactory azureComponentFactory, out ServiceEndpoint endpoint)
+        public static bool TryGetEndpointFromIdentity(this IConfigurationSection section, AzureComponentFactory azureComponentFactory, out ServiceEndpoint endpoint, bool isNamed = true)
         {
             var text = section[ServiceUriKey];
             if (text != null)
             {
                 var key = section.Key;
+                var name = isNamed ? key : string.Empty;
                 var value = section.GetValue(TypeKey, EndpointType.Primary);
                 var credential = azureComponentFactory.CreateTokenCredential(section);
                 var serverEndpoint = section.GetValue<Uri>(ServerEndpointKey);
                 var clientEndpoint = section.GetValue<Uri>(ClientEndpointKey);
-                endpoint = new ServiceEndpoint(new Uri(text), credential, value, key, serverEndpoint, clientEndpoint);
+                endpoint = new ServiceEndpoint(new Uri(text), credential, value, name, serverEndpoint, clientEndpoint);
                 return true;
             }
 

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/OptionsSetup.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/OptionsSetup.cs
@@ -45,10 +45,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             }
 
             var endpoints = _configuration.GetSection(Constants.AzureSignalREndpoints).GetEndpoints(_azureComponentFactory);
-            // Fall back to use a section to configure Azure identity
-            if (options.ConnectionString == null && _configuration.GetSection(_connectionStringKey).TryGetNamedEndpointFromIdentity(_azureComponentFactory, out var endpoint))
+
+            // when the configuration is in the style: AzureSignalRConnectionString:serviceUri = https://xxx.service.signalr.net , we see the endpoint as unnamed.
+            if (options.ConnectionString == null && _configuration.GetSection(_connectionStringKey).TryGetEndpointFromIdentity(_azureComponentFactory, out var endpoint, isNamed: false))
             {
-                endpoint.Name = string.Empty;
                 endpoints = endpoints.Append(endpoint);
             }
             if (endpoints.Any())

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Config/IConfigurationExtensionsFacts.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Config/IConfigurationExtensionsFacts.cs
@@ -24,7 +24,7 @@ namespace SignalRServiceExtension.Tests.Config
             services.AddAzureClientsCore();
             var factory = services.BuildServiceProvider().GetRequiredService<AzureComponentFactory>();
             var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
-            Assert.False(config.GetSection("eastus").TryGetNamedEndpointFromIdentity(factory, out _));
+            Assert.False(config.GetSection("eastus").TryGetEndpointFromIdentity(factory, out _));
         }
 
         [Fact]
@@ -38,7 +38,7 @@ namespace SignalRServiceExtension.Tests.Config
             var uri = "http://signalr.service.uri.com:441";
             config["eastus:serviceUri"] = uri;
 
-            Assert.True(config.GetSection("eastus").TryGetNamedEndpointFromIdentity(factory, out var endpoint));
+            Assert.True(config.GetSection("eastus").TryGetEndpointFromIdentity(factory, out var endpoint));
             Assert.Equal("eastus", endpoint.Name);
             Assert.Equal(uri, endpoint.Endpoint);
             Assert.IsType<DefaultAzureCredential>((endpoint.AccessKey as AadAccessKey).TokenCredential);
@@ -60,7 +60,7 @@ namespace SignalRServiceExtension.Tests.Config
             config["eastus:serverEndpoint"] = "https://serverEndpoint.com";
             config["eastus:clientEndpoint"] = "https://clientEndpoint.com";
 
-            Assert.True(config.GetSection("eastus").TryGetNamedEndpointFromIdentity(factory, out var endpoint));
+            Assert.True(config.GetSection("eastus").TryGetEndpointFromIdentity(factory, out var endpoint));
             Assert.Equal("eastus", endpoint.Name);
             Assert.Equal(uri, endpoint.Endpoint);
             Assert.Equal(new Uri("https://serverEndpoint.com"), endpoint.ServerEndpoint);


### PR DESCRIPTION
The `set` accessor of `ServiceEndpoint.Name` is internal and wil be removed
