### PR TITLE
AuthenticatedRegionCryptoStream fixes

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/AuthenticatedRegionCryptoStream.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/AuthenticatedRegionCryptoStream.cs
@@ -24,7 +24,7 @@ namespace Azure.Storage.Cryptography
         // need to record how much data in buffer is legitimate
         private int _bufferPopulatedLength;
 
-        private readonly int _tempRefilBufferSize;
+        private readonly int _tempRefillBufferSize;
 
         public override bool CanRead => _mode == CryptoStreamMode.Read;
 
@@ -56,7 +56,7 @@ namespace Azure.Storage.Cryptography
                 (transform.TransformMode == TransformMode.Decrypt && streamMode == CryptoStreamMode.Read))
             {
                 bufferSize = regionDataSize;
-                _tempRefilBufferSize = transform.NonceLength + regionDataSize + transform.TagLength;
+                _tempRefillBufferSize = transform.NonceLength + regionDataSize + transform.TagLength;
             }
                 // read and encrypt plaintext from innerStream, then store ciphertext results in _buffer to be read by caller
             else if ((transform.TransformMode == TransformMode.Encrypt && streamMode == CryptoStreamMode.Read) ||
@@ -64,7 +64,7 @@ namespace Azure.Storage.Cryptography
                 (transform.TransformMode == TransformMode.Decrypt && streamMode == CryptoStreamMode.Write))
             {
                 bufferSize = transform.NonceLength + regionDataSize + transform.TagLength;
-                _tempRefilBufferSize = regionDataSize;
+                _tempRefillBufferSize = regionDataSize;
             }
             else
             {
@@ -109,7 +109,7 @@ namespace Azure.Storage.Cryptography
             // refill _buffer with transformed contents from innerStream
             if (_bufferPos >= _buffer.Length)
             {
-                var transformInputBuffer = new byte[_tempRefilBufferSize];
+                var transformInputBuffer = new byte[_tempRefillBufferSize];
 
                 int totalRead = 0;
                 while (totalRead < transformInputBuffer.Length)
@@ -195,7 +195,7 @@ namespace Azure.Storage.Cryptography
             // flush buffer if full, else ignore
             if (_bufferPos >= _buffer.Length)
             {
-                var transformedContentsBuffer = new byte[_tempRefilBufferSize];
+                var transformedContentsBuffer = new byte[_tempRefillBufferSize];
                 int outputBytes = _transform.TransformAuthenticationBlock(
                     input: _buffer,
                     output: transformedContentsBuffer);
@@ -239,7 +239,7 @@ namespace Azure.Storage.Cryptography
             // if there is a final partial block, force-flush
             if (_bufferPos != 0)
             {
-                var transformedContentsBuffer = new byte[_tempRefilBufferSize];
+                var transformedContentsBuffer = new byte[_tempRefillBufferSize];
                 int outputBytes = _transform.TransformAuthenticationBlock(
                     input: new ReadOnlySpan<byte>(_buffer, 0, _bufferPos),
                     output: transformedContentsBuffer);

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/AuthenticatedRegionCryptoStream.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/AuthenticatedRegionCryptoStream.cs
@@ -88,25 +88,18 @@ namespace Azure.Storage.Cryptography
 
         #region Read
         public override int Read(byte[] buffer, int offset, int count)
-        {
-            if (!CanRead)
-            {
-                throw new NotSupportedException();
-            }
-            return ReadInternal(buffer, offset, count, false, default).EnsureCompleted();
-        }
+            => ReadInternal(buffer, offset, count, false, default).EnsureCompleted();
 
         public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            if (!CanRead)
-            {
-                throw new NotSupportedException();
-            }
-            return await ReadInternal(buffer, offset, count, true, cancellationToken).ConfigureAwait(false);
-        }
+            => await ReadInternal(buffer, offset, count, true, cancellationToken).ConfigureAwait(false);
 
         private async Task<int> ReadInternal(byte[] buffer, int offset, int count, bool async, CancellationToken cancellationToken)
         {
+            if (!CanRead)
+            {
+                throw new NotSupportedException();
+            }
+
             // refill _buffer with transformed contents from innerStream
             if (_bufferPos >= _buffer.Length)
             {


### PR DESCRIPTION
Addresses
- https://github.com/Azure/azure-sdk-for-net/pull/28870#discussion_r897388595
- https://github.com/Azure/azure-sdk-for-net/pull/28870#discussion_r897389351
- https://github.com/Azure/azure-sdk-for-net/pull/28870#discussion_r897390344

Part of https://github.com/Azure/azure-sdk-for-net/issues/29305

Note that this PR doesn't entirely replace buffer allocations in this class. The main buffer in the class has been left as a new array instance. This class has a lot of code dependent on the main buffer length being exactly as requested. If we feel this should also be shifted to array pool renting, a separate issue can be filed to address this. This PR does replace all temporary buffers with array pool rents.