### PR TITLE
Update Azure.Identity changelog entry for ESTS-R

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -112,6 +112,9 @@ Thank you to our developer community members who helped to make Azure Identity b
 
 ### New Features
 
+- Added regional STS support to client credential types
+  - Added `RegionalAuthority` extensible enum
+  - Added `RegionalAuthority` property to `ClientSecretCredentialOptions` and `ClientCertificateCredentialOptions`
 - Added support to `ManagedIdentityCredential` for Bridge to Kubernetes local development authentication.
 - TenantId values returned from service challenge responses can now be used to request tokens from the correct tenantId. To support this feature, there is a new `AllowMultiTenantAuthentication` option on `TokenCredentialOptions`.
   - By default, `AllowMultiTenantAuthentication` is false. When this option property is false and the tenant Id configured in the credential options differs from the tenant Id set in the `TokenRequestContext` sent to a credential, an `AuthorizationFailedException` will be thrown. This is potentially breaking change as it could be a different exception than what was thrown previously. This exception behavior can be overridden by either setting an `AppContext` switch named "Azure.Identity.EnableLegacyTenantSelection" to `true` or by setting the environment variable "AZURE_IDENTITY_ENABLE_LEGACY_TENANT_SELECTION" to "true". Note: AppContext switches can also be configured via configuration like below:
@@ -124,11 +127,6 @@ Thank you to our developer community members who helped to make Azure Identity b
   ```
   
 ## 1.5.0-beta.1 (2021-06-08)
-
-### New Features
-- Added regional STS support to client credential types
-  - Added `RegionalAuthority` extensible enum
-  - Added `RegionalAuthority` property to `ClientSecretCredentialOptions` and `ClientCertificateCredentialOptions`
 
 ### Fixes and improvements
 


### PR DESCRIPTION
Moving the ESTS-R line items to the correct release section. The following features were introduced in the 1.5.0-beta.2 release of Azure.Identity:

- `RegionalAuthority` enum
- `ClientCertificateCredentialOptions.RegionalAuthority` property
- `ClientSecretCredentialOptions.RegionalAuthority` property

As seen in dotPeek, 1.5.0-beta.1 lacks this support:

![image](https://user-images.githubusercontent.com/10702007/171709086-f7841106-a22e-44fe-b07c-29766e533b5e.png)
