### PR TITLE
[Event Hubs] Enter Idle State with Empty Buffers

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -14,9 +14,11 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 ### Bugs Fixed
 
+- Fixed an issue with the `EventHubBufferedProducerClient` where it was not properly identifying when buffers were empty and should enter an idle state; this caused the background task that manages publishing to spin and consume an unreasonable amount of resources.  
+
 ### Other Changes
 
-- Samples now each havee a table of contents to help discover and navigate to the topics discussed for a scenario. _(A community contribution, courtesy of [chadvidovcich](https://github.com/chadvidovcich))_
+- Samples now each have a table of contents to help discover and navigate to the topics discussed for a scenario. _(A community contribution, courtesy of [chadvidovcich](https://github.com/chadvidovcich))_
 
 ## 5.7.0 (2022-05-10)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -2631,7 +2631,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="operationId">An artificial identifier for the idle operation.</param>
         /// <param name="durationSeconds">The total duration that the idle await took place, in seconds.</param>
         ///
-        [Event(127, Level = EventLevel.Verbose, Message = "Publishing for the buffered producer instance with identifier '{0}' for Event Hub: {1} has completed its idle state; one or more events was enqueued.  Operation Id: '{2},' Duration: '{3:0.00}' seconds.")]
+        [Event(127, Level = EventLevel.Verbose, Message = "Publishing for the buffered producer instance with identifier '{0}' for Event Hub: {1} has exited the idle state; one or more events was enqueued.  Operation Id: '{2},' Duration: '{3:0.00}' seconds.")]
         public virtual void BufferedProducerIdleComplete(string identifier,
                                                                  string eventHubName,
                                                                  string operationId,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -2602,6 +2602,48 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance publishing task
+        ///   detected an empty buffer and is entering an idle state to await an event being enqueued.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the buffered producer.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the buffered producer is associated with.</param>
+        /// <param name="operationId">An artificial identifier for the idle operation.</param>
+        ///
+        [Event(126, Level = EventLevel.Verbose, Message = "Publishing for the buffered producer instance with identifier '{0}' to Event Hub: {1} has detected an empty buffer and is waiting for an event to be enqueued.  Operation Id: '{2}'")]
+        public virtual void BufferedProducerIdleStart(string identifier,
+                                                      string eventHubName,
+                                                      string operationId)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(126, identifier ?? string.Empty, eventHubName ?? string.Empty, operationId ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance publishing task
+        ///   has detected an event being enqueued and has exiting an idle state.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the buffered producer.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the buffered producer is associated with.</param>
+        /// <param name="operationId">An artificial identifier for the idle operation.</param>
+        /// <param name="durationSeconds">The total duration that the idle await took place, in seconds.</param>
+        ///
+        [Event(127, Level = EventLevel.Verbose, Message = "Publishing for the buffered producer instance with identifier '{0}' for Event Hub: {1} has completed its idle state; one or more events was enqueued.  Operation Id: '{2},' Duration: '{3:0.00}' seconds.")]
+        public virtual void BufferedProducerIdleComplete(string identifier,
+                                                                 string eventHubName,
+                                                                 string operationId,
+                                                                 double durationSeconds)
+        {
+            if (IsEnabled())
+            {
+                BufferedProducerIdleCompleteCore(127, identifier ?? string.Empty, eventHubName ?? string.Empty, operationId ?? string.Empty, durationSeconds);
+            }
+        }
+
+        /// <summary>
         ///   Indicates that the publishing of events has completed, writing into a stack allocated
         ///   <see cref="EventSource.EventData"/> struct to avoid the parameter array allocation on the WriteEvent methods.
         /// </summary>
@@ -3030,6 +3072,48 @@ namespace Azure.Messaging.EventHubs.Diagnostics
                 eventPayload[5].DataPointer = (IntPtr)Unsafe.AsPointer(ref durationSeconds);
 
                 WriteEventCore(eventId, 6, eventPayload);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance publishing task
+        ///   has completed an idle await for an event to be enqueued, writing into a stack allocated
+        ///   <see cref="EventSource.EventData"/>  struct to avoid the parameter array allocation on the WriteEvent methods.
+        /// </summary>
+        ///
+        /// <param name="eventId">The identifier of the event.</param>
+        /// <param name="identifier">A unique name used to identify the buffered producer.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the buffered producer is associated with.</param>
+        /// <param name="operationId">An artificial identifier for the await operation.</param>
+        /// <param name="durationSeconds">The total duration that the cycle took to complete, in seconds.</param>
+        ///
+        [NonEvent]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe void BufferedProducerIdleCompleteCore(int eventId,
+                                                             string identifier,
+                                                             string eventHubName,
+                                                             string operationId,
+                                                             double durationSeconds)
+        {
+            fixed (char* identifierPtr = identifier)
+            fixed (char* eventHubNamePtr = eventHubName)
+            fixed (char* operationIdPtr = operationId)
+            {
+                var eventPayload = stackalloc EventData[4];
+
+                eventPayload[0].Size = (identifier.Length + 1) * sizeof(char);
+                eventPayload[0].DataPointer = (IntPtr)identifierPtr;
+
+                eventPayload[1].Size = (eventHubName.Length + 1) * sizeof(char);
+                eventPayload[1].DataPointer = (IntPtr)eventHubNamePtr;
+
+                eventPayload[3].Size = (operationId.Length + 1) * sizeof(char);
+                eventPayload[3].DataPointer = (IntPtr)operationIdPtr;
+
+                eventPayload[4].Size = Unsafe.SizeOf<double>();
+                eventPayload[4].DataPointer = (IntPtr)Unsafe.AsPointer(ref durationSeconds);
+
+                WriteEventCore(eventId, 4, eventPayload);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
@@ -2409,26 +2409,6 @@ namespace Azure.Messaging.EventHubs.Producer
                                                        TimeSpan delayInterval) => ((remainingTime != Timeout.InfiniteTimeSpan) && (remainingTime < delayInterval)) ? remainingTime : delayInterval;
 
         /// <summary>
-        ///   Calculates the amount of delay to apply between checks when no events are available
-        ///   in the buffers for any partition, gradually increasing for each empty check until it
-        ///   reaches the maximum limit.
-        /// </summary>
-        ///
-        /// <param name="consecutiveEmptyBufferCount">The consecutive number of times that the buffers have been empty when checked.</param>
-        /// <param name="startingEmptyBufferDelaySeconds">The number of seconds to use as the starting point for the delay.</param>
-        /// <param name="maximumBufferDelaySeconds">The maximum number of seconds to allow as a delay.</param>
-        ///
-        /// <returns>The amount of delay to apply before checking the buffers for available events.</returns>
-        ///
-        private static TimeSpan CalculateEmptyBufferDelay(int consecutiveEmptyBufferCount,
-                                                          double startingEmptyBufferDelaySeconds,
-                                                          double maximumBufferDelaySeconds)
-        {
-            var delay = (Math.Pow(1.4, consecutiveEmptyBufferCount) * startingEmptyBufferDelaySeconds);
-            return TimeSpan.FromSeconds(delay > maximumBufferDelaySeconds ? maximumBufferDelaySeconds : delay);
-        }
-
-        /// <summary>
         ///   The set of information needed to track and manage the active publishing
         ///   activities for a partition.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
@@ -58,12 +58,6 @@ namespace Azure.Messaging.EventHubs.Producer
         /// <summary>The maximum amount of time, in milliseconds, to allow for acquiring the semaphore guarding a partition's publishing eligibility.</summary>
         private const int PartitionPublishingGuardAcquireLimitMilliseconds = 100;
 
-        /// <summary>The maximum number of seconds to delay between checks when no events are available in the buffers for any partition.</summary>
-        private const double MaximumEmptyBufferDelaySeconds = 1;
-
-        /// <summary>The number of seconds to use as the starting delay between checks when no events are available in the buffers for any partition.</summary>
-        private static readonly double StartingEmptyBufferDelaySeconds = TimeSpan.FromMilliseconds(25).TotalSeconds;
-
         /// <summary>The base interval to delay when publishing is throttled and an operation needs to back-off before retrying.  Four seconds is recommended by the service.</summary>
         private static readonly TimeSpan ThrottleBackoffInterval = TimeSpan.FromSeconds(4);
 
@@ -71,7 +65,7 @@ namespace Azure.Messaging.EventHubs.Producer
         private static readonly TimeSpan MinimumPublishingWaitInterval = TimeSpan.FromMilliseconds(5);
 
         /// <summary>The default interval to delay for events to be available when building a batch to publish.</summary>
-        private static readonly TimeSpan DefaultPublishingDelayInterval = TimeSpan.FromMilliseconds(25);
+        private static readonly TimeSpan PublishingDelayInterval = TimeSpan.FromMilliseconds(100);
 
         /// <summary>The set of client options to use when options were not passed when the producer was instantiated.</summary>
         private static readonly EventHubBufferedProducerClientOptions DefaultOptions = new();
@@ -102,6 +96,9 @@ namespace Azure.Messaging.EventHubs.Producer
 
         /// <summary>A <see cref="CancellationTokenSource"/> instance to signal that any active publishing operations, including those in-flight, should terminate immediately.</summary>
         private CancellationTokenSource _activeSendOperationsCancellationSource;
+
+        /// <summary>A completion source that be awaited when publishing would like to pause and wait for an event to be enqueued.</summary>
+        private TaskCompletionSource<bool> _eventEnqueuedCompletionSource;
 
         /// <summary>The task responsible for managing the operations of the producer when it is running.</summary>
         private Task _producerManagementTask;
@@ -796,6 +793,7 @@ namespace Azure.Messaging.EventHubs.Producer
                 var count = Interlocked.Increment(ref _totalBufferedEventCount);
                 Interlocked.Increment(ref partitionState.BufferedEventCount);
 
+                _eventEnqueuedCompletionSource?.TrySetResult(true);
                 Logger.BufferedProducerEventEnqueued(Identifier, EventHubName, logPartition, partitionId, operationId, count);
             }
             catch (Exception ex)
@@ -974,6 +972,7 @@ namespace Azure.Messaging.EventHubs.Producer
                     var count = Interlocked.Increment(ref _totalBufferedEventCount);
                     Interlocked.Increment(ref activePartitionState.BufferedEventCount);
 
+                    _eventEnqueuedCompletionSource?.TrySetResult(true);
                     Logger.BufferedProducerEventEnqueued(Identifier, EventHubName, logPartition, eventPartitionId, operationId, count);
                 }
             }
@@ -1388,7 +1387,7 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 var totalWaitTime = _options.MaximumWaitTime ?? Timeout.InfiniteTimeSpan;
                 var remainingWaitTime = totalWaitTime;
-                var delayInterval = CalculateBatchingDelay(totalWaitTime, DefaultPublishingDelayInterval);
+                var delayInterval = CalculateBatchingDelay(totalWaitTime, PublishingDelayInterval);
 
                 // The wait time constraint should not consider creating the batch; start tracking after the batch is available to build.
 
@@ -2150,7 +2149,6 @@ namespace Azure.Messaging.EventHubs.Producer
                     existingSource?.Dispose();
 
                     var partitionIndex = 0u;
-                    var consecutiveEmptyBufferCount = 0;
                     var partitions = default(string[]);
                     var activeTasks = new List<Task>(_options.MaximumConcurrentSends);
 
@@ -2204,21 +2202,40 @@ namespace Azure.Messaging.EventHubs.Producer
                                 // Responsibility for releasing the guard semaphore is passed to the task.
 
                                 activeTasks.Add(PublishBatchToPartition(partitionState, releaseGuard: true, activeOperationCancellationSource.Token));
-                                consecutiveEmptyBufferCount = 0;
                             }
 
-                            // If there are no publishing tasks active, introduce a small delay to avoid a tight loop.  If no events are
-                            // available in the buffers, use an increasing delay to avoid wasting resources during periods of low activity.
+                            // If there are no events in the buffer, avoid a tight loop by blocking to wait for events to be enqueued
+                            // after a small delay.
 
-                            if (activeTasks.Count == 0)
+                            if (_totalBufferedEventCount == 0)
                             {
-                                var delay = _totalBufferedEventCount switch
-                                {
-                                    0 => CalculateEmptyBufferDelay(++consecutiveEmptyBufferCount, StartingEmptyBufferDelaySeconds, MaximumEmptyBufferDelaySeconds),
-                                    _ => DefaultPublishingDelayInterval
-                                };
+                                // If completion source doesn't exist or was already set, then swap in a new completion source to be
+                                // set when an event is enqueued.  Allow the publishing loop to tick for one additional check of the
+                                // buffers, to ensure that no events were enqueued during the swap.
 
-                                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                                if ((_eventEnqueuedCompletionSource == null) || (_eventEnqueuedCompletionSource.Task.IsCompleted))
+                                {
+                                    // Because we want to ensure that calls to enqueue events see the new completion source, use
+                                    // an interlocked operation to ensure the new value is visible to other threads.
+
+                                    Interlocked.Exchange(ref _eventEnqueuedCompletionSource, new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously));
+                                    await Task.Delay(PublishingDelayInterval, cancellationToken).ConfigureAwait(false);
+                                }
+                                else
+                                {
+                                    // If the buffer is still empty and no event was enqueued since the completion source was created,
+                                    // await an event to be enqueued.  Clearing the completion source after the await does not need a memory
+                                    // fence; it does not matter if other threads see the stale value.
+
+                                    Logger.BufferedProducerIdleStart(Identifier, EventHubName, operationId);
+
+                                    var idleWatch = ValueStopwatch.StartNew();
+
+                                    await _eventEnqueuedCompletionSource.Task.AwaitWithCancellation(cancellationToken);
+                                    _eventEnqueuedCompletionSource = null;
+
+                                    Logger.BufferedProducerIdleComplete(Identifier, EventHubName, operationId, idleWatch.GetElapsedTime().TotalSeconds);
+                                }
                             }
                         }
                         catch (OperationCanceledException)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientLiveTests.cs
@@ -13,7 +13,9 @@ using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Messaging.EventHubs.Consumer;
+using Azure.Messaging.EventHubs.Diagnostics;
 using Azure.Messaging.EventHubs.Producer;
+using Moq;
 using NUnit.Framework;
 
 namespace Azure.Messaging.EventHubs.Tests
@@ -659,6 +661,134 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        public async Task ProducerCanPublisAfterIdle()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var partitionCount = 4;
+            var eventsPerPartition = 20;
+            var batchCount = (partitionCount * eventsPerPartition);
+            var expectedCount = (batchCount * 2);
+            var events = EventGenerator.CreateSmallEvents(expectedCount).ToList();
+            var handlerEvents = new ConcurrentBag<EventWithPartition>();
+            var readEvents = new List<EventWithPartition>();
+            var initialCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var idleCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var afterIdleCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockLogger = new Mock<EventHubsEventSource>();
+
+            mockLogger
+                .Setup(log => log.BufferedProducerIdleStart(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .Callback(() => idleCompletionSource.TrySetResult(true));
+
+            await using var scope = await EventHubScope.CreateAsync(partitionCount);
+            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            var partitions = await producer.GetPartitionIdsAsync(cancellationSource.Token);
+
+            producer.Logger = mockLogger.Object;
+
+            producer.SendEventBatchSucceededAsync += args =>
+            {
+                foreach (var item in args.EventBatch.Select(item => new EventWithPartition(args.PartitionId, item)))
+                {
+                    handlerEvents.Add(item);
+                }
+
+                if (handlerEvents.Count >= batchCount)
+                {
+                    initialCompletionSource.TrySetResult(true);
+                }
+
+                if (handlerEvents.Count >= expectedCount)
+                {
+                    afterIdleCompletionSource.TrySetResult(true);
+                }
+
+                return Task.CompletedTask;
+            };
+
+            producer.SendEventBatchFailedAsync += args =>
+            {
+                ExceptionDispatchInfo.Capture(args.Exception).Throw();
+                return Task.CompletedTask;
+            };
+
+            await producer.EnqueueEventsAsync(events.Take(batchCount), cancellationSource.Token);
+
+            // Avoid flushing and wait for publishing to complete naturally.
+
+            try
+            {
+                await initialCompletionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                Assert.Fail($"The handler did not receive all events.  {handlerEvents.Count} of {events.Count} were captured.");
+            }
+
+            // Wait for a short period to allow the producer to go idle and then
+            // enqueue all events again.
+
+            await idleCompletionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+            await Task.Delay(TimeSpan.FromSeconds(2), cancellationSource.Token);
+            await producer.EnqueueEventsAsync(events.Skip(batchCount), cancellationSource.Token);
+
+            try
+            {
+                await afterIdleCompletionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                Assert.Fail($"The handler did not receive all events after it was idle.  {handlerEvents.Count} of {events.Count} were captured.");
+            }
+
+            // Ensure that publishing completed with the expected state.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been signaled.");
+            Assert.That(handlerEvents.Count, Is.EqualTo(expectedCount), "All events should have been sent.");
+
+            // Because the handlers are fired in the background before state is updated, it is possible that the buffered event count may not have been fully updated
+            // when the handler sets the completion source.  Allow for a short spin and back-off if needed to allow it to settle.
+
+            await PollForZeroBufferedEventCount(producer);
+            Assert.That(producer.TotalBufferedEventCount, Is.EqualTo(0), "No events should remain in the buffer.");
+
+            // Read back the events and ensure all were successfully published.
+
+            await using var consumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            await foreach (var partitionEvent in consumerClient.ReadEventsAsync(cancellationSource.Token))
+            {
+                readEvents.Add(new EventWithPartition(partitionEvent.Partition.PartitionId, partitionEvent.Data));
+
+                if (readEvents.Count >= expectedCount)
+                {
+                    break;
+                }
+            }
+
+            // Ensure that all sent events were read back.
+
+            readEvents = readEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+            var sortedHandlerEvents = handlerEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+
+            for (var index = 0; index < readEvents.Count; ++index)
+            {
+                Assert.That(readEvents[index].PartitionId, Is.EqualTo(sortedHandlerEvents[index].PartitionId), $"The partition for the read and sent events should match at index: [{index}].");
+                Assert.That(readEvents[index].Event.IsEquivalentTo(sortedHandlerEvents[index].Event), Is.True, $"The event for the read and sent events should match at index: [{index}].");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to publish events.
+        /// </summary>
+        ///
+        [Test]
         public async Task FlushSendsAllEventsAndWaitsForHandlersWithDefaultOptions()
         {
             using var cancellationSource = new CancellationTokenSource();
@@ -1110,6 +1240,192 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(producer.IsClosed, Is.True, "The producer should report that it is closed.");
             Assert.That(producer.IsPublishing, Is.False, "The producer should report that it is not publishing.");
             Assert.That(producer.TotalBufferedEventCount, Is.EqualTo(0), "No events should remain in the buffer.");
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to publish events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseSendsEventsWhenFlushingAfterIdle()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var closeCount = 0;
+            var handlerInvokedAfterClose = false;
+            var partitionCount = 2;
+            var eventsPerPartition = 50;
+            var expectedEvents = (eventsPerPartition * partitionCount);
+            var events = EventGenerator.CreateSmallEvents(expectedEvents).ToList();
+            var finalEvent = EventGenerator.CreateSmallEvents(1).First();
+            var handlerEvents = new ConcurrentBag<EventWithPartition>();
+            var readEvents = new List<EventWithPartition>();
+            var initialSendCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var idleCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var options = new EventHubBufferedProducerClientOptions { MaximumConcurrentSends = partitionCount };
+            var mockLogger = new Mock<EventHubsEventSource>();
+
+            mockLogger
+                .Setup(log => log.BufferedProducerIdleStart(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .Callback(() => idleCompletionSource.TrySetResult(true));
+
+            await using var scope = await EventHubScope.CreateAsync(partitionCount);
+            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName, options);
+
+            producer.Logger = mockLogger.Object;
+
+            producer.SendEventBatchSucceededAsync += args =>
+            {
+                // If close was already completed, do not capture the
+                // events; the handler should not have been invoked.
+
+                if (closeCount > 0)
+                {
+                    handlerInvokedAfterClose = true;
+                    return Task.CompletedTask;
+                }
+
+                foreach (var item in args.EventBatch.Select(item => new EventWithPartition(args.PartitionId, item)))
+                {
+                    handlerEvents.Add(item);
+                }
+
+                if (handlerEvents.Count >= expectedEvents)
+                {
+                    initialSendCompletionSource.TrySetResult(true);
+                }
+
+                return Task.CompletedTask;
+            };
+
+            producer.SendEventBatchFailedAsync += args =>
+            {
+                ExceptionDispatchInfo.Capture(args.Exception).Throw();
+                return Task.CompletedTask;
+            };
+
+            // Enqueue and wait for the initial send to complete.
+
+            await producer.EnqueueEventsAsync(events, cancellationSource.Token);
+            await initialSendCompletionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+
+            // Wait for the producer to go idle and then enqueue another event.
+
+            await idleCompletionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+            await Task.Delay(TimeSpan.FromSeconds(2), cancellationSource.Token);
+
+            await producer.EnqueueEventAsync(finalEvent, cancellationSource.Token);
+            await producer.CloseAsync(flush: true, cancellationSource.Token);
+
+            Interlocked.Increment(ref closeCount);
+
+            // Ensure that publishing completed with the expected state.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been signaled.");
+            Assert.That(handlerInvokedAfterClose, Is.False, "The handler should not have been invoked after the CloseAsync call completed.");
+            Assert.That(producer.IsClosed, Is.True, "The producer should report that it is closed.");
+            Assert.That(producer.IsPublishing, Is.False, "The producer should report that it is not publishing.");
+            Assert.That(producer.TotalBufferedEventCount, Is.EqualTo(0), "No events should remain in the buffer.");
+            Assert.That(handlerEvents.Count, Is.EqualTo(events.Count + 1), "All events should have been sent.");
+
+            // Read back the events and ensure all were successfully published.
+
+            await using var consumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            await foreach (var partitionEvent in consumerClient.ReadEventsAsync(cancellationSource.Token))
+            {
+                readEvents.Add(new EventWithPartition(partitionEvent.Partition.PartitionId, partitionEvent.Data));
+
+                if (readEvents.Count >= events.Count + 1)
+                {
+                    break;
+                }
+            }
+
+            // Ensure that all sent events were read back.
+
+            readEvents = readEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+            var sortedHandlerEvents = handlerEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+
+            for (var index = 0; index < readEvents.Count; ++index)
+            {
+                Assert.That(readEvents[index].PartitionId, Is.EqualTo(sortedHandlerEvents[index].PartitionId), $"The partition for the read and sent events should match at index: [{index}].");
+                Assert.That(readEvents[index].Event.IsEquivalentTo(sortedHandlerEvents[index].Event), Is.True, $"The event for the read and sent events should match at index: [{index}].");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to publish events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseIsSuccessfulWhileIdle()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var handlerEvents = 0;
+            var partitionCount = 2;
+            var eventsPerPartition = 50;
+            var expectedEvents = (eventsPerPartition * partitionCount);
+            var events = EventGenerator.CreateSmallEvents(expectedEvents).ToList();
+            var initialSendCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var idleCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var options = new EventHubBufferedProducerClientOptions { MaximumConcurrentSends = partitionCount };
+            var mockLogger = new Mock<EventHubsEventSource>();
+
+            mockLogger
+                .Setup(log => log.BufferedProducerIdleStart(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .Callback(() => idleCompletionSource.TrySetResult(true));
+
+            await using var scope = await EventHubScope.CreateAsync(partitionCount);
+            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName, options);
+
+            producer.Logger = mockLogger.Object;
+
+            producer.SendEventBatchSucceededAsync += args =>
+            {
+                handlerEvents += args.EventBatch.Count;
+
+                if (handlerEvents >= expectedEvents)
+                {
+                    initialSendCompletionSource.TrySetResult(true);
+                }
+
+                return Task.CompletedTask;
+            };
+
+            producer.SendEventBatchFailedAsync += args =>
+            {
+                ExceptionDispatchInfo.Capture(args.Exception).Throw();
+                return Task.CompletedTask;
+            };
+
+            // Enqueue and wait for the initial send to complete.
+
+            await producer.EnqueueEventsAsync(events, cancellationSource.Token);
+            await initialSendCompletionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+
+            // Wait for the producer to go idle and then close.
+
+            await idleCompletionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+            await Task.Delay(TimeSpan.FromSeconds(2), cancellationSource.Token);
+            await producer.CloseAsync(flush: true, cancellationSource.Token);
+
+            // Ensure that publishing completed with the expected state.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been signaled.");
+            Assert.That(producer.IsClosed, Is.True, "The producer should report that it is closed.");
+            Assert.That(producer.IsPublishing, Is.False, "The producer should report that it is not publishing.");
+            Assert.That(producer.TotalBufferedEventCount, Is.EqualTo(0), "No events should remain in the buffer.");
+            Assert.That(handlerEvents, Is.EqualTo(events.Count), "All events should have been sent.");
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientLiveTests.cs
@@ -661,7 +661,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ProducerCanPublisAfterIdle()
+        public async Task ProducerCanPublishAfterIdle()
         {
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientTests.cs
@@ -5213,7 +5213,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 })
                 .Returns(Task.CompletedTask);
 
-             // Create a buffered event for each partition.
+            // Create a buffered event for each partition.
 
             foreach (var partition in validPartitions)
             {
@@ -5223,6 +5223,11 @@ namespace Azure.Messaging.EventHubs.Tests
                 await state.PendingEventsWriter.WriteAsync(new EventData($"single-for-{ partition }"), cancellationSource.Token);
                 state.BufferedEventCount = 1;
             }
+
+            // Since enqueue was bypassed, set the total buffered count to match the
+            // partition state.
+
+            SetTotalBufferedEventCount(mockBufferedProducer.Object, validPartitions.Length);
 
             try
             {
@@ -5308,6 +5313,11 @@ namespace Azure.Messaging.EventHubs.Tests
                 }
             }
 
+            // Since enqueue was bypassed, set the total buffered count to match the
+            // partition state.
+
+            SetTotalBufferedEventCount(mockBufferedProducer.Object, validPartitions.Length);
+
             try
             {
                 // Start publishing and wait for publishing to complete.
@@ -5392,6 +5402,11 @@ namespace Azure.Messaging.EventHubs.Tests
                     ++state.BufferedEventCount;
                 }
             }
+
+            // Since enqueue was bypassed, set the total buffered count to match the
+            // partition state.
+
+            SetTotalBufferedEventCount(mockBufferedProducer.Object, expectedPublishCount);
 
             try
             {
@@ -5479,6 +5494,11 @@ namespace Azure.Messaging.EventHubs.Tests
                 }
             }
 
+            // Since enqueue was bypassed, set the total buffered count to match the
+            // partition state.
+
+            SetTotalBufferedEventCount(mockBufferedProducer.Object, expectedPublishCount);
+
             try
             {
                 // Start publishing and wait for publishing to complete.
@@ -5505,6 +5525,124 @@ namespace Azure.Messaging.EventHubs.Tests
                     true,
                     It.IsAny<CancellationToken>()),
                 Times.Exactly(expectedPublishCount));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the background management task.
+        /// </summary>
+        ///
+        [Test]
+        public async Task BackgroundPublishingTaskPublishesAfterAnEmptyBufferIdle()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var eventsPerPartition = 8;
+            var concurrentSendsPerPartition = 3;
+            var validPartitions = new[] { "5", "8", "11", "frank" };
+            var concurentSends = (validPartitions.Length * concurrentSendsPerPartition);
+            var publishCount = 0;
+            var expectedPublishCount = validPartitions.Length * eventsPerPartition;
+            var initialPublishCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var delayPublishCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var idleCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var options = new EventHubBufferedProducerClientOptions { MaximumConcurrentSends = concurentSends, MaximumConcurrentSendsPerPartition = concurrentSendsPerPartition };
+            var mockLogger = new Mock<EventHubsEventSource>();
+            var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
+            var mockBufferedProducer = new Mock<EventHubBufferedProducerClient>(mockProducer.Object, options) { CallBase = true };
+
+            mockLogger
+                .Setup(log => log.BufferedProducerIdleStart(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .Callback(() => idleCompletionSource.TrySetResult(true));
+
+            mockProducer
+                .Setup(producer => producer.GetPartitionIdsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(validPartitions);
+
+            mockBufferedProducer
+                .Setup(producer => producer.PublishBatchToPartition(It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Callback<EventHubBufferedProducerClient.PartitionPublishingState, bool, CancellationToken>((state, releaseFlag, token) =>
+                {
+                    state.TryReadEvent(out _);
+                    Interlocked.Decrement(ref state.BufferedEventCount);
+
+                    if (releaseFlag)
+                    {
+                        state.PartitionGuard.Release();
+                    }
+
+                    if (Interlocked.Increment(ref publishCount) == expectedPublishCount)
+                    {
+                        SetTotalBufferedEventCount(mockBufferedProducer.Object, 0);
+                        initialPublishCompletionSource.TrySetResult(true);
+                    }
+
+                    if (publishCount > expectedPublishCount)
+                    {
+                        delayPublishCompletionSource.TrySetResult(true);
+                    }
+                })
+                .Returns(Task.CompletedTask);
+
+            mockBufferedProducer.Object.Logger = mockLogger.Object;
+            mockBufferedProducer.Object.SendEventBatchFailedAsync += args => Task.CompletedTask;
+
+            // Enqueue events into each partition.
+
+            foreach (var partition in validPartitions)
+            {
+                for (int index = 0; index < eventsPerPartition; ++index)
+                {
+                    await mockBufferedProducer.Object.EnqueueEventAsync(new EventData($"{index}-for-{partition}"), cancellationSource.Token);
+                }
+            }
+
+            try
+            {
+                // Start publishing and wait for the initial set of publishing to complete.
+
+                await InvokeStartPublishingAsync(mockBufferedProducer.Object, cancellationSource.Token);
+                await initialPublishCompletionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+
+                // Delay to give the background task time to reach a blocking state, then publish a follow-up
+                // event and wait for it to be completed.
+
+                await idleCompletionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+                await Task.Delay(TimeSpan.FromSeconds(2), cancellationSource.Token);
+
+                await mockBufferedProducer.Object.EnqueueEventAsync(new EventData("Delay event"), cancellationSource.Token);
+                await delayPublishCompletionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+            }
+            finally
+            {
+                await InvokeStopPublishingAsync(mockBufferedProducer.Object, cancellationSource.Token).IgnoreExceptions();
+            }
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
+
+            foreach (var partition in validPartitions)
+            {
+                var state = mockBufferedProducer.Object.ActivePartitionStateMap[partition];
+                Assert.That(state.BufferedEventCount, Is.EqualTo(0), $"There should be no events in the buffer for partition: [{partition}].");
+            }
+
+            mockBufferedProducer
+                .Verify(producer => producer.PublishBatchToPartition(
+                    It.Is<EventHubBufferedProducerClient.PartitionPublishingState>(value => validPartitions.Any(item => item == value.PartitionId)),
+                    true,
+                    It.IsAny<CancellationToken>()),
+                Times.Exactly(expectedPublishCount + 1));
+
+            mockLogger
+                .Verify(log => log.BufferedProducerIdleComplete(
+                    mockBufferedProducer.Object.Identifier,
+                    mockBufferedProducer.Object.EventHubName,
+                    It.IsAny<string>(),
+                    It.IsAny<double>()),
+                Times.Once);
         }
 
         /// <summary>
@@ -5577,6 +5715,11 @@ namespace Azure.Messaging.EventHubs.Tests
                 await state.PendingEventsWriter.WriteAsync(new EventData($"single-for-{ partition }"), executionLimitCancellationSource.Token);
                 state.BufferedEventCount = 1;
             }
+
+            // Since enqueue was bypassed, set the total buffered count to match the
+            // partition state.
+
+            SetTotalBufferedEventCount(mockBufferedProducer.Object, validPartitions.Length);
 
             try
             {
@@ -6257,6 +6400,17 @@ namespace Azure.Messaging.EventHubs.Tests
             typeof(EventHubBufferedProducerClient)
                 .GetField("_producerManagementTask", BindingFlags.Instance | BindingFlags.NonPublic)
                 .SetValue(client, backgroundManagementTask);
+
+        /// <summary>
+        ///   Sets the non-public field for the count of total buffered events on the
+        ///   specified client instance.
+        /// </summary>
+        ///
+        private void SetTotalBufferedEventCount(EventHubBufferedProducerClient client,
+                                                int bufferedEventCount) =>
+            typeof(EventHubBufferedProducerClient)
+                .GetField("_totalBufferedEventCount", BindingFlags.Instance | BindingFlags.NonPublic)
+                .SetValue(client, bufferedEventCount);
 
         /// <summary>
         ///   Sets the non-public background publishing task field on the specified


### PR DESCRIPTION
# Summary

The focus of these changes is to fix an issue with the `EventHubBufferedProducerClient` where it failed to detect empty buffers and enter an idle state.  Instead, the background task that manages publishing would spin and consume an unreasonable amount of resources.

# References and Related

- [[BUG] EventHubBufferedProducerClient: high CPU usage when no events are being sent (#28926)](https://github.com/Azure/azure-sdk-for-net/issues/28926)
- [Buffered Producer: Consider Blocking when No Events Available (#28840)](https://github.com/Azure/azure-sdk-for-net/issues/28840)