### PR TITLE
Add missing type property for PacketCapture

### DIFF
--- a/sdk/network/Azure.ResourceManager.Network/api/Azure.ResourceManager.Network.netstandard2.0.cs
+++ b/sdk/network/Azure.ResourceManager.Network/api/Azure.ResourceManager.Network.netstandard2.0.cs
@@ -2728,14 +2728,12 @@ namespace Azure.ResourceManager.Network
         System.Collections.Generic.IEnumerator<Azure.ResourceManager.Network.PacketCaptureResource> System.Collections.Generic.IEnumerable<Azure.ResourceManager.Network.PacketCaptureResource>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
     }
-    public partial class PacketCaptureData
+    public partial class PacketCaptureData : Azure.ResourceManager.Models.ResourceData
     {
         internal PacketCaptureData() { }
         public long? BytesToCapturePerPacket { get { throw null; } }
         public Azure.ETag? Etag { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.Network.Models.PacketCaptureFilter> Filters { get { throw null; } }
-        public Azure.Core.ResourceIdentifier Id { get { throw null; } }
-        public string Name { get { throw null; } }
         public Azure.ResourceManager.Network.Models.NetworkProvisioningState? ProvisioningState { get { throw null; } }
         public Azure.ResourceManager.Network.Models.PacketCaptureStorageLocation StorageLocation { get { throw null; } }
         public string Target { get { throw null; } }

--- a/sdk/network/Azure.ResourceManager.Network/src/Generated/Models/PacketCaptureData.Serialization.cs
+++ b/sdk/network/Azure.ResourceManager.Network/src/Generated/Models/PacketCaptureData.Serialization.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Azure;
 using Azure.Core;
+using Azure.ResourceManager.Models;
 using Azure.ResourceManager.Network.Models;
 
 namespace Azure.ResourceManager.Network
@@ -17,9 +18,11 @@ namespace Azure.ResourceManager.Network
     {
         internal static PacketCaptureData DeserializePacketCaptureData(JsonElement element)
         {
-            Optional<string> name = default;
-            Optional<ResourceIdentifier> id = default;
             Optional<ETag> etag = default;
+            ResourceIdentifier id = default;
+            string name = default;
+            ResourceType type = default;
+            SystemData systemData = default;
             Optional<string> target = default;
             Optional<long> bytesToCapturePerPacket = default;
             Optional<long> totalBytesPerSession = default;
@@ -29,21 +32,6 @@ namespace Azure.ResourceManager.Network
             Optional<NetworkProvisioningState> provisioningState = default;
             foreach (var property in element.EnumerateObject())
             {
-                if (property.NameEquals("name"))
-                {
-                    name = property.Value.GetString();
-                    continue;
-                }
-                if (property.NameEquals("id"))
-                {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        property.ThrowNonNullablePropertyIsNull();
-                        continue;
-                    }
-                    id = new ResourceIdentifier(property.Value.GetString());
-                    continue;
-                }
                 if (property.NameEquals("etag"))
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
@@ -52,6 +40,26 @@ namespace Azure.ResourceManager.Network
                         continue;
                     }
                     etag = new ETag(property.Value.GetString());
+                    continue;
+                }
+                if (property.NameEquals("id"))
+                {
+                    id = new ResourceIdentifier(property.Value.GetString());
+                    continue;
+                }
+                if (property.NameEquals("name"))
+                {
+                    name = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("type"))
+                {
+                    type = new ResourceType(property.Value.GetString());
+                    continue;
+                }
+                if (property.NameEquals("systemData"))
+                {
+                    systemData = JsonSerializer.Deserialize<SystemData>(property.Value.ToString());
                     continue;
                 }
                 if (property.NameEquals("properties"))
@@ -137,7 +145,7 @@ namespace Azure.ResourceManager.Network
                     continue;
                 }
             }
-            return new PacketCaptureData(name.Value, id.Value, Optional.ToNullable(etag), target.Value, Optional.ToNullable(bytesToCapturePerPacket), Optional.ToNullable(totalBytesPerSession), Optional.ToNullable(timeLimitInSeconds), storageLocation.Value, Optional.ToList(filters), Optional.ToNullable(provisioningState));
+            return new PacketCaptureData(id, name, type, systemData, Optional.ToNullable(etag), target.Value, Optional.ToNullable(bytesToCapturePerPacket), Optional.ToNullable(totalBytesPerSession), Optional.ToNullable(timeLimitInSeconds), storageLocation.Value, Optional.ToList(filters), Optional.ToNullable(provisioningState));
         }
     }
 }

--- a/sdk/network/Azure.ResourceManager.Network/src/Generated/PacketCaptureData.cs
+++ b/sdk/network/Azure.ResourceManager.Network/src/Generated/PacketCaptureData.cs
@@ -8,12 +8,13 @@
 using System.Collections.Generic;
 using Azure;
 using Azure.Core;
+using Azure.ResourceManager.Models;
 using Azure.ResourceManager.Network.Models;
 
 namespace Azure.ResourceManager.Network
 {
     /// <summary> A class representing the PacketCapture data model. </summary>
-    public partial class PacketCaptureData
+    public partial class PacketCaptureData : ResourceData
     {
         /// <summary> Initializes a new instance of PacketCaptureData. </summary>
         internal PacketCaptureData()
@@ -22,8 +23,10 @@ namespace Azure.ResourceManager.Network
         }
 
         /// <summary> Initializes a new instance of PacketCaptureData. </summary>
-        /// <param name="name"> Name of the packet capture session. </param>
-        /// <param name="id"> ID of the packet capture operation. </param>
+        /// <param name="id"> The id. </param>
+        /// <param name="name"> The name. </param>
+        /// <param name="resourceType"> The resourceType. </param>
+        /// <param name="systemData"> The systemData. </param>
         /// <param name="etag"> A unique read-only string that changes whenever the resource is updated. </param>
         /// <param name="target"> The ID of the targeted resource, only VM is currently supported. </param>
         /// <param name="bytesToCapturePerPacket"> Number of bytes captured per packet, the remaining bytes are truncated. </param>
@@ -32,10 +35,8 @@ namespace Azure.ResourceManager.Network
         /// <param name="storageLocation"> The storage location for a packet capture session. </param>
         /// <param name="filters"> A list of packet capture filters. </param>
         /// <param name="provisioningState"> The provisioning state of the packet capture session. </param>
-        internal PacketCaptureData(string name, ResourceIdentifier id, ETag? etag, string target, long? bytesToCapturePerPacket, long? totalBytesPerSession, int? timeLimitInSeconds, PacketCaptureStorageLocation storageLocation, IReadOnlyList<PacketCaptureFilter> filters, NetworkProvisioningState? provisioningState)
+        internal PacketCaptureData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, ETag? etag, string target, long? bytesToCapturePerPacket, long? totalBytesPerSession, int? timeLimitInSeconds, PacketCaptureStorageLocation storageLocation, IReadOnlyList<PacketCaptureFilter> filters, NetworkProvisioningState? provisioningState) : base(id, name, resourceType, systemData)
         {
-            Name = name;
-            Id = id;
             Etag = etag;
             Target = target;
             BytesToCapturePerPacket = bytesToCapturePerPacket;
@@ -46,10 +47,6 @@ namespace Azure.ResourceManager.Network
             ProvisioningState = provisioningState;
         }
 
-        /// <summary> Name of the packet capture session. </summary>
-        public string Name { get; }
-        /// <summary> ID of the packet capture operation. </summary>
-        public ResourceIdentifier Id { get; }
         /// <summary> A unique read-only string that changes whenever the resource is updated. </summary>
         public ETag? Etag { get; }
         /// <summary> The ID of the targeted resource, only VM is currently supported. </summary>

--- a/sdk/network/Azure.ResourceManager.Network/src/autorest.md
+++ b/sdk/network/Azure.ResourceManager.Network/src/autorest.md
@@ -226,7 +226,11 @@ directive:
       $.AvailableProvidersListParameters.properties.azureLocations.items['x-ms-format'] = 'azure-location';
       $.AzureReachabilityReportParameters.properties.azureLocations.items['x-ms-format'] = 'azure-location';
       $.AzureReachabilityReportItem.properties.azureLocation['x-ms-format'] = 'azure-location';
-      $.PacketCapture.properties.id['x-ms-format'] = 'arm-id';
+      $.PacketCapture.properties.type = {
+        "readOnly": true,
+        "type": "string",
+        "description": "Resource type."
+      };
       $.ConnectionMonitorWorkspaceSettings.properties.workspaceResourceId['x-ms-format'] = 'arm-id';
       $.TrafficAnalyticsConfigurationProperties.properties.workspaceResourceId['x-ms-format'] = 'arm-id';
       $.EvaluatedNetworkSecurityGroup.properties.networkSecurityGroupId['x-ms-format'] = 'arm-id';


### PR DESCRIPTION
Based on [real response](https://portal.azure-devex-tools.com/issues/correctness/detail?errorId=CFC5FD81-2358-43F0-81EC-DF70D6B1CDC7), PacketCapture is a resource and has a type property.


# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
