### PR TITLE
Properly cast byte[] for BinaryData ctor in TableEntity.GetBinaryData

### DIFF
--- a/sdk/tables/Azure.Data.Tables/src/TableEntity.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableEntity.cs
@@ -245,9 +245,9 @@ namespace Azure.Data.Tables
                 {
                     return new DateTimeOffset((DateTime)value);
                 }
-                if (type == typeof(BinaryData) && valueType == typeof(byte[]))
+                if (type == typeof(BinaryData) && value is byte[] byteArray)
                 {
-                     return new BinaryData(value);
+                     return new BinaryData(byteArray);
                 }
                 EnforceType(type, valueType);
             }

--- a/sdk/tables/Azure.Data.Tables/tests/TableEntityTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableEntityTests.cs
@@ -247,7 +247,7 @@ namespace Azure.Data.Tables.Tests
             Assert.That(entity["Foo3"] is DateTime);
         }
 
-         [Test]
+        [Test]
         public void TypeCoercionForDateTimeTypes()
         {
             var entity = new TableEntity("partition", "row");
@@ -268,6 +268,16 @@ namespace Azure.Data.Tables.Tests
             Assert.That(entity["DT"], Is.EqualTo(dateNow));
             Assert.That(entity.GetDateTime("DT"), Is.EqualTo(dateNow));
             Assert.That(entity.GetDateTimeOffset("DT"), Is.EqualTo(offsetNow));
+        }
+
+        [Test]
+        public void GetBinaryDataRoundtripsBytes()
+        {
+            TableEntity te = new("a", "b");
+            byte[] array = new byte[] { 1, 2, 3, 4, 5 };
+            te.Add("binarydata", array);
+            byte[] roundTrip = te.GetBinaryData("binarydata").ToArray();
+            CollectionAssert.AreEqual(array, roundTrip);
         }
     }
 }


### PR DESCRIPTION
fixes #29029