### PR TITLE
[Event Hubs Stress] Trim Quotes in .env Values

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.sln
@@ -29,6 +29,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs.S
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs.Processor.Perf", "Azure.Messaging.EventHubs.Processor\perf\Azure.Messaging.EventHubs.Processor.Perf.csproj", "{E9EF4740-4B32-401C-BE22-70CE11C62629}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs.Stress", "Azure.Messaging.EventHubs\stress\src\Azure.Messaging.EventHubs.Stress.csproj", "{86B3D4A0-ACF0-45F1-9ACB-F6A786F49DA4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -79,6 +81,10 @@ Global
 		{E9EF4740-4B32-401C-BE22-70CE11C62629}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E9EF4740-4B32-401C-BE22-70CE11C62629}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E9EF4740-4B32-401C-BE22-70CE11C62629}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86B3D4A0-ACF0-45F1-9ACB-F6A786F49DA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86B3D4A0-ACF0-45F1-9ACB-F6A786F49DA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86B3D4A0-ACF0-45F1-9ACB-F6A786F49DA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86B3D4A0-ACF0-45F1-9ACB-F6A786F49DA4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/eventhub/Azure.Messaging.EventHubs/stress/Azure.Messaging.EventHubs.Stress.slnf
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/stress/Azure.Messaging.EventHubs.Stress.slnf
@@ -1,0 +1,11 @@
+{
+  "solution": {
+    "path": "..\\..\\Azure.Messaging.EventHubs.sln",
+     "projects": [
+      "Azure.Messaging.EventHubs.Processor\\src\\Azure.Messaging.EventHubs.Processor.csproj",
+      "Azure.Messaging.EventHubs\\src\\Azure.Messaging.EventHubs.csproj",
+      "Azure.Messaging.EventHubs\\stress\\src\\Azure.Messaging.EventHubs.Stress.csproj"
+    ]
+  }
+  }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Infrastructure/EnvironmentReader.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Infrastructure/EnvironmentReader.cs
@@ -63,7 +63,7 @@ internal static class EnvironmentReader
             try
             {
                 var parsedKey = line.Slice(firstCharacterPos, separator).Trim().ToString();
-                var parsedValue = line.Slice(separator + 1).Trim().ToString();
+                var parsedValue = line.Slice(separator + 1).Trim().Trim('"').ToString();
 
                 if (environment.ContainsKey(parsedKey))
                 {


### PR DESCRIPTION
# Summary

The focus of these changes is to make a minor adjustment to the way that .env files are parsed, treating quotes as wrappers around a value rather than part of it.
