### PR TITLE
[FormRecognizer] Added IgnoreServiceError attribute to FormRecognizerSamples

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample_MockClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample_MockClient.cs
@@ -8,11 +8,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Training;
+using Azure.Core.TestFramework;
 using Moq;
 using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
+    [IgnoreServiceError(200, "3014", Message = "Generic error during training.", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28913")]
     public partial class FormRecognizerSamples
     {
         [Test]


### PR DESCRIPTION
Missed this scenario in the [previous PR](https://github.com/Azure/azure-sdk-for-net/pull/28559).