### PR TITLE
Fix storage blob tests by enabling public signing for dependencies

### DIFF
--- a/eng/mgmt/Directory.Build.Mgmt.props
+++ b/eng/mgmt/Directory.Build.Mgmt.props
@@ -13,7 +13,13 @@
   <Import Project="$(RepoRoot)\tools\bootstrapTools\bootstrap.targets" />
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
-    <DelaySign>true</DelaySign>
+    <!--
+      In order to be able to run our tests on .NET Framework we should use public signing by default so
+      we don't have to disable strong name validation for things that are delay signed.
+    -->
+    <PublicSign Condition="'$(PublicSign)' == ''">true</PublicSign>
+    <DelaySign Condition="'$(PublicSign)' == 'true'">false</DelaySign>
+    <DelaySign Condition="'$(PublicSign)' != 'true'">true</DelaySign>
     <AssemblyOriginatorKeyFile>$(RepoEngPath)\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 </Project>

--- a/eng/nunit.runsettings
+++ b/eng/nunit.runsettings
@@ -5,8 +5,12 @@
     </NUnit>
     <RunConfiguration>
         <TargetPlatform>x64</TargetPlatform>
+
+        <!-- Return non-zero exit code if a test run finds no tests -->
+        <!-- disable for now because there are a lot of test projects that don't find tests and would start failing -->
+        <!-- <TreatNoTestsAsError>true</TreatNoTestsAsError> -->
     </RunConfiguration>
-    
+
     <TestRunParameters>
         <!-- Controls which service versions are running in live mode  -->
         <!-- <Parameter name="LiveTestServiceVersions" value="V2019_02_02" /> -->
@@ -16,7 +20,7 @@
 
         <!-- Change the test mode -->
         <!-- <Parameter name="TestMode" value="Record" /> -->
-        
+
         <!-- Enable running Fiddler -->
         <!-- <Parameter name="EnableFiddler" value="true" /> -->
     </TestRunParameters>

--- a/sdk/batch/Microsoft.Azure.Management.Batch/tests/Microsoft.Azure.Management.Batch.Tests.csproj
+++ b/sdk/batch/Microsoft.Azure.Management.Batch/tests/Microsoft.Azure.Management.Batch.Tests.csproj
@@ -12,7 +12,6 @@
     <Version>1.0.0.0</Version>
     <Company>MSIT</Company>
     <Copyright>Copyright © MSIT 2013</Copyright>
-    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
     <PropertyGroup>
     <ExcludeFromBuild>false</ExcludeFromBuild>


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/26881

Microsoft.Azure.Management.Storage was delay signed and is referenced by Azure.Storage.Blobs.Tests and caused the tests to fail to run on .NET Framework. In order to fix this we need the track 1 mgmt libraries to be public signed so that they can be ran on .NET framework before real signing.

As a follow-up we will want to enable TreatNoTestsAsError as for our run configs to help catch this type of issue in the future. However before we can enable that we need to fix a number of test projects which are currently either failing to load or have no tests in their projects. 
