### PR TITLE
[Event Hubs] Recover From Ownership Blob Deletion

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- `EventProcessorClient` and `BlobCheckpointStore` will now detect when an ownership blob has been deleted externally while the processor is running and gracefully recover.
+
 ## 5.7.0 (2022-05-10)
 
 ### Acknowledgments

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/BlobCheckpointStoreInternalDiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/BlobCheckpointStoreInternalDiagnosticsTests.cs
@@ -234,37 +234,6 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         }
 
         /// <summary>
-        ///   Verifies basic functionality of ClaimOwnershipAsync and ensures the appropriate events are emitted on failure.
-        /// </summary>
-        ///
-        [Test]
-        public void ClaimOwnershipForMissingPartitionLogsClaimOwnershipError()
-        {
-            var partitionOwnership = new List<EventProcessorPartitionOwnership>
-            {
-                new EventProcessorPartitionOwnership
-                {
-                    FullyQualifiedNamespace = FullyQualifiedNamespace,
-                    EventHubName = EventHubName,
-                    ConsumerGroup = ConsumerGroup,
-                    OwnerIdentifier = OwnershipIdentifier,
-                    PartitionId = PartitionId,
-                    LastModifiedTime = DateTime.UtcNow,
-                    Version = MatchingEtag
-                }
-            };
-
-            var mockBlobContainerClient = new MockBlobContainerClient().AddBlobClient($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/ownership/1", _ => { });
-            var target = new BlobCheckpointStoreInternal(mockBlobContainerClient);
-
-            var mockLog = new Mock<BlobEventStoreEventSource>();
-            target.Logger = mockLog.Object;
-
-            Assert.That(async () => await target.ClaimOwnershipAsync(partitionOwnership, CancellationToken.None), Throws.InstanceOf<RequestFailedException>());
-            mockLog.Verify(m => m.ClaimOwnershipError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, OwnershipIdentifier, It.Is<string>(e => e.Contains(BlobErrorCode.BlobNotFound.ToString()))));
-        }
-
-        /// <summary>
         ///   Verifies basic functionality of UpdateCheckpointAsync and ensures the appropriate events are emitted on success.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobCheckpointStoreInternal.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobCheckpointStoreInternal.cs
@@ -204,6 +204,30 @@ namespace Azure.Messaging.EventHubs.Primitives
                     // Even though documentation states otherwise, we cannot use UploadAsync when the blob already exists in
                     // the current storage SDK.  For this reason, we are using the specified ETag as an indication of what
                     // method to use.
+                    //
+                    // If an ETag is associated with ownership, assume the blob exists and attempt to update it.
+
+                    if (ownership.Version != null)
+                    {
+                        try
+                        {
+                            blobRequestConditions.IfMatch = new ETag(ownership.Version);
+                            infoResponse = await blobClient.SetMetadataAsync(metadata, blobRequestConditions, cancellationToken).ConfigureAwait(false);
+
+                            ownership.LastModifiedTime = infoResponse.Value.LastModified;
+                            ownership.Version = infoResponse.Value.ETag.ToString();
+                        }
+                        catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.BlobNotFound)
+                        {
+                            // This is an unlikely corner case that indicates that the blob was unexpectedly deleted while the
+                            // processor is running.  Attempt to recover by resetting the ETag and considering it an upload scenario
+                            // to be handled by the next block.
+
+                            ownership.Version = null;
+                        }
+                    }
+
+                    // If no ETag is associated with ownership, attempt to upload a new blob with the needed metadata.
 
                     if (ownership.Version == null)
                     {
@@ -218,7 +242,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                         catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.BlobAlreadyExists)
                         {
                             // A blob could have just been created by another Event Processor that claimed ownership of this
-                            // partition.  In this case, there's no point in retrying because we don't have the correct ETag.
+                            // partition.  In this case, there's no point in retrying because we don't have the correct eTag.
 
                             OwnershipNotClaimable(ownership.PartitionId, ownership.FullyQualifiedNamespace, ownership.EventHubName, ownership.ConsumerGroup, ownership.OwnerIdentifier, ex.Message);
                             continue;
@@ -227,16 +251,8 @@ namespace Azure.Messaging.EventHubs.Primitives
                         ownership.LastModifiedTime = contentInfoResponse.Value.LastModified;
                         ownership.Version = contentInfoResponse.Value.ETag.ToString();
                     }
-                    else
-                    {
-                        blobRequestConditions.IfMatch = new ETag(ownership.Version);
-                        infoResponse = await blobClient.SetMetadataAsync(metadata, blobRequestConditions, cancellationToken).ConfigureAwait(false);
 
-                        ownership.LastModifiedTime = infoResponse.Value.LastModified;
-                        ownership.Version = infoResponse.Value.ETag.ToString();
-                    }
-
-                    // Small workaround to retrieve the eTag.  The current storage SDK returns it enclosed in
+                    // Small workaround to retrieve the ETag.  The current storage SDK returns it enclosed in
                     // double quotes ("ETAG_VALUE" instead of ETAG_VALUE).
 
                     ownership.Version = ownership.Version?.Trim('"');

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobCheckpointStoreInternal.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobCheckpointStoreInternal.cs
@@ -242,7 +242,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                         catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.BlobAlreadyExists)
                         {
                             // A blob could have just been created by another Event Processor that claimed ownership of this
-                            // partition.  In this case, there's no point in retrying because we don't have the correct eTag.
+                            // partition.  In this case, there's no point in retrying because we don't have the correct ETag.
 
                             OwnershipNotClaimable(ownership.PartitionId, ownership.FullyQualifiedNamespace, ownership.EventHubName, ownership.ConsumerGroup, ownership.OwnerIdentifier, ex.Message);
                             continue;

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/BlobCheckpointStore/BlobsCheckpointStoreInternalTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/BlobCheckpointStore/BlobsCheckpointStoreInternalTests.cs
@@ -272,12 +272,17 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies basic functionality of ClaimOwnershipAsync and ensures the appropriate events are emitted on failure.
+        ///   Verifies functionality of ClaimOwnershipAsync.
         /// </summary>
         ///
         [Test]
-        public void ClaimOwnershipForMissingPartitionThrowsAndLogsClaimOwnershipError()
+        public async Task ClaimOwnershipCompensatesWhenABlobIsDeleted()
         {
+            var ownershipBlobName = $"{FullyQualifiedNamespaceLowercase}/{EventHubNameLowercase}/{ConsumerGroupLowercase}/ownership/{PartitionId}";
+            var setMetadataException = new RequestFailedException(404, "No blob here", BlobErrorCode.BlobNotFound.ToString(), null);
+            var setMetadataCalled = false;
+            var uploadBlobCalled = false;
+
             var partitionOwnership = new List<EventProcessorPartitionOwnership>
             {
                 new EventProcessorPartitionOwnership
@@ -288,18 +293,32 @@ namespace Azure.Messaging.EventHubs.Tests
                     OwnerIdentifier = OwnershipIdentifier,
                     PartitionId = PartitionId,
                     LastModifiedTime = DateTime.UtcNow,
-                    Version = MatchingEtag
+                    Version = "FAKE"
                 }
             };
 
-            var mockBlobContainerClient = new MockBlobContainerClient().AddBlobClient($"{FullyQualifiedNamespaceLowercase}/{EventHubNameLowercase}/{ConsumerGroupLowercase}/ownership/1", _ => { });
+            var mockBlobContainerClient = new MockBlobContainerClient().AddBlobClient(ownershipBlobName, client =>
+            {
+                client.SetMetadataException = setMetadataException;
+
+                client.SetMetadataAsyncCallback = (_, _, _) =>
+                {
+                    setMetadataCalled = true;
+                };
+
+                client.UploadAsyncCallback = (_, _, _, _, _, _, _, _) =>
+                {
+                    uploadBlobCalled = true;
+                };
+            });
+
             var target = new BlobCheckpointStoreInternal(mockBlobContainerClient);
 
-            var mockLog = new Mock<IBlobEventLogger>();
-            target.Logger = mockLog.Object;
+            var result = (await target.ClaimOwnershipAsync(partitionOwnership, CancellationToken.None)).ToList();
+            CollectionAssert.AreEquivalent(partitionOwnership, result);
 
-            Assert.That(async () => await target.ClaimOwnershipAsync(partitionOwnership, CancellationToken.None), Throws.InstanceOf<RequestFailedException>());
-            mockLog.Verify(m => m.ClaimOwnershipError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, OwnershipIdentifier, It.Is<string>(e => e.Contains(BlobErrorCode.BlobNotFound.ToString()))));
+            Assert.That(setMetadataCalled, "SetMetadata should have been called.");
+            Assert.That(uploadBlobCalled, "UploadBlob should have been called.");
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary

The focus of these changes is to adjust the approach used for claiming ownership such that the processor can recover gracefully when a blob was deleted while the processor is running.  Previously, this scenario would cause the processor to remain in a bad state where the partition was considered owned locally, but Storage did not reflect that, causing load balancing issues within the cluster.