### PR TITLE
[FormRecognizer] Updated samples to use the RecordedTest attr

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/SampleSnippets.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/SampleSnippets.cs
@@ -5,16 +5,16 @@ using System;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
     /// <summary>
     /// Samples that are used in the associated README.md file.
     /// </summary>
+    [LiveOnly]
     public partial class Snippets : SamplesBase<DocumentAnalysisTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public void CreateDocumentAnalysisClient()
         {
             #region Snippet:CreateDocumentAnalysisClient
@@ -30,7 +30,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
             #endregion
         }
 
-        [Test]
+        [RecordedTest]
         public void CreateDocumentAnalysisClientTokenCredential()
         {
             #region Snippet:CreateDocumentAnalysisClientTokenCredential
@@ -43,7 +43,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
             #endregion
         }
 
-        [Test]
+        [RecordedTest]
         public void CreateDocumentModelAdministrationClient()
         {
             #region Snippet:CreateDocumentModelAdministrationClient
@@ -59,7 +59,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
             #endregion
         }
 
-        [Test]
+        [RecordedTest]
         public async Task BadRequestSnippet()
         {
             string endpoint = TestEnvironment.Endpoint;
@@ -81,7 +81,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
             #endregion
         }
 
-        [Test]
+        [RecordedTest]
         public void CreateDocumentAnalysisClients()
         {
             #region Snippet:CreateDocumentAnalysisClients

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltDocumentFromFileAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltDocumentFromFileAsync.cs
@@ -6,14 +6,14 @@ using System.IO;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
+    [LiveOnly]
     [IgnoreServiceError(400, "InvalidRequest", Message = "Content is not accessible: Invalid data URL", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28923")]
     public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task AnalyzePrebuiltDocumentFromFileAsync()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltDocumentFromUriAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltDocumentFromUriAsync.cs
@@ -5,13 +5,12 @@ using System;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
     public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task AnalyzePrebuiltDocumentFromUriAsync()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromFileAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromFileAsync.cs
@@ -6,13 +6,12 @@ using System.IO;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
     public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task AnalyzePrebuiltReadFromFileAsync()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromUriAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromUriAsync.cs
@@ -5,13 +5,12 @@ using System;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
     public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task AnalyzePrebuiltReadFromUriAsync()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithCustomModelFromFileAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithCustomModelFromFileAsync.cs
@@ -7,13 +7,12 @@ using System.IO;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
     public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task AnalyzeWithCustomModelFromFileAsync()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithCustomModelFromUriAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithCustomModelFromUriAsync.cs
@@ -6,13 +6,12 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
     public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task AnalyzeWithCustomModelFromUriAsync()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromFileAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromFileAsync.cs
@@ -7,13 +7,12 @@ using System.IO;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
     public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task AnalyzeWithPrebuiltModelFromFileAsync()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromUriAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromUriAsync.cs
@@ -6,13 +6,12 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
     public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task AnalyzeWithPrebuiltModelFromUriAsync()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_BuildCustomModelAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_BuildCustomModelAsync.cs
@@ -6,13 +6,12 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
     public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task BuildCustomModelAsync()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_CopyModelAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_CopyModelAsync.cs
@@ -5,13 +5,12 @@ using System;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
     public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task CopyModelAsync()
         {
             #region Snippet:FormRecognizerSampleCreateCopySourceClient

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_CreateComposedModelAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_CreateComposedModelAsync.cs
@@ -6,13 +6,12 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
     public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task CreateComposedModelAsync()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ExtractLayoutFromFileAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ExtractLayoutFromFileAsync.cs
@@ -6,13 +6,12 @@ using System.IO;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
     public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task ExtractLayoutFromFileAsync()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ExtractLayoutFromUriAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ExtractLayoutFromUriAsync.cs
@@ -5,13 +5,12 @@ using System;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
     public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task ExtractLayoutFromUriAsync()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_GetAndListOperationsAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_GetAndListOperationsAsync.cs
@@ -5,13 +5,12 @@ using System;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
     public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task GetAndListOperationsAsync()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ManageModels.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ManageModels.cs
@@ -6,13 +6,12 @@ using System.Linq;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
     public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task ManageModels()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ManageModelsAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ManageModelsAsync.cs
@@ -5,13 +5,12 @@ using System;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
     public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task ManageModelsAsync()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample10_DifferentiateOutputModelsTrainedWithAndWithoutLabels.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample10_DifferentiateOutputModelsTrainedWithAndWithoutLabels.cs
@@ -9,7 +9,6 @@ using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.AI.FormRecognizer.Training;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
@@ -22,7 +21,7 @@ namespace Azure.AI.FormRecognizer.Samples
 
         /// For more information see https://docs.microsoft.com/azure/cognitive-services/form-recognizer/overview#custom-models
 
-        [Test]
+        [RecordedTest]
         public async Task OutputModelsTrainedWithLabels()
         {
             string endpoint = TestEnvironment.Endpoint;
@@ -78,7 +77,7 @@ namespace Azure.AI.FormRecognizer.Samples
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task OutputModelsTrainedWithoutLabels()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample11_ComposedModel.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample11_ComposedModel.cs
@@ -10,13 +10,12 @@ using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.AI.FormRecognizer.Training;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task CreateComposedModel()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample12_RecognizeBusinessCardsFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample12_RecognizeBusinessCardsFromFile.cs
@@ -8,13 +8,12 @@ using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task RecognizeBusinessCardsFromFile()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample12_RecognizeBusinessCardsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample12_RecognizeBusinessCardsFromUri.cs
@@ -7,13 +7,12 @@ using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task RecognizeBusinessCardsFromUri()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample13_RecognizeInvoicesFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample13_RecognizeInvoicesFromFile.cs
@@ -9,13 +9,12 @@ using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task RecognizeInvoicesFromFile()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample13_RecognizeInvoicesFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample13_RecognizeInvoicesFromUri.cs
@@ -8,13 +8,12 @@ using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task RecognizeInvoicesFromUri()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample14_RecognizeIdentityDocumentsFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample14_RecognizeIdentityDocumentsFromFile.cs
@@ -8,13 +8,12 @@ using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task RecognizeIdentityDocumentsFromFile()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample14_RecognizeIdentityDocumentsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample14_RecognizeIdentityDocumentsFromUri.cs
@@ -7,13 +7,12 @@ using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task RecognizeIdentityDocumentsFromUri()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample15_DifferentiateOutputLabeledTables.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample15_DifferentiateOutputLabeledTables.cs
@@ -8,7 +8,6 @@ using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.AI.FormRecognizer.Training;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
@@ -28,7 +27,7 @@ namespace Azure.AI.FormRecognizer.Samples
         /// A conceptual explanation of using table tags to train your custom form model can be found in the
         /// service documentation: https://docs.microsoft.com/azure/cognitive-services/form-recognizer/supervised-table-tags
 
-        [Test]
+        [RecordedTest]
         public async Task OutputModelsTrainedWithFixedRowsTables()
         {
             string endpoint = TestEnvironment.Endpoint;
@@ -96,7 +95,7 @@ namespace Azure.AI.FormRecognizer.Samples
             }
         }
 
-        [Test]
+        [RecordedTest]
         public async Task OutputModelsTrainedWithDynamicRowsTables()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample1_RecognizeContentFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample1_RecognizeContentFromFile.cs
@@ -7,13 +7,12 @@ using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task RecognizeContentFromFile()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample1_RecognizeContentFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample1_RecognizeContentFromUri.cs
@@ -6,13 +6,12 @@ using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task RecognizeContentFromUri()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample2_RecognizeCustomFormsFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample2_RecognizeCustomFormsFromFile.cs
@@ -8,13 +8,12 @@ using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.AI.FormRecognizer.Training;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task RecognizeCustomFormsFromFile()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample2_RecognizeCustomFormsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample2_RecognizeCustomFormsFromUri.cs
@@ -7,13 +7,12 @@ using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.AI.FormRecognizer.Training;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task RecognizeCustomFormsFromUri()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample3_RecognizeReceiptsFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample3_RecognizeReceiptsFromFile.cs
@@ -8,13 +8,12 @@ using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task RecognizeReceiptsFromFile()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample3_RecognizeReceiptsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample3_RecognizeReceiptsFromUri.cs
@@ -7,13 +7,12 @@ using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task RecognizeReceiptsFromUri()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample4_StronglyTypingARecognizedForm.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample4_StronglyTypingARecognizedForm.cs
@@ -6,13 +6,12 @@ using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task StronglyTypingARecognizedForm()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample5_TrainModelWithForms.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample5_TrainModelWithForms.cs
@@ -6,13 +6,12 @@ using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.AI.FormRecognizer.Training;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task TrainModelWithForms()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample6_TrainModelWithFormsAndLabels.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample6_TrainModelWithFormsAndLabels.cs
@@ -6,13 +6,12 @@ using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.AI.FormRecognizer.Training;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task TrainModelWithFormsAndLabels()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample7_ManageCustomModels.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample7_ManageCustomModels.cs
@@ -7,13 +7,12 @@ using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.AI.FormRecognizer.Training;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task ManageCustomModels()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample7_ManageCustomModelsAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample7_ManageCustomModelsAsync.cs
@@ -6,13 +6,12 @@ using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.AI.FormRecognizer.Training;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task ManageCustomModelsAsync()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample8_CopyModel.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample8_CopyModel.cs
@@ -6,13 +6,12 @@ using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.AI.FormRecognizer.Training;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public async Task CopyModel()
         {
             #region Snippet:FormRecognizerSampleCreateCopySourceClientV3

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample9_FieldBoundingBox.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample9_FieldBoundingBox.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
@@ -22,7 +21,7 @@ namespace Azure.AI.FormRecognizer.Samples
         /// Units type of a recognized page can be found at <see cref="FormPage.Unit"/>.
         /// For the purpose of the sample, we will use the StartRecognizeContent capability.
         /// </summary>
-        [Test]
+        [RecordedTest]
         public async Task FieldBoundingBoxSample()
         {
             string endpoint = TestEnvironment.Endpoint;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/SampleSnippets.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/SampleSnippets.cs
@@ -7,16 +7,16 @@ using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.AI.FormRecognizer.Training;
 using Azure.Core.TestFramework;
-using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
     /// <summary>
     /// Samples that are used in the associated README.md file.
     /// </summary>
+    [LiveOnly]
     public partial class Snippets : SamplesBase<FormRecognizerTestEnvironment>
     {
-        [Test]
+        [RecordedTest]
         public void CreateFormRecognizerClient()
         {
             #region Snippet:CreateFormRecognizerClient
@@ -32,7 +32,7 @@ namespace Azure.AI.FormRecognizer.Samples
             #endregion
         }
 
-        [Test]
+        [RecordedTest]
         public void CreateFormRecognizerClientTokenCredential()
         {
             #region Snippet:CreateFormRecognizerClientTokenCredential
@@ -45,7 +45,7 @@ namespace Azure.AI.FormRecognizer.Samples
             #endregion
         }
 
-        [Test]
+        [RecordedTest]
         public void CreateFormTrainingClient()
         {
             #region Snippet:CreateFormTrainingClient
@@ -61,7 +61,7 @@ namespace Azure.AI.FormRecognizer.Samples
             #endregion
         }
 
-        [Test]
+        [RecordedTest]
         public async Task BadRequestSnippet()
         {
             string endpoint = TestEnvironment.Endpoint;
@@ -82,7 +82,7 @@ namespace Azure.AI.FormRecognizer.Samples
             #endregion
         }
 
-        [Test]
+        [RecordedTest]
         public void CreateFormRecognizerClients()
         {
             #region Snippet:CreateFormRecognizerClients

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample_MockClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample_MockClient.cs
@@ -14,10 +14,11 @@ using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
+    [LiveOnly]
     [IgnoreServiceError(200, "3014", Message = "Generic error during training.", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28913")]
     public partial class FormRecognizerSamples
     {
-        [Test]
+        [RecordedTest]
         public async Task RecognizeCustomFormsAsync()
         {
             #region Snippet:FormRecognizerCreateMocks
@@ -86,7 +87,7 @@ namespace Azure.AI.FormRecognizer.Samples
         }
         #endregion
 
-        [Test]
+        [RecordedTest]
         public async Task GetCustomModelsAsync()
         {
             var fakeReadyModelId = Guid.NewGuid().ToString();


### PR DESCRIPTION
Even though our samples are not actually recorded, using the `RecordedTest` attribute instead of NUnit's native `Test` attribute can be beneficial since it can include some Test Framework's features. In particular, we're interested in the `IgnoreServiceError` feature that has worked wonders in our live tests, but could not be applied to our samples.

We're also adding the `LiveOnly` attribute to our sample classes to ensure we are not expecting recordings for them.