### PR TITLE
Fix IgnoreServiceErrorAttributeTests

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestAttribute.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestAttribute.cs
@@ -125,27 +125,25 @@ namespace Azure.Core.TestFramework
 
         private class RecordedTestAttributeCommand : DelegatingTestCommand
         {
-            private readonly List<IgnoreServiceErrorAttribute> _ignoreServiceErrorAttributes;
             public RecordedTestAttributeCommand(TestCommand innerCommand) : base(innerCommand)
             {
-                Test test = innerCommand.Test;
-
-                // Check if there are any service errors we should ignore.
-                _ignoreServiceErrorAttributes = innerCommand.Test.GetCustomAttributes<IgnoreServiceErrorAttribute>(true).ToList();
-
-                // Check parents for service errors to ignore.
-                while (test.Parent is Test t)
-                {
-                    _ignoreServiceErrorAttributes.AddRange(t.GetCustomAttributes<IgnoreServiceErrorAttribute>(true));
-                    test = t;
-                }
             }
 
             public override TestResult Execute(TestExecutionContext context)
             {
                 if (IsTestFailed(context))
                 {
-                    foreach (IgnoreServiceErrorAttribute attr in _ignoreServiceErrorAttributes)
+                    // Check if there are any service errors we should ignore.
+                    var ignoreServiceErrorAttributes = innerCommand.Test.GetCustomAttributes<IgnoreServiceErrorAttribute>(true).ToList();
+
+                    // Check parents for service errors to ignore.
+                    var test = Test;
+                    while (test.Parent is Test t)
+                    {
+                        ignoreServiceErrorAttributes.AddRange(t.GetCustomAttributes<IgnoreServiceErrorAttribute>(true));
+                        test = t;
+                    }
+                    foreach (IgnoreServiceErrorAttribute attr in ignoreServiceErrorAttributes)
                     {
                         if (attr.Matches(context.CurrentResult.Message))
                         {

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestAttribute.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestAttribute.cs
@@ -109,15 +109,10 @@ namespace Azure.Core.TestFramework
                                 "Test timed out in initial run, but was retried successfully.");
                         }
                     }
-                    else
-                    {
-                        CheckForIgnoredServiceErrors(context);
-                    }
                 }
-                else
-                {
-                    CheckForIgnoredServiceErrors(context);
-                }
+
+                CheckForIgnoredServiceErrors(context);
+
                 return context.CurrentResult;
             }
 

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestAttribute.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestAttribute.cs
@@ -35,21 +35,6 @@ namespace Azure.Core.TestFramework
             return command;
         }
 
-        private static List<IgnoreServiceErrorAttribute> GetServiceErrorsToIgnore(Test test)
-        {
-            // Check if there are any service errors we should ignore.
-            List<IgnoreServiceErrorAttribute> attributes = test.GetCustomAttributes<IgnoreServiceErrorAttribute>(true).ToList();
-
-            // Check parents for service errors to ignore.
-            while (test.Parent is Test t)
-            {
-                attributes.AddRange(t.GetCustomAttributes<IgnoreServiceErrorAttribute>(true));
-                test = t;
-            }
-
-            return attributes;
-        }
-
         private static bool IsTestFailed(TestExecutionContext context)
         {
             return context.CurrentResult.ResultState.Status switch

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestAttribute.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestAttribute.cs
@@ -109,10 +109,15 @@ namespace Azure.Core.TestFramework
                                 "Test timed out in initial run, but was retried successfully.");
                         }
                     }
+                    else
+                    {
+                        CheckForIgnoredServiceErrors(context);
+                    }
                 }
-
-                CheckForIgnoredServiceErrors(context);
-
+                else
+                {
+                    CheckForIgnoredServiceErrors(context);
+                }
                 return context.CurrentResult;
             }
 

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestAttribute.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestAttribute.cs
@@ -87,8 +87,10 @@ namespace Azure.Core.TestFramework
 
                         // revert RecordTestMode to Playback
                         SetRecordMode(context.TestObject as RecordedTestBase, RecordedTestMode.Playback);
+                        return context.CurrentResult;
                     }
-                    else if (resultMessage.Contains(typeof(TestTimeoutException).FullName))
+
+                    if (resultMessage.Contains(typeof(TestTimeoutException).FullName))
                     {
                         // retry once
                         context.CurrentResult = context.CurrentTest.MakeTestResult();
@@ -108,16 +110,12 @@ namespace Azure.Core.TestFramework
                                 context.CurrentResult.ResultState,
                                 "Test timed out in initial run, but was retried successfully.");
                         }
-                    }
-                    else
-                    {
-                        CheckForIgnoredServiceErrors(context);
+
+                        return context.CurrentResult;
                     }
                 }
-                else
-                {
-                    CheckForIgnoredServiceErrors(context);
-                }
+
+                CheckForIgnoredServiceErrors(context);
                 return context.CurrentResult;
             }
 


### PR DESCRIPTION
Previously the ignore service error attribute would only be applied during Playback, which was not the intent.

Addresses https://github.com/Azure/azure-sdk-for-net/issues/28895