### PR TITLE
Stops building and testing deprecated t1 search packages.

### DIFF
--- a/sdk/search/service.projects
+++ b/sdk/search/service.projects
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <!-- Remove data plane tests from nightly live runs: https://github.com/Azure/azure-sdk-for-net/issues/10437 -->
-    <ProjectReference Remove="$(MSBuildThisFileDirectory)Microsoft.Azure.*\**\*.csproj" Condition="'$(AZURE_SEARCH_TEST_MODE)' == 'Live'" />
+    <!-- Remove deprecated track 1 packages from builds and live testing. -->
+    <ProjectReference Remove="$(MSBuildThisFileDirectory)Microsoft.Azure.*\**\*.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/29299#issue-1271224177

I removed the deprecated track 1 search packages from builds and live testing.

