### PR TITLE
[AzureMonitorExporter] refactor event source tests

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterEventSource.cs
@@ -13,7 +13,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     [EventSource(Name = EventSourceName)]
     internal sealed class AzureMonitorExporterEventSource : EventSource
     {
-        private const string EventSourceName = "OpenTelemetry-AzureMonitor-Exporter";
+        internal const string EventSourceName = "OpenTelemetry-AzureMonitor-Exporter";
 
         internal static readonly AzureMonitorExporterEventSource Log = new AzureMonitorExporterEventSource();
         internal static readonly AzureMonitorExporterEventListener Listener = new AzureMonitorExporterEventListener();
@@ -88,7 +88,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             protected override void OnEventWritten(EventWrittenEventArgs eventData)
             {
                 string message = EventSourceEventFormatting.Format(eventData);
-                TelemetryDebugWriter.Writer.WriteMessage($"{eventData.EventSource.Name} - EventId: [{eventData.EventId}], EventName: [{eventData.EventName}], Message: [{message}]");
+                TelemetryDebugWriter.WriteMessage($"{eventData.EventSource.Name} - EventId: [{eventData.EventId}], EventName: [{eventData.EventName}], Message: [{message}]");
             }
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/ApplicationInsightsRestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/ApplicationInsightsRestClient.cs
@@ -90,7 +90,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 content.WriteNewLine();
             }
             request.Content = RequestContent.Create(content.ToBytes());
-            TelemetryDebugWriter.Writer.WriteTelemetry(content);
+            TelemetryDebugWriter.WriteTelemetry(content);
             return message;
         }
 
@@ -108,7 +108,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             request.Headers.Add("Accept", "application/json");
             using var content = new NDJsonWriter();
             request.Content = RequestContent.Create(body);
-            TelemetryDebugWriter.Writer.WriteTelemetry(content);
+            TelemetryDebugWriter.WriteTelemetry(content);
             return message;
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryDebugWriter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryDebugWriter.cs
@@ -5,11 +5,9 @@ using System.Diagnostics;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter
 {
-    internal class TelemetryDebugWriter : IDebugWritter
+    internal static class TelemetryDebugWriter
     {
-        public static IDebugWritter Writer = new TelemetryDebugWriter();
-
-        public void WriteMessage(string message)
+        public static void WriteMessage(string message)
         {
             if (message == null)
             {
@@ -22,7 +20,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             }
         }
 
-        public void WriteTelemetry(NDJsonWriter content)
+        public static void WriteTelemetry(NDJsonWriter content)
         {
             if (content == null)
             {
@@ -34,12 +32,5 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 Debugger.Log(0, null, content.ToString());
             }
         }
-    }
-
-    internal interface IDebugWritter
-    {
-        void WriteMessage(string message);
-
-        void WriteTelemetry(NDJsonWriter content);
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/Azure.Monitor.OpenTelemetry.Exporter.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/Azure.Monitor.OpenTelemetry.Exporter.Tests.csproj
@@ -18,4 +18,5 @@
     <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="6.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
   </ItemGroup>
+  
 </Project>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/Azure.Monitor.OpenTelemetry.Exporter.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/Azure.Monitor.OpenTelemetry.Exporter.Tests.csproj
@@ -18,5 +18,4 @@
     <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="6.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
   </ItemGroup>
-  
 </Project>


### PR DESCRIPTION
fix #29146
Amending my work from my previous PR #29017

The `AzureMonitorExporterEventSourceTests` tests are intermittently failing. When tests run in parallel, they can capture the messages from other tests.

> System.InvalidOperationException : Sequence contains more than one element

> System.InvalidOperationException : Collection was modified; enumeration operation may not execute.

## Changes
- revert changes from previous PR
  - remove static singleton `TelemetryDebugWriter.Writer`
  - remove interface `IDebugWritter`.
  - remove `private class TestWriter : IDebugWriter`
- unit tests now use a discrete EventListener `TestListener`
  This lets us evaluate the full `EventWrittenEventArgs` object.
- unit tests now use a GUID to identify events generated by specific tests