### PR TITLE
[AzureMonitorExporter] implementing Truncation rules for ExceptionData

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryExceptionData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryExceptionData.cs
@@ -21,7 +21,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             var message = LogsHelper.GetMessageAndSetProperties(logRecord, Properties);
 
             SeverityLevel = LogsHelper.GetSeverityLevel(logRecord.LogLevel);
-            ProblemId = LogsHelper.GetProblemId(logRecord.Exception);
+            ProblemId = LogsHelper.GetProblemId(logRecord.Exception).Truncate(SchemaConstants.ExceptionData_ProblemId_MaxLength);
 
             // collect the set of exceptions detail info from the passed in exception
             List<TelemetryExceptionDetails> exceptions = new List<TelemetryExceptionDetails>();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LogsHelper.cs
@@ -80,7 +80,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
             if (!string.IsNullOrEmpty(logRecord.EventId.Name))
             {
-                properties.Add("EventName", logRecord.EventId.Name);
+                properties.Add("EventName", logRecord.EventId.Name.Truncate(SchemaConstants.KVP_MaxValueLength));
             }
 
             return message;
@@ -123,7 +123,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
             if (builder?.Length > 0)
             {
-                properties.Add("Scope", builder.ToString());
+                properties.Add("Scope", builder.ToString().Truncate(SchemaConstants.KVP_MaxValueLength));
             }
         }
 
@@ -194,12 +194,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     }
                     else
                     {
-                        properties.Add("OriginalFormat", item.Value.ToString());
+                        properties.Add("OriginalFormat", item.Value.ToString().Truncate(SchemaConstants.KVP_MaxValueLength));
                     }
                 }
-                else
+                else if (item.Key.Length <= SchemaConstants.KVP_MaxKeyLength)
                 {
-                    properties.Add(item.Key, item.Value.ToString());
+                    // Note: if Key exceeds MaxLength, the entire KVP will be dropped.
+
+                    properties.Add(item.Key, item.Value.ToString().Truncate(SchemaConstants.KVP_MaxValueLength));
                 }
             }
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/SchemaConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/SchemaConstants.cs
@@ -16,14 +16,20 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     /// </remarks>
     internal static class SchemaConstants
     {
+        /// <remarks>
+        /// If a Key exceeds maximum allowable length limit, then that particular Key-Value pair should be dropped.
+        /// </remarks>
+        public const int KVP_MaxKeyLength = 150;
+        public const int KVP_MaxValueLength = 8192;
+
         // TODO: Apply these rules
         public const int AvailabilityData_Id_MaxLength = 512;
         public const int AvailabilityData_Name_MaxLength = 1024;
         public const int AvailabilityData_RunLocation_MaxLength = 1024;
         public const int AvailabilityData_Message_MaxLength = 8192;
-        public const int AvailabilityData_Properties_MaxKeyLength = 150;
-        public const int AvailabilityData_Properties_MaxValueLength = 8192;
-        public const int AvailabilityData_Measurements_MaxKeyLength = 150;
+        public const int AvailabilityData_Properties_MaxKeyLength = KVP_MaxKeyLength;
+        public const int AvailabilityData_Properties_MaxValueLength = KVP_MaxValueLength;
+        public const int AvailabilityData_Measurements_MaxKeyLength = KVP_MaxKeyLength;
         public const int AvailabilityData_Duration_LessThanDays = 1000;
 
         // TODO: Apply these rules
@@ -32,15 +38,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
         // TODO: Apply these rules
         public const int EventData_Name_MaxLength = 512;
-        public const int EventData_Properties_MaxKeyLength = 150;
+        public const int EventData_Properties_MaxKeyLength = KVP_MaxKeyLength;
         public const int EventData_Properties_MaxValueLength = 8192;
-        public const int EventData_Measurements_MaxKeyLength = 150;
+        public const int EventData_Measurements_MaxKeyLength = KVP_MaxKeyLength;
 
-        // TODO: Apply these rules
         public const int ExceptionData_ProblemId_MaxLength = 1024;
-        public const int ExceptionData_Properties_MaxKeyLength = 150;
-        public const int ExceptionData_Properties_MaxValueLength = 8192;
-        public const int ExceptionData_Measurements_MaxKeyLength = 150;
+        public const int ExceptionData_Properties_MaxKeyLength = KVP_MaxKeyLength;
+        public const int ExceptionData_Properties_MaxValueLength = KVP_MaxValueLength;
+        public const int ExceptionData_Measurements_MaxKeyLength = KVP_MaxKeyLength; // TODO: ExceptionData.Measurements is currently not in use (2022-06-07).
 
         public const int ExceptionDetails_TypeName_MaxLength = 1024;
         public const int ExceptionDetails_Message_MaxLength = 32768;
@@ -49,31 +54,31 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
         // TODO: Apply these rules
         public const int MessageData_Message_MaxLength = 32768;
-        public const int MessageData_Properties_MaxKeyLength = 150;
-        public const int MessageData_Properties_MaxValueLength = 8192;
-        public const int MessageData_Measurements_MaxKeyLength = 150;
+        public const int MessageData_Properties_MaxKeyLength = KVP_MaxKeyLength;
+        public const int MessageData_Properties_MaxValueLength = KVP_MaxValueLength;
+        public const int MessageData_Measurements_MaxKeyLength = KVP_MaxKeyLength;
 
         // TODO: Apply these rules
-        public const int MetricsData_Properties_MaxKeyLength = 150;
-        public const int MetricsData_Properties_MaxValueLength = 8192;
+        public const int MetricsData_Properties_MaxKeyLength = KVP_MaxKeyLength;
+        public const int MetricsData_Properties_MaxValueLength = KVP_MaxValueLength;
 
         // TODO: Apply these rules
         public const int PageViewData_Id_MaxLength = 512;
         public const int PageViewData_Name_MaxLength = 1024;
         public const int PageViewData_Url_MaxLength = 2048;
         public const int PageViewData_ReferredUri_MaxLength = 2048;
-        public const int PageViewData_Properties_MaxKeyLength = 150;
-        public const int PageViewData_Properties_MaxValueLength = 8192;
-        public const int PageViewData_Measurements_MaxKeyLength = 150;
+        public const int PageViewData_Properties_MaxKeyLength = KVP_MaxKeyLength;
+        public const int PageViewData_Properties_MaxValueLength = KVP_MaxValueLength;
+        public const int PageViewData_Measurements_MaxKeyLength = KVP_MaxKeyLength;
         public const int PageViewData_Duration_LessThanDays = 1000;
 
         // TODO: Apply these rules
         public const int PageViewPerfData_Id_MaxLength = 512;
         public const int PageViewPerfData_Name_MaxLength = 1024;
         public const int PageViewPerfData_Url_MaxLength = 2048;
-        public const int PageViewPerfData_Properties_MaxKeyLength = 150;
-        public const int PageViewPerfData_Properties_MaxValueLength = 8192;
-        public const int PageViewPerfData_Measurements_MaxKeyLength = 150;
+        public const int PageViewPerfData_Properties_MaxKeyLength = KVP_MaxKeyLength;
+        public const int PageViewPerfData_Properties_MaxValueLength = KVP_MaxValueLength;
+        public const int PageViewPerfData_Measurements_MaxKeyLength = KVP_MaxKeyLength;
         public const int PageViewPerfData_Duration_LessThanDays = 1000;
 
         // TODO: Apply these rules
@@ -83,9 +88,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public const int RemoteDependencyData_Data_MaxLength = 8192;
         public const int RemoteDependencyData_Type_MaxLength = 1024;
         public const int RemoteDependencyData_Target_MaxLength = 1024;
-        public const int RemoteDependencyData_Properties_MaxKeyLength = 150;
-        public const int RemoteDependencyData_Properties_MaxValueLength = 8192;
-        public const int RemoteDependencyData_Measurements_MaxKeyLength = 150;
+        public const int RemoteDependencyData_Properties_MaxKeyLength = KVP_MaxKeyLength;
+        public const int RemoteDependencyData_Properties_MaxValueLength = KVP_MaxValueLength;
+        public const int RemoteDependencyData_Measurements_MaxKeyLength = KVP_MaxKeyLength;
         public const int RemoteDependencyData_Duration_LessThanDays = 1000;
 
         // TODO: Apply these rules
@@ -94,9 +99,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public const int RequestData_ResponseCode_MaxLength = 1024;
         public const int RequestData_Source_MaxLength = 1024;
         public const int RequestData_Url_MaxLength = 2048;
-        public const int RequestData_Properties_MaxKeyLength = 150;
-        public const int RequestData_Properties_MaxValueLength = 8192;
-        public const int RequestData_Measurements_MaxKeyLength = 150;
+        public const int RequestData_Properties_MaxKeyLength = KVP_MaxKeyLength;
+        public const int RequestData_Properties_MaxValueLength = KVP_MaxValueLength;
+        public const int RequestData_Measurements_MaxKeyLength = KVP_MaxKeyLength;
         public const int RequestData_Duration_LessThanDays = 1000;
 
         public const int StackFrame_Method_MaxLength = 1024;


### PR DESCRIPTION
Continuation of #29094

## Changes
- implement truncation for `ExceptionData`
- `ExceptionData.Properties` is set in `LogHelper`
- refactor `SchemaConstants`
  - added `KVP_MaxKeyLength` and `KVP_MaxValueLength`
    these generic constants are to be used in `LogHelper`.
    the specific constants are still needed to track limits in other classes.
