### PR TITLE
Use UtcDateTime when setting StartTime for the current Activity

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -293,7 +293,7 @@ namespace Azure.Core.Pipeline
 
                     if (_startTime != default)
                     {
-                        _currentActivity.SetStartTime(_startTime.DateTime);
+                        _currentActivity.SetStartTime(_startTime.UtcDateTime);
                     }
 
                     if (_tagCollection != null)

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.cs
@@ -51,7 +51,7 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void ActivityDurationIsNotZeroWhenStoping()
+        public void ActivityDurationIsNotZeroWhenStopping()
         {
             TimeSpan? duration = null;
             using var testListener = new TestDiagnosticListener("Azure.Clients");
@@ -68,6 +68,25 @@ namespace Azure.Core.Tests
             scope.Dispose();
 
             Assert.True(duration > TimeSpan.Zero);
+        }
+
+        [Test]
+        public void ActivityStartTimeCanBeSet()
+        {
+            DateTime? actualStartTimeUtc = null;
+            using var testListener = new TestDiagnosticListener("Azure.Clients");
+            testListener.EventCallback = _ => { actualStartTimeUtc = Activity.Current?.StartTimeUtc; };
+
+            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true, false);
+
+            DiagnosticScope scope = clientDiagnostics.CreateScope("ActivityName");
+
+            DateTime expectedStartTimeUtc = DateTime.UtcNow - TimeSpan.FromSeconds(10);
+            scope.SetStartTime(expectedStartTimeUtc);
+            scope.Start();
+            scope.Dispose();
+
+            Assert.AreEqual(expectedStartTimeUtc, actualStartTimeUtc);
         }
 
         [Test]


### PR DESCRIPTION
This fixes #26763 

The existing code results in a DateTimeKind of Unspecified. 
This is detected and rejected in Activity.StartTime (resulting in an InvalidOperationException that is immediately swallowed in Activity.NotifyError).
While it's not a fatal error, it does mean that the start time is not set correctly. Instead, the start time will be set to DateTime.UtcNow when the activity is started. This will lead to subtle timestamping and duration errors.

I added a unit test that fails with the original code and passes with the fix.