### PR TITLE
Fix for Bug #29029 TableEntity.GetBinaryData does not return the correct data after downloading the entity

### DIFF
--- a/sdk/tables/Azure.Data.Tables/src/TableEntity.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableEntity.cs
@@ -247,7 +247,7 @@ namespace Azure.Data.Tables
                 }
                 if (type == typeof(BinaryData) && valueType == typeof(byte[]))
                 {
-                     return new BinaryData(value);
+                     return new BinaryData((byte[])value);
                 }
                 EnforceType(type, valueType);
             }

--- a/sdk/tables/Azure.Data.Tables/tests/TableEntityTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableEntityTests.cs
@@ -43,6 +43,17 @@ namespace Azure.Data.Tables.Tests
             Assert.That(fullEntity.GetString("string"), Is.InstanceOf(typeof(string)));
         }
 
+
+        /// <summary>
+        /// Validates that the typed getter for Binary Data can also retrieve data set as a byte array.
+        /// </summary>
+        [Test]
+        public void ValidateDictionaryEntityByteArrayAsBinaryData()
+        {
+            Assert.That(fullEntity.GetBinaryData("binary"), Is.InstanceOf(typeof(BinaryData)));
+            CollectionAssert.AreEqual(fullEntity.GetBinaryData("binary").ToArray(), fullEntity.GetBinary("binary"));
+        }
+
         /// <summary>
         /// Validates the typed getters throws InvalidOperationException when the retrieved value doesn't match the type.
         /// </summary>
@@ -249,6 +260,30 @@ namespace Azure.Data.Tables.Tests
 
          [Test]
         public void TypeCoercionForDateTimeTypes()
+        {
+            var entity = new TableEntity("partition", "row");
+            var offsetNow = DateTimeOffset.UtcNow;
+            var dateNow = offsetNow.UtcDateTime;
+
+            // Initialize a property to an DateTimeOffset value
+            entity["DTOffset"] = offsetNow;
+            Assert.That(entity["DTOffset"] is DateTimeOffset);
+            Assert.That(entity["DTOffset"], Is.EqualTo(offsetNow));
+            Assert.That(entity.GetDateTimeOffset("DTOffset"), Is.EqualTo(offsetNow));
+            Assert.That(entity.GetDateTime("DTOffset"), Is.EqualTo(dateNow));
+
+            // Initialize a property to an DateTime value
+            entity["DT"] = dateNow;
+            Assert.AreEqual(typeof(DateTime), entity["DT"].GetType());
+            DateTimeOffset dtoffset = (DateTime)entity["DT"];
+            Assert.That(entity["DT"], Is.EqualTo(dateNow));
+            Assert.That(entity.GetDateTime("DT"), Is.EqualTo(dateNow));
+            Assert.That(entity.GetDateTimeOffset("DT"), Is.EqualTo(offsetNow));
+        }
+
+
+        [Test]
+        public void TypeCoercionForBinaryData()
         {
             var entity = new TableEntity("partition", "row");
             var offsetNow = DateTimeOffset.UtcNow;

--- a/sdk/tables/Azure.Data.Tables/tests/TableEntityTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableEntityTests.cs
@@ -281,28 +281,14 @@ namespace Azure.Data.Tables.Tests
             Assert.That(entity.GetDateTimeOffset("DT"), Is.EqualTo(offsetNow));
         }
 
-
+        /// <summary>
+        /// Validates that the typed getter for Binary Data can also retrieve data set as a byte array.
+        /// </summary>
         [Test]
-        public void TypeCoercionForBinaryData()
+        public void ValidateDictionaryEntityByteArrayAsBinaryData()
         {
-            var entity = new TableEntity("partition", "row");
-            var offsetNow = DateTimeOffset.UtcNow;
-            var dateNow = offsetNow.UtcDateTime;
-
-            // Initialize a property to an DateTimeOffset value
-            entity["DTOffset"] = offsetNow;
-            Assert.That(entity["DTOffset"] is DateTimeOffset);
-            Assert.That(entity["DTOffset"], Is.EqualTo(offsetNow));
-            Assert.That(entity.GetDateTimeOffset("DTOffset"), Is.EqualTo(offsetNow));
-            Assert.That(entity.GetDateTime("DTOffset"), Is.EqualTo(dateNow));
-
-            // Initialize a property to an DateTime value
-            entity["DT"] = dateNow;
-            Assert.AreEqual(typeof(DateTime), entity["DT"].GetType());
-            DateTimeOffset dtoffset = (DateTime)entity["DT"];
-            Assert.That(entity["DT"], Is.EqualTo(dateNow));
-            Assert.That(entity.GetDateTime("DT"), Is.EqualTo(dateNow));
-            Assert.That(entity.GetDateTimeOffset("DT"), Is.EqualTo(offsetNow));
+            Assert.That(fullEntity.GetBinaryData("binary"), Is.InstanceOf(typeof(BinaryData)));
+            CollectionAssert.AreEqual(fullEntity.GetBinaryData("binary").ToArray(), fullEntity.GetBinary("binary"));
         }
     }
 }

--- a/sdk/tables/Azure.Data.Tables/tests/TableEntityTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableEntityTests.cs
@@ -43,17 +43,6 @@ namespace Azure.Data.Tables.Tests
             Assert.That(fullEntity.GetString("string"), Is.InstanceOf(typeof(string)));
         }
 
-
-        /// <summary>
-        /// Validates that the typed getter for Binary Data can also retrieve data set as a byte array.
-        /// </summary>
-        [Test]
-        public void ValidateDictionaryEntityByteArrayAsBinaryData()
-        {
-            Assert.That(fullEntity.GetBinaryData("binary"), Is.InstanceOf(typeof(BinaryData)));
-            CollectionAssert.AreEqual(fullEntity.GetBinaryData("binary").ToArray(), fullEntity.GetBinary("binary"));
-        }
-
         /// <summary>
         /// Validates the typed getters throws InvalidOperationException when the retrieved value doesn't match the type.
         /// </summary>
@@ -258,7 +247,7 @@ namespace Azure.Data.Tables.Tests
             Assert.That(entity["Foo3"] is DateTime);
         }
 
-         [Test]
+        [Test]
         public void TypeCoercionForDateTimeTypes()
         {
             var entity = new TableEntity("partition", "row");


### PR DESCRIPTION
This fixes [BUG # 29029](https://github.com/Azure/azure-sdk-for-net/issues/29029)

basically the code in [object TableEntity.GetValue(string key, Type type = null)](https://github.com/Azure/azure-sdk-for-net/blob/02c3ba28187ce4bc478072e1ca98d25949c75125/sdk/tables/Azure.Data.Tables/src/TableEntity.cs#L250) lets you ask for a `byte[]` as a `BinaryData` However it passes the value from the property dictionary still typed as object to the `BinaryData` constructor instead of casting it to byte[] first. This results in the constructor for json objects being matched and the underlying byte array representing the json serialization of the actual array object instead of the expected bytes.


