### PR TITLE
[FormRecognizer] Added IgnoreServiceError attribute to v3 samples

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltDocumentFromFileAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltDocumentFromFileAsync.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
+    [IgnoreServiceError(400, "InvalidRequest", Message = "Content is not accessible: Invalid data URL", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28923")]
     public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
     {
         [Test]


### PR DESCRIPTION
Missed v3 samples scenarios in two previous PRs (https://github.com/Azure/azure-sdk-for-net/pull/28559 and https://github.com/Azure/azure-sdk-for-net/pull/29014).