### PR TITLE
Updating CODEOWNERS Communication NetworkTraversal

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -205,7 +205,7 @@
 /sdk/communication/Azure.Communication.Identity/        @Azure/acs-identity-sdk @petrsvihlik @AikoBB @maximrytych-ms @martinbarnas-ms
 
 # PRLabel: %Communication - Network Traversal
-/sdk/communication/Azure.Communication.NetworkTraversal/ @AriZavala2
+/sdk/communication/Azure.Communication.NetworkTraversal/ @ajpeacock0 @nathpete-msft
 
 # PRLabel: %Communication - Phone Numbers
 /sdk/communication/Azure.Communication.PhoneNumbers/    @miguhern @whisper6284 @lucasrsant @RoyHerrod @danielav7


### PR DESCRIPTION
Updating owners for ACS NetworkTraversal after current owner left.
