### PR TITLE
[AzureMonitorExporter] implementing Truncation rules for RemoteDependencyData and RequestData

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
@@ -33,7 +33,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             }
 
             Name = dependencyName.Truncate(SchemaConstants.RemoteDependencyData_Name_MaxLength);
-            Id = activity.Context.SpanId.ToHexString().Truncate(SchemaConstants.RemoteDependencyData_Id_MaxLength);
+            Id = activity.Context.SpanId.ToHexString();
             Duration = activity.Duration < SchemaConstants.RemoteDependencyData_Duration_LessThanDays
                 ? activity.Duration.ToString("c", CultureInfo.InvariantCulture)
                 : SchemaConstants.Duration_MaxValue;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
@@ -32,35 +32,39 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                 dependencyName = activity.DisplayName;
             }
 
-            Name = dependencyName;
-            Id = activity.Context.SpanId.ToHexString();
-            Duration = activity.Duration.ToString("c", CultureInfo.InvariantCulture);
+            Name = dependencyName.Truncate(SchemaConstants.RemoteDependencyData_Name_MaxLength);
+            Id = activity.Context.SpanId.ToHexString().Truncate(SchemaConstants.RemoteDependencyData_Id_MaxLength);
+            Duration = activity.Duration < SchemaConstants.RemoteDependencyData_Duration_LessThanDays
+                ? activity.Duration.ToString("c", CultureInfo.InvariantCulture)
+                : SchemaConstants.Duration_MaxValue;
             Success = activity.GetStatus().StatusCode != StatusCode.Error;
 
             switch (monitorTags.activityType)
             {
                 case OperationType.Http:
-                    Data = httpUrl;
-                    Target = monitorTags.MappedTags.GetDependencyTarget(OperationType.Http);
+                    Data = httpUrl.Truncate(SchemaConstants.RemoteDependencyData_Data_MaxLength);
+                    Target = monitorTags.MappedTags.GetDependencyTarget(OperationType.Http).Truncate(SchemaConstants.RemoteDependencyData_Target_MaxLength);
                     Type = "Http";
-                    ResultCode = AzMonList.GetTagValue(ref monitorTags.MappedTags, SemanticConventions.AttributeHttpStatusCode)?.ToString() ?? "0";
+                    ResultCode = AzMonList.GetTagValue(ref monitorTags.MappedTags, SemanticConventions.AttributeHttpStatusCode)
+                        ?.ToString().Truncate(SchemaConstants.RemoteDependencyData_ResultCode_MaxLength)
+                        ?? "0";
                     break;
                 case OperationType.Db:
                     var depDataAndType = AzMonList.GetTagValues(ref monitorTags.MappedTags, SemanticConventions.AttributeDbStatement, SemanticConventions.AttributeDbSystem);
-                    Data = depDataAndType[0]?.ToString();
-                    Target = monitorTags.MappedTags.GetDbDependencyTarget();
-                    Type = s_sqlDbs.Contains(depDataAndType[1]?.ToString()) ? "SQL" : depDataAndType[1]?.ToString();
+                    Data = depDataAndType[0]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Data_MaxLength);
+                    Target = monitorTags.MappedTags.GetDbDependencyTarget().Truncate(SchemaConstants.RemoteDependencyData_Target_MaxLength);
+                    Type = s_sqlDbs.Contains(depDataAndType[1]?.ToString()) ? "SQL" : depDataAndType[1]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Type_MaxLength);
                     break;
                 case OperationType.Rpc:
                     var depInfo = AzMonList.GetTagValues(ref monitorTags.MappedTags, SemanticConventions.AttributeRpcService, SemanticConventions.AttributeRpcSystem, SemanticConventions.AttributeRpcStatus);
-                    Data = depInfo[0]?.ToString();
-                    Type = depInfo[1]?.ToString();
-                    ResultCode = depInfo[2]?.ToString();
+                    Data = depInfo[0]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Data_MaxLength);
+                    Type = depInfo[1]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Type_MaxLength);
+                    ResultCode = depInfo[2]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_ResultCode_MaxLength);
                     break;
                 case OperationType.Messaging:
                     depDataAndType = AzMonList.GetTagValues(ref monitorTags.MappedTags, SemanticConventions.AttributeMessagingUrl, SemanticConventions.AttributeMessagingSystem);
-                    Data = depDataAndType[0]?.ToString();
-                    Type = depDataAndType[1]?.ToString();
+                    Data = depDataAndType[0]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Data_MaxLength);
+                    Type = depDataAndType[1]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Type_MaxLength);
                     break;
             }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RequestData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RequestData.cs
@@ -27,7 +27,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                     break;
             }
 
-            Id = activity.Context.SpanId.ToHexString().Truncate(SchemaConstants.RequestData_Id_MaxLength);
+            Id = activity.Context.SpanId.ToHexString();
             Name = TraceHelper.GetOperationName(activity, ref monitorTags.MappedTags).Truncate(SchemaConstants.RequestData_Name_MaxLength);
             Duration = activity.Duration < SchemaConstants.RequestData_Duration_LessThanDays
                 ? activity.Duration.ToString("c", CultureInfo.InvariantCulture)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RequestData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RequestData.cs
@@ -27,12 +27,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                     break;
             }
 
-            Id = activity.Context.SpanId.ToHexString();
-            Name = TraceHelper.GetOperationName(activity, ref monitorTags.MappedTags);
-            Duration = activity.Duration.ToString("c", CultureInfo.InvariantCulture);
+            Id = activity.Context.SpanId.ToHexString().Truncate(SchemaConstants.RequestData_Id_MaxLength);
+            Name = TraceHelper.GetOperationName(activity, ref monitorTags.MappedTags).Truncate(SchemaConstants.RequestData_Name_MaxLength);
+            Duration = activity.Duration < SchemaConstants.RequestData_Duration_LessThanDays
+                ? activity.Duration.ToString("c", CultureInfo.InvariantCulture)
+                : SchemaConstants.Duration_MaxValue;
             Success = activity.GetStatus().StatusCode != StatusCode.Error;
-            ResponseCode = AzMonList.GetTagValue(ref monitorTags.MappedTags, SemanticConventions.AttributeHttpStatusCode)?.ToString() ?? "0";
-            Url = url;
+            ResponseCode = AzMonList.GetTagValue(ref monitorTags.MappedTags, SemanticConventions.AttributeHttpStatusCode)
+                ?.ToString().Truncate(SchemaConstants.RequestData_ResponseCode_MaxLength)
+                ?? "0";
+            Url = url.Truncate(SchemaConstants.RequestData_Url_MaxLength);
 
             Properties = new ChangeTrackingDictionary<string, string>();
             Measurements = new ChangeTrackingDictionary<string, double>();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SchemaConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SchemaConstants.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Azure.Monitor.OpenTelemetry.Exporter
 {
     /// <summary>
@@ -21,6 +23,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         /// </remarks>
         public const int KVP_MaxKeyLength = 150;
         public const int KVP_MaxValueLength = 8192;
+
+        /// <remarks>
+        /// Represents 1 tick (1 ten-millionth of a second) less than 1000 days.
+        /// </remarks>
+        public const string Duration_MaxValue = "999.23:59:59.9999999";
 
         // TODO: AvailabilityData is currently not in use (2022-06-10).
         public const int AvailabilityData_Id_MaxLength = 512;
@@ -79,7 +86,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public const int PageViewPerfData_Measurements_MaxKeyLength = KVP_MaxKeyLength;
         public const int PageViewPerfData_Duration_LessThanDays = 1000;
 
-        // TODO: Apply these rules
         public const int RemoteDependencyData_Id_MaxLength = 512;
         public const int RemoteDependencyData_Name_MaxLength = 1024;
         public const int RemoteDependencyData_ResultCode_MaxLength = 1024;
@@ -88,19 +94,18 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public const int RemoteDependencyData_Target_MaxLength = 1024;
         public const int RemoteDependencyData_Properties_MaxKeyLength = KVP_MaxKeyLength;
         public const int RemoteDependencyData_Properties_MaxValueLength = KVP_MaxValueLength;
-        public const int RemoteDependencyData_Measurements_MaxKeyLength = KVP_MaxKeyLength;
-        public const int RemoteDependencyData_Duration_LessThanDays = 1000;
+        public const int RemoteDependencyData_Measurements_MaxKeyLength = KVP_MaxKeyLength; // TODO: RemoteDependencyData.Measurements is currently not in use (2022-06-10).
+        public static readonly TimeSpan RemoteDependencyData_Duration_LessThanDays = TimeSpan.FromDays(1000);
 
-        // TODO: Apply these rules
         public const int RequestData_Id_MaxLength = 512;
         public const int RequestData_Name_MaxLength = 1024;
         public const int RequestData_ResponseCode_MaxLength = 1024;
-        public const int RequestData_Source_MaxLength = 1024;
+        public const int RequestData_Source_MaxLength = 1024; // TODO: RequestData.Source is currently not in use (2022-06-10).
         public const int RequestData_Url_MaxLength = 2048;
         public const int RequestData_Properties_MaxKeyLength = KVP_MaxKeyLength;
         public const int RequestData_Properties_MaxValueLength = KVP_MaxValueLength;
-        public const int RequestData_Measurements_MaxKeyLength = KVP_MaxKeyLength;
-        public const int RequestData_Duration_LessThanDays = 1000;
+        public const int RequestData_Measurements_MaxKeyLength = KVP_MaxKeyLength; // TODO: RequestData.Measurements is currently not in use (2022-06-10).
+        public static readonly TimeSpan RequestData_Duration_LessThanDays = TimeSpan.FromDays(1000);
 
         public const int StackFrame_Method_MaxLength = 1024;
         public const int StackFrame_Assembly_MaxLength = 1024;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/StringExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/StringExtensions.cs
@@ -16,12 +16,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         /// <param name="input">A string to be evaluated.</param>
         /// <param name="maxLength">A specified length which is used to evaluate the input string.</param>
         /// <returns>The input string if less than max length, or a substring that begins at 0.</returns>
-        /// <exception cref="ArgumentNullException"></exception>
         public static string Truncate(this string input, int maxLength)
         {
             if (input == null)
             {
-                throw new ArgumentNullException(nameof(input));
+                return null;
             }
 
             if (maxLength <= 0)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
@@ -60,7 +60,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             // TODO: Iterate only interested fields. Ref: https://github.com/Azure/azure-sdk-for-net/pull/14254#discussion_r470907560
             for (int i = 0; i < UnMappedTags.Length; i++)
             {
-                destination.Add(UnMappedTags[i].Key, UnMappedTags[i].Value?.ToString());
+                var tag = UnMappedTags[i];
+                if (tag.Key.Length <= SchemaConstants.KVP_MaxKeyLength && tag.Value != null)
+                {
+                    // Note: if Key exceeds MaxLength or if Value is null, the entire KVP will be dropped.
+
+                    destination.Add(tag.Key, tag.Value.ToString().Truncate(SchemaConstants.KVP_MaxValueLength));
+                }
             }
         }
 


### PR DESCRIPTION
Continuation of #29094

## Changes
- implement truncation for `RemoteDependencyData` and `RequestData`
- update `SchemaConstants`
  - Duration must be less than 1000 days. 1 tick less than 1000 days is "999.23:59:59.9999999".
    I verified that Ingestion will accept this value (using Application Insights SDK) and added it to the constants.
- remove null check from Truncate() method.
   Some of these fields are optional and could be null.