### PR TITLE
Revert "Override live test location default to westus"

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -49,14 +49,8 @@ parameters:
   default:
     Public:
       SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
-      # TODO: Migrate location override into azure-sdk-tools eng/common
-      # See https://github.com/Azure/azure-sdk-tools/issues/3398
-      Location: 'westus'
     Preview:
       SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-      # TODO: Migrate location override into azure-sdk-tools eng/common
-      # See https://github.com/Azure/azure-sdk-tools/issues/3398
-      Location: 'westus'
     Canary:
       SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
       Location: 'eastus2euap'


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-net#29092