### PR TITLE
Add catch all code owners for the repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 #########
 
 # Catch all
-/sdk/                                           
+/sdk/                                           @pallavit @jsquire
 
 # ######## Core Libraries ########
 


### PR DESCRIPTION
Add the catch all owners for the repo. In some places we depend on this fallback having an owner (example docs or pipeline ownership) for any paths that do not have a natural owner.


https://github.com/Azure/azure-sdk-for-net/pull/28768#discussion_r891756947_