### PR TITLE
[Translation] Rename asc to ascending

### DIFF
--- a/sdk/translation/Azure.AI.Translation.Document/CHANGELOG.md
+++ b/sdk/translation/Azure.AI.Translation.Document/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 - Added optional parameter `categoryId` to the `DocumentTranslationInput.AddTarget`.
+- Added property `Ascending` to type `DocumentFilterOrder` and `TranslationFilterOrder`.
+- Renamed parameter `asc` to `ascending` in `TranslationFilterOrder` constructor.
 
 ### Breaking Changes
 

--- a/sdk/translation/Azure.AI.Translation.Document/api/Azure.AI.Translation.Document.netstandard2.0.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/api/Azure.AI.Translation.Document.netstandard2.0.cs
@@ -3,6 +3,7 @@ namespace Azure.AI.Translation.Document
     public partial class DocumentFilterOrder
     {
         public DocumentFilterOrder(Azure.AI.Translation.Document.DocumentFilterProperty property, bool ascending = true) { }
+        public bool Ascending { get { throw null; } set { } }
         public Azure.AI.Translation.Document.DocumentFilterProperty Property { get { throw null; } set { } }
     }
     public enum DocumentFilterProperty
@@ -160,7 +161,8 @@ namespace Azure.AI.Translation.Document
     }
     public partial class TranslationFilterOrder
     {
-        public TranslationFilterOrder(Azure.AI.Translation.Document.TranslationFilterProperty property, bool asc = true) { }
+        public TranslationFilterOrder(Azure.AI.Translation.Document.TranslationFilterProperty property, bool ascending = true) { }
+        public bool Ascending { get { throw null; } set { } }
         public Azure.AI.Translation.Document.TranslationFilterProperty Property { get { throw null; } set { } }
     }
     public enum TranslationFilterProperty

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentFilterOrder.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentFilterOrder.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace Azure.AI.Translation.Document
 {
     /// <summary>
@@ -23,8 +19,10 @@ namespace Azure.AI.Translation.Document
         }
         /// <summary>
         /// Sort results ascendingly if true, or descendingly if false.
+        /// Default value is false.
         /// </summary>
-        internal bool Ascending { get; set; }
+        public bool Ascending { get; set; } = true;
+
         /// <summary>
         /// See <see cref="DocumentFilterProperty"/> for list of properties supported.
         /// </summary>

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentFilterOrder.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentFilterOrder.cs
@@ -19,7 +19,7 @@ namespace Azure.AI.Translation.Document
         }
         /// <summary>
         /// Sort results ascendingly if true, or descendingly if false.
-        /// Default value is false.
+        /// Default value is true.
         /// </summary>
         public bool Ascending { get; set; } = true;
 

--- a/sdk/translation/Azure.AI.Translation.Document/src/TranslationFilterOrder.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/TranslationFilterOrder.cs
@@ -11,15 +11,17 @@ namespace Azure.AI.Translation.Document
         /// <summary>
         /// Initializes an instance of <see cref="TranslationFilterOrder"/>.
         /// </summary>
-        public TranslationFilterOrder(TranslationFilterProperty property, bool asc = true)
+        public TranslationFilterOrder(TranslationFilterProperty property, bool ascending = true)
         {
-            Asc = asc;
+            Ascending = ascending;
             Property = property;
         }
         /// <summary>
         /// Sort results ascendingly if true, or descendingly if false.
+        /// Default value is true.
         /// </summary>
-        internal bool Asc { get; set; }
+        public bool Ascending { get; set; } = true;
+
         /// <summary>
         /// See <see cref="TranslationFilterProperty"/> for list of properties supported.
         /// </summary>
@@ -43,7 +45,7 @@ namespace Azure.AI.Translation.Document
             }
 
             // sorting direction
-            var direction = Asc ? "Asc" : "Desc";
+            var direction = Ascending ? "Asc" : "Desc";
 
             return $"{property} {direction}";
         }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/GetAllTranslationsFilterTests.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/GetAllTranslationsFilterTests.cs
@@ -204,7 +204,7 @@ namespace Azure.AI.Translation.Document.Tests
             // list translations with filter
             var options = new GetTranslationStatusesOptions
             {
-                OrderBy = { new TranslationFilterOrder(property: TranslationFilterProperty.CreatedOn, asc: false) },
+                OrderBy = { new TranslationFilterOrder(property: TranslationFilterProperty.CreatedOn, ascending: false) },
                 CreatedAfter = recentTimestamp
             };
 


### PR DESCRIPTION
Missing work form issue https://github.com/Azure/azure-sdk-for-net/issues/23353 . to:
- Rename parameter `asc` to `ascending`
- Expose `Ascending` property

This follows [feedback](https://apiview.dev/Assemblies/Review/46373cdd5bff4c86aeef03d3b8f79d50?doc=False#Azure.AI.Translation.Document.DocumentFilterOrder) from the architects.