### PR TITLE
[AzureMonitorExporter] add Truncation rules for TelemetryEnvelope

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SchemaConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SchemaConstants.cs
@@ -111,7 +111,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public const int StackFrame_Assembly_MaxLength = 1024;
         public const int StackFrame_FileName_MaxLength = 1024;
 
-        // TODO: Apply these rules
-        public const int TelemetryEnvelope_Seq_MaxLength = 64;
+        public const int TelemetryEnvelope_Seq_MaxLength = 64; // TODO: TelemetryItem.Sequence is currently not in use (2022-06-20).
+        public const int TelemetryEnvelope_Name_MaxLength = 1024;
+        public const int TelemetryEnvelope_Time_MaxLength = 64;
+        public const int TelemetryEnvelope_InstrumentationKey_MaxLength = 40;
     }
 }


### PR DESCRIPTION
Continuation of #29094 

### Changes
- add truncation rules for `TelemetryEnvelope` to `SchemaConstants`
- No rules were implemented. 
  - Ikey and Time are formatted values that are under the limit.
  - Name is set from a set of discrete values, all under length.