### PR TITLE
[Event Hubs] Restore Options Initialization

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/BatchPublishPerfTest.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/BatchPublishPerfTest.cs
@@ -55,6 +55,18 @@ namespace Azure.Messaging.EventHubs.Perf
         }
 
         /// <summary>
+        ///   Performs the tasks needed to initialize and set up the environment for the test scenario.
+        ///   This setup will take place once for each instance, running after the global setup has
+        ///   completed.
+        /// </summary>
+        ///
+        public override async Task SetupAsync()
+        {
+            await base.SetupAsync();
+            _batchOptions = await CreateBatchOptions(s_producer).ConfigureAwait(false);
+        }
+
+        /// <summary>
         ///   Performs the tasks needed to clean up the environment for the test scenario.
         ///   When multiple instances are run in parallel, the cleanup will take place once,
         ///   after the execution of all test instances.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/EventPublishPerfTest.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/EventPublishPerfTest.cs
@@ -56,6 +56,18 @@ namespace Azure.Messaging.EventHubs.Perf
         }
 
         /// <summary>
+        ///   Performs the tasks needed to initialize and set up the environment for the test scenario.
+        ///   This setup will take place once for each instance, running after the global setup has
+        ///   completed.
+        /// </summary>
+        ///
+        public override async Task SetupAsync()
+        {
+            await base.SetupAsync();
+            _sendOptions = await CreateSendOptions(s_producer).ConfigureAwait(false);
+        }
+
+        /// <summary>
         ///   Performs the tasks needed to clean up the environment for the test scenario.
         ///   When multiple instances are run in parallel, the cleanup will take place once,
         ///   after the execution of all test instances.


### PR DESCRIPTION
# Summary

The focus of these changes is to restore the accidentally removed setup step for initializing the send/batch options used by the test.