### PR TITLE
Support outputting the entire message envelope for out of proc functions

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Bindings/AsyncCollectorArgumentBindingProvider.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Bindings/AsyncCollectorArgumentBindingProvider.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Newtonsoft.Json;
 
@@ -29,6 +30,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
                 return null;
             }
 
+            var attribute = TypeUtility.GetResolvedAttribute<ServiceBusAttribute>(parameter);
+
             Type genericTypeDefinition = parameterType.GetGenericTypeDefinition();
 
             if (genericTypeDefinition != typeof(IAsyncCollector<>))
@@ -37,25 +40,25 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
             }
 
             Type itemType = parameterType.GetGenericArguments()[0];
-            return CreateBinding(itemType);
+            return CreateBinding(itemType, attribute.IncludeMetadata);
         }
 
-        private IArgumentBinding<ServiceBusEntity> CreateBinding(Type itemType)
+        private IArgumentBinding<ServiceBusEntity> CreateBinding(Type itemType, bool includeMetadata)
         {
             MethodInfo method = typeof(AsyncCollectorArgumentBindingProvider).GetMethod("CreateBindingGeneric",
                 BindingFlags.NonPublic | BindingFlags.Instance);
             Debug.Assert(method != null);
             MethodInfo genericMethod = method.MakeGenericMethod(itemType);
             Debug.Assert(genericMethod != null);
-            Func<IArgumentBinding<ServiceBusEntity>> lambda =
-                (Func<IArgumentBinding<ServiceBusEntity>>)Delegate.CreateDelegate(
-                typeof(Func<IArgumentBinding<ServiceBusEntity>>), this, genericMethod);
-            return lambda.Invoke();
+            Func<bool, IArgumentBinding<ServiceBusEntity>> lambda =
+                (Func<bool, IArgumentBinding<ServiceBusEntity>>)Delegate.CreateDelegate(
+                typeof(Func<bool, IArgumentBinding<ServiceBusEntity>>), this, genericMethod);
+            return lambda.Invoke(includeMetadata);
         }
 
-        private IArgumentBinding<ServiceBusEntity> CreateBindingGeneric<TItem>()
+        private IArgumentBinding<ServiceBusEntity> CreateBindingGeneric<TItem>(bool includeMetadata)
         {
-            return new AsyncCollectorArgumentBinding<TItem>(MessageConverterFactory.Create<TItem>(_jsonSerializerSettings));
+            return new AsyncCollectorArgumentBinding<TItem>(MessageConverterFactory.Create<TItem>(_jsonSerializerSettings, includeMetadata));
         }
 
         private class AsyncCollectorArgumentBinding<TItem> : IArgumentBinding<ServiceBusEntity>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Bindings/MessageConverterFactory.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Bindings/MessageConverterFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
 {
     internal static class MessageConverterFactory
     {
-        internal static IConverter<TInput, ServiceBusMessage> Create<TInput>(JsonSerializerSettings jsonSerializerSettings)
+        internal static IConverter<TInput, ServiceBusMessage> Create<TInput>(JsonSerializerSettings jsonSerializerSettings, bool includeMetadata)
         {
             if (typeof(TInput) == typeof(ServiceBusMessage))
             {
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
             }
             else if (typeof(TInput) == typeof(string))
             {
-                return (IConverter<TInput, ServiceBusMessage>)new StringToMessageConverter();
+                return (IConverter<TInput, ServiceBusMessage>)new StringToMessageConverter(includeMetadata);
             }
             else if (typeof(TInput) == typeof(byte[]))
             {

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Bindings/StringArgumentBindingProvider.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Bindings/StringArgumentBindingProvider.cs
@@ -23,11 +23,11 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
 
         private class StringArgumentBinding : IArgumentBinding<ServiceBusEntity>
         {
-            private readonly bool _includeMessageMetadata;
+            private readonly bool _includeMetadata;
 
-            public StringArgumentBinding(bool includeMessageMetadata)
+            public StringArgumentBinding(bool includeMetadata)
             {
-                _includeMessageMetadata = includeMessageMetadata;
+                _includeMetadata = includeMetadata;
             }
             public Type ValueType
             {
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
                 }
 
                 IValueProvider provider = new NonNullConverterValueBinder<string>(value,
-                    new StringToMessageConverter(_includeMessageMetadata), context.FunctionInstanceId);
+                    new StringToMessageConverter(_includeMetadata), context.FunctionInstanceId);
 
                 return Task.FromResult(provider);
             }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Bindings/StringToMessageConverter.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Bindings/StringToMessageConverter.cs
@@ -9,11 +9,11 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
 {
     internal class StringToMessageConverter : IConverter<string, ServiceBusMessage>
     {
-        private readonly bool _includeMessageMetadata;
+        private readonly bool _includeMetadata;
 
-        public StringToMessageConverter(bool includeMessageMetadata)
+        public StringToMessageConverter(bool includeMetadata)
         {
-            _includeMessageMetadata = includeMessageMetadata;
+            _includeMetadata = includeMetadata;
         }
         public ServiceBusMessage Convert(string input)
         {
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
                 throw new InvalidOperationException("A brokered message cannot contain a null string instance.");
             }
 
-            if (_includeMessageMetadata)
+            if (_includeMetadata)
             {
                 return JsonSerializer.Deserialize<ServiceBusMessage>(input, new JsonSerializerOptions { Converters = { new ServiceBusMessageConverter()}});
             }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Bindings/StringToMessageConverter.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Bindings/StringToMessageConverter.cs
@@ -2,17 +2,29 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Text.Json;
 using Azure.Messaging.ServiceBus;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
 {
     internal class StringToMessageConverter : IConverter<string, ServiceBusMessage>
     {
+        private readonly bool _includeMessageMetadata;
+
+        public StringToMessageConverter(bool includeMessageMetadata)
+        {
+            _includeMessageMetadata = includeMessageMetadata;
+        }
         public ServiceBusMessage Convert(string input)
         {
             if (input == null)
             {
                 throw new InvalidOperationException("A brokered message cannot contain a null string instance.");
+            }
+
+            if (_includeMessageMetadata)
+            {
+                return JsonSerializer.Deserialize<ServiceBusMessage>(input, new JsonSerializerOptions { Converters = { new ServiceBusMessageConverter()}});
             }
 
             byte[] bytes = StrictEncodings.Utf8.GetBytes(input);

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/ServiceBusAttribute.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/ServiceBusAttribute.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.ServiceBus;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Azure.WebJobs
 {
@@ -41,6 +43,14 @@ namespace Microsoft.Azure.WebJobs
             EntityType = entityType;
         }
 
+        // for testing of the internal IncludeMetadata property. Internal properties cannot be set on attributes outside of the constructor.
+        internal ServiceBusAttribute(string queueOrTopicName, bool includeMetadata, ServiceBusEntityType entityType = ServiceBusEntityType.Queue)
+        {
+            QueueOrTopicName = queueOrTopicName;
+            EntityType = entityType;
+            IncludeMetadata = includeMetadata;
+        }
+
         /// <summary>
         /// Gets the name of the queue or topic to bind to.
         /// </summary>
@@ -55,5 +65,13 @@ namespace Microsoft.Azure.WebJobs
         /// Value indicating the type of the entity to bind to.
         /// </summary>
         public ServiceBusEntityType EntityType { get; set; }
+
+        /// <summary>
+        /// This property indicates whether the string being sent from out of process functions
+        /// includes the message metadata. By default this is false, meaning the string represents
+        /// only the message body.
+        /// </summary>
+        [JsonProperty]
+        internal bool IncludeMetadata { get; set; }
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/ServiceBusMessageConverter.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/ServiceBusMessageConverter.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Azure.Messaging.ServiceBus;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus
+{
+    internal class ServiceBusMessageConverter : JsonConverter<ServiceBusMessage>
+    {
+        public override ServiceBusMessage Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var message = new ServiceBusMessage();
+            using JsonDocument document = JsonDocument.ParseValue(ref reader);
+            foreach (JsonProperty property in document.RootElement.EnumerateObject())
+            {
+                if (property.Name.Equals(nameof(ServiceBusMessage.Body), StringComparison.OrdinalIgnoreCase))
+                {
+                    // Body must be a string. For binary payloads, customers can base64 encode the data.
+                    message.Body = new BinaryData(property.Value.GetString());
+                }
+                else if (property.Name.Equals(nameof(ServiceBusMessage.ContentType), StringComparison.OrdinalIgnoreCase))
+                {
+                    message.ContentType = property.Value.GetString();
+                }
+                else if (property.Name.Equals(nameof(ServiceBusMessage.CorrelationId), StringComparison.OrdinalIgnoreCase))
+                {
+                    message.CorrelationId = property.Value.GetString();
+                }
+                else if (property.Name.Equals(nameof(ServiceBusMessage.MessageId), StringComparison.OrdinalIgnoreCase))
+                {
+                    message.MessageId = property.Value.GetString();
+                }
+                else if (property.Name.Equals(nameof(ServiceBusMessage.PartitionKey), StringComparison.OrdinalIgnoreCase))
+                {
+                    message.PartitionKey = property.Value.GetString();
+                }
+                else if (property.Name.Equals(nameof(ServiceBusMessage.ReplyTo), StringComparison.OrdinalIgnoreCase))
+                {
+                    message.ReplyTo = property.Value.GetString();
+                }
+                else if (property.Name.Equals(nameof(ServiceBusMessage.ReplyToSessionId), StringComparison.OrdinalIgnoreCase))
+                {
+                    message.ReplyToSessionId = property.Value.GetString();
+                }
+                else if (property.Name.Equals(nameof(ServiceBusMessage.SessionId), StringComparison.OrdinalIgnoreCase))
+                {
+                    message.SessionId = property.Value.GetString();
+                }
+                else if (property.Name.Equals(nameof(ServiceBusMessage.ScheduledEnqueueTime), StringComparison.OrdinalIgnoreCase))
+                {
+                    message.ScheduledEnqueueTime = DateTimeOffset.Parse(property.Value.GetString(), CultureInfo.InvariantCulture);
+                }
+                else if (property.Name.Equals(nameof(ServiceBusMessage.TimeToLive), StringComparison.OrdinalIgnoreCase))
+                {
+                    message.TimeToLive = TimeSpan.Parse(property.Value.GetString(), CultureInfo.InvariantCulture);
+                }
+                else if (property.Name.Equals(nameof(ServiceBusMessage.To), StringComparison.OrdinalIgnoreCase))
+                {
+                    message.To = property.Value.GetString();
+                }
+                else if (property.Name.Equals(nameof(ServiceBusMessage.TransactionPartitionKey), StringComparison.OrdinalIgnoreCase))
+                {
+                    message.TransactionPartitionKey = property.Value.GetString();
+                }
+                else if (property.Name.Equals(nameof(ServiceBusMessage.ApplicationProperties), StringComparison.OrdinalIgnoreCase))
+                {
+                    foreach (JsonProperty applicationProperty in property.Value.EnumerateObject())
+                    {
+                        switch (applicationProperty.Value.ValueKind)
+                        {
+                            case JsonValueKind.Null:
+                            case JsonValueKind.Undefined:
+                                message.ApplicationProperties[applicationProperty.Name] = null;
+                                break;
+                            case JsonValueKind.Number:
+                                message.ApplicationProperties[applicationProperty.Name] = GetNumber(applicationProperty.Value);
+                                break;
+                            case JsonValueKind.True:
+                                message.ApplicationProperties[applicationProperty.Name] = true;
+                                break;
+                            case JsonValueKind.False:
+                                message.ApplicationProperties[applicationProperty.Name] = false;
+                                break;
+                            case JsonValueKind.String:
+                                message.ApplicationProperties[applicationProperty.Name] = applicationProperty.Value.GetString();
+                                break;
+                            default:
+                                throw new InvalidOperationException(
+                                    $"{applicationProperty.Value.ValueKind} is not a valid ApplicationProperty value.");
+                        }
+                    }
+                }
+            }
+
+            return message;
+        }
+
+        public override void Write(Utf8JsonWriter writer, ServiceBusMessage value, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static object GetNumber(in JsonElement element)
+        {
+            if (element.TryGetInt32(out int intValue))
+            {
+                return intValue;
+            }
+            if (element.TryGetInt64(out long longValue))
+            {
+                return longValue;
+            }
+            return element.GetDouble();
+        }
+    }
+}


### PR DESCRIPTION
Contributes to https://github.com/Azure/azure-sdk-for-net/issues/21884

The attribute will need to be implemented in the out of process worker to light things up end-to-end.