### PR TITLE
Tweak IsClosed behavior for Session receiver

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -475,6 +475,7 @@ namespace Azure.Messaging.ServiceBus
     public partial class ServiceBusSessionReceiver : Azure.Messaging.ServiceBus.ServiceBusReceiver
     {
         protected ServiceBusSessionReceiver() { }
+        public override bool IsClosed { get { throw null; } }
         public virtual string SessionId { get { throw null; } }
         public virtual System.DateTimeOffset SessionLockedUntil { get { throw null; } }
         public virtual System.Threading.Tasks.Task<System.BinaryData> GetSessionStateAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -40,9 +40,9 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <value>
         /// <c>true</c> if the receiver is closed; otherwise, <c>false</c>.
         /// </value>
-        public override bool IsReceiverClosedByUser => _receiverClosedByUserByUser;
+        public override bool WasClosedExplicitly => _receiverClosedExplicitlyExplicitly;
 
-        private volatile bool _receiverClosedByUserByUser;
+        private volatile bool _receiverClosedExplicitlyExplicitly;
 
         /// <summary>
         /// Indicates whether or not the session link has been closed.
@@ -1297,12 +1297,12 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         public override async Task CloseAsync(CancellationToken cancellationToken)
         {
-            if (_receiverClosedByUserByUser)
+            if (_receiverClosedExplicitlyExplicitly)
             {
                 return;
             }
 
-            _receiverClosedByUserByUser = true;
+            _receiverClosedExplicitlyExplicitly = true;
 
             await CloseCoreAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -1390,7 +1390,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         }
 
         private bool HasLinkCommunicationError(ReceivingAmqpLink link) =>
-            !_receiverClosedByUserByUser && (link?.IsClosing() ?? false);
+            !_receiverClosedExplicitlyExplicitly && (link?.IsClosing() ?? false);
 
         private void ThrowIfSessionLockLost()
         {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -53,9 +53,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <value>
         /// <c>true</c> if the receiver link was closed; otherwise, <c>false</c>.
         /// </value>
-        public override bool IsSessionLinkClosed => _sessionLinkClosed;
-
-        private volatile bool _sessionLinkClosed;
+        public override bool IsSessionLinkClosed => _isSessionReceiver && LinkException != null;
 
         /// <summary>
         /// The name of the Service Bus entity to which the receiver is bound.
@@ -1339,10 +1337,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 LinkException = exception;
             }
 
-            if (_isSessionReceiver)
-            {
-                _sessionLinkClosed = true;
-            }
             ServiceBusEventSource.Log.ReceiveLinkClosed(
                 _identifier,
                 SessionId,
@@ -1388,7 +1382,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
         private void ThrowIfSessionLockLost()
         {
-            if (_isSessionReceiver && LinkException != null)
+            if (IsSessionLinkClosed)
             {
                 throw LinkException;
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
@@ -24,7 +24,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// <c>true</c> if the consumer is closed; otherwise, <c>false</c>.
         /// </value>
         ///
-        public abstract bool IsReceiverClosed { get; }
+        public abstract bool IsReceiverClosedByUser { get; }
 
         /// <summary>
         /// Indicates whether the session link has been closed. This is useful for session receiver scenarios because once the link is closed for a

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
@@ -24,7 +24,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// <c>true</c> if the consumer is closed; otherwise, <c>false</c>.
         /// </value>
         ///
-        public abstract bool IsReceiverClosedByUser { get; }
+        public abstract bool WasClosedExplicitly { get; }
 
         /// <summary>
         /// Indicates whether the session link has been closed. This is useful for session receiver scenarios because once the link is closed for a

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
@@ -17,14 +17,20 @@ namespace Azure.Messaging.ServiceBus.Core
     internal abstract class TransportReceiver
     {
         /// <summary>
-        /// Indicates whether or not this receiver has been closed.
+        /// Indicates whether or not this receiver has been closed by the user.
         /// </summary>
         ///
         /// <value>
         /// <c>true</c> if the consumer is closed; otherwise, <c>false</c>.
         /// </value>
         ///
-        public abstract bool IsClosed { get; }
+        public abstract bool IsReceiverClosed { get; }
+
+        /// <summary>
+        /// Indicates whether the session link has been closed. This is useful for session receiver scenarios because once the link is closed for a
+        /// session receiver it will not be reopened.
+        /// </summary>
+        public abstract bool IsSessionLinkClosed { get; }
 
         /// <summary>
         ///

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -85,6 +85,11 @@ namespace Azure.Messaging.ServiceBus
         private volatile bool _closed;
 
         /// <summary>
+        /// Indicates whether or not the user has called CloseAsync or DisposeAsync on the receiver.
+        /// </summary>
+        internal bool IsDisposed => _closed;
+
+        /// <summary>
         /// The policy to use for determining retry behavior for when an operation fails.
         /// </summary>
         ///
@@ -221,7 +226,7 @@ namespace Azure.Messaging.ServiceBus
         /// request to cancel the operation.</param>
         public virtual async Task CloseAsync(CancellationToken cancellationToken = default)
         {
-            IsClosed = true;
+            _closed = true;
             Type clientType = GetType();
 
             Logger.ClientCloseStart(clientType, Identifier);
@@ -264,7 +269,7 @@ namespace Azure.Messaging.ServiceBus
             CancellationToken cancellationToken)
         {
             Argument.AssertAtLeast(maxMessages, 1, nameof(maxMessages));
-            Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
+            Argument.AssertNotDisposed(IsDisposed, nameof(ServiceBusReceiver));
             _connection.ThrowIfClosed();
 
             if (maxWaitTime.HasValue)
@@ -446,7 +451,7 @@ namespace Azure.Messaging.ServiceBus
             CancellationToken cancellationToken)
         {
             Argument.AssertAtLeast(maxMessages, 1, nameof(maxMessages));
-            Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
+            Argument.AssertNotDisposed(IsDisposed, nameof(ServiceBusReceiver));
             _connection.ThrowIfClosed();
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
@@ -538,7 +543,7 @@ namespace Azure.Messaging.ServiceBus
             Guid lockToken,
             CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
+            Argument.AssertNotDisposed(IsDisposed, nameof(ServiceBusReceiver));
             _connection.ThrowIfClosed();
             ThrowIfNotPeekLockMode();
             ThrowIfLockTokenIsEmpty(lockToken);
@@ -632,7 +637,7 @@ namespace Azure.Messaging.ServiceBus
             IDictionary<string, object> propertiesToModify = null,
             CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
+            Argument.AssertNotDisposed(IsDisposed, nameof(ServiceBusReceiver));
             _connection.ThrowIfClosed();
             ThrowIfNotPeekLockMode();
             ThrowIfLockTokenIsEmpty(lockToken);
@@ -830,7 +835,7 @@ namespace Azure.Messaging.ServiceBus
             IDictionary<string, object> propertiesToModify = default,
             CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
+            Argument.AssertNotDisposed(IsDisposed, nameof(ServiceBusReceiver));
             _connection.ThrowIfClosed();
             ThrowIfNotPeekLockMode();
             ThrowIfLockTokenIsEmpty(lockToken);
@@ -928,7 +933,7 @@ namespace Azure.Messaging.ServiceBus
             IDictionary<string, object> propertiesToModify = null,
             CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
+            Argument.AssertNotDisposed(IsDisposed, nameof(ServiceBusReceiver));
             _connection.ThrowIfClosed();
             ThrowIfNotPeekLockMode();
             ThrowIfLockTokenIsEmpty(lockToken);
@@ -1021,7 +1026,7 @@ namespace Azure.Messaging.ServiceBus
             CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(sequenceNumbers, nameof(sequenceNumbers));
-            Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
+            Argument.AssertNotDisposed(IsDisposed, nameof(ServiceBusReceiver));
             _connection.ThrowIfClosed();
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
@@ -1109,7 +1114,7 @@ namespace Azure.Messaging.ServiceBus
             Guid lockToken,
             CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
+            Argument.AssertNotDisposed(IsDisposed, nameof(ServiceBusReceiver));
             _connection.ThrowIfClosed();
             ThrowIfNotPeekLockMode();
             ThrowIfSessionReceiver();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
@@ -32,6 +32,19 @@ namespace Azure.Messaging.ServiceBus
         public virtual string SessionId => InnerReceiver.SessionId;
 
         /// <summary>
+        /// Indicates whether or not this <see cref="ServiceBusSessionReceiver"/> has been closed by the user, or whether the underlying
+        /// session link was closed due to either losing the session lock or having the link disconnected. If this is <c>true</c>, the
+        /// receiver cannot be used for any more operations. If this is <c>false</c>, it is still possible that the session lock has been lost
+        /// so it is important to still handle <see cref="ServiceBusException" /> with <see cref="ServiceBusException.Reason" /> equal to
+        /// <see cref="ServiceBusFailureReason.SessionLockLost"/>.
+        /// </summary>
+        ///
+        /// <value>
+        /// <c>true</c> if the session receiver was closed by the user or if the underlying link was closed; otherwise, <c>false</c>.
+        /// </value>
+        public override bool IsClosed => base.IsClosed || InnerReceiver.IsSessionLinkClosed;
+
+        /// <summary>
         /// Gets the <see cref="DateTimeOffset"/> that the receiver's session is locked until.
         /// </summary>
         public virtual DateTimeOffset SessionLockedUntil => InnerReceiver.SessionLockedUntil;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
@@ -45,11 +45,6 @@ namespace Azure.Messaging.ServiceBus
         public override bool IsClosed => IsDisposed || InnerReceiver.IsSessionLinkClosed;
 
         /// <summary>
-        /// Indicates whether or not the user has called CloseAsync or DisposeAsync on the receiver.
-        /// </summary>
-        internal bool IsDisposed => base.IsClosed;
-
-        /// <summary>
         /// Gets the <see cref="DateTimeOffset"/> that the receiver's session is locked until.
         /// </summary>
         public virtual DateTimeOffset SessionLockedUntil => InnerReceiver.SessionLockedUntil;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
@@ -42,7 +42,12 @@ namespace Azure.Messaging.ServiceBus
         /// <value>
         /// <c>true</c> if the session receiver was closed by the user or if the underlying link was closed; otherwise, <c>false</c>.
         /// </value>
-        public override bool IsClosed => base.IsClosed || InnerReceiver.IsSessionLinkClosed;
+        public override bool IsClosed => IsDisposed || InnerReceiver.IsSessionLinkClosed;
+
+        /// <summary>
+        /// Indicates whether or not the user has called CloseAsync or DisposeAsync on the receiver.
+        /// </summary>
+        internal bool IsDisposed => base.IsClosed;
 
         /// <summary>
         /// Gets the <see cref="DateTimeOffset"/> that the receiver's session is locked until.
@@ -140,7 +145,7 @@ namespace Azure.Messaging.ServiceBus
         /// </exception>
         public virtual async Task<BinaryData> GetSessionStateAsync(CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusSessionReceiver));
+            Argument.AssertNotDisposed(IsDisposed, nameof(ServiceBusSessionReceiver));
             _connection.ThrowIfClosed();
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             Logger.GetSessionStateStart(Identifier, SessionId);
@@ -184,7 +189,7 @@ namespace Azure.Messaging.ServiceBus
             BinaryData sessionState,
             CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusSessionReceiver));
+            Argument.AssertNotDisposed(IsDisposed, nameof(ServiceBusSessionReceiver));
             _connection.ThrowIfClosed();
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             Logger.SetSessionStateStart(Identifier, SessionId);
@@ -229,7 +234,7 @@ namespace Azure.Messaging.ServiceBus
         /// </exception>
         public virtual async Task RenewSessionLockAsync(CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusSessionReceiver));
+            Argument.AssertNotDisposed(IsDisposed, nameof(ServiceBusSessionReceiver));
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             Logger.RenewSessionLockStart(Identifier, SessionId);
             using DiagnosticScope scope = ScopeFactory.CreateScope(

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
@@ -109,10 +109,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         {
             var receiver = CreateReceiver();
 
-            Assert.That(receiver.IsReceiverClosed, Is.False, "The receiver should not be closed on creation");
+            Assert.That(receiver.IsReceiverClosedByUser, Is.False, "The receiver should not be closed on creation");
 
             await receiver.CloseAsync(CancellationToken.None);
-            Assert.That(receiver.IsReceiverClosed, Is.True, "The receiver should be marked as closed after closing");
+            Assert.That(receiver.IsReceiverClosedByUser, Is.True, "The receiver should be marked as closed after closing");
         }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
@@ -109,10 +109,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         {
             var receiver = CreateReceiver();
 
-            Assert.That(receiver.IsReceiverClosedByUser, Is.False, "The receiver should not be closed on creation");
+            Assert.That(receiver.WasClosedExplicitly, Is.False, "The receiver should not be closed on creation");
 
             await receiver.CloseAsync(CancellationToken.None);
-            Assert.That(receiver.IsReceiverClosedByUser, Is.True, "The receiver should be marked as closed after closing");
+            Assert.That(receiver.WasClosedExplicitly, Is.True, "The receiver should be marked as closed after closing");
         }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
@@ -109,10 +109,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         {
             var receiver = CreateReceiver();
 
-            Assert.That(receiver.IsClosed, Is.False, "The receiver should not be closed on creation");
+            Assert.That(receiver.IsReceiverClosed, Is.False, "The receiver should not be closed on creation");
 
             await receiver.CloseAsync(CancellationToken.None);
-            Assert.That(receiver.IsClosed, Is.True, "The receiver should be marked as closed after closing");
+            Assert.That(receiver.IsReceiverClosed, Is.True, "The receiver should be marked as closed after closing");
         }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
@@ -293,23 +293,20 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             // mutate the cancellation token to distinguish it from CancellationToken.None
             cts.CancelAfter(100);
 
-            var mockConnection = ServiceBusTestUtilities.CreateMockConnection();
-            mockConnection.Setup(
-                connection => connection.CreateTransportReceiver(
-                    It.IsAny<string>(),
-                    It.IsAny<ServiceBusRetryPolicy>(),
-                    It.IsAny<ServiceBusReceiveMode>(),
-                    It.IsAny<uint>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<bool>(),
-                    It.IsAny<bool>(),
-                    It.IsAny<CancellationToken>()))
-                .Returns(mockTransportReceiver.Object);
+            var mockConnection = ServiceBusTestUtilities.GetMockedReceiverConnection();
 
-            var receiver = new ServiceBusReceiver(mockConnection.Object, "fake", default, new ServiceBusReceiverOptions());
+            var receiver = new ServiceBusReceiver(mockConnection, "fake", default, new ServiceBusReceiverOptions());
             await receiver.CloseAsync(cts.Token);
             mockTransportReceiver.Verify(transportReceiver => transportReceiver.CloseAsync(It.Is<CancellationToken>(ct => ct == cts.Token)));
+        }
+
+        [Test]
+        public async Task CallingCloseAsyncUpdatesIsClosed()
+        {
+            var mockConnection = ServiceBusTestUtilities.GetMockedReceiverConnection();
+            var receiver = new ServiceBusReceiver(mockConnection, "fake", default, new ServiceBusReceiverOptions());
+            await receiver.CloseAsync();
+            Assert.IsTrue(receiver.IsClosed);
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
@@ -295,16 +295,16 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
             var mockConnection = ServiceBusTestUtilities.CreateMockConnection();
             mockConnection.Setup(
-                    connection => connection.CreateTransportReceiver(
-                        It.IsAny<string>(),
-                        It.IsAny<ServiceBusRetryPolicy>(),
-                        It.IsAny<ServiceBusReceiveMode>(),
-                        It.IsAny<uint>(),
-                        It.IsAny<string>(),
-                        It.IsAny<string>(),
-                        It.IsAny<bool>(),
-                        It.IsAny<bool>(),
-                        It.IsAny<CancellationToken>()))
+                connection => connection.CreateTransportReceiver(
+                    It.IsAny<string>(),
+                    It.IsAny<ServiceBusRetryPolicy>(),
+                    It.IsAny<ServiceBusReceiveMode>(),
+                    It.IsAny<uint>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
                 .Returns(mockTransportReceiver.Object);
 
             var receiver = new ServiceBusReceiver(mockConnection.Object, "fake", default, new ServiceBusReceiverOptions());

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
@@ -293,9 +293,21 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             // mutate the cancellation token to distinguish it from CancellationToken.None
             cts.CancelAfter(100);
 
-            var mockConnection = ServiceBusTestUtilities.GetMockedReceiverConnection();
+            var mockConnection = ServiceBusTestUtilities.CreateMockConnection();
+            mockConnection.Setup(
+                    connection => connection.CreateTransportReceiver(
+                        It.IsAny<string>(),
+                        It.IsAny<ServiceBusRetryPolicy>(),
+                        It.IsAny<ServiceBusReceiveMode>(),
+                        It.IsAny<uint>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<CancellationToken>()))
+                .Returns(mockTransportReceiver.Object);
 
-            var receiver = new ServiceBusReceiver(mockConnection, "fake", default, new ServiceBusReceiverOptions());
+            var receiver = new ServiceBusReceiver(mockConnection.Object, "fake", default, new ServiceBusReceiverOptions());
             await receiver.CloseAsync(cts.Token);
             mockTransportReceiver.Verify(transportReceiver => transportReceiver.CloseAsync(It.Is<CancellationToken>(ct => ct == cts.Token)));
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverTests.cs
@@ -47,5 +47,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             Assert.That(async () => await receiver.SetSessionStateAsync(new BinaryData("new!")),
                 Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
         }
+
+        [Test]
+        public async Task CallingCloseAsyncUpdatesIsClosed()
+        {
+            var mockConnection = ServiceBusTestUtilities.GetMockedReceiverConnection();
+            var receiver = new ServiceBusSessionReceiver(mockConnection, "fake", default, CancellationToken.None);
+            await receiver.CloseAsync();
+            Assert.IsTrue(receiver.IsClosed);
+        }
     }
 }


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-sdk-for-net/issues/29116

IsClosed on ServiceBusSessionReceiver will now return true if the session link dropped (either due to network flakiness or session lock lost), in addition to returning true if user calls CloseAsync or DisposeAsync. 

The behavior when calling an operation on a receiver that had the session link dropped is **not** changed - SessionLockLostException will still be thrown. ObjectDisposedException is only thrown if user calls CloseAsync or DisposeAsync.

Because this is a subtle behavioral change, will need to run it by the architects. The use case for IsClosed is that it can be checked to determine if the receiver should not be used anymore. Thus the change here is an enhancement to make this property more useful.