### PR TITLE
[Event Hubs Extension] Bump E2E Test Timeout

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
@@ -628,7 +628,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 string input,
                 [EventHub(TestHubName, Connection = TestHubName)] EventHubProducerClient client)
             {
-                List<EventData> list = new List<EventData>();
                 EventData evt = new EventData(Encoding.UTF8.GetBytes(input));
 
                 // Send event without PK

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/WebJobsEventHubTestBase.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/WebJobsEventHubTestBase.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
     public class WebJobsEventHubTestBase
     {
         protected const string TestHubName = "%webjobstesthub%";
-        protected static readonly int Timeout = (int)TimeSpan.FromSeconds(60).TotalMilliseconds;
+        protected static readonly int Timeout = (int)TimeSpan.FromSeconds(75).TotalMilliseconds;
 
         /// <summary>The active Event Hub resource scope for the test fixture.</summary>
         protected EventHubScope _eventHubScope;


### PR DESCRIPTION
# Summary

Bumping the timeout used for the end-to-end live tests by 15 seconds to reduce flakiness.  Currently, the same value is used for the timeout that Event Hubs uses for the operation timeout.  When the network is slow or overloaded, this prevents the client from attempting a retry.  The new value allows a small window above the operation timeout which allows the client to perform one retry in timeout scenarios, which often is successful.