### PR TITLE
Fix the broken test records in CosmosDB and KeyVault

### DIFF
--- a/sdk/cosmosdb/Azure.ResourceManager.CosmosDB/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionCreateAndUpdate.json
+++ b/sdk/cosmosdb/Azure.ResourceManager.CosmosDB/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionCreateAndUpdate.json
@@ -444,9 +444,9 @@
         "location": "westus",
         "properties": {
           "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/dbaccount-6494/providers/Microsoft.Network/virtualNetworks/vnet-3557/subnets/default",
             "name": "default",
             "type": "Microsoft.Network/virtualNetworks/subnets",
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/dbaccount-6494/providers/Microsoft.Network/virtualNetworks/vnet-3557/subnets/default",
             "properties": {
               "addressPrefix": "10.0.1.0/24",
               "delegations": [],

--- a/sdk/cosmosdb/Azure.ResourceManager.CosmosDB/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionCreateAndUpdateAsync.json
+++ b/sdk/cosmosdb/Azure.ResourceManager.CosmosDB/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionCreateAndUpdateAsync.json
@@ -444,9 +444,9 @@
         "location": "westus",
         "properties": {
           "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/dbaccount-7978/providers/Microsoft.Network/virtualNetworks/vnet-3557/subnets/default",
             "name": "default",
             "type": "Microsoft.Network/virtualNetworks/subnets",
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/dbaccount-7978/providers/Microsoft.Network/virtualNetworks/vnet-3557/subnets/default",
             "properties": {
               "addressPrefix": "10.0.1.0/24",
               "delegations": [],

--- a/sdk/cosmosdb/Azure.ResourceManager.CosmosDB/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionDelete.json
+++ b/sdk/cosmosdb/Azure.ResourceManager.CosmosDB/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionDelete.json
@@ -444,9 +444,9 @@
         "location": "westus",
         "properties": {
           "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/dbaccount-6494/providers/Microsoft.Network/virtualNetworks/vnet-9279/subnets/default",
             "name": "default",
             "type": "Microsoft.Network/virtualNetworks/subnets",
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/dbaccount-6494/providers/Microsoft.Network/virtualNetworks/vnet-9279/subnets/default",
             "properties": {
               "addressPrefix": "10.0.1.0/24",
               "delegations": [],

--- a/sdk/cosmosdb/Azure.ResourceManager.CosmosDB/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionDeleteAsync.json
+++ b/sdk/cosmosdb/Azure.ResourceManager.CosmosDB/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionDeleteAsync.json
@@ -444,9 +444,9 @@
         "location": "westus",
         "properties": {
           "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/dbaccount-7978/providers/Microsoft.Network/virtualNetworks/vnet-2037/subnets/default",
             "name": "default",
             "type": "Microsoft.Network/virtualNetworks/subnets",
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/dbaccount-7978/providers/Microsoft.Network/virtualNetworks/vnet-2037/subnets/default",
             "properties": {
               "addressPrefix": "10.0.1.0/24",
               "delegations": [],

--- a/sdk/cosmosdb/Azure.ResourceManager.CosmosDB/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionList.json
+++ b/sdk/cosmosdb/Azure.ResourceManager.CosmosDB/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionList.json
@@ -444,9 +444,9 @@
         "location": "westus",
         "properties": {
           "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/dbaccount-6494/providers/Microsoft.Network/virtualNetworks/vnet-2326/subnets/default",
             "name": "default",
             "type": "Microsoft.Network/virtualNetworks/subnets",
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/dbaccount-6494/providers/Microsoft.Network/virtualNetworks/vnet-2326/subnets/default",
             "properties": {
               "addressPrefix": "10.0.1.0/24",
               "delegations": [],

--- a/sdk/cosmosdb/Azure.ResourceManager.CosmosDB/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionListAsync.json
+++ b/sdk/cosmosdb/Azure.ResourceManager.CosmosDB/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionListAsync.json
@@ -444,9 +444,9 @@
         "location": "westus",
         "properties": {
           "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/dbaccount-7978/providers/Microsoft.Network/virtualNetworks/vnet-9684/subnets/default",
             "name": "default",
             "type": "Microsoft.Network/virtualNetworks/subnets",
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/dbaccount-7978/providers/Microsoft.Network/virtualNetworks/vnet-9684/subnets/default",
             "properties": {
               "addressPrefix": "10.0.1.0/24",
               "delegations": [],

--- a/sdk/cosmosdb/ci.yml
+++ b/sdk/cosmosdb/ci.yml
@@ -22,6 +22,7 @@ pr:
     include:
     - sdk/cosmosdb/
     - sdk/resourcemanager/
+    - sdk/network/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/keyvault/Azure.ResourceManager.KeyVault/tests/PrivateEndpointConnectionTests.cs
+++ b/sdk/keyvault/Azure.ResourceManager.KeyVault/tests/PrivateEndpointConnectionTests.cs
@@ -11,7 +11,6 @@ using NUnit.Framework;
 namespace Azure.ResourceManager.KeyVault.Tests
 {
     [NonParallelizable]
-    [RunFrequency(RunTestFrequency.Manually)]
     public class PrivateEndpointConnectionTests : VaultOperationsTestsBase
     {
         public PrivateEndpointConnectionTests(bool isAsync)
@@ -32,6 +31,7 @@ namespace Azure.ResourceManager.KeyVault.Tests
         [RecordedTest]
         public async Task PrivateEndpointConnectionCreateAndUpdate()
         {
+            IgnoreTestInLiveMode();
             /*
             CAUTION: all private endpoint methods do not work properly now, so just temporally use Network's private endpoint methods for testing.
             Will confirm service team that this is expected.
@@ -68,14 +68,14 @@ namespace Azure.ResourceManager.KeyVault.Tests
             // get
             privateEndpoint = (await privateEndpointCollection.GetAsync(privateEndpointName)).Value;
             Assert.AreEqual(privateEndpoint.Data.Name, privateEndpointName);
-            Assert.AreEqual(privateEndpoint.Data.Location, Location.ToString());
+            Assert.AreEqual(privateEndpoint.Data.Location, Location);
             Assert.IsEmpty(privateEndpoint.Data.Tags);
 
             // update
             privateEndpointData.Tags.Add("test", "test");
             privateEndpoint = (await privateEndpointCollection.CreateOrUpdateAsync(WaitUntil.Completed, privateEndpoint.Data.Name, privateEndpointData)).Value;
             Assert.AreEqual(privateEndpoint.Data.Name, privateEndpointName);
-            Assert.AreEqual(privateEndpoint.Data.Location, Location.ToString());
+            Assert.AreEqual(privateEndpoint.Data.Location, Location);
             Assert.That(privateEndpoint.Data.Tags, Has.Count.EqualTo(1));
             Assert.That(privateEndpoint.Data.Tags, Does.ContainKey("test").WithValue("test"));
 

--- a/sdk/keyvault/Azure.ResourceManager.KeyVault/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionCreateAndUpdate.json
+++ b/sdk/keyvault/Azure.ResourceManager.KeyVault/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionCreateAndUpdate.json
@@ -1202,9 +1202,9 @@
         "location": "canadacentral",
         "properties": {
           "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/sdktestrg-kv-1340/providers/Microsoft.Network/virtualNetworks/vnet-9448/subnets/default",
             "name": "default",
             "type": "Microsoft.Network/virtualNetworks/subnets",
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/sdktestrg-kv-1340/providers/Microsoft.Network/virtualNetworks/vnet-9448/subnets/default",
             "properties": {
               "addressPrefix": "10.0.1.0/24",
               "delegations": [],
@@ -1627,9 +1627,9 @@
         },
         "properties": {
           "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/sdktestrg-kv-1340/providers/Microsoft.Network/virtualNetworks/vnet-9448/subnets/default",
             "name": "default",
             "type": "Microsoft.Network/virtualNetworks/subnets",
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/sdktestrg-kv-1340/providers/Microsoft.Network/virtualNetworks/vnet-9448/subnets/default",
             "properties": {
               "addressPrefix": "10.0.1.0/24",
               "delegations": [],

--- a/sdk/keyvault/Azure.ResourceManager.KeyVault/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionCreateAndUpdateAsync.json
+++ b/sdk/keyvault/Azure.ResourceManager.KeyVault/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionCreateAndUpdateAsync.json
@@ -1202,9 +1202,9 @@
         "location": "canadacentral",
         "properties": {
           "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/sdktestrg-kv-9165/providers/Microsoft.Network/virtualNetworks/vnet-6237/subnets/default",
             "name": "default",
             "type": "Microsoft.Network/virtualNetworks/subnets",
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/sdktestrg-kv-9165/providers/Microsoft.Network/virtualNetworks/vnet-6237/subnets/default",
             "properties": {
               "addressPrefix": "10.0.1.0/24",
               "delegations": [],
@@ -1590,9 +1590,9 @@
         },
         "properties": {
           "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/sdktestrg-kv-9165/providers/Microsoft.Network/virtualNetworks/vnet-6237/subnets/default",
             "name": "default",
             "type": "Microsoft.Network/virtualNetworks/subnets",
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/sdktestrg-kv-9165/providers/Microsoft.Network/virtualNetworks/vnet-6237/subnets/default",
             "properties": {
               "addressPrefix": "10.0.1.0/24",
               "delegations": [],

--- a/sdk/keyvault/Azure.ResourceManager.KeyVault/tests/VaultOperationsTests.cs
+++ b/sdk/keyvault/Azure.ResourceManager.KeyVault/tests/VaultOperationsTests.cs
@@ -12,7 +12,6 @@ using NUnit.Framework;
 namespace Azure.ResourceManager.KeyVault.Tests
 {
     [NonParallelizable]
-    [RunFrequency(RunTestFrequency.Manually)]
     public class VaultOperationsTests : VaultOperationsTestsBase
     {
         public VaultOperationsTests(bool isAsync)
@@ -32,6 +31,7 @@ namespace Azure.ResourceManager.KeyVault.Tests
         [Test]
         public async Task KeyVaultManagementVaultCreateWithoutAccessPolicies()
         {
+            IgnoreTestInLiveMode();
             VaultProperties vaultProperties = new VaultProperties(TenantIdGuid, new KeyVaultSku(KeyVaultSkuFamily.A, KeyVaultSkuName.Standard));
             VaultCreateOrUpdateContent content = new VaultCreateOrUpdateContent(Location, vaultProperties);
             ArmOperation<VaultResource> rawVault = await VaultCollection.CreateOrUpdateAsync(WaitUntil.Completed, VaultName, content);
@@ -43,6 +43,7 @@ namespace Azure.ResourceManager.KeyVault.Tests
         [Test]
         public async Task KeyVaultManagementVaultCreateUpdateDelete()
         {
+            IgnoreTestInLiveMode();
             VaultProperties.EnableSoftDelete = null;
 
             VaultCreateOrUpdateContent parameters = new VaultCreateOrUpdateContent(Location, VaultProperties);
@@ -135,6 +136,7 @@ namespace Azure.ResourceManager.KeyVault.Tests
         [Test]
         public async Task KeyVaultManagementVaultTestCompoundIdentityAccessControlPolicy()
         {
+            IgnoreTestInLiveMode();
             AccessPolicy.ApplicationId = Guid.Parse(TestEnvironment.ClientId);
             VaultProperties.EnableSoftDelete = null;
 
@@ -189,6 +191,7 @@ namespace Azure.ResourceManager.KeyVault.Tests
         [Test]
         public async Task KeyVaultManagementListVaults()
         {
+            IgnoreTestInLiveMode();
             int n = 3;
             int top = 2;
             VaultProperties.EnableSoftDelete = null;
@@ -231,6 +234,7 @@ namespace Azure.ResourceManager.KeyVault.Tests
         [Test]
         public async Task KeyVaultManagementRecoverDeletedVault()
         {
+            IgnoreTestInLiveMode();
             VaultCreateOrUpdateContent parameters = new VaultCreateOrUpdateContent(Location, VaultProperties);
             parameters.Tags.InitializeFrom(Tags);
             ArmOperation<VaultResource> createdVault = await VaultCollection.CreateOrUpdateAsync(WaitUntil.Completed, VaultName, parameters).ConfigureAwait(false);
@@ -277,6 +281,7 @@ namespace Azure.ResourceManager.KeyVault.Tests
         [Test]
         public async Task KeyVaultManagementListDeletedVaults()
         {
+            IgnoreTestInLiveMode();
             int n = 3;
             List<string> resourceIds = new List<string>();
             List<VaultResource> vaultList = new List<VaultResource>();

--- a/sdk/keyvault/Azure.ResourceManager.KeyVault/tests/VaultOperationsTestsBase.cs
+++ b/sdk/keyvault/Azure.ResourceManager.KeyVault/tests/VaultOperationsTestsBase.cs
@@ -11,6 +11,7 @@ using Azure.Graph.Rbac;
 using Azure.ResourceManager.KeyVault.Models;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.TestFramework;
+using NUnit.Framework;
 
 namespace Azure.ResourceManager.KeyVault.Tests
 {
@@ -128,6 +129,14 @@ namespace Azure.ResourceManager.KeyVault.Tests
             };
             ManagedHsmProperties.PublicNetworkAccess = PublicNetworkAccess.Disabled;
             ManagedHsmProperties.TenantId = TenantIdGuid;
+        }
+
+        public void IgnoreTestInLiveMode()
+        {
+            if (Mode == RecordedTestMode.Live)
+            {
+                Assert.Ignore();
+            }
         }
     }
 }

--- a/sdk/keyvault/ci.yml
+++ b/sdk/keyvault/ci.yml
@@ -21,6 +21,7 @@ pr:
     include:
     - sdk/keyvault/
     - sdk/resourcemanager/
+    - sdk/network/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml


### PR DESCRIPTION
What happened in this PR:

- Update the test records and fix tests in CosmosDB and KeyVault to ensure the test pass after network update
- Add `netowrk` in the ci.yml of CosmosDB and KeyVault
- Remove the `RunTestFrequency.Manually` in KeyVault tests so these tests can be run in pipeline with playback mode.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
