### PR TITLE
[TA] Add audience

### DIFF
--- a/sdk/translation/Azure.AI.Translation.Document/CHANGELOG.md
+++ b/sdk/translation/Azure.AI.Translation.Document/CHANGELOG.md
@@ -5,11 +5,12 @@
 ### Features Added
 - Added optional parameter `categoryId` to the `DocumentTranslationInput.AddTarget`.
 - Added property `Ascending` to type `DocumentFilterOrder` and `TranslationFilterOrder`.
-- Renamed parameter `asc` to `ascending` in `TranslationFilterOrder` constructor.
+- `DocumentTranslationAudience` has been added to allow the user to select the Azure cloud where the resource is located.
 
 ### Breaking Changes
 - Renamed type `StorageInputType` to `StorageInputUriKind`.
 - Renamed property `StorageType` to `StorageUriKind` in `DocumentTranslationInput`.
+- Renamed parameter `asc` to `ascending` in `TranslationFilterOrder` constructor.
 
 ### Bugs Fixed
 

--- a/sdk/translation/Azure.AI.Translation.Document/api/Azure.AI.Translation.Document.netstandard2.0.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/api/Azure.AI.Translation.Document.netstandard2.0.cs
@@ -24,6 +24,25 @@ namespace Azure.AI.Translation.Document
         public string TranslatedToLanguageCode { get { throw null; } }
         public float TranslationProgressPercentage { get { throw null; } }
     }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct DocumentTranslationAudience : System.IEquatable<Azure.AI.Translation.Document.DocumentTranslationAudience>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public DocumentTranslationAudience(string value) { throw null; }
+        public static Azure.AI.Translation.Document.DocumentTranslationAudience AzureChina { get { throw null; } }
+        public static Azure.AI.Translation.Document.DocumentTranslationAudience AzureGovernment { get { throw null; } }
+        public static Azure.AI.Translation.Document.DocumentTranslationAudience AzurePublicCloud { get { throw null; } }
+        public bool Equals(Azure.AI.Translation.Document.DocumentTranslationAudience other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.AI.Translation.Document.DocumentTranslationAudience left, Azure.AI.Translation.Document.DocumentTranslationAudience right) { throw null; }
+        public static implicit operator Azure.AI.Translation.Document.DocumentTranslationAudience (string value) { throw null; }
+        public static bool operator !=(Azure.AI.Translation.Document.DocumentTranslationAudience left, Azure.AI.Translation.Document.DocumentTranslationAudience right) { throw null; }
+        public override string ToString() { throw null; }
+    }
     public partial class DocumentTranslationClient
     {
         protected DocumentTranslationClient() { }
@@ -51,6 +70,7 @@ namespace Azure.AI.Translation.Document
     public partial class DocumentTranslationClientOptions : Azure.Core.ClientOptions
     {
         public DocumentTranslationClientOptions(Azure.AI.Translation.Document.DocumentTranslationClientOptions.ServiceVersion version = Azure.AI.Translation.Document.DocumentTranslationClientOptions.ServiceVersion.V1_0) { }
+        public Azure.AI.Translation.Document.DocumentTranslationAudience? Audience { get { throw null; } set { } }
         public enum ServiceVersion
         {
             V1_0 = 1,

--- a/sdk/translation/Azure.AI.Translation.Document/src/Constants.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/Constants.cs
@@ -6,7 +6,5 @@ namespace Azure.AI.Translation.Document
     internal static class Constants
     {
         public const string AuthorizationHeader = "Ocp-Apim-Subscription-Key";
-
-        public const string DefaultCognitiveScope = "https://cognitiveservices.azure.com/.default";
     }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationAudience.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationAudience.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+using Azure.Core;
+
+namespace Azure.AI.Translation.Document
+{
+    /// <summary> Cloud audiences available for the Azure Document Translation Service. </summary>
+    public readonly partial struct DocumentTranslationAudience : IEquatable<DocumentTranslationAudience>
+    {
+        private readonly string _value;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DocumentTranslationAudience"/> object.
+        /// </summary>
+        /// <param name="value">The Azure Active Directory audience to use when forming authorization scopes. For the Azure Document Translation Service, this value corresponds
+        /// to a URL that identifies the Azure cloud where the resource is located. For more information: <see href="https://docs.microsoft.com/azure/azure-government/documentation-government-cognitiveservices" />.</param>
+        /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="value"/> is empty. </exception>
+        /// <remarks>Please use one of the constant members over creating a custom value unless you have special needs for doing so.</remarks>
+        public DocumentTranslationAudience(string value)
+        {
+            Argument.AssertNotNullOrEmpty(value, nameof(value));
+            _value = value;
+        }
+
+        private const string AzureChinaValue = "https://cognitiveservices.azure.cn";
+        private const string AzureGovernmentValue = "https://cognitiveservices.azure.us";
+        private const string AzurePublicCloudValue = "https://cognitiveservices.azure.com";
+
+        /// <summary> Azure China. </summary>
+        public static DocumentTranslationAudience AzureChina { get; } = new DocumentTranslationAudience(AzureChinaValue);
+
+        /// <summary> Azure Government. </summary>
+        public static DocumentTranslationAudience AzureGovernment { get; } = new DocumentTranslationAudience(AzureGovernmentValue);
+
+        /// <summary> Azure Public Cloud. </summary>
+        public static DocumentTranslationAudience AzurePublicCloud { get; } = new DocumentTranslationAudience(AzurePublicCloudValue);
+
+        /// <summary> Determines if two <see cref="DocumentTranslationAudience"/> values are the same. </summary>
+        public static bool operator ==(DocumentTranslationAudience left, DocumentTranslationAudience right) => left.Equals(right);
+        /// <summary> Determines if two <see cref="DocumentTranslationAudience"/> values are not the same. </summary>
+        public static bool operator !=(DocumentTranslationAudience left, DocumentTranslationAudience right) => !left.Equals(right);
+        /// <summary> Converts a string to a <see cref="DocumentTranslationAudience"/>. </summary>
+        public static implicit operator DocumentTranslationAudience(string value) => new DocumentTranslationAudience(value);
+
+        /// <inheritdoc />
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => obj is DocumentTranslationAudience other && Equals(other);
+        /// <inheritdoc />
+        public bool Equals(DocumentTranslationAudience other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
+
+        /// <inheritdoc />
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => _value?.GetHashCode() ?? 0;
+        /// <inheritdoc />
+        public override string ToString() => _value;
+    }
+}

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationAudience.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationAudience.cs
@@ -16,7 +16,7 @@ namespace Azure.AI.Translation.Document
         /// Initializes a new instance of the <see cref="DocumentTranslationAudience"/> object.
         /// </summary>
         /// <param name="value">The Azure Active Directory audience to use when forming authorization scopes. For the Azure Document Translation Service, this value corresponds
-        /// to a URL that identifies the Azure cloud where the resource is located. For more information: <see href="https://docs.microsoft.com/azure/azure-government/documentation-government-cognitiveservices" />.</param>
+        /// to a URL that identifies the Azure cloud where the resource is located. For more information: <see href="https://docs.microsoft.com/azure/cognitive-services/translator/sovereign-clouds?tabs=us" />.</param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="value"/> is empty. </exception>
         /// <remarks>Please use one of the constant members over creating a custom value unless you have special needs for doing so.</remarks>

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationClient.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationClient.cs
@@ -57,10 +57,11 @@ namespace Azure.AI.Translation.Document
             Argument.AssertNotNull(credential, nameof(credential));
             Argument.AssertNotNull(options, nameof(options));
 
-            _options = options;
             _clientDiagnostics = new ClientDiagnostics(options);
+            _options = options;
+            string defaultScope = $"{(string.IsNullOrEmpty(options.Audience?.ToString()) ? DocumentTranslationAudience.AzurePublicCloud : options.Audience)}/.default";
 
-            HttpPipeline pipeline = HttpPipelineBuilder.Build(options, new BearerTokenAuthenticationPolicy(credential, Constants.DefaultCognitiveScope));
+            HttpPipeline pipeline = HttpPipelineBuilder.Build(options, new BearerTokenAuthenticationPolicy(credential, defaultScope));
             _serviceRestClient = new DocumentTranslationRestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri);
         }
 

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationClientOptions.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationClientOptions.cs
@@ -31,9 +31,6 @@ namespace Azure.AI.Translation.Document
         {
             Version = version;
             AddLoggedHeadersAndQueryParameters();
-
-            //Default Audience to Azure Public Cloud
-            Audience ??= DocumentTranslationAudience.AzurePublicCloud;
         }
 
         internal string GetVersionString()

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationClientOptions.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationClientOptions.cs
@@ -31,6 +31,9 @@ namespace Azure.AI.Translation.Document
         {
             Version = version;
             AddLoggedHeadersAndQueryParameters();
+
+            //Default Audience to Azure Public Cloud
+            Audience ??= DocumentTranslationAudience.AzurePublicCloud;
         }
 
         internal string GetVersionString()
@@ -53,6 +56,12 @@ namespace Azure.AI.Translation.Document
             /// </summary>
             V1_0 = 1
         }
+
+        /// <summary>
+        /// Gets or sets the Audience to use for authentication with Azure Active Directory (AAD). The audience is not considered when using a shared key.
+        /// </summary>
+        /// <value>If <c>null</c>, <see cref="DocumentTranslationAudience.AzurePublicCloud" /> will be assumed.</value>
+        public DocumentTranslationAudience? Audience { get; set; }
 
         /// <summary>
         /// Add headers and query parameters that are considered safe for logging or including in


### PR DESCRIPTION
Same as https://github.com/Azure/azure-sdk-for-net/pull/26583 it adds a `DocumentTranslationAudience` a user to select which Azure cloud the resource is located at.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/28674