### PR TITLE
[AzureMonitorExporter] implementing Truncation rules for ExceptionDetails and StackFrame

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/StackFrame.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/StackFrame.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Linq;
-using System.Collections.Generic;
-using System.Diagnostics;
-
 namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 {
     internal partial class StackFrame
@@ -53,51 +48,5 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         /// Gets the stack frame length for only the strings in the stack frame.
         /// </summary>
         internal int GetStackFrameLength() => (this.Method?.Length ?? 0) + (this.Assembly?.Length ?? 0) + (this.FileName?.Length ?? 0);
-
-        internal static List<StackFrame> GetSanitizedStackFrame(Exception exception, out bool hasFullStack)
-        {
-            var orderedStackTrace = new List<StackFrame>();
-            hasFullStack = true;
-
-            var stack = new StackTrace(exception, true);
-            var frames = stack.GetFrames();
-            if (frames != null && frames.Any())
-            {
-                int totalLength = 0;
-                for (int counter = 0; counter < frames.Length; counter++)
-                {
-                    // 1) Check that we don't exceeded MaxFrames.
-                    if (orderedStackTrace.Count == SchemaConstants.ExceptionDetails_Stack_MaxFrames)
-                    {
-                        hasFullStack = false;
-                        break;
-                    }
-
-                    // 2) Skip middle part of the stack.
-                    // This algorithm will select FRAMES from beginning and end of the collection.
-                    // Once the LENGTH exceeds max, any remaining FRAMES in the middle of the collection will be ignored.
-                    // Example: Assuming frames.Length == 10
-                    // counter: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
-                    // index:   9, 0, 8, 1, 7, 2, 6, 3, 5, 4
-                    int index = (counter % 2 == 0) ? (frames.Length - 1 - (counter / 2)) : (counter / 2);
-
-                    var convertedStackFrame = new StackFrame(frames[index], index);
-                    totalLength += convertedStackFrame.GetStackFrameLength();
-
-                    if (totalLength > SchemaConstants.ExceptionDetails_Stack_MaxLength)
-                    {
-                        hasFullStack = false;
-                        break;
-                    }
-                    else
-                    {
-                        // Always insert FRAMES in the middle of the new collection to preserve original order.
-                        orderedStackTrace.Insert(orderedStackTrace.Count / 2, convertedStackFrame);
-                    }
-                }
-            }
-
-            return orderedStackTrace;
-        }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/StackFrame.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/StackFrame.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Models
+{
+    internal partial class StackFrame
+    {
+        /// <summary>
+        /// Converts a System.Diagnostics.StackFrame to a Azure.Monitor.OpenTelemetry.Exporter.Models.StackFrame.
+        /// </summary>
+        public StackFrame(System.Diagnostics.StackFrame stackFrame, int frameId)
+        {
+            string fullName, assemblyName;
+
+            var methodInfo = stackFrame.GetMethod();
+            if (methodInfo == null)
+            {
+                fullName = "unknown";
+                assemblyName = "unknown";
+            }
+            else
+            {
+                assemblyName = methodInfo.Module.Assembly.FullName;
+                if (methodInfo.DeclaringType != null)
+                {
+                    fullName = methodInfo.DeclaringType.FullName + "." + methodInfo.Name;
+                }
+                else
+                {
+                    fullName = methodInfo.Name;
+                }
+            }
+
+            // Setters
+            this.Method = fullName.Truncate(SchemaConstants.StackFrame_Method_MaxLength);
+            this.Level = frameId;
+            this.Assembly = assemblyName.Truncate(SchemaConstants.StackFrame_Assembly_MaxLength);
+            this.FileName = stackFrame.GetFileName()?.Truncate(SchemaConstants.StackFrame_FileName_MaxLength);
+
+            int line = stackFrame.GetFileLineNumber();
+            if (line != 0) // 0 means it is unavailable
+            {
+                this.Line = line;
+            }
+        }
+
+        /// <summary>
+        /// Gets the stack frame length for only the strings in the stack frame.
+        /// </summary>
+        internal int GetStackFrameLength() => (this.Method?.Length ?? 0) + (this.Assembly?.Length ?? 0) + (this.FileName?.Length ?? 0);
+
+        internal static List<StackFrame> GetSanitizedStackFrame(Exception exception, out bool hasFullStack)
+        {
+            var orderedStackTrace = new List<StackFrame>();
+            hasFullStack = true;
+
+            var stack = new StackTrace(exception, true);
+            var frames = stack.GetFrames();
+            if (frames != null && frames.Any())
+            {
+                int totalLength = 0;
+                for (int counter = 0; counter < frames.Length; counter++)
+                {
+                    // 1) Check that we don't exceeded MaxFrames.
+                    if (orderedStackTrace.Count == SchemaConstants.ExceptionDetails_Stack_MaxFrames)
+                    {
+                        hasFullStack = false;
+                        break;
+                    }
+
+                    // 2) Skip middle part of the stack.
+                    // This algorithm will select FRAMES from beginning and end of the collection.
+                    // Once the LENGTH exceeds max, any remaining FRAMES in the middle of the collection will be ignored.
+                    // Example: Assuming frames.Length == 10
+                    // counter: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+                    // index:   9, 0, 8, 1, 7, 2, 6, 3, 5, 4
+                    int index = (counter % 2 == 0) ? (frames.Length - 1 - (counter / 2)) : (counter / 2);
+
+                    var convertedStackFrame = new StackFrame(frames[index], index);
+                    totalLength += convertedStackFrame.GetStackFrameLength();
+
+                    if (totalLength > SchemaConstants.ExceptionDetails_Stack_MaxLength)
+                    {
+                        hasFullStack = false;
+                        break;
+                    }
+                    else
+                    {
+                        // Always insert FRAMES in the middle of the new collection to preserve original order.
+                        orderedStackTrace.Insert(orderedStackTrace.Count / 2, convertedStackFrame);
+                    }
+                }
+            }
+
+            return orderedStackTrace;
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryExceptionDetails.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryExceptionDetails.cs
@@ -49,7 +49,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                 int totalLength = 0;
                 for (int counter = 0; counter < frames.Length; counter++)
                 {
-                    // 1) Check that we don't exceeded MaxFrames.
+                    // 1) Check if we have exceeded MaxFrames.
                     if (orderedStackTrace.Count == SchemaConstants.ExceptionDetails_Stack_MaxFrames)
                     {
                         hasFullStack = false;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryExceptionDetails.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryExceptionDetails.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 {
@@ -21,17 +24,63 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                 throw new ArgumentNullException(nameof(message));
             }
 
-            Message = message.Truncate(SchemaConstants.ExceptionDetails_Message_MaxLength);
-            Id = exception.GetHashCode();
-            TypeName = exception.GetType().FullName.Truncate(SchemaConstants.ExceptionDetails_TypeName_MaxLength);
+            this.Message = message.Truncate(SchemaConstants.ExceptionDetails_Message_MaxLength);
+            this.Id = exception.GetHashCode();
+            this.TypeName = exception.GetType().FullName.Truncate(SchemaConstants.ExceptionDetails_TypeName_MaxLength);
 
             if (parentExceptionDetails != null)
             {
-                OuterId = parentExceptionDetails.Id;
+                this.OuterId = parentExceptionDetails.Id;
             }
 
-            ParsedStack = StackFrame.GetSanitizedStackFrame(exception, out bool hasFullStack);
-            HasFullStack = hasFullStack;
+            this.ParsedStack = GetSanitizedStackFrame(exception, out bool hasFullStack);
+            this.HasFullStack = hasFullStack;
+        }
+
+        internal static List<StackFrame> GetSanitizedStackFrame(Exception exception, out bool hasFullStack)
+        {
+            var orderedStackTrace = new List<StackFrame>();
+            hasFullStack = true;
+
+            var stack = new StackTrace(exception, true);
+            var frames = stack.GetFrames();
+            if (frames != null && frames.Any())
+            {
+                int totalLength = 0;
+                for (int counter = 0; counter < frames.Length; counter++)
+                {
+                    // 1) Check that we don't exceeded MaxFrames.
+                    if (orderedStackTrace.Count == SchemaConstants.ExceptionDetails_Stack_MaxFrames)
+                    {
+                        hasFullStack = false;
+                        break;
+                    }
+
+                    // 2) Skip middle part of the stack.
+                    // This algorithm will select FRAMES from beginning and end of the collection.
+                    // Once the LENGTH exceeds max, any remaining FRAMES in the middle of the collection will be ignored.
+                    // Example: Assuming frames.Length == 10
+                    // counter: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+                    // index:   9, 0, 8, 1, 7, 2, 6, 3, 5, 4
+                    int index = (counter % 2 == 0) ? (frames.Length - 1 - (counter / 2)) : (counter / 2);
+
+                    var convertedStackFrame = new StackFrame(frames[index], index);
+                    totalLength += convertedStackFrame.GetStackFrameLength();
+
+                    if (totalLength > SchemaConstants.ExceptionDetails_Stack_MaxLength)
+                    {
+                        hasFullStack = false;
+                        break;
+                    }
+                    else
+                    {
+                        // Always insert FRAMES in the middle of the new collection to preserve original order.
+                        orderedStackTrace.Insert(orderedStackTrace.Count / 2, convertedStackFrame);
+                    }
+                }
+            }
+
+            return orderedStackTrace;
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryExceptionDetails.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryExceptionDetails.cs
@@ -2,126 +2,36 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 {
     internal partial class TelemetryExceptionDetails
     {
-        public const int MaxParsedStackLength = 32768;
-
         /// <summary>
         /// Creates a new instance of ExceptionDetails from a System.Exception and a parent ExceptionDetails.
         /// </summary>
-        internal TelemetryExceptionDetails(Exception exception, string message, TelemetryExceptionDetails parentExceptionDetails) : this(message)
+        internal TelemetryExceptionDetails(Exception exception, string message, TelemetryExceptionDetails parentExceptionDetails)
         {
             if (exception == null)
             {
                 throw new ArgumentNullException(nameof(exception));
             }
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
 
+            Message = message.Truncate(SchemaConstants.ExceptionDetails_Message_MaxLength);
             Id = exception.GetHashCode();
-            TypeName = exception.GetType().FullName;
+            TypeName = exception.GetType().FullName.Truncate(SchemaConstants.ExceptionDetails_TypeName_MaxLength);
 
             if (parentExceptionDetails != null)
             {
                 OuterId = parentExceptionDetails.Id;
             }
 
-            var stack = new StackTrace(exception, true);
-
-            var frames = stack.GetFrames();
-            Tuple<List<StackFrame>, bool> sanitizedTuple = SanitizeStackFrame(frames, GetStackFrame, GetStackFrameLength);
-            ParsedStack = sanitizedTuple.Item1;
-            HasFullStack = sanitizedTuple.Item2;
-        }
-
-        /// <summary>
-        /// Converts a System.Diagnostics.StackFrame to a Azure.Monitor.OpenTelemetry.Exporter.Models.StackFrame.
-        /// </summary>
-        internal static StackFrame GetStackFrame(System.Diagnostics.StackFrame stackFrame, int frameId)
-        {
-            var methodInfo = stackFrame.GetMethod();
-            string fullName;
-            string assemblyName;
-
-            if (methodInfo == null)
-            {
-                fullName = "unknown";
-                assemblyName = "unknown";
-            }
-            else
-            {
-                assemblyName = methodInfo.Module.Assembly.FullName;
-                if (methodInfo.DeclaringType != null)
-                {
-                    fullName = methodInfo.DeclaringType.FullName + "." + methodInfo.Name;
-                }
-                else
-                {
-                    fullName = methodInfo.Name;
-                }
-            }
-
-            var convertedStackFrame = new StackFrame(frameId, fullName);
-
-            convertedStackFrame.Assembly = assemblyName;
-            convertedStackFrame.FileName = stackFrame.GetFileName();
-
-            // 0 means it is unavailable
-            int line = stackFrame.GetFileLineNumber();
-            if (line != 0)
-            {
-                convertedStackFrame.Line = line;
-            }
-
-            return convertedStackFrame;
-        }
-
-        /// <summary>
-        /// Gets the stack frame length for only the strings in the stack frame.
-        /// </summary>
-        internal static int GetStackFrameLength(StackFrame stackFrame)
-        {
-            var stackFrameLength = (stackFrame.Method == null ? 0 : stackFrame.Method.Length)
-                                   + (stackFrame.Assembly == null ? 0 : stackFrame.Assembly.Length)
-                                   + (stackFrame.FileName == null ? 0 : stackFrame.FileName.Length);
-            return stackFrameLength;
-        }
-
-        /// <summary>
-        /// Sanitizing stack to 32k while selecting the initial and end stack trace.
-        /// </summary>
-        private static Tuple<List<TOutput>, bool> SanitizeStackFrame<TInput, TOutput>(
-            IList<TInput> inputList,
-            Func<TInput, int, TOutput> converter,
-            Func<TOutput, int> lengthGetter)
-        {
-            List<TOutput> orderedStackTrace = new List<TOutput>();
-            bool hasFullStack = true;
-            if (inputList != null && inputList.Count > 0)
-            {
-                int currentParsedStackLength = 0;
-                for (int level = 0; level < inputList.Count; level++)
-                {
-                    // Skip middle part of the stack
-                    int current = (level % 2 == 0) ? (inputList.Count - 1 - (level / 2)) : (level / 2);
-
-                    TOutput convertedStackFrame = converter(inputList[current], current);
-                    currentParsedStackLength += lengthGetter(convertedStackFrame);
-
-                    if (currentParsedStackLength > MaxParsedStackLength)
-                    {
-                        hasFullStack = false;
-                        break;
-                    }
-
-                    orderedStackTrace.Insert(orderedStackTrace.Count / 2, convertedStackFrame);
-                }
-            }
-
-            return new Tuple<List<TOutput>, bool>(orderedStackTrace, hasFullStack);
+            ParsedStack = StackFrame.GetSanitizedStackFrame(exception, out bool hasFullStack);
+            HasFullStack = hasFullStack;
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/SchemaConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/SchemaConstants.cs
@@ -42,7 +42,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public const int ExceptionData_Properties_MaxValueLength = 8192;
         public const int ExceptionData_Measurements_MaxKeyLength = 150;
 
-        // TODO: Apply these rules
         public const int ExceptionDetails_TypeName_MaxLength = 1024;
         public const int ExceptionDetails_Message_MaxLength = 32768;
         public const int ExceptionDetails_Stack_MaxLength = 32768;
@@ -100,7 +99,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public const int RequestData_Measurements_MaxKeyLength = 150;
         public const int RequestData_Duration_LessThanDays = 1000;
 
-        // TODO: Apply these rules
         public const int StackFrame_Method_MaxLength = 1024;
         public const int StackFrame_Assembly_MaxLength = 1024;
         public const int StackFrame_FileName_MaxLength = 1024;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StringExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StringExtensions.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter
+{
+    internal static class StringExtensions
+    {
+        /// <summary>
+        /// This method will truncate a string if that string exceeds a specified max length.
+        /// </summary>
+        /// <remarks>
+        /// This method is a wrapper around <see cref="string.Substring(int, int)"/>.
+        /// </remarks>
+        /// <param name="input">A string to be evaluated.</param>
+        /// <param name="maxLength">A specified length which is used to evaluate the input string.</param>
+        /// <returns>The input string if less than max length, or a substring that begins at 0.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static string Truncate(this string input, int maxLength)
+        {
+            if (input == null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            if (maxLength <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxLength), "Must be a positive integer.");
+            }
+
+            return input.Length > maxLength
+                ? input.Substring(0, maxLength)
+                : input;
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryExceptionDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryExceptionDataTests.cs
@@ -86,9 +86,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var frameMock = new Mock<System.Diagnostics.StackFrame>(null, 0, 0);
             frameMock.Setup(x => x.GetMethod()).Returns((MethodBase)null);
 
-            Models.StackFrame stackFrame = null;
-
-            stackFrame = TelemetryExceptionDetails.GetStackFrame(frameMock.Object, 0);
+            Models.StackFrame stackFrame = new Models.StackFrame(frameMock.Object, 0);
 
             Assert.Equal("unknown", stackFrame.Assembly);
             Assert.Null(stackFrame.FileName);
@@ -151,16 +149,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var exception = CreateException(300);
 
             var exceptionDetails = new TelemetryExceptionDetails(exception, exception.Message, null);
-            int parsedStackLength = 0;
 
             var stack = exceptionDetails.ParsedStack;
-            for (int i = 0; i < stack.Count; i++)
-            {
-                parsedStackLength += (stack[i].Method == null ? 0 : stack[i].Method.Length)
-                                     + (stack[i].Assembly == null ? 0 : stack[i].Assembly.Length)
-                                     + (stack[i].FileName == null ? 0 : stack[i].FileName.Length);
-            }
-            Assert.True(parsedStackLength <= TelemetryExceptionDetails.MaxParsedStackLength);
+
+            int parsedStackLength = stack.Sum(x => x.GetStackFrameLength());
+
+            Assert.True(parsedStackLength <= SchemaConstants.ExceptionDetails_Stack_MaxLength);
         }
 
         [Fact]


### PR DESCRIPTION
Continuation of #29094

## Changes
- new class `StringExtensions` to hold `Truncation()` extension method.
- new `partial class StackFrame`
  - custom ctor with truncation rules.
- `partial class TelemetryExceptionDetails`
  - remove use of base ctor. Need to apply truncation rules to props in the base ctor, have to implement this in custom ctor.
  - remove `public const int MaxParsedStackLength`, use `SchemaConstants` instead.
  - moved helper methods to `StackFrame` class.
  - refactor method `SanitizeStackFrame`.
    - old: `Tuple<List<TOutput>, bool> SanitizeStackFrame<TInput, TOutput>(IList<TInput> inputList, Func<TInput, int, TOutput> converter, Func<TOutput, int> lengthGetter)` 
    - new: `List<StackFrame> GetSanitizedStackFrame(Exception exception, out bool hasFullStack)`