### PR TITLE
Remove locale string from DataProtection extension docs link

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/Azure.Extensions.AspNetCore.DataProtection.Blobs.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/Azure.Extensions.AspNetCore.DataProtection.Blobs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <Description>Microsoft Azure Blob storage support as key store (https://docs.microsoft.com/en-us/aspnet/core/security/data-protection/implementation/key-storage-providers).</Description>
+    <Description>Microsoft Azure Blob storage support as key store (https://docs.microsoft.com/aspnet/core/security/data-protection/implementation/key-storage-providers).</Description>
     <PackageTags>aspnetcore;dataprotection;azure;blob;key store</PackageTags>
     <Version>1.3.0-beta.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->


### PR DESCRIPTION
Remove the *en-us* locale string from the docs link referenced in the project file.

![image](https://user-images.githubusercontent.com/10702007/173686951-88a5fd02-4435-46f8-a0da-e3dbd56d57e5.png)
