### PR TITLE
[FormRecognizer] 2022-06-30-preview: updated docs and samples to reflect new features

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/MigrationGuide.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/MigrationGuide.md
@@ -1,6 +1,6 @@
 # Guide for migrating Azure.AI.FormRecognizer to version 4.0.x from versions 3.1.x and below
 
-This guide is intended to assist in the migration to `Azure.AI.FormRecognizer (4.0.x)` from versions `3.1.x` and below. It will focus on side-by-side comparisons for similar operations between versions. Please note that version `4.0.0-beta.3` will be used for comparison with `3.1.1`.
+This guide is intended to assist in the migration to `Azure.AI.FormRecognizer (4.0.x)` from versions `3.1.x` and below. It will focus on side-by-side comparisons for similar operations between versions. Please note that version `4.0.0-beta.4` will be used for comparison with `3.1.1`.
 
 Familiarity with `Azure.AI.FormRecognizer (3.1.x and below)` package is assumed. For those new to the Azure Form Recognizer client library for .NET please refer to the [README][readme] rather than this guide.
 
@@ -19,7 +19,7 @@ Familiarity with `Azure.AI.FormRecognizer (3.1.x and below)` package is assumed.
 
 A natural question to ask when considering whether to adopt a new version of the library is what the benefits of doing so would be. As Azure Form Recognizer has matured and been embraced by a more diverse group of developers, we have been focused on learning the patterns and practices to best support developer productivity and add value to our customers.
 
-There are many benefits to using the new design of the `Azure.AI.FormRecognizer (4.0.x)` library. This new version of the library introduces two new clients `DocumentAnalysisClient` and the `DocumentModelAdministrationClient` with unified methods for analyzing documents and provides support for the new features added by the service in API version `2022-01-30-preview` and later.
+There are many benefits to using the new design of the `Azure.AI.FormRecognizer (4.0.x)` library. This new version of the library introduces two new clients `DocumentAnalysisClient` and the `DocumentModelAdministrationClient` with unified methods for analyzing documents and provides support for the new features added by the service in API version `2022-06-30-preview` and later.
 
 New features provided by the `DocumentAnalysisClient` include:
 - One consolidated method for analyzing document layout, a general prebuilt document model type, along with the same prebuilt models that were included previously (receipts, invoices, business cards, ID documents), and custom models.
@@ -37,7 +37,7 @@ The table below describes the relationship of each client and its supported API 
 
 |API version|Supported clients
 |-|-
-|2022-01-30-preview | DocumentAnalysisClient and DocumentModelAdministrationClient
+|2022-06-30-preview | DocumentAnalysisClient and DocumentModelAdministrationClient
 |2.1 | FormRecognizerClient and FormTrainingClient
 |2.0 | FormRecognizerClient and FormTrainingClient
 
@@ -58,7 +58,7 @@ and is not limited to documents that are "forms". As a result, we've made the fo
 
 We continue to support API key and AAD authentication methods when creating the clients. Below are the differences between the two versions:
 
-- In `4.0.x`, we have added `DocumentAnalysisClient` and `DocumentModelAdministrationClient` which support API version `2022-01-30-preview` and later.
+- In `4.0.x`, we have added `DocumentAnalysisClient` and `DocumentModelAdministrationClient` which support API version `2022-06-30-preview` and later.
 - `FormRecognizerClient` and `FormTrainingClient` will continue to work targetting API version `2.1` and `2.0`. 
 - In `DocumentAnalysisClient` all prebuilt model methods along with custom model, layout, and a prebuilt general document analysis model are unified into two methods called
 `StartAnalyzeDocument` and `StartAnalyzeDocumentFromUri`.
@@ -91,7 +91,7 @@ Differences between the versions:
 - Along with more consolidated analysis methods in the `DocumentAnalysisClient`, the return types have also been improved and remove the hierarchical dependencies between elements. An instance of the `AnalyzeResult` model is now returned which showcases important document elements, such as key-value pairs, entities, tables, and document fields and values, among others, at the top level of the returned model. This can be contrasted with `RecognizedForm` which included more hierarchical relationships, for instance tables were an element of a `FormPage` and not a top-level element.
 - In the new version of the library, the functionality of `StartRecognizeContent` has been added as a prebuilt model and can be called in library version `Azure.AI.FormRecognizer (4.0.x)` with `StartAnalyzeDocument` by passing in the `prebuilt-layout` model ID. Similarly, to get general document information, such as key-value pairs, entities, and text layout, the `prebuilt-document` model ID can be used with `StartAnalyzeDocument`.
 - When calling `StartAnalyzeDocument` and `StartAnalyzeDocumentFromUri` the returned type is an `AnalyzeResult` object, while the various methods used with `FormRecognizerClient` return a list of `RecognizedForm`.
-- The optional `IncludeFieldElements` parameter is not supported with the `DocumentAnalysisClient`. Text details are automatically included with API version `2022-01-30-preview` and later.
+- The optional `IncludeFieldElements` parameter is not supported with the `DocumentAnalysisClient`. Text details are automatically included with API version `2022-06-30-preview` and later.
 - The optional `ReadingOrder` parameter does not exist on `StartAnalyzeDocument` and `StartAnalyzeDocumentFromUri`. The service uses `natural` reading order to return data.
 
 Analyzing prebuilt models like business cards, identity documents, invoices, and receipts with `3.1.x`:
@@ -424,6 +424,18 @@ foreach (DocumentPage page in result.Pages)
     }
 }
 
+Console.WriteLine("Paragraphs:");
+
+foreach (DocumentParagraph paragraph in result.Paragraphs)
+{
+    Console.WriteLine($"  Paragraph content: {paragraph.Content}");
+
+    if (paragraph.Role != null)
+    {
+        Console.WriteLine($"    Role: {paragraph.Role}");
+    }
+}
+
 foreach (DocumentStyle style in result.Styles)
 {
     // Check the style and style confidence to see if text is handwritten.
@@ -641,7 +653,7 @@ foreach (KeyValuePair<string, DocTypeInfo> docType in model.DocTypes)
 Differences between the versions:
 - Analyzing a custom model with `DocumentAnalysisClient` uses the general `StartAnalyzeDocument` and `StartAnalyzeDocumentFromUri` methods.
 - In order to analyze a custom model with `FormRecognizerClient` the `StartRecognizeCustomModels` and its corresponding Uri methods are used.
-- The `IncludeFieldElements` keyword argument is not supported with the `DocumentAnalysisClient`, text details are automatically included with API version `2022-01-30-preview` and later.
+- The `IncludeFieldElements` keyword argument is not supported with the `DocumentAnalysisClient`, text details are automatically included with API version `2022-06-30-preview` and later.
 
 Analyze a document using a custom model with `3.1.x`:
 ```C# Snippet:FormRecognizerSampleRecognizeCustomFormsFromUri
@@ -734,7 +746,7 @@ foreach (AnalyzedDocument document in result.Documents)
 ### Managing models
 
 Differences between the versions:
-- When using API version `2022-01-30-preview` and later models no longer include submodels, instead a model can analyze different document types.
+- When using API version `2022-06-30-preview` and later models no longer include submodels, instead a model can analyze different document types.
 - When building, composing, or copying models users can now assign their own model IDs and specify a description.
 - In version `4.0.x` of the library, only models that build successfully can be retrieved from the get and list model calls. Unsuccessful model operations can be viewed with the `GetOperation()` and `GetOperations()` methods (note that document model operation data persists for only 24 hours). In version `3.1.x` of the library, models that had not succeeded were still created, had to be deleted by the user, and were returned in the `GetCustomModels()` response.
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -5,7 +5,7 @@ Azure Cognitive Services Form Recognizer is a cloud service that uses machine le
 - Layout - Extract text, selection marks, table structures, styles, and paragraphs, along with their bounding region coordinates from documents.
 - Document - Analyze key-value pairs in addition to general layout from documents.
 - Read - Read information about textual elements, such as page words and lines in addition to text language information.
-- Prebuilt - Analyze data from certain types of common documents using prebuilt models. Supported documents include receipts, invoices, business cards, identity documents, vaccination cards, US W2 tax forms, and US health insurance cards.
+- Prebuilt - Analyze data from certain types of common documents using prebuilt models. Supported documents include receipts, invoices, business cards, identity documents, US W2 tax forms, and more.
 - Custom - Build custom models to analyze text, field values, selection marks, table structures, styles, and paragraphs from documents. Custom models are built with your own data, so they're tailored to your documents.
 
 [Source code][formreco_client_src] | [Package (NuGet)][formreco_nuget_package] | [API reference documentation][formreco_refdocs] | [Product documentation][formreco_docs] | [Samples][formreco_samples]
@@ -137,20 +137,6 @@ var client = new DocumentAnalysisClient(new Uri(endpoint), new DefaultAzureCrede
 ### DocumentAnalysisClient
 
 `DocumentAnalysisClient` provides operations for analyzing input documents using prebuilt and custom models through the `StartAnalyzeDocument` and `StartAnalyzeDocumentFromUri` APIs. Use the `modelId` parameter to select the type of model for analysis.
-
-|Model ID|Features
-|-|-
-|`prebuilt-layout`| Text extraction, selection marks, tables, styles, and paragraphs
-|`prebuilt-document`| Text extraction, selection marks, tables, styles, paragraphs, and key-value pairs
-|`prebuilt-read`| Text extraction, styles, paragraphs, and text languages
-|`prebuilt-invoices`| Text extraction, selection marks, tables, styles, paragraphs, key-value pairs, and pre-trained fields and values pertaining to invoices
-|`prebuilt-businessCard`| Text extraction, styles, paragraphs, and pre-trained fields and values pertaining to business cards
-|`prebuilt-healthInsuranceCard.us`| Text extraction, selection marks, styles, paragraphs, and pre-trained fields and values pertaining to US health insurance cards
-|`prebuilt-idDocument`| Text extraction, styles, paragraphs, and pre-trained fields and values pertaining to driver licenses and international passports
-|`prebuilt-receipt`| Text extraction, styles, paragraphs, and pre-trained fields and values pertaining to sales receipts
-|`prebuilt-tax.us.w2`| Text extraction, selection marks, styles, paragraphs, and pre-trained fields and values pertaining to US W2 tax forms
-|`prebuilt-vaccinationCard`| Text extraction, selection marks, styles, paragraphs, and pre-trained fields and values pertaining to vaccination cards
-|`{custom-model-id}`| Text extraction, selection marks, tables, styles, paragraphs, and labeled fields and values from your custom documents
 
 Sample code snippets are provided to illustrate using a DocumentAnalysisClient [here](#examples).
 More information about analyzing documents, including supported features, locales, and document types can be found in the [service documentation][formreco_models].
@@ -555,16 +541,9 @@ for (int i = 0; i < result.Documents.Count; i++)
 }
 ```
 
-You are not limited to invoices! There are a couple of prebuilt models to choose from, each of which has its own set of supported fields:
-- Analyze business cards using the `prebuilt-businessCard` model. [Supported fields][businessCard_fields].
-- Analyze driver licenses and international passports using the `prebuilt-idDocument` model. [Supported fields][idDocument_fields].
-- Analyze US health insurance cards using the `prebuilt-healthInsuranceCard.us` model.
-- Analyze invoices using the `prebuilt-invoice` model. [Supported fields][invoice_fields].
-- Analyze receipts using the `prebuilt-receipt` model. [Supported fields][receipt_fields].
-- Analyze US W2 tax forms using the `prebuilt-tax.us.w2` model. [Supported fields][w2_fields].
-- Analyze vaccination cards using the `prebuilt-vaccinationCard` model.
+You are not limited to invoices! There are a couple of prebuilt models to choose from, each of which has its own set of supported fields. More information about the supported document types can be found in the [service documentation][formreco_models].
 
-For more samples and information about which types of documents are supported, see [here][analyze_prebuilt].
+For more information and samples, see [here][analyze_prebuilt].
 
 ### Build a Custom Model
 Build a custom model on your own document type. The resulting model can be used to analyze values from the types of documents it was built on.
@@ -843,11 +822,6 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 
 
 [labeling_tool]: https://aka.ms/azsdk/formrecognizer/labelingtool
-[businessCard_fields]: https://aka.ms/azsdk/formrecognizer/businesscardfieldschema
-[idDocument_fields]: https://aka.ms/azsdk/formrecognizer/iddocumentfieldschema
-[invoice_fields]: https://aka.ms/azsdk/formrecognizer/invoicefieldschema
-[receipt_fields]: https://aka.ms/azsdk/formrecognizer/receiptfieldschema
-[w2_fields]: https://aka.ms/azsdk/formrecognizer/taxusw2fieldschema
 [dotnet_lro_guidelines]: https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning
 
 [logging]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/core/Azure.Core/samples/Diagnostics.md

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -2,11 +2,11 @@
 
 Azure Cognitive Services Form Recognizer is a cloud service that uses machine learning to analyze text and structured data from your documents. It includes the following main features:
 
-- Layout - Extract text, selection marks, and table structures, along with their bounding region coordinates, from documents.
-- Document - Analyze key-value pairs and entities in addition to general layout from documents.
+- Layout - Extract text, selection marks, table structures, styles, and paragraphs, along with their bounding region coordinates from documents.
+- Document - Analyze key-value pairs in addition to general layout from documents.
 - Read - Read information about textual elements, such as page words and lines in addition to text language information.
-- Prebuilt - Analyze data from certain types of common documents (such as receipts, invoices, business cards, identity documents, or US W2 tax forms) using prebuilt models.
-- Custom - Build custom models to analyze text, field values, selection marks, and tabular data from documents. Custom models are trained with your own data, so they're tailored to your documents.
+- Prebuilt - Analyze data from certain types of common documents using prebuilt models. Supported documents include receipts, invoices, business cards, identity documents, vaccination cards, US W2 tax forms, and US health insurance cards.
+- Custom - Build custom models to analyze text, field values, selection marks, table structures, styles, and paragraphs from documents. Custom models are built with your own data, so they're tailored to your documents.
 
 [Source code][formreco_client_src] | [Package (NuGet)][formreco_nuget_package] | [API reference documentation][formreco_refdocs] | [Product documentation][formreco_docs] | [Samples][formreco_samples]
 
@@ -19,13 +19,13 @@ Install the Azure Form Recognizer client library for .NET with [NuGet][nuget]:
 dotnet add package Azure.AI.FormRecognizer
 ``` 
 
-> Note: This version of the client library defaults to the `2022-01-30-preview` version of the service.
+> Note: This version of the client library defaults to the `2022-06-30-preview` version of the service.
 
 This table shows the relationship between SDK versions and supported API versions of the service:
 
 |SDK version|Supported API version of service
 |-|-
-|4.0.0-beta.3 | 2.0, 2.1, 2022-01-30-preview
+|4.0.0-beta.4 | 2.0, 2.1, 2022-06-30-preview
 |3.1.X        | 2.0, 2.1
 |3.0.X        | 2.0
 
@@ -33,7 +33,7 @@ This table shows the relationship between SDK versions and supported API version
 
 |API version|Supported clients
 |-|-
-|2022-01-30-preview|DocumentAnalysisClient and DocumentModelAdministrationClient
+|2022-06-30-preview|DocumentAnalysisClient and DocumentModelAdministrationClient
 |2.1|FormRecognizerClient and FormTrainingClient
 |2.0|FormRecognizerClient and FormTrainingClient
 
@@ -140,15 +140,17 @@ var client = new DocumentAnalysisClient(new Uri(endpoint), new DefaultAzureCrede
 
 |Model ID|Features
 |-|-
-|`prebuilt-layout`| Text extraction, selection marks, tables
-|`prebuilt-document`| Text extraction, selection marks, tables, key-value pairs and entities
-|`prebuilt-read`| Text extraction, text languages and styles
-|`prebuilt-invoices`| Text extraction, selection marks, tables, and pre-trained fields and values pertaining to invoices
-|`prebuilt-businessCard`| Text extraction and pre-trained fields and values pertaining to business cards
-|`prebuilt-idDocument`| Text extraction and pre-trained fields and values pertaining to driver licenses and international passports
-|`prebuilt-receipt`| Text extraction and pre-trained fields and values pertaining to sales receipts
-|`prebuilt-tax.us.w2`| Text extraction and pre-trained fields and values pertaining to US W2 tax forms
-|`{custom-model-id}`| Text extraction, selection marks, tables, labeled fields and values from your custom documents
+|`prebuilt-layout`| Text extraction, selection marks, tables, styles, and paragraphs
+|`prebuilt-document`| Text extraction, selection marks, tables, styles, paragraphs, and key-value pairs
+|`prebuilt-read`| Text extraction, styles, paragraphs, and text languages
+|`prebuilt-invoices`| Text extraction, selection marks, tables, styles, paragraphs, key-value pairs, and pre-trained fields and values pertaining to invoices
+|`prebuilt-businessCard`| Text extraction, styles, paragraphs, and pre-trained fields and values pertaining to business cards
+|`prebuilt-healthInsuranceCard.us`| Text extraction, selection marks, styles, paragraphs, and pre-trained fields and values pertaining to US health insurance cards
+|`prebuilt-idDocument`| Text extraction, styles, paragraphs, and pre-trained fields and values pertaining to driver licenses and international passports
+|`prebuilt-receipt`| Text extraction, styles, paragraphs, and pre-trained fields and values pertaining to sales receipts
+|`prebuilt-tax.us.w2`| Text extraction, selection marks, styles, paragraphs, and pre-trained fields and values pertaining to US W2 tax forms
+|`prebuilt-vaccinationCard`| Text extraction, selection marks, styles, paragraphs, and pre-trained fields and values pertaining to vaccination cards
+|`{custom-model-id}`| Text extraction, selection marks, tables, styles, paragraphs, and labeled fields and values from your custom documents
 
 Sample code snippets are provided to illustrate using a DocumentAnalysisClient [here](#examples).
 More information about analyzing documents, including supported features, locales, and document types can be found in the [service documentation][formreco_models].
@@ -157,8 +159,7 @@ More information about analyzing documents, including supported features, locale
 
 `DocumentModelAdministrationClient` provides operations for:
 
-- Building custom models to analyze specific fields you specify by labeling your custom documents. A `DocumentModel` is returned indicating the document type(s) the model can analyze, the fields it can analyze for each document type,
-as well as the estimated confidence for each field. See the [service documentation][formreco_build_model] for a more detailed explanation.
+- Building custom models to analyze specific fields you specify by labeling your custom documents. A `DocumentModel` is returned indicating the document type(s) the model can analyze, the fields it can analyze for each document type, as well as the estimated confidence for each field. See the [service documentation][formreco_build_model] for a more detailed explanation.
 - Creating a composed model from a collection of existing models.
 - Managing models created in your account.
 - Listing document model operations or getting a specific model operation created within the last 24 hours.
@@ -205,7 +206,7 @@ The following section provides several code snippets illustrating common pattern
 > Note that these samples use SDK `V4.0.0-beta.X`. For lower versions of the SDK, please see [Form Recognizer Samples for V3.1.X][formrecov3_samples].
 
 ### Extract Layout
-Extract text, selection marks, text styles, and table structures, along with their bounding region coordinates from documents.
+Extract text, selection marks, table structures, styles, and paragraphs, along with their bounding region coordinates from documents.
 
 ```C# Snippet:FormRecognizerExtractLayoutFromUriAsync
 Uri fileUri = new Uri("<fileUri>");
@@ -248,6 +249,18 @@ foreach (DocumentPage page in result.Pages)
     }
 }
 
+Console.WriteLine("Paragraphs:");
+
+foreach (DocumentParagraph paragraph in result.Paragraphs)
+{
+    Console.WriteLine($"  Paragraph content: {paragraph.Content}");
+
+    if (paragraph.Role != null)
+    {
+        Console.WriteLine($"    Role: {paragraph.Role}");
+    }
+}
+
 foreach (DocumentStyle style in result.Styles)
 {
     // Check the style and style confidence to see if text is handwritten.
@@ -283,7 +296,7 @@ for (int i = 0; i < result.Tables.Count; i++)
 For more information and samples see [here][extract_layout].
 
 ### Use the General Prebuilt Document Model
-Analyze key-value pairs, entities, tables, and selection marks from documents using the general prebuilt document model.
+Analyze text, selection marks, table structures, styles, paragraphs, and key-value pairs from documents using the general prebuilt document model.
 
 ```C# Snippet:FormRecognizerAnalyzePrebuiltDocumentFromUriAsync
 Uri fileUri = new Uri("<fileUri>");
@@ -375,7 +388,7 @@ for (int i = 0; i < result.Tables.Count; i++)
 For more information and samples see [here][analyze_prebuilt_document].
 
 ### Use the Prebuilt Read Model
-Analyze textual elements, such as page words and lines, styles, and text language information from documents using the prebuilt read model.
+Analyze textual elements, such as page words and lines, styles, paragraphs, and text language information from documents using the prebuilt read model.
 
 ```C# Snippet:FormRecognizerAnalyzePrebuiltReadFromUriAsync
 Uri fileUri = new Uri("<fileUri>");
@@ -434,7 +447,7 @@ foreach (DocumentStyle style in result.Styles)
 For more information and samples see [here][analyze_prebuilt_read].
 
 ### Use Prebuilt Models
-Analyze data from certain types of common documents using pre-trained models provided by the Form Recognizer service.
+Analyze data from certain types of common documents using prebuilt models provided by the Form Recognizer service.
 
 For example, to analyze fields from an invoice, use the prebuilt Invoice model provided by passing the `prebuilt-invoice` model ID into the `StartAnalyzeDocumentAsync` method:
 
@@ -542,12 +555,14 @@ for (int i = 0; i < result.Documents.Count; i++)
 }
 ```
 
-You are not limited to invoices! There are a few prebuilt models to choose from, each of which has its own set of supported fields:
+You are not limited to invoices! There are a couple of prebuilt models to choose from, each of which has its own set of supported fields:
 - Analyze business cards using the `prebuilt-businessCard` model. [Supported fields][businessCard_fields].
 - Analyze driver licenses and international passports using the `prebuilt-idDocument` model. [Supported fields][idDocument_fields].
+- Analyze US health insurance cards using the `prebuilt-healthInsuranceCard.us` model.
 - Analyze invoices using the `prebuilt-invoice` model. [Supported fields][invoice_fields].
 - Analyze receipts using the `prebuilt-receipt` model. [Supported fields][receipt_fields].
 - Analyze US W2 tax forms using the `prebuilt-tax.us.w2` model. [Supported fields][w2_fields].
+- Analyze vaccination cards using the `prebuilt-vaccinationCard` model.
 
 For more samples and information about which types of documents are supported, see [here][analyze_prebuilt].
 
@@ -592,7 +607,7 @@ foreach (KeyValuePair<string, DocTypeInfo> docType in model.DocTypes)
 For more information and samples see [here][build_a_custom_model].
 
 ### Analyze Custom Documents
-Analyze text, field values, selection marks, and table data from custom documents, using models you built with your own document types.
+Analyze text, field values, selection marks, and table structures, styles, and paragraphs from custom documents, using models you built with your own document types.
 
 ```C# Snippet:FormRecognizerAnalyzeWithCustomModelFromUriAsync
 string modelId = "<modelId>";

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/README.md
@@ -15,11 +15,11 @@ description: Samples for the Azure.AI.FormRecognizer client library
 
 Azure Cognitive Services Form Recognizer is a cloud service that uses machine learning to analyze text and structured data from your documents. It includes the following main features:
 
-- Layout - Extract text, selection marks, and table structures, along with their bounding region coordinates, from documents.
-- Document - Analyze key-value pairs and entities in addition to general layout from documents.
+- Layout - Extract text, selection marks, table structures, styles, and paragraphs, along with their bounding region coordinates from documents.
+- Document - Analyze key-value pairs in addition to general layout from documents.
 - Read - Read information about textual elements, such as page words and lines in addition to text language information.
-- Prebuilt - Analyze data from certain types of common documents (such as receipts, invoices, business cards, identity documents, or US W2 tax forms) using prebuilt models.
-- Custom - Build custom models to analyze text, field values, selection marks, and tabular data from documents. Custom models are trained with your own data, so they're tailored to your documents.
+- Prebuilt - Analyze data from certain types of common documents using prebuilt models. Supported documents include receipts, invoices, business cards, identity documents, vaccination cards, US W2 tax forms, and US health insurance cards.
+- Custom - Build custom models to analyze text, field values, selection marks, table structures, styles, and paragraphs from documents. Custom models are built with your own data, so they're tailored to your documents.
 
 ## Common scenarios samples for client library version 4.0.0-beta.x
 - [Extract the layout of a document](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ExtractLayout.md)

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithPrebuiltModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithPrebuiltModel.md
@@ -1,6 +1,6 @@
 # Analyze a document with a prebuilt model
 
-This sample demonstrates how to analyze data from certain types of common documents with pre-trained models, using an invoice as an example. For a list of the types of documents supported by the Form Recognize service's prebuilt models, please check the [Choosing the prebuilt model ID][choosing-the-prebuilt-model-id] section.
+This sample demonstrates how to analyze data from certain types of common documents with prebuilt models, using an invoice as an example. For a list of the types of documents supported by the Form Recognize service's prebuilt models, please check the [Choosing the prebuilt model ID][choosing-the-prebuilt-model-id] section.
 
 To get started you'll need a Cognitive Services resource or a Form Recognizer resource.  See [README][README] for prerequisites and instructions.
 
@@ -22,10 +22,12 @@ var client = new DocumentAnalysisClient(new Uri(endpoint), credential);
 The model to use for the analyze operation depends on the type of document to be analyzed. These are the IDs of the prebuilt models currently supported by the Form Recognizer service:
 
 - prebuilt-businessCard: extracts text and key information from business cards. [Supported fields][businessCard_fields].
+- prebuilt-healthInsuranceCard.us: extracts text, selection marks, and key information from US health insurance cards.
 - prebuilt-idDocument: extracts text and key information from driver licenses and international passports. [Supported fields][idDocument_fields].
 - prebuilt-invoice: extracts text, selection marks, tables, key-value pairs, and key information from invoices. [Supported fields][invoice_fields].
 - prebuilt-receipt: extracts text and key information from receipts. [Supported fields][receipt_fields].
-- prebuilt-tax.us.w2: extracts text and key information from US W2 tax forms. [Supported fields][w2_fields].
+- prebuilt-tax.us.w2: extracts text, selection marks, and key information from US W2 tax forms. [Supported fields][w2_fields].
+- prebuilt-vaccinationCard: extracts text, selection marks, and key information from vaccination cards.
 
 For more information about prebuilt models and which types of documents are supported, see the [service documentation][formreco_models].
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithPrebuiltModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithPrebuiltModel.md
@@ -1,6 +1,6 @@
 # Analyze a document with a prebuilt model
 
-This sample demonstrates how to analyze data from certain types of common documents with prebuilt models, using an invoice as an example. For a list of the types of documents supported by the Form Recognize service's prebuilt models, please check the [Choosing the prebuilt model ID][choosing-the-prebuilt-model-id] section.
+This sample demonstrates how to analyze data from certain types of common documents with prebuilt models, using an invoice as an example. For more information about prebuilt models and which types of documents are supported, see the [service documentation][formreco_models].
 
 To get started you'll need a Cognitive Services resource or a Form Recognizer resource.  See [README][README] for prerequisites and instructions.
 
@@ -17,25 +17,11 @@ var credential = new AzureKeyCredential(apiKey);
 var client = new DocumentAnalysisClient(new Uri(endpoint), credential);
 ```
 
-## Choosing the prebuilt model ID
-
-The model to use for the analyze operation depends on the type of document to be analyzed. These are the IDs of the prebuilt models currently supported by the Form Recognizer service:
-
-- prebuilt-businessCard: extracts text and key information from business cards. [Supported fields][businessCard_fields].
-- prebuilt-healthInsuranceCard.us: extracts text, selection marks, and key information from US health insurance cards.
-- prebuilt-idDocument: extracts text and key information from driver licenses and international passports. [Supported fields][idDocument_fields].
-- prebuilt-invoice: extracts text, selection marks, tables, key-value pairs, and key information from invoices. [Supported fields][invoice_fields].
-- prebuilt-receipt: extracts text and key information from receipts. [Supported fields][receipt_fields].
-- prebuilt-tax.us.w2: extracts text, selection marks, and key information from US W2 tax forms. [Supported fields][w2_fields].
-- prebuilt-vaccinationCard: extracts text, selection marks, and key information from vaccination cards.
-
-For more information about prebuilt models and which types of documents are supported, see the [service documentation][formreco_models].
-
 ## Use a prebuilt model to analyze a document from a URI
 
 To analyze a given file at a URI, use the `StartAnalyzeDocumentFromUri` method. The returned value is an `AnalyzeResult` object containing data about the submitted document. Since we're analyzing an invoice, we'll pass the model ID `prebuilt-invoice` to the method.
 
-For simplicity, we are not showing all the fields that the service returns. To see the list of all the supported fields returned by service and its corresponding types, consult the [Choosing the prebuilt model ID][choosing-the-prebuilt-model-id] section.
+For simplicity, we are not showing all the fields that the service returns. To see the list of all the supported fields returned by service and its corresponding types, consult the [invoice model documentation][invoice_fields].
 
 ```C# Snippet:FormRecognizerAnalyzeWithPrebuiltModelFromUriAsync
 Uri fileUri = new Uri("<fileUri>");
@@ -143,7 +129,7 @@ for (int i = 0; i < result.Documents.Count; i++)
 
 To analyze a given file at a file stream, use the `StartAnalyzeDocument` method. The returned value is an `AnalyzeResult` object containing data about the submitted document. Since we're analyzing an invoice, we'll pass the model ID `prebuilt-invoice` to the method.
 
-For simplicity, we are not showing all the fields that the service returns. To see the list of all the supported fields returned by service and its corresponding types, consult the [Choosing the prebuilt model ID][choosing-the-prebuilt-model-id] section.
+For simplicity, we are not showing all the fields that the service returns. To see the list of all the supported fields returned by service and its corresponding types, consult the [invoice model documentation][invoice_fields].
 
 ```C# Snippet:FormRecognizerAnalyzeWithPrebuiltModelFromFileAsync
 string filePath = "<filePath>";
@@ -254,12 +240,7 @@ To see the full example source files, see:
 * [Analyze with prebuilt model from URI](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromUriAsync.cs)
 * [Analyze with prebuilt model from file](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromFileAsync.cs)
 
-[businessCard_fields]: https://aka.ms/azsdk/formrecognizer/businesscardfieldschema
-[idDocument_fields]: https://aka.ms/azsdk/formrecognizer/iddocumentfieldschema
 [invoice_fields]: https://aka.ms/azsdk/formrecognizer/invoicefieldschema
-[receipt_fields]: https://aka.ms/azsdk/formrecognizer/receiptfieldschema
-[w2_fields]: https://aka.ms/azsdk/formrecognizer/taxusw2fieldschema
-
 [formreco_models]: https://aka.ms/azsdk/formrecognizer/models
 
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ExtractLayout.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ExtractLayout.md
@@ -1,6 +1,6 @@
 # Extract the layout of a document
 
-This sample demonstrates how to extract text, table structures, and selection marks, along with their bounding region coordinates from documents. If you want to analyze entities and key-value pairs in addition to this data, please see the [Analyze a general document][document_sample] sample. 
+This sample demonstrates how to extract text, paragraphs, styles, table structures, and selection marks, along with their bounding region coordinates from documents. If you want to analyze entities and key-value pairs in addition to this data, please see the [Analyze a general document][document_sample] sample.
 
 To get started you'll need a Cognitive Services resource or a Form Recognizer resource.  See [README][README] for prerequisites and instructions.
 
@@ -59,6 +59,18 @@ foreach (DocumentPage page in result.Pages)
         {
             Console.WriteLine($"      Point {j} => X: {selectionMark.BoundingPolygon[j].X}, Y: {selectionMark.BoundingPolygon[j].Y}");
         }
+    }
+}
+
+Console.WriteLine("Paragraphs:");
+
+foreach (DocumentParagraph paragraph in result.Paragraphs)
+{
+    Console.WriteLine($"  Paragraph content: {paragraph.Content}");
+
+    if (paragraph.Role != null)
+    {
+        Console.WriteLine($"    Role: {paragraph.Role}");
     }
 }
 
@@ -137,6 +149,18 @@ foreach (DocumentPage page in result.Pages)
         {
             Console.WriteLine($"      Point {j} => X: {selectionMark.BoundingPolygon[j].X}, Y: {selectionMark.BoundingPolygon[j].Y}");
         }
+    }
+}
+
+Console.WriteLine("Paragraphs:");
+
+foreach (DocumentParagraph paragraph in result.Paragraphs)
+{
+    Console.WriteLine($"  Paragraph content: {paragraph.Content}");
+
+    if (paragraph.Role != null)
+    {
+        Console.WriteLine($"    Role: {paragraph.Role}");
     }
 }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ExtractLayoutFromFileAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ExtractLayoutFromFileAsync.cs
@@ -66,6 +66,18 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
                 }
             }
 
+            Console.WriteLine("Paragraphs:");
+
+            foreach (DocumentParagraph paragraph in result.Paragraphs)
+            {
+                Console.WriteLine($"  Paragraph content: {paragraph.Content}");
+
+                if (paragraph.Role != null)
+                {
+                    Console.WriteLine($"    Role: {paragraph.Role}");
+                }
+            }
+
             foreach (DocumentStyle style in result.Styles)
             {
                 // Check the style and style confidence to see if text is handwritten.

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ExtractLayoutFromUriAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ExtractLayoutFromUriAsync.cs
@@ -64,6 +64,18 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
                 }
             }
 
+            Console.WriteLine("Paragraphs:");
+
+            foreach (DocumentParagraph paragraph in result.Paragraphs)
+            {
+                Console.WriteLine($"  Paragraph content: {paragraph.Content}");
+
+                if (paragraph.Role != null)
+                {
+                    Console.WriteLine($"    Role: {paragraph.Role}");
+                }
+            }
+
             foreach (DocumentStyle style in result.Styles)
             {
                 // Check the style and style confidence to see if text is handwritten.


### PR DESCRIPTION
This PR:
- Updates docs to reflect the new 2022-06-30-preview version.
- Added usage of `DocumentParagraph` to the prebuilt-layout sample. Didn't added it to other models' samples since I believe they have other specific features that are more important to showcase.

Other features such as footnotes/caption, page kind, and address fields are too specific and not worth showcasing.