### PR TITLE
Support explicit implementations of ITableEntity in the TypeBinder.

### DIFF
--- a/sdk/tables/Azure.Data.Tables/src/Extensions/TablesTypeBinder.cs
+++ b/sdk/tables/Azure.Data.Tables/src/Extensions/TablesTypeBinder.cs
@@ -10,7 +10,10 @@ namespace Azure.Data.Tables
 {
     internal class TablesTypeBinder: TypeBinder<IDictionary<string, object>>
     {
-        private TablesTypeBinder() : base(bindITableEntityProperties: true) { }
+        private TablesTypeBinder()
+        {
+            AddInterfaceOfInterest(typeof(ITableEntity));
+        }
 
         public static TablesTypeBinder Shared { get; } = new();
         protected override void Set<T>(IDictionary<string, object> destination, T value, BoundMemberInfo memberInfo)

--- a/sdk/tables/Azure.Data.Tables/src/Extensions/TablesTypeBinder.cs
+++ b/sdk/tables/Azure.Data.Tables/src/Extensions/TablesTypeBinder.cs
@@ -10,6 +10,8 @@ namespace Azure.Data.Tables
 {
     internal class TablesTypeBinder: TypeBinder<IDictionary<string, object>>
     {
+        private TablesTypeBinder() : base(bindITableEntityProperties: true) { }
+
         public static TablesTypeBinder Shared { get; } = new();
         protected override void Set<T>(IDictionary<string, object> destination, T value, BoundMemberInfo memberInfo)
         {


### PR DESCRIPTION
* Add support to TypeBinder for binding ITableEntity properties when:
  * the behavior is requested
  * The type implements ITableEntity
  * The type doesn't provide implementations of properties with the same names
* Opt TablesTypeBinder into this new behavior

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
