### PR TITLE
[AzureMonitorExporter] adding unit tests for EventSource

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterEventSource.cs
@@ -104,7 +104,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             protected override void OnEventWritten(EventWrittenEventArgs eventData)
             {
                 string message = EventSourceEventFormatting.Format(eventData);
-                TelemetryDebugWriter.WriteMessage($"{eventData.EventSource.Name} - EventId: [{eventData.EventId}], EventName: [{eventData.EventName}], Message: [{message}]");
+                TelemetryDebugWriter.Writer.WriteMessage($"{eventData.EventSource.Name} - EventId: [{eventData.EventId}], EventName: [{eventData.EventName}], Message: [{message}]");
             }
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/ApplicationInsightsRestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/ApplicationInsightsRestClient.cs
@@ -90,7 +90,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 content.WriteNewLine();
             }
             request.Content = RequestContent.Create(content.ToBytes());
-            TelemetryDebugWriter.WriteTelemetry(content);
+            TelemetryDebugWriter.Writer.WriteTelemetry(content);
             return message;
         }
 
@@ -108,7 +108,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             request.Headers.Add("Accept", "application/json");
             using var content = new NDJsonWriter();
             request.Content = RequestContent.Create(body);
-            TelemetryDebugWriter.WriteTelemetry(content);
+            TelemetryDebugWriter.Writer.WriteTelemetry(content);
             return message;
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryDebugWriter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryDebugWriter.cs
@@ -5,9 +5,11 @@ using System.Diagnostics;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter
 {
-    internal class TelemetryDebugWriter
+    internal class TelemetryDebugWriter : IDebugWritter
     {
-        internal static void WriteMessage(string message)
+        public static IDebugWritter Writer = new TelemetryDebugWriter();
+
+        public void WriteMessage(string message)
         {
             if (message == null)
             {
@@ -16,11 +18,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
             if (Debugger.IsAttached && Debugger.IsLogging())
             {
-                Debugger.Log(0, null,  message);
+                Debugger.Log(0, null, message);
             }
         }
 
-        internal static void WriteTelemetry(NDJsonWriter content)
+        public void WriteTelemetry(NDJsonWriter content)
         {
             if (content == null)
             {
@@ -32,5 +34,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 Debugger.Log(0, null, content.ToString());
             }
         }
+    }
+
+    internal interface IDebugWritter
+    {
+        void WriteMessage(string message);
+
+        void WriteTelemetry(NDJsonWriter content);
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorExporterEventSourceTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorExporterEventSourceTests.cs
@@ -61,7 +61,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             public void WriteTelemetry(NDJsonWriter content)
             {
-                throw new NotImplementedException();
+                // no-op
             }
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorExporterEventSourceTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorExporterEventSourceTests.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 using Xunit;
 
-namespace Azure.Monitor.OpenTelemetry.Exporter
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 {
     /// <summary>
     /// These tests depend on the <see cref="AzureMonitorExporterEventListener"/> to subscribe to the <see cref="AzureMonitorExporterEventSource"/> and write events to the <see cref="TelemetryDebugWriter"/>.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorExporterEventSourceTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorExporterEventSourceTests.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter
+{
+    /// <summary>
+    /// These tests depend on the <see cref="AzureMonitorExporterEventListener"/> to subscribe to the <see cref="AzureMonitorExporterEventSource"/> and write events to the <see cref="TelemetryDebugWriter"/>.
+    /// </summary>
+    public class AzureMonitorExporterEventSourceTests
+    {
+        [Fact]
+        public void VerifyEventSource_Critical() => Test(writeAction: AzureMonitorExporterEventSource.Log.WriteCritical, expectedId: 1, expectedName: "WriteCritical");
+
+        [Fact]
+        public void VerifyEventSource_Error() => Test(writeAction: AzureMonitorExporterEventSource.Log.WriteError, expectedId: 2, expectedName: "WriteError");
+
+        [Fact]
+        public void VerifyEventSource_Warning() => Test(writeAction: AzureMonitorExporterEventSource.Log.WriteWarning, expectedId: 3, expectedName: "WriteWarning");
+
+        [Fact]
+        public void VerifyEventSource_Informational() => Test(writeAction: AzureMonitorExporterEventSource.Log.WriteInformational, expectedId: 4, expectedName: "WriteInformational");
+
+        [Fact]
+        public void VerifyEventSource_Verbose() => Test(writeAction: AzureMonitorExporterEventSource.Log.WriteVerbose, expectedId: 5, expectedName: "WriteVerbose");
+
+        private void Test(Action<string> writeAction, int expectedId, string expectedName)
+        {
+            try
+            {
+                // Normally our Listener will write to the Debugger.
+                // Here, we override the behavior of the TelemetryDebugWriter to intercept messages.
+                var writer = new TestWriter();
+                TelemetryDebugWriter.Writer = writer;
+
+                writeAction("hello world");
+
+                var test = writer.Messages.Single();
+                Assert.Equal($"OpenTelemetry-AzureMonitor-Exporter - EventId: [{expectedId}], EventName: [{expectedName}], Message: [hello world]", test);
+            }
+            finally
+            {
+                // Reset singleton to not affect other tests.
+                TelemetryDebugWriter.Writer = new TelemetryDebugWriter();
+            }
+        }
+
+        private class TestWriter : IDebugWritter
+        {
+            public List<string> Messages = new();
+
+            public void WriteMessage(string message)
+            {
+                Messages.Add(message);
+            }
+
+            public void WriteTelemetry(NDJsonWriter content)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is preparing for refactoring the EventSource class.


### Changes
- New test class `AzureMonitorExporterEventSourceTests`.
  This validates EventSource -> Listener -> DebugWriter.
  This verifies that when `EventSource.Write` is called, an event is created that can be subscribed to in the Listener.
  This also verifies the full text of the event message.
- refactor `TelemetryDebugWriter` to facilitate unit testing.
  Introduces an interface `IDebugWritter` and singleton `TelemetryDebugWriter.Writer` that can be overridden for test scenarios.