### PR TITLE
Allowing communication SDK to load in Mac

### DIFF
--- a/sdk/communication/Azure.Communication.CallingServer/tests/Azure.Communication.CallingServer.Tests.csproj
+++ b/sdk/communication/Azure.Communication.CallingServer/tests/Azure.Communication.CallingServer.Tests.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\src\Azure.Communication.CallingServer.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\tests.yml" Link="\tests.yml" />
+    <None Include="..\tests.yml" Link="tests.yml" />
     <None Include="..\samples\README.md" Link="samples\README.md" />
     <None Include="..\samples\Sample1_CreateCall.md" Link="samples\Sample1_CreateCall.md" />
     <None Include="..\samples\Sample1_CreateCallAsync.md" Link="samples\Sample1_CreateCallAsync.md" />

--- a/sdk/communication/Azure.Communication.Chat/tests/Azure.Communication.Chat.Tests.csproj
+++ b/sdk/communication/Azure.Communication.Chat/tests/Azure.Communication.Chat.Tests.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\src\Azure.Communication.Chat.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\tests.yml" Link="\tests.yml" />
+    <None Include="..\tests.yml" Link="tests.yml" />
   </ItemGroup>
 
   <!-- Shared source from Azure.Core -->

--- a/sdk/communication/Azure.Communication.Identity/tests/Azure.Communication.Identity.Tests.csproj
+++ b/sdk/communication/Azure.Communication.Identity/tests/Azure.Communication.Identity.Tests.csproj
@@ -21,7 +21,7 @@
     <Compile Include="$(AzureCoreSharedSources)ConnectionString.cs" LinkBase="Shared" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\tests.yml" Link="\tests.yml" />
+    <None Include="..\tests.yml" Link="tests.yml" />
     <None Include="..\samples\README.md" Link="samples\README.md" />
     <None Include="..\samples\Sample1_CommunicationIdentityClient.md" Link="samples\Sample1_CommunicationIdentityClient.md" />
     <None Include="..\samples\Sample1_CommunicationIdentityClientAsync.md" Link="samples\Sample1_CommunicationIdentityClientAsync.md" />

--- a/sdk/communication/Azure.Communication.NetworkTraversal/tests/Azure.Communication.NetworkTraversal.Tests.csproj
+++ b/sdk/communication/Azure.Communication.NetworkTraversal/tests/Azure.Communication.NetworkTraversal.Tests.csproj
@@ -22,7 +22,7 @@
     <Compile Include="$(AzureCoreSharedSources)ConnectionString.cs" LinkBase="Shared" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\tests.yml" Link="\tests.yml" />
+    <None Include="..\tests.yml" Link="tests.yml" />
     <None Include="..\samples\README.md" Link="samples\README.md" />
   </ItemGroup>
 </Project>

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/Azure.Communication.PhoneNumbers.Tests.csproj
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/Azure.Communication.PhoneNumbers.Tests.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <None Include="..\samples\Sample_SipRoutingClient.md" Link="samples\Sample_SipRoutingClient.md" />
     <None Include="..\samples\Sample_SipRoutingClientAsync.md" Link="samples\Sample_SipRoutingClientAsync.md" />
-    <None Include="..\tests.yml" Link="\tests.yml" />
+    <None Include="..\tests.yml" Link="tests.yml" />
     <None Include="..\samples\README.md" Link="samples\README.md" />
     <None Include="..\samples\Sample_PhoneNumbersClient.md" Link="samples\Sample_PhoneNumbersClient.md" />
     <None Include="..\samples\Sample_PhoneNumbersClientAsync.md" Link="samples\Sample_PhoneNumbersClientAsync.md" />

--- a/sdk/communication/Azure.Communication.ShortCodes/tests/Azure.Communication.ShortCodes.Tests.csproj
+++ b/sdk/communication/Azure.Communication.ShortCodes/tests/Azure.Communication.ShortCodes.Tests.csproj
@@ -22,7 +22,7 @@
     <Compile Include="$(AzureCoreSharedSources)ConnectionString.cs" LinkBase="Shared" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\tests.yml" Link="\tests.yml" />
+    <None Include="..\tests.yml" Link="tests.yml" />
     <None Include="..\samples\README.md" Link="samples\README.md" />
     <None Include="..\samples\Sample1_ShortCodesClient.md" Link="samples\Sample1_ShortCodesClient.md" />
   </ItemGroup>

--- a/sdk/communication/Azure.Communication.Sms/tests/Azure.Communication.Sms.Tests.csproj
+++ b/sdk/communication/Azure.Communication.Sms/tests/Azure.Communication.Sms.Tests.csproj
@@ -20,7 +20,7 @@
     <Compile Include="$(AzureCoreSharedSources)ConnectionString.cs" Link="Shared\\ConnectionString.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\tests.yml" Link="\tests.yml" />
+    <None Include="..\tests.yml" Link="tests.yml" />
     <None Include="..\samples\README.md" Link="samples\README.md" />
     <None Include="..\samples\Sample1_SendSms.md" Link="samples\Sample1_SendSms.md" />
     <None Include="..\samples\Sample1_SendSmsAsync.md" Link="samples\Sample1_SendSmsAsync.md" />


### PR DESCRIPTION
When opening the SDK solution in VS for Mac, it fails because it cannot load the `csproj` files. 
The error is that VS for Mac apparently doesn't understand the backslash ("\") at the beginning of the routes.