### PR TITLE
[Event Hubs] Flaky Test Tweaks

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/WebJobsEventHubTestBase.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/WebJobsEventHubTestBase.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
     public class WebJobsEventHubTestBase
     {
         protected const string TestHubName = "%webjobstesthub%";
-        protected static readonly int Timeout = (int)TimeSpan.FromSeconds(75).TotalMilliseconds;
+        protected static readonly int Timeout = (int)TimeSpan.FromSeconds(90).TotalMilliseconds;
 
         /// <summary>The active Event Hub resource scope for the test fixture.</summary>
         protected EventHubScope _eventHubScope;


### PR DESCRIPTION
# Summary

The focus of these changes is to tweak some tests that have been flaky during nightly runs.  The timeout for Functions end-to-end tests has been bumped slightly to allow additional time for an event to be made available for reading in the partition, since this is not governed by an SLA on the service-side. The buffered producer idle test been focused on its core scenario, removing one of the synchronization gates to help streamline and keep forward progress.