### PR TITLE
swagger symbol is not required

### DIFF
--- a/sdk/template/.template.config/template.json
+++ b/sdk/template/.template.config/template.json
@@ -85,7 +85,7 @@
     "swagger": {
       "type": "parameter",
       "datatype":"text",
-      "isRequired": true,
+      "isRequired": false,
       "description": "The swagger file link. It can be local file e.g. ./swagger/compute.json or premlink, e.g. https://github.com/dpokluda/azure-rest-api-specs/blob/be397aa65510bd4e8f87da539af2b0025f6f44ca/specification/deviceupdate/data-plane/Microsoft.DeviceUpdate/preview/2020-09-01/deviceupdate.json",
       "replaces": "SwaggerFileLink"
     },


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

We will support both swagger json files and readme.md configure file to generate the SDK package. So --swagger is not mandatory symbols. change it from require to optional  