### PR TITLE
[AzureMonitorExporter] implementing Truncation rules for MessageData and MetricsData

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MessageData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MessageData.cs
@@ -16,7 +16,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         {
             Properties = new ChangeTrackingDictionary<string, string>();
             Measurements = new ChangeTrackingDictionary<string, double>();
-            Message = LogsHelper.GetMessageAndSetProperties(logRecord, Properties);
+            Message = LogsHelper.GetMessageAndSetProperties(logRecord, Properties).Truncate(SchemaConstants.MessageData_Message_MaxLength);
             SeverityLevel = LogsHelper.GetSeverityLevel(logRecord.LogLevel);
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricsData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricsData.cs
@@ -69,7 +69,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             Properties = new ChangeTrackingDictionary<string, string>();
             foreach (var tag in metricPoint.Tags)
             {
-                Properties.Add(new KeyValuePair<string, string>(tag.Key, tag.Value?.ToString()));
+                if (tag.Key.Length <= SchemaConstants.MetricsData_Properties_MaxKeyLength && tag.Value != null)
+                {
+                    // Note: if Key exceeds MaxLength or if Value is null, the entire KVP will be dropped.
+
+                    Properties.Add(new KeyValuePair<string, string>(tag.Key, tag.Value.ToString().Truncate(SchemaConstants.MetricsData_Properties_MaxValueLength)));
+                }
             }
             Properties.Add(AggregationIntervalMsKey, DefaultExportIntervalMilliseconds);
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SchemaConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SchemaConstants.cs
@@ -22,7 +22,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public const int KVP_MaxKeyLength = 150;
         public const int KVP_MaxValueLength = 8192;
 
-        // TODO: Apply these rules
+        // TODO: AvailabilityData is currently not in use (2022-06-10).
         public const int AvailabilityData_Id_MaxLength = 512;
         public const int AvailabilityData_Name_MaxLength = 1024;
         public const int AvailabilityData_RunLocation_MaxLength = 1024;
@@ -32,11 +32,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public const int AvailabilityData_Measurements_MaxKeyLength = KVP_MaxKeyLength;
         public const int AvailabilityData_Duration_LessThanDays = 1000;
 
-        // TODO: Apply these rules
+        // TODO: DataPoint is currently not in use (2022-06-10).
         public const int DataPoint_Ns_MaxLength = 256;
         public const int DataPoint_Name_MaxLength = 1024;
 
-        // TODO: Apply these rules
+        // TODO: EventData is currently not in use (2022-06-10).
         public const int EventData_Name_MaxLength = 512;
         public const int EventData_Properties_MaxKeyLength = KVP_MaxKeyLength;
         public const int EventData_Properties_MaxValueLength = 8192;
@@ -52,17 +52,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public const int ExceptionDetails_Stack_MaxLength = 32768;
         public const int ExceptionDetails_Stack_MaxFrames = 100;
 
-        // TODO: Apply these rules
         public const int MessageData_Message_MaxLength = 32768;
         public const int MessageData_Properties_MaxKeyLength = KVP_MaxKeyLength;
         public const int MessageData_Properties_MaxValueLength = KVP_MaxValueLength;
-        public const int MessageData_Measurements_MaxKeyLength = KVP_MaxKeyLength;
+        public const int MessageData_Measurements_MaxKeyLength = KVP_MaxKeyLength; // TODO: MessageData.Measurements is currently not in use (2022-06-10).
 
-        // TODO: Apply these rules
         public const int MetricsData_Properties_MaxKeyLength = KVP_MaxKeyLength;
         public const int MetricsData_Properties_MaxValueLength = KVP_MaxValueLength;
 
-        // TODO: Apply these rules
+        // TODO: PageViewData is currently not in use (2022-06-10).
         public const int PageViewData_Id_MaxLength = 512;
         public const int PageViewData_Name_MaxLength = 1024;
         public const int PageViewData_Url_MaxLength = 2048;
@@ -72,7 +70,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public const int PageViewData_Measurements_MaxKeyLength = KVP_MaxKeyLength;
         public const int PageViewData_Duration_LessThanDays = 1000;
 
-        // TODO: Apply these rules
+        // TODO: PageViewPerfData is currently not in use (2022-06-10).
         public const int PageViewPerfData_Id_MaxLength = 512;
         public const int PageViewPerfData_Name_MaxLength = 1024;
         public const int PageViewPerfData_Url_MaxLength = 2048;


### PR DESCRIPTION
Continuation of #29094

## Changes
- implement truncation for `MessageData` and `MetricsData`
- rename "Customizations\Models\MetricData" to "Customizations\Models\MetricsData" (plural) to match the type name `MetricsData`.
- update `SchemaConstants`
  - several types are not yet implemented. I've updated the TODO for `AvailabilityData`, `DataPoint`, `EventData`, `PageViewData`, and `PageViewPerfData`.
