### PR TITLE
Add credscan for mgmt ci pipeline.

### DIFF
--- a/eng/pipelines/templates/jobs/ci.mgmt.yml
+++ b/eng/pipelines/templates/jobs/ci.mgmt.yml
@@ -107,3 +107,13 @@ jobs:
             }
           failOnStderr: true
           pwsh: true
+
+  - job: Compliance
+    pool:
+      name: azsdk-pool-mms-win-2019-general
+      vmImage: MMS2019
+    steps:      
+      - template: /eng/common/pipelines/templates/steps/credscan.yml
+        parameters:
+          BaselineFilePath: $(Build.sourcesdirectory)/eng/dotnet.gdnbaselines
+          ServiceDirectory: ${{ parameters.ServiceDirectory }}


### PR DESCRIPTION
# Contributing to the Azure SDK

There are some credscan errors not checked into the repo which failed the ci nightly build.
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1653887&view=logs&j=bc67675d-56bf-581f-e0a2-208848ba68ca&t=7eee3a58-6120-518b-7fcb-7e943712aa81

It is due to we are lack of the credscan step for mgmt PR checking. The PR is to add the check to right place.

This is the pre-requisite [PR](https://github.com/Azure/azure-sdk-for-net/pull/29374/files) before this can be checked in.

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
