### PR TITLE
Adding test coverage for account SAS generated in different resource …

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/Azure.Storage.Blobs.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Blobs/tests/Azure.Storage.Blobs.Tests.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Microsoft.Azure.Management.Storage\src\Microsoft.Azure.Management.Storage.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(AzureStorageSharedTestSources)..\Sas\*.cs" LinkBase="Shared\Sas" />
     <Compile Include="$(AzureStorageSharedTestSources)\**\*.cs" LinkBase="Shared" />
     <None Include="$(AzureStorageSharedTestSources)\*.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasTests.cs
@@ -307,15 +307,10 @@ namespace Azure.Storage.Blobs.Test
             await sasBlobClient.GetPropertiesAsync();
         }
 
-        [RecordedTest]
-        [TestCase("sco")]
-        [TestCase("soc")]
-        [TestCase("cos")]
-        [TestCase("ocs")]
-        [TestCase("os")]
-        [TestCase("oc")]
-        [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2020_06_12)]
-        public async Task AccountSas_ResourceTypeOrder(string resourceType)
+        private async Task InvokeAccountSasTest(
+            string permissions = "rwdylacuptfi",
+            string services = "bqtf",
+            string resourceType = "sco")
         {
             // Arrange
             await using DisposingContainer test = await GetTestContainerAsync();
@@ -325,8 +320,6 @@ namespace Azure.Storage.Blobs.Test
 
             // Generate a SAS that would set the srt / ResourceTypes in a different order than
             // the .NET SDK would normally create the SAS
-            string permissions = "rwdylacuptfi";
-            string services = "bqtf";
             TestAccountSasBuilder accountSasBuilder = new TestAccountSasBuilder(
                 permissions: permissions,
                 expiresOn: Recording.UtcNow.AddDays(1),
@@ -344,6 +337,19 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [RecordedTest]
+        [TestCase("sco")]
+        [TestCase("soc")]
+        [TestCase("cos")]
+        [TestCase("ocs")]
+        [TestCase("os")]
+        [TestCase("oc")]
+        [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2020_06_12)]
+        public async Task AccountSas_ResourceTypeOrder(string resourceType)
+        {
+            await InvokeAccountSasTest(resourceType: resourceType);
+        }
+
+        [RecordedTest]
         [TestCase("bfqt")]
         [TestCase("qftb")]
         [TestCase("tqfb")]
@@ -353,30 +359,7 @@ namespace Azure.Storage.Blobs.Test
         [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2020_06_12)]
         public async Task AccountSas_ServiceOrder(string services)
         {
-            // Arrange
-            await using DisposingContainer test = await GetTestContainerAsync();
-            string blobName = GetNewBlobName();
-            AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(blobName));
-            await blob.CreateAsync();
-
-            // Generate a SAS that would set the srt / ResourceTypes in a different order than
-            // the .NET SDK would normally create the SAS
-            string permissions = "rwdylacuptfi";
-            string resourceTypes = "sco";
-            TestAccountSasBuilder accountSasBuilder = new TestAccountSasBuilder(
-                permissions: permissions,
-                expiresOn: Recording.UtcNow.AddDays(1),
-                services: services,
-                resourceTypes: resourceTypes);
-
-            UriBuilder blobUriBuilder = new UriBuilder(blob.Uri)
-            {
-                Query = accountSasBuilder.ToTestSasQueryParameters(Tenants.GetNewSharedKeyCredentials()).ToString()
-            };
-
-            // Assert
-            AppendBlobClient sasBlobClient = InstrumentClient(new AppendBlobClient(blobUriBuilder.Uri, GetOptions()));
-            await sasBlobClient.GetPropertiesAsync();
+            await InvokeAccountSasTest(services: services);
         }
 
         [RecordedTest]
@@ -389,30 +372,7 @@ namespace Azure.Storage.Blobs.Test
         [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2020_06_12)]
         public async Task AccountSas_PermissionsOrder(string permissions)
         {
-            // Arrange
-            await using DisposingContainer test = await GetTestContainerAsync();
-            string blobName = GetNewBlobName();
-            AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(blobName));
-            await blob.CreateAsync();
-
-            // Generate a SAS that would set the srt / ResourceTypes in a different order than
-            // the .NET SDK would normally create the SAS
-            string services = "bqtf";
-            string resourceTypes = "sco";
-            TestAccountSasBuilder accountSasBuilder = new TestAccountSasBuilder(
-                permissions: permissions,
-                expiresOn: Recording.UtcNow.AddDays(1),
-                services: services,
-                resourceTypes: resourceTypes);
-
-            UriBuilder blobUriBuilder = new UriBuilder(blob.Uri)
-            {
-                Query = accountSasBuilder.ToTestSasQueryParameters(Tenants.GetNewSharedKeyCredentials()).ToString()
-            };
-
-            // Assert
-            AppendBlobClient sasBlobClient = InstrumentClient(new AppendBlobClient(blobUriBuilder.Uri, GetOptions()));
-            await sasBlobClient.GetPropertiesAsync();
+            await InvokeAccountSasTest(permissions: permissions);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasTests.cs
@@ -10,6 +10,7 @@ using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Blobs.Tests;
 using Azure.Storage.Sas;
 using Azure.Storage.Test.Shared;
+using NUnit.Framework;
 
 namespace Azure.Storage.Blobs.Test
 {
@@ -303,6 +304,114 @@ namespace Azure.Storage.Blobs.Test
 
             // Assert
             AppendBlobClient sasBlobClient = InstrumentClient(new AppendBlobClient(blobUriBuilder.ToUri(), GetOptions()));
+            await sasBlobClient.GetPropertiesAsync();
+        }
+
+        [RecordedTest]
+        [TestCase("sco")]
+        [TestCase("soc")]
+        [TestCase("cos")]
+        [TestCase("ocs")]
+        [TestCase("os")]
+        [TestCase("oc")]
+        [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2020_06_12)]
+        public async Task AccountSas_ResourceTypeOrder(string resourceType)
+        {
+            // Arrange
+            await using DisposingContainer test = await GetTestContainerAsync();
+            string blobName = GetNewBlobName();
+            AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(blobName));
+            await blob.CreateAsync();
+
+            // Generate a SAS that would set the srt / ResourceTypes in a different order than
+            // the .NET SDK would normally create the SAS
+            string permissions = "rwdylacuptfi";
+            string services = "bqtf";
+            TestAccountSasBuilder accountSasBuilder = new TestAccountSasBuilder(
+                permissions: permissions,
+                expiresOn: Recording.UtcNow.AddDays(1),
+                services: services,
+                resourceTypes: resourceType);
+
+            UriBuilder blobUriBuilder = new UriBuilder(blob.Uri)
+            {
+                Query = accountSasBuilder.ToTestSasQueryParameters(Tenants.GetNewSharedKeyCredentials()).ToString()
+            };
+
+            // Assert
+            AppendBlobClient sasBlobClient = InstrumentClient(new AppendBlobClient(blobUriBuilder.Uri, GetOptions()));
+            await sasBlobClient.GetPropertiesAsync();
+        }
+
+        [RecordedTest]
+        [TestCase("bfqt")]
+        [TestCase("qftb")]
+        [TestCase("tqfb")]
+        [TestCase("bqt")]
+        [TestCase("qb")]
+        [TestCase("fb")]
+        [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2020_06_12)]
+        public async Task AccountSas_ServiceOrder(string services)
+        {
+            // Arrange
+            await using DisposingContainer test = await GetTestContainerAsync();
+            string blobName = GetNewBlobName();
+            AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(blobName));
+            await blob.CreateAsync();
+
+            // Generate a SAS that would set the srt / ResourceTypes in a different order than
+            // the .NET SDK would normally create the SAS
+            string permissions = "rwdylacuptfi";
+            string resourceTypes = "sco";
+            TestAccountSasBuilder accountSasBuilder = new TestAccountSasBuilder(
+                permissions: permissions,
+                expiresOn: Recording.UtcNow.AddDays(1),
+                services: services,
+                resourceTypes: resourceTypes);
+
+            UriBuilder blobUriBuilder = new UriBuilder(blob.Uri)
+            {
+                Query = accountSasBuilder.ToTestSasQueryParameters(Tenants.GetNewSharedKeyCredentials()).ToString()
+            };
+
+            // Assert
+            AppendBlobClient sasBlobClient = InstrumentClient(new AppendBlobClient(blobUriBuilder.Uri, GetOptions()));
+            await sasBlobClient.GetPropertiesAsync();
+        }
+
+        [RecordedTest]
+        [TestCase("rwdylacuptfi")]
+        [TestCase("cuprwdylatfi")]
+        [TestCase("cudypafitrwl")]
+        [TestCase("cuprwdyla")]
+        [TestCase("rywdlcaup")]
+        [TestCase("larwdycup")]
+        [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2020_06_12)]
+        public async Task AccountSas_PermissionsOrder(string permissions)
+        {
+            // Arrange
+            await using DisposingContainer test = await GetTestContainerAsync();
+            string blobName = GetNewBlobName();
+            AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(blobName));
+            await blob.CreateAsync();
+
+            // Generate a SAS that would set the srt / ResourceTypes in a different order than
+            // the .NET SDK would normally create the SAS
+            string services = "bqtf";
+            string resourceTypes = "sco";
+            TestAccountSasBuilder accountSasBuilder = new TestAccountSasBuilder(
+                permissions: permissions,
+                expiresOn: Recording.UtcNow.AddDays(1),
+                services: services,
+                resourceTypes: resourceTypes);
+
+            UriBuilder blobUriBuilder = new UriBuilder(blob.Uri)
+            {
+                Query = accountSasBuilder.ToTestSasQueryParameters(Tenants.GetNewSharedKeyCredentials()).ToString()
+            };
+
+            // Assert
+            AppendBlobClient sasBlobClient = InstrumentClient(new AppendBlobClient(blobUriBuilder.Uri, GetOptions()));
             await sasBlobClient.GetPropertiesAsync();
         }
     }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%cudypafitrwl%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%cudypafitrwl%).json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-4a7388b0-d0f8-38a1-03e4-f011076d82f7?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-8df847ec06aa58eada4eb5f6a448d069-2dc23923422d0a25-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "c0fb654c-9804-2fdc-0080-2514a1f9be3a",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "ETag": "\u00220x8DA540ADF8B0B91\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c0fb654c-9804-2fdc-0080-2514a1f9be3a",
+        "x-ms-request-id": "47b0882a-001e-0072-15f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-4a7388b0-d0f8-38a1-03e4-f011076d82f7/test-blob-da67a3b3-f1f0-f7a5-1a1b-0b2332d900e9",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-6cc3ccbc069901cda5f657e682a7f102-8df380ab05a9934e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "94136415-b2b1-5a00-bf03-a6e88db9fc27",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "ETag": "\u00220x8DA540ADF9508A8\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "94136415-b2b1-5a00-bf03-a6e88db9fc27",
+        "x-ms-request-id": "47b08855-001e-0072-3cf3-8572ae000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:30.3838888Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-4a7388b0-d0f8-38a1-03e4-f011076d82f7/test-blob-da67a3b3-f1f0-f7a5-1a1b-0b2332d900e9?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T04%3A51%3A28Z\u0026sp=cudypafitrwl\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-dd8b501d169b4fb9c45e937f21c96e74-47255e3576f328f7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ce0dc565-6bc6-a438-006a-e26e1c09e313",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "ETag": "\u00220x8DA540ADF9508A8\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "ce0dc565-6bc6-a438-006a-e26e1c09e313",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "47b0886d-001e-0072-53f3-8572ae000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:30.3838888Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-4a7388b0-d0f8-38a1-03e4-f011076d82f7?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9ae68efd4389914bd098d62d68c84683-0c4efd77a6d7a07f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "c783e69f-2dab-1460-0318-a0c93a5ad5a6",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c783e69f-2dab-1460-0318-a0c93a5ad5a6",
+        "x-ms-request-id": "47b08885-001e-0072-66f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:51:28.6841551-07:00",
+    "RandomSeed": "599004257",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%cudypafitrwl%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%cudypafitrwl%)Async.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-7dee04d1-ff50-d00b-f2a3-14ecd9b422e5?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-20664f3e0e95bc01025092a166878843-c6708c46a459c3c8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "54f97bf3-3d31-ad44-4bfb-4847dabb15f6",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "ETag": "\u00220x8DA540A8F9B9442\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "54f97bf3-3d31-ad44-4bfb-4847dabb15f6",
+        "x-ms-request-id": "bf2c83e3-901e-003d-1bf3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-7dee04d1-ff50-d00b-f2a3-14ecd9b422e5/test-blob-8ce0732b-7409-762a-1d92-0e08cdb5b35d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-013423c6704a8eba0f70d78ae1a8a447-f9a7f4dc51b211ac-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "a92a3b31-f0b3-7f29-5083-379f2e3cdf96",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "ETag": "\u00220x8DA540A8FA78AB0\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a92a3b31-f0b3-7f29-5083-379f2e3cdf96",
+        "x-ms-request-id": "bf2c841f-901e-003d-53f3-8503fa000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:16.2874544Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-7dee04d1-ff50-d00b-f2a3-14ecd9b422e5/test-blob-8ce0732b-7409-762a-1d92-0e08cdb5b35d?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T04%3A49%3A14Z\u0026sp=cudypafitrwl\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-3a6f47c7e1c8767b6b84f837299662f9-e5b8c5bc50df11cb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "91d65a11-098b-36aa-b679-0d389614b78c",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "ETag": "\u00220x8DA540A8FA78AB0\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "91d65a11-098b-36aa-b679-0d389614b78c",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bf2c8456-901e-003d-04f3-8503fa000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:16.2874544Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-7dee04d1-ff50-d00b-f2a3-14ecd9b422e5?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-56283a634c378b32ae2f589bdbccaae8-269f7d6d17511442-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d38eb920-4d65-3f0b-3fea-4347aa03c7ab",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d38eb920-4d65-3f0b-3fea-4347aa03c7ab",
+        "x-ms-request-id": "bf2c8488-901e-003d-32f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:49:14.5867869-07:00",
+    "RandomSeed": "312802378",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%cuprwdyla%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%cuprwdyla%).json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-989d4ed9-656d-4352-fb8f-ebab6278c564?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-03342ef671cc085817e5608c1de2ba20-7a85c43ec4ff4b2d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "dcea0902-9909-b8f9-bbeb-ff32bb568d0b",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "ETag": "\u00220x8DA540ADFB6A903\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dcea0902-9909-b8f9-bbeb-ff32bb568d0b",
+        "x-ms-request-id": "47b088a6-001e-0072-03f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-989d4ed9-656d-4352-fb8f-ebab6278c564/test-blob-dff7f36a-0d98-8da2-b722-74c391985849",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-7c48ba0b079ddb6bfea03c8256a9aeca-09f575abc85b849c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "f74fc71d-cbba-f4f7-665c-25e725362622",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "ETag": "\u00220x8DA540ADFC05811\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f74fc71d-cbba-f4f7-665c-25e725362622",
+        "x-ms-request-id": "47b088bd-001e-0072-18f3-8572ae000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:30.6677265Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-989d4ed9-656d-4352-fb8f-ebab6278c564/test-blob-dff7f36a-0d98-8da2-b722-74c391985849?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T04%3A51%3A28Z\u0026sp=cuprwdyla\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-0b3bfcc3b3e50978ca8b7a4e5e1e1aff-054e1b9df5408567-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "c9a6a662-6049-1a8e-64b4-f231c373cebe",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "ETag": "\u00220x8DA540ADFC05811\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "c9a6a662-6049-1a8e-64b4-f231c373cebe",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "47b088ed-001e-0072-45f3-8572ae000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:30.6677265Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-989d4ed9-656d-4352-fb8f-ebab6278c564?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1abe3630d41f028402ad7705708ab5b2-9033b7b44a66c03c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "7e84d31b-5c8f-32d9-2631-fbf9404cbd26",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7e84d31b-5c8f-32d9-2631-fbf9404cbd26",
+        "x-ms-request-id": "47b08906-001e-0072-5ef3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:51:28.9756571-07:00",
+    "RandomSeed": "561846264",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%cuprwdyla%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%cuprwdyla%)Async.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-f685a969-75d6-b073-1fd0-7ae34e8bd5b7?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-f50b309fe42b840c56e4c5fd6a48da98-c60f56324bce9b76-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "16976a67-7aac-8552-dfdc-f001cee1bbce",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "ETag": "\u00220x8DA540A8FC6BCB2\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "16976a67-7aac-8552-dfdc-f001cee1bbce",
+        "x-ms-request-id": "bf2c84c5-901e-003d-6ef3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-f685a969-75d6-b073-1fd0-7ae34e8bd5b7/test-blob-bfee3ca5-01cf-59af-9d8b-749dd037d70a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-1205d0f46ba87320ea56672e45bec345-dc7471035dbbb5c8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "9b97d67e-7f25-6634-bb3e-782106b4b5a8",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "ETag": "\u00220x8DA540A8FCF0A15\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9b97d67e-7f25-6634-bb3e-782106b4b5a8",
+        "x-ms-request-id": "bf2c84ed-901e-003d-13f3-8503fa000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:16.5463061Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-f685a969-75d6-b073-1fd0-7ae34e8bd5b7/test-blob-bfee3ca5-01cf-59af-9d8b-749dd037d70a?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T04%3A49%3A14Z\u0026sp=cuprwdyla\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-480c37aa6699c3eb9d64391714deed22-224fd683f38d5c4a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "fa1fd35e-3c9f-12e4-4215-29b546e96bea",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "ETag": "\u00220x8DA540A8FCF0A15\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "fa1fd35e-3c9f-12e4-4215-29b546e96bea",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bf2c8538-901e-003d-56f3-8503fa000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:16.5463061Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-f685a969-75d6-b073-1fd0-7ae34e8bd5b7?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b5c80c6be1afc5a21446a15b87ba2c05-8f6afd533358aa59-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "32c2e504-ba95-c808-015c-1451ad259f49",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "32c2e504-ba95-c808-015c-1451ad259f49",
+        "x-ms-request-id": "bf2c8569-901e-003d-02f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:49:14.8463783-07:00",
+    "RandomSeed": "1929838772",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%cuprwdylatfi%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%cuprwdylatfi%).json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-6a578dee-27c5-214b-ab32-b47dc39fdc80?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3f34e66098c435a3bff7443085a51270-46ed6a745c34b75c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "d0f1ec55-df3c-05c4-40ff-e1a38c817680",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "ETag": "\u00220x8DA540ADF5A65CE\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d0f1ec55-df3c-05c4-40ff-e1a38c817680",
+        "x-ms-request-id": "47b087a0-001e-0072-15f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-6a578dee-27c5-214b-ab32-b47dc39fdc80/test-blob-17b355e8-7580-68bd-20d3-e8257c11fe42",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-f229d584b1bc8757413c4bb8c883b06a-71c54d0de77b4cac-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "cd512a29-91b6-df20-2e89-b068f69f882e",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "ETag": "\u00220x8DA540ADF6796AD\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cd512a29-91b6-df20-2e89-b068f69f882e",
+        "x-ms-request-id": "47b087be-001e-0072-30f3-8572ae000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:30.0860589Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-6a578dee-27c5-214b-ab32-b47dc39fdc80/test-blob-17b355e8-7580-68bd-20d3-e8257c11fe42?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T04%3A51%3A28Z\u0026sp=cuprwdylatfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-99972b7bd467a7da371f2031d2b05211-031564e56fa39302-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "51fce8dc-30c0-f78b-f349-a9255bdcfd25",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "ETag": "\u00220x8DA540ADF6796AD\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "51fce8dc-30c0-f78b-f349-a9255bdcfd25",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "47b087d8-001e-0072-48f3-8572ae000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:30.0860589Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-6a578dee-27c5-214b-ab32-b47dc39fdc80?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-01f673b5f763064de75fd6c71362e340-d50d77172aefb50c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "0e8b59c5-36a3-d06e-1322-850ff5ac8135",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0e8b59c5-36a3-d06e-1322-850ff5ac8135",
+        "x-ms-request-id": "47b087fd-001e-0072-6af3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:51:28.3909776-07:00",
+    "RandomSeed": "1384191148",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%cuprwdylatfi%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%cuprwdylatfi%)Async.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-8a7c0b1d-d003-05d5-af99-27b3b08dac6b?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-cad10b3f5bd403beee8c2b9f351b9909-f0f27b6ea132021a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "dffee141-3bcd-ee88-8039-4829a41a5b97",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "ETag": "\u00220x8DA540A8F73519C\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dffee141-3bcd-ee88-8039-4829a41a5b97",
+        "x-ms-request-id": "bf2c8327-901e-003d-72f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-8a7c0b1d-d003-05d5-af99-27b3b08dac6b/test-blob-7fb84e12-e015-1489-6aff-d92e4629d311",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c9364183fb6f7cf1dfd3aa83a88608d7-abafa2647716fa3d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "e39af279-71e6-61a1-57e9-75cd625aa857",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "ETag": "\u00220x8DA540A8F7C3B42\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e39af279-71e6-61a1-57e9-75cd625aa857",
+        "x-ms-request-id": "bf2c8359-901e-003d-1cf3-8503fa000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:16.0036162Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-8a7c0b1d-d003-05d5-af99-27b3b08dac6b/test-blob-7fb84e12-e015-1489-6aff-d92e4629d311?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T04%3A49%3A14Z\u0026sp=cuprwdylatfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-1df4128de26c27d8492e36de865b77d8-f91514e1bb89de7a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "53b44127-ef8e-362a-cf10-76a557cf29a9",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "ETag": "\u00220x8DA540A8F7C3B42\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "53b44127-ef8e-362a-cf10-76a557cf29a9",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bf2c8390-901e-003d-4ef3-8503fa000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:16.0036162Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-8a7c0b1d-d003-05d5-af99-27b3b08dac6b?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-63cb8ceb47b636168ab0f4cc56254089-a5312a58fed37822-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "20a68194-54a5-76c8-0c4a-64981563ede1",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "20a68194-54a5-76c8-0c4a-64981563ede1",
+        "x-ms-request-id": "bf2c83b8-901e-003d-72f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:49:14.3000060-07:00",
+    "RandomSeed": "815193788",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%larwdycup%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%larwdycup%).json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-a9db7da5-d5fe-c81e-02a6-58f976184bb3?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-bf06b2bb7d71cb6e987bccb3dcf1de19-a71b010723bfeffb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "f5832ede-d129-ffa2-339b-f455d3073f36",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "ETag": "\u00220x8DA540AE016952A\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f5832ede-d129-ffa2-339b-f455d3073f36",
+        "x-ms-request-id": "47b08996-001e-0072-5cf3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-a9db7da5-d5fe-c81e-02a6-58f976184bb3/test-blob-ab2af1ac-6257-8458-be98-1588802f51bb",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-51d96eb0cfb0dd30c65fe0f45d1f1ab2-7a1fdb3bd5486232-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "85431f37-931c-7cc9-d6ff-3790bc1a7e04",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "ETag": "\u00220x8DA540AE024B086\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "85431f37-931c-7cc9-d6ff-3790bc1a7e04",
+        "x-ms-request-id": "47b089b9-001e-0072-7cf3-8572ae000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:31.3253510Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-a9db7da5-d5fe-c81e-02a6-58f976184bb3/test-blob-ab2af1ac-6257-8458-be98-1588802f51bb?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T04%3A51%3A29Z\u0026sp=larwdycup\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-030d35e7c98813e852f7c8d8e3df3c1a-0abfd0b7184f369f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "61518929-cbeb-d49e-6d9e-71951ef9cf3c",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "ETag": "\u00220x8DA540AE024B086\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "61518929-cbeb-d49e-6d9e-71951ef9cf3c",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "47b089d4-001e-0072-14f3-8572ae000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:31.3253510Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-a9db7da5-d5fe-c81e-02a6-58f976184bb3?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4afdb21d7f438deb580ff14e261dde7a-12dc21a83b5491fb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "3267e2a7-1dc8-7f18-9b1a-2e4e850b386e",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3267e2a7-1dc8-7f18-9b1a-2e4e850b386e",
+        "x-ms-request-id": "47b089ed-001e-0072-2bf3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:51:29.6259339-07:00",
+    "RandomSeed": "1584772527",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%larwdycup%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%larwdycup%)Async.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-bd73de28-8389-1eb4-3b6d-4b8dc141ec7d?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-10fe78485d2955a91e1b1009ddff767d-ffbd83b6e0d61287-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "3e4493fc-f0c6-ff7f-402e-c13e805387ed",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "ETag": "\u00220x8DA540A9016F3E4\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3e4493fc-f0c6-ff7f-402e-c13e805387ed",
+        "x-ms-request-id": "bf2c8664-901e-003d-6cf3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-bd73de28-8389-1eb4-3b6d-4b8dc141ec7d/test-blob-b2bd9cf7-48d4-dc46-4663-c9306850b40d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-496e68795ce4b328a6e0e13349cb3c72-9943b13c787551dc-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "cd6b2dd1-506f-b4f6-4d67-f863264f96ef",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "ETag": "\u00220x8DA540A901FDD63\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cd6b2dd1-506f-b4f6-4d67-f863264f96ef",
+        "x-ms-request-id": "bf2c8698-901e-003d-1bf3-8503fa000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:17.0760035Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-bd73de28-8389-1eb4-3b6d-4b8dc141ec7d/test-blob-b2bd9cf7-48d4-dc46-4663-c9306850b40d?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T04%3A49%3A15Z\u0026sp=larwdycup\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-e08542e8a1852e3c796d3b7f25528db4-2646550d323a3692-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "3b5e29d3-e6e5-1a9d-8add-e095b554439d",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "ETag": "\u00220x8DA540A901FDD63\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "3b5e29d3-e6e5-1a9d-8add-e095b554439d",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bf2c86cc-901e-003d-4ff3-8503fa000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:17.0760035Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-bd73de28-8389-1eb4-3b6d-4b8dc141ec7d?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f5165bdbbdca5cebdc300a67c9fae8d8-279aaccad2e6510a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "fd8f0c15-5bf1-930a-16b9-75e57a5a948f",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fd8f0c15-5bf1-930a-16b9-75e57a5a948f",
+        "x-ms-request-id": "bf2c86f4-901e-003d-75f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:49:15.3717930-07:00",
+    "RandomSeed": "604852475",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%rwdylacuptfi%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%rwdylacuptfi%).json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-adb7eb5f-614a-c3b5-0764-043123b50aff?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-4a6e18b562278ed137214dc05be3f83c-9de0d0e005089d6a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "3d8d616c-0af8-64c9-e218-d7d8462bff39",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "ETag": "\u00220x8DA540ADF137C33\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3d8d616c-0af8-64c9-e218-d7d8462bff39",
+        "x-ms-request-id": "47b08709-001e-0072-0df3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-adb7eb5f-614a-c3b5-0764-043123b50aff/test-blob-06db165e-b05a-9c72-5a4d-1d1101c92932",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-59eaca43e860e440a6d8c165eb3fce24-5c5538100168c294-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "838d2739-09f9-bcd2-eff0-e3aaedb86318",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "ETag": "\u00220x8DA540ADF2CB92D\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "838d2739-09f9-bcd2-eff0-e3aaedb86318",
+        "x-ms-request-id": "47b08742-001e-0072-40f3-8572ae000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:29.7002797Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-adb7eb5f-614a-c3b5-0764-043123b50aff/test-blob-06db165e-b05a-9c72-5a4d-1d1101c92932?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T04%3A51%3A28Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-40974ff25a7d4fdcb36234f36afc1bff-7fe8aedf4b87ad0c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d9d8b82a-a53b-4a39-0508-d138e95d8613",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "ETag": "\u00220x8DA540ADF2CB92D\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "d9d8b82a-a53b-4a39-0508-d138e95d8613",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "47b08766-001e-0072-60f3-8572ae000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:29.7002797Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-adb7eb5f-614a-c3b5-0764-043123b50aff?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-3708b9680143279a51dde56c67315bd3-47fc7436ff7c2dec-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "347f413f-89e0-49dc-6b39-695f6dd8a8b1",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "347f413f-89e0-49dc-6b39-695f6dd8a8b1",
+        "x-ms-request-id": "47b08775-001e-0072-6ef3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:51:28.0039856-07:00",
+    "RandomSeed": "854740168",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%rwdylacuptfi%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%rwdylacuptfi%)Async.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-70979c13-3513-5375-f6bc-2fcf88fa40b0?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-87865fc56c9c922a4c8036fd7b26f3ad-1514185f3792044c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "c60f6395-a0fe-6832-f674-391c5820f4f3",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:14 GMT",
+        "ETag": "\u00220x8DA540A8F3392B8\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c60f6395-a0fe-6832-f674-391c5820f4f3",
+        "x-ms-request-id": "bf2c81e3-901e-003d-4ff3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-70979c13-3513-5375-f6bc-2fcf88fa40b0/test-blob-98b2e506-c222-a2a4-8dde-76ab176492ac",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3c4995990358fa651332e31f34f33095-ca21a3e42e4c2a9e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "dc0a2a73-6696-d355-be6c-381f29875091",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "ETag": "\u00220x8DA540A8F47EC77\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dc0a2a73-6696-d355-be6c-381f29875091",
+        "x-ms-request-id": "bf2c824e-901e-003d-2af3-8503fa000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:15.6608119Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-70979c13-3513-5375-f6bc-2fcf88fa40b0/test-blob-98b2e506-c222-a2a4-8dde-76ab176492ac?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T04%3A49%3A13Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-4ce205906454ef3b467e4d4576ded8af-5c340435d53efe91-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ed379c7e-b65a-5816-6366-667e41929e6a",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "ETag": "\u00220x8DA540A8F47EC77\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "ed379c7e-b65a-5816-6366-667e41929e6a",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bf2c827f-901e-003d-56f3-8503fa000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:15.6608119Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-70979c13-3513-5375-f6bc-2fcf88fa40b0?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-907e9f04b577c950e258ac22cea743ec-643acfd1fa55775a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "8da09d01-634f-2c37-7505-3d8168894aa0",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8da09d01-634f-2c37-7505-3d8168894aa0",
+        "x-ms-request-id": "bf2c82ac-901e-003d-80f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:49:13.9575523-07:00",
+    "RandomSeed": "761540219",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%rywdlcaup%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%rywdlcaup%).json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-58ead0fb-fcbc-6c2e-dcf2-67be235e1f5c?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-ce05c889b573d939f2b6e7aff238f0b3-66d04d7e9c3ddc94-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "44ab722e-899a-80a6-9106-6102c4c0a014",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "ETag": "\u00220x8DA540ADFE9233C\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "44ab722e-899a-80a6-9106-6102c4c0a014",
+        "x-ms-request-id": "47b0892f-001e-0072-03f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-58ead0fb-fcbc-6c2e-dcf2-67be235e1f5c/test-blob-3a4b8f47-ff00-a519-6359-d652e7b325bf",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-6ab0f534fdcc5641779163a52436c034-1fd801689b7545cb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "b73400c8-8cd1-2eaf-5905-e041b25499de",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "ETag": "\u00220x8DA540ADFF25D45\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b73400c8-8cd1-2eaf-5905-e041b25499de",
+        "x-ms-request-id": "47b0893c-001e-0072-0ef3-8572ae000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:30.9955397Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-58ead0fb-fcbc-6c2e-dcf2-67be235e1f5c/test-blob-3a4b8f47-ff00-a519-6359-d652e7b325bf?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T04%3A51%3A29Z\u0026sp=rywdlcaup\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-044a18738b61c82514324da1b4cf127a-84b594229e27d73f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "e68a158c-6e7e-9eee-0960-57adfa81eba7",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "ETag": "\u00220x8DA540ADFF25D45\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "e68a158c-6e7e-9eee-0960-57adfa81eba7",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "47b0895b-001e-0072-28f3-8572ae000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:30.9955397Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-58ead0fb-fcbc-6c2e-dcf2-67be235e1f5c?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-62167d86c82bb22429376218a0d304cd-f2c73ea32a67bb09-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "9cb4e753-b3c9-715f-b339-03d097b4714c",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9cb4e753-b3c9-715f-b339-03d097b4714c",
+        "x-ms-request-id": "47b0897a-001e-0072-44f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:51:29.2974513-07:00",
+    "RandomSeed": "1736138770",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%rywdlcaup%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_PermissionsOrder(%rywdlcaup%)Async.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-645fa4a3-1199-88df-d2bd-669e0718d776?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-359929fbc398b854f0762eb65a56dbd0-e1d84fdc5ea2cdcb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "0cf9d452-ff1f-5738-7827-89883469102d",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "ETag": "\u00220x8DA540A8FEEB13E\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0cf9d452-ff1f-5738-7827-89883469102d",
+        "x-ms-request-id": "bf2c85a1-901e-003d-38f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-645fa4a3-1199-88df-d2bd-669e0718d776/test-blob-b220adb0-4d7c-7cc8-ecfb-1b47ce88ad2c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-e8119f0f51fe00d55d470dbdab7f7350-f10ce0af001fad68-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "2da71441-a386-05cc-0b7c-2023e3f088ef",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "ETag": "\u00220x8DA540A8FF773BF\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2da71441-a386-05cc-0b7c-2023e3f088ef",
+        "x-ms-request-id": "bf2c85c9-901e-003d-5cf3-8503fa000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:16.8121545Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-645fa4a3-1199-88df-d2bd-669e0718d776/test-blob-b220adb0-4d7c-7cc8-ecfb-1b47ce88ad2c?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T04%3A49%3A15Z\u0026sp=rywdlcaup\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-381a3f51c252d19d36f46cbad34ad173-5537ee306e519d56-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b9053cca-80e1-c4a6-5145-28a2aa34aad5",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "ETag": "\u00220x8DA540A8FF773BF\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "b9053cca-80e1-c4a6-5145-28a2aa34aad5",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bf2c85fc-901e-003d-0bf3-8503fa000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:16.8121545Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-645fa4a3-1199-88df-d2bd-669e0718d776?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d84a5075df62f762747e4fd14466ce9e-a8f07a3bb43a4c0b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "a758629c-ceea-f80e-b65d-c4d7b46c3a21",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a758629c-ceea-f80e-b65d-c4d7b46c3a21",
+        "x-ms-request-id": "bf2c8625-901e-003d-31f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:49:15.1151154-07:00",
+    "RandomSeed": "1820003759",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%cos%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%cos%).json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-62d1de14-2fe3-8680-7512-6be8a5c8cfce?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3bf3f4ddd12cbc8527f9968bfaab4df1-2ec162354ec3e300-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "40d0a36c-edf8-4a84-9b0f-36f2f776f811",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "ETag": "\u00220x8DA540AE0A15B91\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "40d0a36c-edf8-4a84-9b0f-36f2f776f811",
+        "x-ms-request-id": "47b08adc-001e-0072-06f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-62d1de14-2fe3-8680-7512-6be8a5c8cfce/test-blob-1fc78a05-2fcf-ac32-adf2-5f830ff3e114",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c89771659e5c1622c93648b6b68a84fd-7e325722715d3165-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "1a870e67-c59a-3dff-7123-92068d013ba7",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "ETag": "\u00220x8DA540AE0AABCDC\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1a870e67-c59a-3dff-7123-92068d013ba7",
+        "x-ms-request-id": "47b08af6-001e-0072-1cf3-8572ae000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:32.2048486Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-62d1de14-2fe3-8680-7512-6be8a5c8cfce/test-blob-1fc78a05-2fcf-ac32-adf2-5f830ff3e114?sv=2021-08-06\u0026ss=bqtf\u0026srt=cos\u0026se=2022-06-23T04%3A51%3A30Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-278586b34c95e4dc096dbb734a7dc97c-39b87f4b4268ed0e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "001bd40a-c76b-6879-9d3e-8fd3fbcfea85",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "ETag": "\u00220x8DA540AE0AABCDC\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "001bd40a-c76b-6879-9d3e-8fd3fbcfea85",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "47b08b10-001e-0072-31f3-8572ae000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:32.2048486Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-62d1de14-2fe3-8680-7512-6be8a5c8cfce?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-66d6e4839f8a2b75a1e9d9d5483be46e-845a62a16cc0523d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b9fc22a9-3ae6-663b-a85b-bcbc67457ae5",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b9fc22a9-3ae6-663b-a85b-bcbc67457ae5",
+        "x-ms-request-id": "47b08b2c-001e-0072-4cf3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:51:30.5048765-07:00",
+    "RandomSeed": "431063589",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%cos%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%cos%)Async.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-82a48415-2705-4fb9-6b39-dd732e307497?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-4d0f28914abc505e076a41dd29448682-7df9ceaecce25e58-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "86d7e69f-20cf-f47e-17c8-f96eb9fcafcc",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "ETag": "\u00220x8DA540A908FBBD2\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "86d7e69f-20cf-f47e-17c8-f96eb9fcafcc",
+        "x-ms-request-id": "bf2c88ab-901e-003d-80f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-82a48415-2705-4fb9-6b39-dd732e307497/test-blob-95e47ab1-4b63-5acb-41e0-350dec179184",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b0641bf62a49d03606dea7f5e0bb4bd0-fd37d4310c160c03-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "43f06e48-1502-53b3-1a7c-45efeb7108ff",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "ETag": "\u00220x8DA540A9098CC4C\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "43f06e48-1502-53b3-1a7c-45efeb7108ff",
+        "x-ms-request-id": "bf2c88c2-901e-003d-16f3-8503fa000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:17.8695505Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-82a48415-2705-4fb9-6b39-dd732e307497/test-blob-95e47ab1-4b63-5acb-41e0-350dec179184?sv=2021-08-06\u0026ss=bqtf\u0026srt=cos\u0026se=2022-06-23T04%3A49%3A16Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-b9bb69a4de3bb2cc2ec12f18c5eb946d-163ce91b22a3e8ab-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "7dc4e5d6-4d27-7882-1480-2edca8d8c576",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "ETag": "\u00220x8DA540A9098CC4C\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "7dc4e5d6-4d27-7882-1480-2edca8d8c576",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bf2c88de-901e-003d-31f3-8503fa000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:17.8695505Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-82a48415-2705-4fb9-6b39-dd732e307497?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1d2774bfd6e3080e9bc17b4bd6044309-bf218ee0134b7262-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "0519d9e4-8bac-e9d7-f168-dda738961ad9",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0519d9e4-8bac-e9d7-f168-dda738961ad9",
+        "x-ms-request-id": "bf2c8906-901e-003d-58f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:49:16.1654299-07:00",
+    "RandomSeed": "2014216009",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%oc%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%oc%).json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-e5be4cab-3c0b-95dc-11bc-82a4e3bfab7d?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-6b6bb992e7474c46b931fd19bb209991-89706a45d4de69ad-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "0138240a-37f4-23e6-e1ed-8ed6031da82a",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "ETag": "\u00220x8DA540AE12AE9A2\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0138240a-37f4-23e6-e1ed-8ed6031da82a",
+        "x-ms-request-id": "47b08c2c-001e-0072-38f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-e5be4cab-3c0b-95dc-11bc-82a4e3bfab7d/test-blob-ed6e9958-48f5-b69e-6fc1-d66de8ec40ef",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-2eda637c2c4669d2bee0edb03c384df7-f5d35d2c1c337cd2-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "bb9829f5-ebb2-c132-8682-923260793bf5",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "ETag": "\u00220x8DA540AE133D5FF\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bb9829f5-ebb2-c132-8682-923260793bf5",
+        "x-ms-request-id": "47b08c46-001e-0072-4ef3-8572ae000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:33.1033359Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-e5be4cab-3c0b-95dc-11bc-82a4e3bfab7d/test-blob-ed6e9958-48f5-b69e-6fc1-d66de8ec40ef?sv=2021-08-06\u0026ss=bqtf\u0026srt=oc\u0026se=2022-06-23T04%3A51%3A31Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-8d819c0ca9bf5927040c9e99927468f2-a9a5e418512a5630-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "be78e4c8-8554-f73d-28d8-380416565b57",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "ETag": "\u00220x8DA540AE133D5FF\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "be78e4c8-8554-f73d-28d8-380416565b57",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "47b08c57-001e-0072-5ef3-8572ae000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:33.1033359Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-e5be4cab-3c0b-95dc-11bc-82a4e3bfab7d?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4e49409af046244b8d4319cef7621ec6-18753ae4995119b4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "7c6a2a32-7d01-27a1-61fb-80aab19f97ba",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7c6a2a32-7d01-27a1-61fb-80aab19f97ba",
+        "x-ms-request-id": "47b08c68-001e-0072-6ef3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:51:31.4026482-07:00",
+    "RandomSeed": "202456056",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%oc%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%oc%)Async.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-d67c29b9-5c7d-60dc-2481-3f95825abca4?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-14d593178704fb62b1565711eb17e162-b88824a03b9cc35c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "34bb8e0c-2de5-4fcd-76b0-5bbde1958f81",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "ETag": "\u00220x8DA540A910D8C2B\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "34bb8e0c-2de5-4fcd-76b0-5bbde1958f81",
+        "x-ms-request-id": "bf2c8afc-901e-003d-29f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-d67c29b9-5c7d-60dc-2481-3f95825abca4/test-blob-3f47adb5-9a48-8122-6c21-b88aa92f8291",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-0b6c54117885f9e55a9d0001fa640dd5-ada5b46a6f759691-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "30f73164-644b-723e-6b39-c8c37443a547",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "ETag": "\u00220x8DA540A9116004D\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "30f73164-644b-723e-6b39-c8c37443a547",
+        "x-ms-request-id": "bf2c8b31-901e-003d-59f3-8503fa000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:18.6890829Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-d67c29b9-5c7d-60dc-2481-3f95825abca4/test-blob-3f47adb5-9a48-8122-6c21-b88aa92f8291?sv=2021-08-06\u0026ss=bqtf\u0026srt=oc\u0026se=2022-06-23T04%3A49%3A16Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-e6b21ea93daf72150ec7c71eeb74e422-70fc991528a9f578-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "782531a7-5237-7845-7916-8865c0fb4800",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "ETag": "\u00220x8DA540A9116004D\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "782531a7-5237-7845-7916-8865c0fb4800",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bf2c8b62-901e-003d-07f3-8503fa000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:18.6890829Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-d67c29b9-5c7d-60dc-2481-3f95825abca4?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a7c48c3861894be7d23c40b2301307c1-31595b052dd20149-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "431c5a95-2d1e-da10-8368-b0f6127d6bf2",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "431c5a95-2d1e-da10-8368-b0f6127d6bf2",
+        "x-ms-request-id": "bf2c8b85-901e-003d-27f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:49:16.9866056-07:00",
+    "RandomSeed": "1337829254",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%ocs%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%ocs%).json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-8b41c671-fa86-8bb0-955a-8eeed78cc79e?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-23a03b934c0fbf759fc8e44bb8458ed2-8418e3ef6774476c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "289490f6-6e34-d81f-55ee-962dbe191f7b",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "ETag": "\u00220x8DA540AE0CD2008\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "289490f6-6e34-d81f-55ee-962dbe191f7b",
+        "x-ms-request-id": "47b08b49-001e-0072-69f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-8b41c671-fa86-8bb0-955a-8eeed78cc79e/test-blob-1a405443-9232-71c4-00c2-ebd85aa26bec",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-e211d70d39e71e071bfb95d452ce6db4-b8b89b5e97ea9b7f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "cbc9258d-8e67-644a-cb22-287182477eb2",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "ETag": "\u00220x8DA540AE0D63351\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cbc9258d-8e67-644a-cb22-287182477eb2",
+        "x-ms-request-id": "47b08b5e-001e-0072-7bf3-8572ae000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:32.4886865Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-8b41c671-fa86-8bb0-955a-8eeed78cc79e/test-blob-1a405443-9232-71c4-00c2-ebd85aa26bec?sv=2021-08-06\u0026ss=bqtf\u0026srt=ocs\u0026se=2022-06-23T04%3A51%3A30Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-9c6c6a744191ad0f7d0d9bc744a92299-a23be583cadef297-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "344a6501-9fd8-2485-c793-7bd676f84200",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "ETag": "\u00220x8DA540AE0D63351\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "344a6501-9fd8-2485-c793-7bd676f84200",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "47b08bb0-001e-0072-47f3-8572ae000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:32.4886865Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-8b41c671-fa86-8bb0-955a-8eeed78cc79e?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2107b5f6bb8e41d285815a197991c0eb-40ecb71a851f46c5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "1c70c11a-49fc-e3d9-2556-e58d5dac2ef1",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1c70c11a-49fc-e3d9-2556-e58d5dac2ef1",
+        "x-ms-request-id": "47b08bc5-001e-0072-59f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:51:30.8396009-07:00",
+    "RandomSeed": "636593249",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%ocs%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%ocs%)Async.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-aaabdd64-d0e0-0063-77a5-9e77cdb56091?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-bc0c4f0dc8f8ffdb1026ea4f74929b78-03f767423af07d34-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "cd74423e-79d6-3081-9e0c-57130c54560f",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "ETag": "\u00220x8DA540A90B90FC7\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cd74423e-79d6-3081-9e0c-57130c54560f",
+        "x-ms-request-id": "bf2c894f-901e-003d-1bf3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-aaabdd64-d0e0-0063-77a5-9e77cdb56091/test-blob-001a5c26-25c0-bae6-d706-b3e8ea7ef57d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-092a46fa50fd858be3c99404cb87f6b4-a6647c94332fea80-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "aebed7a2-84de-19cf-5bb9-f5cfc599461f",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "ETag": "\u00220x8DA540A90C2BC58\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "aebed7a2-84de-19cf-5bb9-f5cfc599461f",
+        "x-ms-request-id": "bf2c898d-901e-003d-55f3-8503fa000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:18.1433944Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-aaabdd64-d0e0-0063-77a5-9e77cdb56091/test-blob-001a5c26-25c0-bae6-d706-b3e8ea7ef57d?sv=2021-08-06\u0026ss=bqtf\u0026srt=ocs\u0026se=2022-06-23T04%3A49%3A16Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-962107a36937050c8c81e437f55a7d5d-546926a25b87d78f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "1246126e-46bf-9b9f-3e1f-2f889dec8c75",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "ETag": "\u00220x8DA540A90C2BC58\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "1246126e-46bf-9b9f-3e1f-2f889dec8c75",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bf2c89d0-901e-003d-10f3-8503fa000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:18.1433944Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-aaabdd64-d0e0-0063-77a5-9e77cdb56091?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-52f8c88ef5916da283682722bac05e63-7fb688aa81464cc2-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b3601050-3453-d05f-3a58-bffc9c45f6b4",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b3601050-3453-d05f-3a58-bffc9c45f6b4",
+        "x-ms-request-id": "bf2c89f0-901e-003d-2ef3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:49:16.4459685-07:00",
+    "RandomSeed": "445763354",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%os%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%os%).json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-cfbcd116-7c66-e0e3-243f-40a9ae3ddfe1?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-7b4809346ef862998bb42385403bf0f7-8335ec1a7cc1640d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "57fb7b2f-bff7-a75b-5b8a-3c8b6ac7745f",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "ETag": "\u00220x8DA540AE1020AEB\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "57fb7b2f-bff7-a75b-5b8a-3c8b6ac7745f",
+        "x-ms-request-id": "47b08be8-001e-0072-79f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-cfbcd116-7c66-e0e3-243f-40a9ae3ddfe1/test-blob-5ad0ac13-d1c4-2f0a-985b-2d95513e255f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-ea08ccf6841fcb1c3ff944d5d3147a51-da9afae28b09a815-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "0f90ca5b-c9f5-5da1-70cc-bf9c92c6551d",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "ETag": "\u00220x8DA540AE10B4551\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0f90ca5b-c9f5-5da1-70cc-bf9c92c6551d",
+        "x-ms-request-id": "47b08bf8-001e-0072-07f3-8572ae000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:32.8374875Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-cfbcd116-7c66-e0e3-243f-40a9ae3ddfe1/test-blob-5ad0ac13-d1c4-2f0a-985b-2d95513e255f?sv=2021-08-06\u0026ss=bqtf\u0026srt=os\u0026se=2022-06-23T04%3A51%3A31Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-0374e8e9ae68b949b2325a7b87a68979-bcae2b50c64071b5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "87395364-15ad-526a-381c-c275c84d7d63",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "ETag": "\u00220x8DA540AE10B4551\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "87395364-15ad-526a-381c-c275c84d7d63",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "47b08c0a-001e-0072-18f3-8572ae000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:32.8374875Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-cfbcd116-7c66-e0e3-243f-40a9ae3ddfe1?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a009d8d6852e1245d003219df9d717e-6ad70c50abe398d0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "3e37d546-ce8c-4f6f-711d-58307fa7c374",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3e37d546-ce8c-4f6f-711d-58307fa7c374",
+        "x-ms-request-id": "47b08c14-001e-0072-21f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:51:31.1372795-07:00",
+    "RandomSeed": "182093605",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%os%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%os%)Async.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-5703bbf0-150b-ef58-0d44-fdfee9248b73?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c42da9fb14ed8c24519145a4012124a2-30eb934f0fd27e25-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "a89b4af5-05b0-4037-5ad1-54343bcaceda",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "ETag": "\u00220x8DA540A90E3C30C\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a89b4af5-05b0-4037-5ad1-54343bcaceda",
+        "x-ms-request-id": "bf2c8a28-901e-003d-64f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-5703bbf0-150b-ef58-0d44-fdfee9248b73/test-blob-f2858b5f-a745-faf4-69e8-62204f1a1224",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-e6d615fe270cdec6d9cc1a6f87e8311d-a61539bc18d006d1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "51dfea1c-1163-4e23-56a0-3fc8a317f040",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "ETag": "\u00220x8DA540A90EE32D1\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "51dfea1c-1163-4e23-56a0-3fc8a317f040",
+        "x-ms-request-id": "bf2c8a57-901e-003d-0cf3-8503fa000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:18.4282321Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-5703bbf0-150b-ef58-0d44-fdfee9248b73/test-blob-f2858b5f-a745-faf4-69e8-62204f1a1224?sv=2021-08-06\u0026ss=bqtf\u0026srt=os\u0026se=2022-06-23T04%3A49%3A16Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-f3a14077cb011b146c379e1ee72ab1c2-6cd28847855ea85f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "64033709-c13a-2ec0-70bb-48e7a2fa0f33",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "ETag": "\u00220x8DA540A90EE32D1\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "64033709-c13a-2ec0-70bb-48e7a2fa0f33",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bf2c8a87-901e-003d-39f3-8503fa000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:18.4282321Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-5703bbf0-150b-ef58-0d44-fdfee9248b73?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-afc633843f0ddd56db93e2dd1bd09fa1-26ea3e9639345d80-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "6cbef346-8b13-fd05-6fc5-3706e76ad9cf",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6cbef346-8b13-fd05-6fc5-3706e76ad9cf",
+        "x-ms-request-id": "bf2c8aca-901e-003d-7af3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:49:16.7241540-07:00",
+    "RandomSeed": "1090238612",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%sco%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%sco%).json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1e2c144a-643d-19d3-0d59-63f64f7058da?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-a227a4c840b7be86d92e688a90ee05dd-a647ed7dc8de99f2-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "8e6639a7-a49e-3ffa-429f-df791f1a97fe",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "ETag": "\u00220x8DA540AE0478901\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8e6639a7-a49e-3ffa-429f-df791f1a97fe",
+        "x-ms-request-id": "47b08a0b-001e-0072-47f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1e2c144a-643d-19d3-0d59-63f64f7058da/test-blob-480c579c-d20a-91db-06ab-66ce380674ea",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-e84944fd30e9ae758f2c7b39b6f972c9-e5caf39e448e26ea-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "4c2f2dd6-a516-d4db-5ed5-87f33d2b063b",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "ETag": "\u00220x8DA540AE0515F57\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4c2f2dd6-a516-d4db-5ed5-87f33d2b063b",
+        "x-ms-request-id": "47b08a23-001e-0072-5cf3-8572ae000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:31.6191842Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1e2c144a-643d-19d3-0d59-63f64f7058da/test-blob-480c579c-d20a-91db-06ab-66ce380674ea?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T04%3A51%3A29Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-837a5046d3f5d5c825cd63ce5a92cb7f-22d53c952654d6a8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "0bf8c94a-27d7-c5d3-a17a-b63442495600",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "ETag": "\u00220x8DA540AE0515F57\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "0bf8c94a-27d7-c5d3-a17a-b63442495600",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "47b08a40-001e-0072-77f3-8572ae000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:31.6191842Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1e2c144a-643d-19d3-0d59-63f64f7058da?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-45eb27819898e5c8b35123750b37efb0-c3d755ae58e978dd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "73a8151d-fa33-0363-2049-0151ccc08fd2",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "73a8151d-fa33-0363-2049-0151ccc08fd2",
+        "x-ms-request-id": "47b08a5e-001e-0072-11f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:51:29.9408396-07:00",
+    "RandomSeed": "595976841",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%sco%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%sco%)Async.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-de219b20-1619-aeb8-dde1-eb154087d598?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3b1063aa83633c7d764542086c5e2bcd-15cf6de8a3d8516d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "01a4ff1a-7527-71c3-0268-dd402a241a7d",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "ETag": "\u00220x8DA540A903F5D8E\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "01a4ff1a-7527-71c3-0268-dd402a241a7d",
+        "x-ms-request-id": "bf2c8725-901e-003d-20f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-de219b20-1619-aeb8-dde1-eb154087d598/test-blob-fc21f4c4-0a02-6a6e-c571-08d8c2c03bde",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-a2beaa3eb33ff0b91b9172c0b90a33ca-fc3bfdb358d799ab-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "7f33d526-8add-0f61-9039-3bb66cebae42",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "ETag": "\u00220x8DA540A90489524\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7f33d526-8add-0f61-9039-3bb66cebae42",
+        "x-ms-request-id": "bf2c8754-901e-003d-4bf3-8503fa000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:17.3428516Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-de219b20-1619-aeb8-dde1-eb154087d598/test-blob-fc21f4c4-0a02-6a6e-c571-08d8c2c03bde?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T04%3A49%3A15Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-e687e8992951d708c2945e78f6758569-26061b4faa47266e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ecb157ec-bc8c-cf01-26ea-b1a998ba6b5a",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "ETag": "\u00220x8DA540A90489524\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "ecb157ec-bc8c-cf01-26ea-b1a998ba6b5a",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bf2c8781-901e-003d-76f3-8503fa000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:17.3428516Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-de219b20-1619-aeb8-dde1-eb154087d598?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4433854e7964b9f8fc0bd98dc0757df0-433ffb278db4488f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "15c90aa7-c239-71b5-fd17-7c3f27f157c9",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "15c90aa7-c239-71b5-fd17-7c3f27f157c9",
+        "x-ms-request-id": "bf2c87a3-901e-003d-14f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:49:15.6390390-07:00",
+    "RandomSeed": "61827184",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%soc%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%soc%).json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-26b094b7-42f6-abaf-3860-4ac86ce4489f?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-86ad35627f128bebeb01ee21cc637784-b447a2f71003226f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "49b4ce0d-2c51-74ef-f3e9-ea79d8376631",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "ETag": "\u00220x8DA540AE075BE20\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "49b4ce0d-2c51-74ef-f3e9-ea79d8376631",
+        "x-ms-request-id": "47b08a7c-001e-0072-2df3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-26b094b7-42f6-abaf-3860-4ac86ce4489f/test-blob-c895a73c-27cf-ae30-81fe-3f5c85d09f73",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-1e5c698ad897389d33d980229fbfb937-d12f64ab2c8ab7c7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "64a28b33-6c2e-e62e-9d06-c852ec93ef22",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "ETag": "\u00220x8DA540AE07ED151\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "64a28b33-6c2e-e62e-9d06-c852ec93ef22",
+        "x-ms-request-id": "47b08a8a-001e-0072-39f3-8572ae000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:31.9160145Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-26b094b7-42f6-abaf-3860-4ac86ce4489f/test-blob-c895a73c-27cf-ae30-81fe-3f5c85d09f73?sv=2021-08-06\u0026ss=bqtf\u0026srt=soc\u0026se=2022-06-23T04%3A51%3A30Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-c54731b3e7eaedf20470ce3d31b7d942-f65046c1b4a1600c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f9289025-3b2e-bf44-1cd5-002936fbaaa9",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "ETag": "\u00220x8DA540AE07ED151\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "f9289025-3b2e-bf44-1cd5-002936fbaaa9",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "47b08a9f-001e-0072-4df3-8572ae000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:31.9160145Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-26b094b7-42f6-abaf-3860-4ac86ce4489f?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ba5d910385b3ed1c02d3aaf9a3742db7-350c2d4ea5edab2f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "5b2de176-f56a-0ef4-318e-70a7c6d8065d",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5b2de176-f56a-0ef4-318e-70a7c6d8065d",
+        "x-ms-request-id": "47b08ab2-001e-0072-5ff3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:51:30.2175885-07:00",
+    "RandomSeed": "1667114868",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%soc%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ResourceTypeOrder(%soc%)Async.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1199b45e-525c-dbbd-04b9-145eaab937a8?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-818f77ff50181b73a237637f09e8d994-424f0be986a9fcaf-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "e2857d58-4649-3013-154b-9d6194530865",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "ETag": "\u00220x8DA540A906619DE\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e2857d58-4649-3013-154b-9d6194530865",
+        "x-ms-request-id": "bf2c87de-901e-003d-48f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1199b45e-525c-dbbd-04b9-145eaab937a8/test-blob-586056e6-d672-b2a8-6333-fd1450692b45",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b3ac4d8c91b3970d59d17a0fda903bda-9ead447839bbf81e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "596d9c40-695e-827a-d5d2-7e1549ffdfac",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:16 GMT",
+        "ETag": "\u00220x8DA540A9070FED2\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "596d9c40-695e-827a-d5d2-7e1549ffdfac",
+        "x-ms-request-id": "bf2c8811-901e-003d-76f3-8503fa000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:17.6077010Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1199b45e-525c-dbbd-04b9-145eaab937a8/test-blob-586056e6-d672-b2a8-6333-fd1450692b45?sv=2021-08-06\u0026ss=bqtf\u0026srt=soc\u0026se=2022-06-23T04%3A49%3A15Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-b966d356df9061b3e7b294e3ffc068f1-cf9c4a633df24ba3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b4d33d62-d2fb-8ee7-ac82-5861d7493d6a",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "ETag": "\u00220x8DA540A9070FED2\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "b4d33d62-d2fb-8ee7-ac82-5861d7493d6a",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bf2c8858-901e-003d-34f3-8503fa000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:17.6077010Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1199b45e-525c-dbbd-04b9-145eaab937a8?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7cf9a6e28c534e548d68e34f96979dec-c23e6681a6b80465-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "0bb3092e-2b2b-4db1-70da-c0cb82cfb9ad",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0bb3092e-2b2b-4db1-70da-c0cb82cfb9ad",
+        "x-ms-request-id": "bf2c8880-901e-003d-5af3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:49:15.9058443-07:00",
+    "RandomSeed": "1621483256",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%bfqt%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%bfqt%).json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-0899ce86-15da-cd50-61c6-dd6b11f45f40?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-005adbbb67a2b85ad23123328c6d2558-8f34c749ef8c9d3b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "ce9ea365-97ec-b84f-7819-5aeb559fcd97",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "ETag": "\u00220x8DA540AE154648D\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ce9ea365-97ec-b84f-7819-5aeb559fcd97",
+        "x-ms-request-id": "47b08c83-001e-0072-08f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-0899ce86-15da-cd50-61c6-dd6b11f45f40/test-blob-0101b895-9a3a-69f0-a81c-683b55aa3666",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-7c3f4177c896df45a24a627a9040afb1-008cafac2a4748b9-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "de1029d1-18f9-ca63-b334-25cf2e1363ce",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "ETag": "\u00220x8DA540AE15DC615\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "de1029d1-18f9-ca63-b334-25cf2e1363ce",
+        "x-ms-request-id": "47b08c97-001e-0072-1bf3-8572ae000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:33.3771797Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-0899ce86-15da-cd50-61c6-dd6b11f45f40/test-blob-0101b895-9a3a-69f0-a81c-683b55aa3666?sv=2021-08-06\u0026ss=bfqt\u0026srt=sco\u0026se=2022-06-23T04%3A51%3A31Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-5ceea0d07b57f0c38472bafb8d5ab562-b79018c4c87a23cf-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "2b6a68f5-5799-936c-dc3b-ba216b85d009",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "ETag": "\u00220x8DA540AE15DC615\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "2b6a68f5-5799-936c-dc3b-ba216b85d009",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "47b08ca7-001e-0072-2bf3-8572ae000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:33.3771797Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-0899ce86-15da-cd50-61c6-dd6b11f45f40?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-328593f5827f155081b33b2e77db931f-ba2219bdca608272-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "c6dab88e-37a9-8c34-87ac-395da52099de",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c6dab88e-37a9-8c34-87ac-395da52099de",
+        "x-ms-request-id": "47b08cbf-001e-0072-43f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:51:31.6774497-07:00",
+    "RandomSeed": "950712644",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%bfqt%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%bfqt%)Async.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-bed4380b-2978-815d-d14c-d0e018e16828?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-231f9bc655a46bfd346e42a3eb909078-29f3336bdf2b3ea7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "71ee541d-06b4-2511-345e-aa854ea91da4",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "ETag": "\u00220x8DA540A9134E48D\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "71ee541d-06b4-2511-345e-aa854ea91da4",
+        "x-ms-request-id": "bf2c8bb9-901e-003d-5af3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-bed4380b-2978-815d-d14c-d0e018e16828/test-blob-72fd9f30-c48c-a2f0-96f9-dc7097946215",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-a68bd135101ceaeff1ba0120e77223f8-f7d36aea4e2c002f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "7f98eceb-18be-597e-634c-dbbb2aa18ea0",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "ETag": "\u00220x8DA540A913E9105\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7f98eceb-18be-597e-634c-dbbb2aa18ea0",
+        "x-ms-request-id": "bf2c8bee-901e-003d-0af3-8503fa000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:18.9549317Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-bed4380b-2978-815d-d14c-d0e018e16828/test-blob-72fd9f30-c48c-a2f0-96f9-dc7097946215?sv=2021-08-06\u0026ss=bfqt\u0026srt=sco\u0026se=2022-06-23T04%3A49%3A17Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-df3e784ba1d7c1b875962845153fd28c-86900c52e38a627b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ab84a46c-e2fb-a857-466a-60a61cb8e586",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "ETag": "\u00220x8DA540A913E9105\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "ab84a46c-e2fb-a857-466a-60a61cb8e586",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bf2c8c1d-901e-003d-38f3-8503fa000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:18.9549317Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-bed4380b-2978-815d-d14c-d0e018e16828?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5f34358a364622c5201434714378f77d-23ceecba4eb27a09-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "864f6167-e21d-19a4-3d1c-427bf90b1d72",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "864f6167-e21d-19a4-3d1c-427bf90b1d72",
+        "x-ms-request-id": "bf2c8c4d-901e-003d-62f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:49:17.2505620-07:00",
+    "RandomSeed": "1086297097",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%bqt%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%bqt%).json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-eb00a7d4-dc90-5d09-2c34-1b85a1e5dc4a?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c5a23231bf1a44cdb0213b09c4fa09e8-90ecb749796f3617-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "cb9df249-f46d-5c23-4109-7d343d0b290d",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "ETag": "\u00220x8DA540AE1DA229B\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cb9df249-f46d-5c23-4109-7d343d0b290d",
+        "x-ms-request-id": "47b08d94-001e-0072-0df3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-eb00a7d4-dc90-5d09-2c34-1b85a1e5dc4a/test-blob-3178c0c9-e345-8d15-5182-f463bb825528",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-17fed5fe4582bf08377a7d93ec8ef862-08f991398cea4dbf-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "47bd1304-b48c-661d-dc0f-7aeb00bfa0be",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "ETag": "\u00220x8DA540AE1E30F37\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "47bd1304-b48c-661d-dc0f-7aeb00bfa0be",
+        "x-ms-request-id": "47b08da8-001e-0072-1ff3-8572ae000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:34.2516798Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-eb00a7d4-dc90-5d09-2c34-1b85a1e5dc4a/test-blob-3178c0c9-e345-8d15-5182-f463bb825528?sv=2021-08-06\u0026ss=bqt\u0026srt=sco\u0026se=2022-06-23T04%3A51%3A32Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-5af4e4a30a5644ff47c0c983fda4ef45-7a2e39282dc9643d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "a85f0941-0ec4-989c-9ad5-d23896f116db",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "ETag": "\u00220x8DA540AE1E30F37\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "a85f0941-0ec4-989c-9ad5-d23896f116db",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "47b08dc1-001e-0072-35f3-8572ae000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:34.2516798Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-eb00a7d4-dc90-5d09-2c34-1b85a1e5dc4a?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4f78576e4d1680537fb2788943f13fec-d809fe5e98c8c959-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f6a9494b-f860-a4f9-b84d-eafba68d21f2",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f6a9494b-f860-a4f9-b84d-eafba68d21f2",
+        "x-ms-request-id": "47b08dd2-001e-0072-43f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:51:32.5521204-07:00",
+    "RandomSeed": "1007646620",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%bqt%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%bqt%)Async.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1a5cf06a-1a30-ea22-bd6e-0bd5e6442b39?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-85b60362a1605147f0c8704e4744aad3-ce96686e414222ae-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "738c3f56-38ac-12d1-956c-7a5eeb21fd90",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "ETag": "\u00220x8DA540A91ABB0FF\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "738c3f56-38ac-12d1-956c-7a5eeb21fd90",
+        "x-ms-request-id": "bf2c8e98-901e-003d-04f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1a5cf06a-1a30-ea22-bd6e-0bd5e6442b39/test-blob-77964de1-177f-2d82-aa15-95a5eb599bf5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-6899fe7290680a647bd4dc3a5f88316b-05aa9c693be851bb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "01e79f8d-ad31-3e80-bd5f-c997a22b273c",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "ETag": "\u00220x8DA540A91B3FDF4\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "01e79f8d-ad31-3e80-bd5f-c997a22b273c",
+        "x-ms-request-id": "bf2c8ed0-901e-003d-3af3-8503fa000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:19.7254914Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1a5cf06a-1a30-ea22-bd6e-0bd5e6442b39/test-blob-77964de1-177f-2d82-aa15-95a5eb599bf5?sv=2021-08-06\u0026ss=bqt\u0026srt=sco\u0026se=2022-06-23T04%3A49%3A18Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-12b4a39bed4e892d38e72bd9a3978024-b0fa7f2c749f9963-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "4b1832b9-9971-9cc4-8a40-e958edf566c9",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "ETag": "\u00220x8DA540A91B3FDF4\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "4b1832b9-9971-9cc4-8a40-e958edf566c9",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bf2c8f09-901e-003d-6cf3-8503fa000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:19.7254914Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1a5cf06a-1a30-ea22-bd6e-0bd5e6442b39?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2c3e77e5388e4fb1fe37c24c5dc11edf-019fddfa238a262f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "70de07f5-db12-37ca-c077-56616d7f3ccb",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "70de07f5-db12-37ca-c077-56616d7f3ccb",
+        "x-ms-request-id": "bf2c8f24-901e-003d-03f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:49:18.0208845-07:00",
+    "RandomSeed": "665695627",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%fb%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%fb%).json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-72a4a766-9d36-818d-c93a-207ad61faadf?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-30d4050b9e651c6a81c5bb69950ea12b-d306d7e8e68c98c4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "b9a15fbb-5dec-9d39-6099-0e6777f36086",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "ETag": "\u00220x8DA540AE22FFE25\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b9a15fbb-5dec-9d39-6099-0e6777f36086",
+        "x-ms-request-id": "47b08e6b-001e-0072-53f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-72a4a766-9d36-818d-c93a-207ad61faadf/test-blob-ef7e8c24-6b81-08be-f229-495824351497",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-8b9a7de64e36eeb151e85e3ac4d89d69-5be97e706b27aed8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "e033f37e-8bb3-501b-a199-c6c213e1792b",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "ETag": "\u00220x8DA540AE23938F3\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e033f37e-8bb3-501b-a199-c6c213e1792b",
+        "x-ms-request-id": "47b08e8e-001e-0072-72f3-8572ae000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:34.8153587Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-72a4a766-9d36-818d-c93a-207ad61faadf/test-blob-ef7e8c24-6b81-08be-f229-495824351497?sv=2021-08-06\u0026ss=fb\u0026srt=sco\u0026se=2022-06-23T04%3A51%3A33Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-95f292f51442788a490e5716d2e49b5e-7044eb298ab23d17-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "31da1424-3402-34e3-676e-d5e32a30f4b7",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "ETag": "\u00220x8DA540AE23938F3\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "31da1424-3402-34e3-676e-d5e32a30f4b7",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "47b08eab-001e-0072-0ef3-8572ae000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:34.8153587Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-72a4a766-9d36-818d-c93a-207ad61faadf?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-bc7e6bc9d7a4b46aa3e06fe7cd6fedfe-8b8678a7d432c80c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "fe9e21e0-4807-5028-9372-8cc614240867",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fe9e21e0-4807-5028-9372-8cc614240867",
+        "x-ms-request-id": "47b08ec6-001e-0072-27f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:51:33.1159876-07:00",
+    "RandomSeed": "246242726",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%fb%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%fb%)Async.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-fba5d703-49ef-fadf-22c2-3958f7a455c1?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-7f79f293dc09259d52a107c47f9981a6-9046a06aa9345f23-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "7acb98c2-7611-52f1-7c8a-f50e250c5448",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "ETag": "\u00220x8DA540A91F72DF2\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:20 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7acb98c2-7611-52f1-7c8a-f50e250c5448",
+        "x-ms-request-id": "bf2c9048-901e-003d-01f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-fba5d703-49ef-fadf-22c2-3958f7a455c1/test-blob-3b7bd144-35b3-34d6-90ec-ac2336ef4ec1",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c3de196ffe14464c5a94db71a776e265-79e132e0b6eb6ad9-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "dbaacb78-67e6-8c1c-c196-ea25c9ce1b8c",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "ETag": "\u00220x8DA540A920239A1\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:20 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dbaacb78-67e6-8c1c-c196-ea25c9ce1b8c",
+        "x-ms-request-id": "bf2c9084-901e-003d-2ef3-8503fa000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:20.2372001Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-fba5d703-49ef-fadf-22c2-3958f7a455c1/test-blob-3b7bd144-35b3-34d6-90ec-ac2336ef4ec1?sv=2021-08-06\u0026ss=fb\u0026srt=sco\u0026se=2022-06-23T04%3A49%3A18Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-bbe2f7213e4b25498b013d896546c22c-a49e0953c30dc568-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "6baa6958-7345-b8db-4e09-9e42f08bda68",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "ETag": "\u00220x8DA540A920239A1\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:20 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "6baa6958-7345-b8db-4e09-9e42f08bda68",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:49:20 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bf2c90bc-901e-003d-61f3-8503fa000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:20.2372001Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-fba5d703-49ef-fadf-22c2-3958f7a455c1?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ab71b888cee7bdfd28d30483b26717de-850b662b27277ca6-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "5fcc913b-b024-c846-5836-6d6c562c7894",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5fcc913b-b024-c846-5836-6d6c562c7894",
+        "x-ms-request-id": "bf2c90f5-901e-003d-12f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:49:18.5317070-07:00",
+    "RandomSeed": "458157214",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%qb%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%qb%).json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-d78589f9-0e41-e152-1cff-17fc3c26a5a1?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-136d4ce53573f2c653e2a5fadce8eed3-acb6ae5dc678829d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "cad81ecc-bdc4-4e29-398a-ca906f08ebaa",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "ETag": "\u00220x8DA540AE204D5D2\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cad81ecc-bdc4-4e29-398a-ca906f08ebaa",
+        "x-ms-request-id": "47b08dee-001e-0072-5cf3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-d78589f9-0e41-e152-1cff-17fc3c26a5a1/test-blob-4df59576-427c-a8f7-da13-322c34c304a8",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-7952e1a61cee45e76ea501e05ed30819-f96568659c1baec8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "46183029-d97d-8a41-272f-f0b08bfd1a76",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "ETag": "\u00220x8DA540AE20E3799\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "46183029-d97d-8a41-272f-f0b08bfd1a76",
+        "x-ms-request-id": "47b08e09-001e-0072-75f3-8572ae000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:34.5335193Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-d78589f9-0e41-e152-1cff-17fc3c26a5a1/test-blob-4df59576-427c-a8f7-da13-322c34c304a8?sv=2021-08-06\u0026ss=qb\u0026srt=sco\u0026se=2022-06-23T04%3A51%3A32Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-b8389d4851d5bc3ac1553a5bbe7d4ed8-e72f9ca83ec37ff5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "03029612-bdab-fe2a-18a6-f61eea2c3a97",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "ETag": "\u00220x8DA540AE20E3799\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "03029612-bdab-fe2a-18a6-f61eea2c3a97",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "47b08e1a-001e-0072-06f3-8572ae000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:34.5335193Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-d78589f9-0e41-e152-1cff-17fc3c26a5a1?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-cae43d3763b04e5ebae20b0e7b6ba735-ae6701d950803f38-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f49e350c-16fb-c7ca-f8b9-fd31d63eb18b",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f49e350c-16fb-c7ca-f8b9-fd31d63eb18b",
+        "x-ms-request-id": "47b08e40-001e-0072-2af3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:51:32.8378746-07:00",
+    "RandomSeed": "246863883",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%qb%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%qb%)Async.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-b00962db-de66-fdea-fd7e-2a022f2b3c03?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-7754d1b59e8ffc39eb33c7bd52346a5c-47a44e1732ee6e6e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "294623e6-60e1-a2c7-692d-86f988426c28",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "ETag": "\u00220x8DA540A91D182FF\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "294623e6-60e1-a2c7-692d-86f988426c28",
+        "x-ms-request-id": "bf2c8f54-901e-003d-31f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-b00962db-de66-fdea-fd7e-2a022f2b3c03/test-blob-aa296253-d978-7f0b-0c64-373de20c033e",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-20a2489640d6107982b5830c638cfdbf-09982f4d9a0afcad-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "9689d2bc-6e96-0dd1-17c6-1c7c298ac05c",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "ETag": "\u00220x8DA540A91DA450A\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9689d2bc-6e96-0dd1-17c6-1c7c298ac05c",
+        "x-ms-request-id": "bf2c8f7f-901e-003d-5af3-8503fa000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:19.9753482Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-b00962db-de66-fdea-fd7e-2a022f2b3c03/test-blob-aa296253-d978-7f0b-0c64-373de20c033e?sv=2021-08-06\u0026ss=qb\u0026srt=sco\u0026se=2022-06-23T04%3A49%3A18Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-5acd39928b872a30e8f9d1eaab54b90e-6e03ff8deb61aa64-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "0f810048-6c82-f6a8-0e0f-f31df6a54b85",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "ETag": "\u00220x8DA540A91DA450A\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "0f810048-6c82-f6a8-0e0f-f31df6a54b85",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bf2c8fbb-901e-003d-12f3-8503fa000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:19.9753482Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-b00962db-de66-fdea-fd7e-2a022f2b3c03?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5490a4b9fb4919e27b073dae1b92243c-c9d8bc80d6c3c1ff-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "28346c1b-b008-bdda-a09d-9a166d254a9b",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "28346c1b-b008-bdda-a09d-9a166d254a9b",
+        "x-ms-request-id": "bf2c8fed-901e-003d-40f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:49:18.2700296-07:00",
+    "RandomSeed": "1114309923",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%qftb%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%qftb%).json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-372355b4-0f78-ff5f-a012-efac8602e144?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-ab121dc77c28aa910c6e07b10d4b271d-39c590d0d0a0df7a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "f1018818-0a0c-2a3a-ca93-1642005dc1d2",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "ETag": "\u00220x8DA540AE17EA29C\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f1018818-0a0c-2a3a-ca93-1642005dc1d2",
+        "x-ms-request-id": "47b08cde-001e-0072-62f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-372355b4-0f78-ff5f-a012-efac8602e144/test-blob-94654b91-8bf2-c023-9899-881b88721e79",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-ffd394930eb7a7429936651b1a5f4990-727e8fc6775e8e29-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "955ab49b-e0c2-8df6-6541-5873821fa257",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "ETag": "\u00220x8DA540AE187DD29\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "955ab49b-e0c2-8df6-6541-5873821fa257",
+        "x-ms-request-id": "47b08cf7-001e-0072-79f3-8572ae000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:33.6530217Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-372355b4-0f78-ff5f-a012-efac8602e144/test-blob-94654b91-8bf2-c023-9899-881b88721e79?sv=2021-08-06\u0026ss=qftb\u0026srt=sco\u0026se=2022-06-23T04%3A51%3A31Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-a37b9c0212a3be8e3a4b88a5b5d7f188-2d215845ff878319-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d37f350f-8817-bcb6-0f06-98bf97c48bfc",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "ETag": "\u00220x8DA540AE187DD29\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "d37f350f-8817-bcb6-0f06-98bf97c48bfc",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "47b08d13-001e-0072-12f3-8572ae000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:33.6530217Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-372355b4-0f78-ff5f-a012-efac8602e144?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7863908d2e9fbfb22166440bbfb174f1-6e0412ee9b0fdcfa-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "4c633b5d-cea0-ec3f-e6e7-ebc22a110a4e",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4c633b5d-cea0-ec3f-e6e7-ebc22a110a4e",
+        "x-ms-request-id": "47b08d24-001e-0072-23f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:51:31.9537065-07:00",
+    "RandomSeed": "1829046079",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%qftb%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%qftb%)Async.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-70f3cea8-4072-7940-4ceb-0aa7c53ea169?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-bd083723b713b3f8983a5b42a186a980-cc5f3d0eaaf1509d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "029cbf6d-77c9-8709-b47d-03312c0ff16d",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "ETag": "\u00220x8DA540A915D4E3C\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "029cbf6d-77c9-8709-b47d-03312c0ff16d",
+        "x-ms-request-id": "bf2c8c91-901e-003d-22f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-70f3cea8-4072-7940-4ceb-0aa7c53ea169/test-blob-e3beea15-af63-a2d5-f11b-e5c14294bd28",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-77d28b95660b4a8ec95fae04d385ceec-08620959eee4f635-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "d19590be-1a65-bdf8-eafa-10ad9247451f",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "ETag": "\u00220x8DA540A9165E963\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d19590be-1a65-bdf8-eafa-10ad9247451f",
+        "x-ms-request-id": "bf2c8ccd-901e-003d-59f3-8503fa000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:19.2127843Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-70f3cea8-4072-7940-4ceb-0aa7c53ea169/test-blob-e3beea15-af63-a2d5-f11b-e5c14294bd28?sv=2021-08-06\u0026ss=qftb\u0026srt=sco\u0026se=2022-06-23T04%3A49%3A17Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-825f63cdef7c59239a171e442d872fc3-46843567afd76f35-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b1026970-ebff-d2c2-b67d-1ba78ef25984",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "ETag": "\u00220x8DA540A9165E963\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "b1026970-ebff-d2c2-b67d-1ba78ef25984",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bf2c8d04-901e-003d-0ef3-8503fa000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:19.2127843Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-70f3cea8-4072-7940-4ceb-0aa7c53ea169?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5d95cab982c0e5de034093b1d1cb10ae-7f1812d6bd59c059-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "283dcb5a-9344-d420-1871-c857d024e858",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "283dcb5a-9344-d420-1871-c857d024e858",
+        "x-ms-request-id": "bf2c8d42-901e-003d-49f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:49:17.5074764-07:00",
+    "RandomSeed": "1103774656",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%tqfb%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%tqfb%).json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1078c8ae-71b8-5fda-68ff-3d413a82b22a?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-28d24fc9d98ef80421a07dddc76417f5-0ed1b622861a552c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "792ff71d-d546-c625-4353-a39e897c175d",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "ETag": "\u00220x8DA540AE1B03298\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "792ff71d-d546-c625-4353-a39e897c175d",
+        "x-ms-request-id": "47b08d4e-001e-0072-4bf3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1078c8ae-71b8-5fda-68ff-3d413a82b22a/test-blob-fbb73d19-6c90-5dba-45cd-5eedcc61e1b2",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-85d9973f8dd08c239270e7df817fa5c1-03b9f1a7e1e3d14c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "406047b4-9bfd-b05a-3dd1-33787738fae2",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "ETag": "\u00220x8DA540AE1B9BB56\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "406047b4-9bfd-b05a-3dd1-33787738fae2",
+        "x-ms-request-id": "47b08d5a-001e-0072-56f3-8572ae000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:33.9798358Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1078c8ae-71b8-5fda-68ff-3d413a82b22a/test-blob-fbb73d19-6c90-5dba-45cd-5eedcc61e1b2?sv=2021-08-06\u0026ss=tqfb\u0026srt=sco\u0026se=2022-06-23T04%3A51%3A32Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-df54d2522a024997dc18e001195246f7-3fe51efd0bc85f5b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "853829ab-a001-ccb4-f673-0481056ba1ae",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "ETag": "\u00220x8DA540AE1B9BB56\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "853829ab-a001-ccb4-f673-0481056ba1ae",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "47b08d6f-001e-0072-69f3-8572ae000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:51:33.9798358Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1078c8ae-71b8-5fda-68ff-3d413a82b22a?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-40968755d0b0ff3383e888dc9c59382e-5be656b464d91463-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "4dcdd321-74ff-d1e1-3c68-40e5d088daed",
+        "x-ms-date": "Wed, 22 Jun 2022 04:51:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:51:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4dcdd321-74ff-d1e1-3c68-40e5d088daed",
+        "x-ms-request-id": "47b08d7d-001e-0072-76f3-8572ae000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:51:32.2807907-07:00",
+    "RandomSeed": "173848368",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%tqfb%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasTests/AccountSas_ServiceOrder(%tqfb%)Async.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-0b203a03-58f5-3eae-ec23-64f33277e22b?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3a16149c5dba89ce058f98b3e5389182-c24f40a6c3968f2b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "3e4e53b8-b114-3a21-8bd4-074730da3bb4",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "ETag": "\u00220x8DA540A91845888\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3e4e53b8-b114-3a21-8bd4-074730da3bb4",
+        "x-ms-request-id": "bf2c8d7d-901e-003d-7ef3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-0b203a03-58f5-3eae-ec23-64f33277e22b/test-blob-cd30e700-a11f-53af-f0c6-ce3da23162f1",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-30b491f7c2017d4f50514dbacb4c4af8-39cc5d96f812680c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "f57c017c-fbca-17c2-a3fb-4d4de2e4975a",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "ETag": "\u00220x8DA540A918E2BFC\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f57c017c-fbca-17c2-a3fb-4d4de2e4975a",
+        "x-ms-request-id": "bf2c8db1-901e-003d-2bf3-8503fa000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:19.4766332Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-0b203a03-58f5-3eae-ec23-64f33277e22b/test-blob-cd30e700-a11f-53af-f0c6-ce3da23162f1?sv=2021-08-06\u0026ss=tqfb\u0026srt=sco\u0026se=2022-06-23T04%3A49%3A17Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-66952e8c035ebce92edcc310b0e833a4-464d96ff18b99862-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "a0c16c9d-6db5-5d26-c024-3c2d57c907ef",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "ETag": "\u00220x8DA540A918E2BFC\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "a0c16c9d-6db5-5d26-c024-3c2d57c907ef",
+        "x-ms-creation-time": "Wed, 22 Jun 2022 04:49:19 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bf2c8dfe-901e-003d-71f3-8503fa000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-08-06",
+        "x-ms-version-id": "2022-06-22T04:49:19.4766332Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-0b203a03-58f5-3eae-ec23-64f33277e22b?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-20e9916ed9d21757dd3896bb8d6211cd-0c3036a6a437d00a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.13.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "76b05f4f-f722-04a5-f08f-ed7a1f5e0506",
+        "x-ms-date": "Wed, 22 Jun 2022 04:49:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 04:49:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "76b05f4f-f722-04a5-f08f-ed7a1f5e0506",
+        "x-ms-request-id": "bf2c8e41-901e-003d-31f3-8503fa000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T21:49:17.7715091-07:00",
+    "RandomSeed": "1305740244",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Common/tests/Sas/TestAccountSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Sas/TestAccountSasBuilder.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Azure.Storage.Sas;
-using Castle.Core.Internal;
 
 namespace Azure.Storage.Test.Shared
 {
@@ -114,7 +114,7 @@ namespace Azure.Storage.Test.Shared
         internal static void ValidateAndRawTypes(string rawString,
             List<char> validCharacters)
         {
-            if (rawString.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(rawString))
             {
                 throw new ArgumentException($"{rawString} is empty or null, pass valid type");
             }
@@ -166,11 +166,11 @@ namespace Azure.Storage.Test.Shared
             string stringToSign = string.Join("\n",
                 sharedKeyCredential.AccountName,
                 // Use Permissions if the CustomPermissions is not used
-                CustomSignedPermissions.IsNullOrEmpty() ? Permissions : CustomSignedPermissions,
+                string.IsNullOrEmpty(CustomSignedPermissions) ? Permissions : CustomSignedPermissions,
                 // Use Services if the services is not used
-                CustomSignedServices.IsNullOrEmpty() ? Services.ToString() : CustomSignedServices,
+                string.IsNullOrEmpty(CustomSignedServices) ? Services.ToPermissionsString() : CustomSignedServices,
                 // Use ResourceTypes if the CustomResourceTypes is not used
-                CustomResourceTypes.IsNullOrEmpty() ? ResourceTypes.ToString() : CustomResourceTypes,
+                string.IsNullOrEmpty(CustomResourceTypes) ? ResourceTypes.ToPermissionsString() : CustomResourceTypes,
                 startTime,
                 expiryTime,
                 IPRange.ToString(),
@@ -182,15 +182,15 @@ namespace Azure.Storage.Test.Shared
             string signature = StorageSharedKeyCredentialInternals.ComputeSasSignature(sharedKeyCredential, stringToSign);
             TestSasQueryParameters sasQueryParameters = new TestSasQueryParameters(
                 Version,
-                CustomSignedServices.IsNullOrEmpty() ? Services.ToString() : CustomSignedServices,
-                CustomResourceTypes.IsNullOrEmpty() ? ResourceTypes.ToString() : CustomResourceTypes,
+                string.IsNullOrEmpty(CustomSignedServices) ? Services.ToPermissionsString() : CustomSignedServices,
+                string.IsNullOrEmpty(CustomResourceTypes) ? ResourceTypes.ToPermissionsString() : CustomResourceTypes,
                 Protocol,
                 StartsOn,
                 ExpiresOn,
                 IPRange,
                 identifier: null,
                 resource: null,
-                CustomSignedPermissions.IsNullOrEmpty() ? Permissions : CustomSignedPermissions,
+                string.IsNullOrEmpty(CustomSignedPermissions) ? Permissions : CustomSignedPermissions,
                 signature,
                 encryptionScope: EncryptionScope);
             return sasQueryParameters;

--- a/sdk/storage/Azure.Storage.Common/tests/Sas/TestAccountSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Sas/TestAccountSasBuilder.cs
@@ -68,9 +68,8 @@ namespace Azure.Storage.Test.Shared
         {
             ExpiresOn = expiresOn;
             SetCustomPermissions(permissions);
-            CustomSignedServices = services;
-            ValidateAndRawTypes(resourceTypes, s_resourceTypes);
-            CustomResourceTypes = resourceTypes;
+            SetCustomSignedServices(services);
+            SetCustomResourcesTypes(resourceTypes);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Common/tests/Sas/TestAccountSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Sas/TestAccountSasBuilder.cs
@@ -1,0 +1,233 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using Azure.Storage.Sas;
+using Castle.Core.Internal;
+
+namespace Azure.Storage.Test.Shared
+{
+    /// <summary>
+    /// To test if a SAS generated in different methods will be
+    /// accepted and not altered by the storage clients
+    ///
+    /// The orignal AccountSasBuilder usually will fix the order of the
+    /// resource types, permissions etc
+    ///
+    /// Looking at the Account SAS docs
+    /// https://docs.microsoft.com/en-us/rest/api/storageservices/create-account-sas#specify-the-account-sas-parameters
+    /// There's no requirement on ordering of the Resource Types, Signed Services or Signed Permissions
+    /// </summary>
+    internal class TestAccountSasBuilder : AccountSasBuilder
+    {
+        /// <summary>
+        /// Custom set Resource Account Types in a specific order
+        /// e.g. "sco", "cso", "osc", "ocs", "cos", "soc".
+        /// </summary>
+        public string CustomResourceTypes { get; internal set; }
+
+        /// <summary>
+        /// Custom set Resource Signed Services
+        /// e.g. "bqtf", "qtfb", "fbtq" and more
+        /// </summary>
+        public string CustomSignedServices { get; internal set; }
+
+        /// <summary>
+        /// Custom set Resource Account Types
+        /// e.g. "rwdylacuptfi", "tfirwdylacup"
+        /// </summary>
+        public string CustomSignedPermissions { get; internal set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AccountSasBuilder"/>
+        /// class to create a Blob Container Service Sas.
+        /// </summary>
+        /// <param name="permissions">
+        /// The time at which the shared access signature becomes invalid.
+        /// This field must be omitted if it has been specified in an
+        /// associated stored access policy.
+        /// </param>
+        /// <param name="expiresOn">
+        /// The time at which the shared access signature becomes invalid.
+        /// This field must be omitted if it has been specified in an
+        /// associated stored access policy.
+        /// </param>
+        /// <param name="services">
+        /// Specifies the services accessible from an account level shared access
+        /// signature.
+        /// </param>
+        /// <param name="resourceTypes">
+        /// Specifies the resource types accessible from an account level shared
+        /// access signature.
+        /// </param>
+        public TestAccountSasBuilder(
+            string permissions,
+            DateTimeOffset expiresOn,
+            string services,
+            string resourceTypes)
+        {
+            ExpiresOn = expiresOn;
+            SetCustomPermissions(permissions);
+            CustomSignedServices = services;
+            ValidateAndRawTypes(resourceTypes, s_resourceTypes);
+            CustomResourceTypes = resourceTypes;
+        }
+
+        /// <summary>
+        /// Sets the custom permissions for an account SAS.
+        /// </summary>
+        /// <param name="permissions">
+        /// Contains custom permissions
+        /// </param>
+        public void SetCustomPermissions(string permissions)
+        {
+            // If any of the permission characters are invalid, this will throw.
+            // We're using the SetPermissions because it uses the s_validPermissionsInOrder
+            SetPermissions(permissions);
+            CustomSignedPermissions = permissions;
+        }
+
+        /// <summary>
+        /// Sets the custom resource types for an account SAS.
+        /// </summary>
+        /// <param name="signedServices">
+        /// Contains custom signed services
+        /// </param>
+        public void SetCustomSignedServices(string signedServices)
+        {
+            ValidateAndRawTypes(signedServices, s_signedServices);
+            CustomSignedServices = signedServices;
+        }
+
+        /// <summary>
+        /// Sets the custom resource types for an account SAS.
+        /// </summary>
+        /// <param name="resourceTypes">
+        /// Contains custom resource types
+        /// </param>
+        public void SetCustomResourcesTypes(string resourceTypes)
+        {
+            ValidateAndRawTypes(resourceTypes, s_resourceTypes);
+            CustomResourceTypes = resourceTypes;
+        }
+
+        internal static void ValidateAndRawTypes(string rawString,
+            List<char> validCharacters)
+        {
+            if (rawString.IsNullOrEmpty())
+            {
+                throw new ArgumentException($"{rawString} is empty or null, pass valid type");
+            }
+
+            // Convert permissions string to lower case.
+            rawString = rawString.ToLowerInvariant();
+
+            HashSet<char> validPermissionsSet = new HashSet<char>(validCharacters);
+
+            foreach (char validString in rawString)
+            {
+                // Check that each permission is a real SAS permission.
+                if (!validPermissionsSet.Contains(validString))
+                {
+                    throw new ArgumentException($"{validString} is not a valid SAS character string");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Use an account's <see cref="StorageSharedKeyCredential"/> to sign this
+        /// shared access signature values to produce the proper SAS query
+        /// parameters for authenticating requests.
+        /// </summary>
+        /// <param name="sharedKeyCredential">
+        /// The storage account's <see cref="StorageSharedKeyCredential"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="SasQueryParameters"/> used for authenticating
+        /// requests.
+        /// </returns>
+        public TestSasQueryParameters ToTestSasQueryParameters(StorageSharedKeyCredential sharedKeyCredential)
+        {
+            // https://docs.microsoft.com/en-us/rest/api/storageservices/Constructing-an-Account-SAS
+            sharedKeyCredential = sharedKeyCredential ?? throw Errors.ArgumentNull(nameof(sharedKeyCredential));
+
+            if (ExpiresOn == default || string.IsNullOrEmpty(CustomSignedPermissions) || string.IsNullOrEmpty(CustomResourceTypes) || string.IsNullOrEmpty(CustomSignedServices))
+            {
+                throw Errors.AccountSasMissingData();
+            }
+
+            Version = SasQueryParametersInternals.DefaultSasVersionInternal;
+
+            string startTime = SasExtensions.FormatTimesForSasSigning(StartsOn);
+            string expiryTime = SasExtensions.FormatTimesForSasSigning(ExpiresOn);
+
+            // String to sign: http://msdn.microsoft.com/en-us/library/azure/dn140255.aspx
+            // If the string to sign changes, we need to update this)
+            string stringToSign = string.Join("\n",
+                sharedKeyCredential.AccountName,
+                // Use Permissions if the CustomPermissions is not used
+                CustomSignedPermissions.IsNullOrEmpty() ? Permissions : CustomSignedPermissions,
+                // Use Services if the services is not used
+                CustomSignedServices.IsNullOrEmpty() ? Services.ToString() : CustomSignedServices,
+                // Use ResourceTypes if the CustomResourceTypes is not used
+                CustomResourceTypes.IsNullOrEmpty() ? ResourceTypes.ToString() : CustomResourceTypes,
+                startTime,
+                expiryTime,
+                IPRange.ToString(),
+                Protocol.ToProtocolString(),
+                Version,
+                EncryptionScope,
+                string.Empty);  // That's right, the account SAS requires a terminating extra newline
+
+            string signature = StorageSharedKeyCredentialInternals.ComputeSasSignature(sharedKeyCredential, stringToSign);
+            TestSasQueryParameters sasQueryParameters = new TestSasQueryParameters(
+                Version,
+                CustomSignedServices.IsNullOrEmpty() ? Services.ToString() : CustomSignedServices,
+                CustomResourceTypes.IsNullOrEmpty() ? ResourceTypes.ToString() : CustomResourceTypes,
+                Protocol,
+                StartsOn,
+                ExpiresOn,
+                IPRange,
+                identifier: null,
+                resource: null,
+                CustomSignedPermissions.IsNullOrEmpty() ? Permissions : CustomSignedPermissions,
+                signature,
+                encryptionScope: EncryptionScope);
+            return sasQueryParameters;
+        }
+
+        /// <summary>
+        /// All the signed resource types that are possible
+        /// See <see cref="AccountSasResourceTypes"/>
+        /// Might have to update if any other resource type gets added
+        /// See <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-account-sas#specify-the-account-sas-parameters"/>
+        /// </summary>
+        private static readonly List<char> s_resourceTypes = new List<char>
+        {
+            // Service
+            's',
+            // Container
+            'c',
+            // Object
+            'o'
+        };
+
+        /// <summary>
+        /// All the signed services that are possible
+        /// See <see cref="AccountSasServices"/>
+        /// Might have to update if any other service gets added
+        /// See <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-account-sas#specify-the-account-sas-parameters"/>
+        /// </summary>
+        private static readonly List<char> s_signedServices = new List<char>
+        {
+            // Blobs
+            'b',
+            // Files
+            'f',
+            // Queues
+            'q',
+            // Table
+            't',
+        };
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/tests/Sas/TestSasQueryParameters.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Sas/TestSasQueryParameters.cs
@@ -2,14 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Net;
 using System.Text;
-using System.Threading.Tasks;
 using Azure.Storage.Sas;
-using Castle.Core.Internal;
 
 namespace Azure.Storage.Test.Shared
 {
@@ -95,7 +91,7 @@ namespace Azure.Storage.Test.Shared
                 stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.Version, Version);
             }
 
-            if (!_rawServices.IsNullOrEmpty())
+            if (!string.IsNullOrEmpty(_rawServices))
             {
                 stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.Services, _rawServices);
             }
@@ -104,7 +100,7 @@ namespace Azure.Storage.Test.Shared
                 stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.Services, Services.ToString());
             }
 
-            if (!_rawResourceTypes.IsNullOrEmpty())
+            if (!string.IsNullOrEmpty(_rawResourceTypes))
             {
                 stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.ResourceTypes, _rawResourceTypes);
             }

--- a/sdk/storage/Azure.Storage.Common/tests/Sas/TestSasQueryParameters.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Sas/TestSasQueryParameters.cs
@@ -1,0 +1,208 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Storage.Sas;
+using Castle.Core.Internal;
+
+namespace Azure.Storage.Test.Shared
+{
+    internal class TestSasQueryParameters : SasQueryParameters
+    {
+        private string _rawResourceTypes;
+        private string _rawServices;
+
+        /// <summary>
+        /// Creates a new SasQueryParameters instance.
+        /// </summary>
+        public TestSasQueryParameters(
+            string version,
+            string services,
+            string resourceTypes,
+            SasProtocol protocol,
+            DateTimeOffset startsOn,
+            DateTimeOffset expiresOn,
+            SasIPRange ipRange,
+            string identifier,
+            string resource,
+            string permissions,
+            string signature,
+            string cacheControl = default,
+            string contentDisposition = default,
+            string contentEncoding = default,
+            string contentLanguage = default,
+            string contentType = default,
+            string authorizedAadObjectId = default,
+            string unauthorizedAadObjectId = default,
+            string correlationId = default,
+            int? directoryDepth = default,
+            string encryptionScope = default)
+            : base(version,
+                    default, // Services
+                    default, // Resource Types
+                    protocol,
+                    startsOn,
+                    expiresOn,
+                    ipRange,
+                    identifier,
+                    resource,
+                    permissions,
+                    signature,
+                    cacheControl,
+                    contentDisposition,
+                    contentEncoding,
+                    contentLanguage,
+                    contentType,
+                    authorizedAadObjectId,
+                    unauthorizedAadObjectId,
+                    correlationId,
+                    directoryDepth,
+                    encryptionScope)
+        {
+            _rawServices = services;
+            _rawResourceTypes = resourceTypes;
+        }
+
+        /// <summary>
+        /// Convert the SAS query parameters into a URL encoded query string.
+        /// </summary>
+        /// <returns>
+        /// A URL encoded query string representing the SAS.
+        /// </returns>
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            AppendCustomProperties(sb);
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Builds the query parameter string for the SasQueryParameters instance.
+        /// </summary>
+        /// <param name="stringBuilder">
+        /// StringBuilder instance to add the query params to
+        /// </param>
+        protected internal void AppendCustomProperties(StringBuilder stringBuilder)
+        {
+            if (!string.IsNullOrWhiteSpace(Version))
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.Version, Version);
+            }
+
+            if (!_rawServices.IsNullOrEmpty())
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.Services, _rawServices);
+            }
+            else if (Services != null)
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.Services, Services.ToString());
+            }
+
+            if (!_rawResourceTypes.IsNullOrEmpty())
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.ResourceTypes, _rawResourceTypes);
+            }
+            else if (ResourceTypes != null)
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.ResourceTypes, ResourceTypes.Value.ToPermissionsString());
+            }
+
+            if (Protocol != default)
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.Protocol, Protocol.ToProtocolString());
+            }
+
+            if (StartsOn != DateTimeOffset.MinValue)
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.StartTime, WebUtility.UrlEncode(StartsOn.ToString(Constants.SasTimeFormatSeconds, CultureInfo.InvariantCulture)));
+            }
+
+            if (ExpiresOn != DateTimeOffset.MinValue)
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.ExpiryTime, WebUtility.UrlEncode(ExpiresOn.ToString(Constants.SasTimeFormatSeconds, CultureInfo.InvariantCulture)));
+            }
+
+            var ipr = IPRange.ToString();
+            if (ipr.Length > 0)
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.IPRange, ipr);
+            }
+
+            if (!string.IsNullOrWhiteSpace(Identifier))
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.Identifier, Identifier);
+            }
+
+            if (!string.IsNullOrWhiteSpace(Resource))
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.Resource, Resource);
+            }
+
+            if (!string.IsNullOrWhiteSpace(Permissions))
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.Permissions, Permissions);
+            }
+
+            if (!string.IsNullOrWhiteSpace(CacheControl))
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.CacheControl, WebUtility.UrlEncode(CacheControl));
+            }
+
+            if (!string.IsNullOrWhiteSpace(ContentDisposition))
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.ContentDisposition, WebUtility.UrlEncode(ContentDisposition));
+            }
+
+            if (!string.IsNullOrWhiteSpace(ContentEncoding))
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.ContentEncoding, WebUtility.UrlEncode(ContentEncoding));
+            }
+
+            if (!string.IsNullOrWhiteSpace(ContentLanguage))
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.ContentLanguage, WebUtility.UrlEncode(ContentLanguage));
+            }
+
+            if (!string.IsNullOrWhiteSpace(ContentType))
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.ContentType, WebUtility.UrlEncode(ContentType));
+            }
+
+            if (!string.IsNullOrWhiteSpace(PreauthorizedAgentObjectId))
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.PreauthorizedAgentObjectId, WebUtility.UrlEncode(PreauthorizedAgentObjectId));
+            }
+
+            if (!string.IsNullOrWhiteSpace(AgentObjectId))
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.AgentObjectId, WebUtility.UrlEncode(AgentObjectId));
+            }
+
+            if (!string.IsNullOrWhiteSpace(CorrelationId))
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.CorrelationId, WebUtility.UrlEncode(CorrelationId));
+            }
+
+            if (!(DirectoryDepth == default))
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.DirectoryDepth, WebUtility.UrlEncode(DirectoryDepth.ToString()));
+            }
+
+            if (!string.IsNullOrWhiteSpace(EncryptionScope))
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.EncryptionScope, WebUtility.UrlEncode(EncryptionScope));
+            }
+
+            if (!string.IsNullOrWhiteSpace(Signature))
+            {
+                stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.Signature, WebUtility.UrlEncode(Signature));
+            }
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/Azure.Storage.Files.DataLake.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/Azure.Storage.Files.DataLake.Tests.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="SessionRecords\" />
-    <Compile Include="$(AzureStorageSharedTestSources)..\Sas\*.cs" LinkBase="Shared\Sas" />
     <Compile Include="$(AzureStorageSharedTestSources)\**\*.cs" LinkBase="Shared" />
     <Compile Remove="$(AzureStorageSharedTestSources)\AzuriteFixture.cs" />
     <Compile Remove="$(AzureStorageSharedTestSources)\AzuriteNUnitFixture.cs" />

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/Azure.Storage.Files.DataLake.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/Azure.Storage.Files.DataLake.Tests.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="SessionRecords\" />
+    <Compile Include="$(AzureStorageSharedTestSources)..\Sas\*.cs" LinkBase="Shared\Sas" />
     <Compile Include="$(AzureStorageSharedTestSources)\**\*.cs" LinkBase="Shared" />
     <Compile Remove="$(AzureStorageSharedTestSources)\AzuriteFixture.cs" />
     <Compile Remove="$(AzureStorageSharedTestSources)\AzuriteNUnitFixture.cs" />

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
@@ -12,7 +12,6 @@ using Azure.Identity;
 using Azure.Storage.Files.DataLake.Models;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
-using Azure.Storage.Test.Shared;
 using Moq;
 using NUnit.Framework;
 

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
@@ -12,6 +12,7 @@ using Azure.Identity;
 using Azure.Storage.Files.DataLake.Models;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
+using Azure.Storage.Test.Shared;
 using Moq;
 using NUnit.Framework;
 
@@ -975,31 +976,6 @@ namespace Azure.Storage.Files.DataLake.Tests
             UriBuilder expectedUri = new UriBuilder(serviceUri);
             expectedUri.Query += sasBuilder.ToSasQueryParameters(constants.Sas.SharedKeyCredential).ToString();
             Assert.AreEqual(expectedUri.Uri, sasUri);
-        }
-
-        [RecordedTest]
-        public void GenerateAccountSas_WrongService_Service()
-        {
-            TestConstants constants = TestConstants.Create(this);
-            Uri serviceUri = new Uri($"https://{constants.Sas.Account}.dfs.core.windows.net");
-            AccountSasPermissions permissions = AccountSasPermissions.Read | AccountSasPermissions.Write;
-            DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
-            AccountSasServices services = AccountSasServices.Files; // Wrong Service
-            AccountSasResourceTypes resourceTypes = AccountSasResourceTypes.All;
-            DataLakeServiceClient serviceClient = InstrumentClient(new DataLakeServiceClient(
-                serviceUri,
-                constants.Sas.SharedKeyCredential,
-                GetOptions()));
-
-            AccountSasBuilder sasBuilder = new AccountSasBuilder(permissions, expiresOn, services, resourceTypes);
-
-            // Add more properties on the builder
-            sasBuilder.SetPermissions(permissions);
-
-            // Act
-            TestHelper.AssertExpectedException(
-                () => serviceClient.GenerateAccountSasUri(sasBuilder),
-                new InvalidOperationException("SAS Uri cannot be generated. builder.Services does specify Blobs. builder.Services must either specify Blobs or specify all Services are accessible in the value."));
         }
         #endregion
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/Azure.Storage.Files.Shares.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/Azure.Storage.Files.Shares.Tests.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="SessionRecords\" />
+    <Compile Include="$(AzureStorageSharedTestSources)..\Sas\*.cs" LinkBase="Shared\Sas" />
     <Compile Include="$(AzureStorageSharedTestSources)\**\*.cs" LinkBase="Shared" />
     <Compile Remove="$(AzureStorageSharedTestSources)\AzuriteFixture.cs" />
     <Compile Remove="$(AzureStorageSharedTestSources)\AzuriteNUnitFixture.cs" />

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
@@ -605,15 +605,10 @@ namespace Azure.Storage.Files.Shares.Tests
                 new InvalidOperationException("SAS Uri cannot be generated. builder.Services does specify Files. builder.Services must either specify Files or specify all Services are accessible in the value."));
         }
 
-        [RecordedTest]
-        [TestCase("sco")]
-        [TestCase("soc")]
-        [TestCase("cos")]
-        [TestCase("ocs")]
-        [TestCase("os")]
-        [TestCase("oc")]
-        [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2020_06_12)]
-        public async Task AccountSas_ResourceTypeOrder(string resourceType)
+        private async Task InvokeAccountSasTest(
+            string permissions = "rwdylacuptfi",
+            string services = "bqtf",
+            string resourceType = "sco")
         {
             // Arrange
             await using DisposingShare test = await GetTestShareAsync();
@@ -626,8 +621,6 @@ namespace Azure.Storage.Files.Shares.Tests
 
             // Generate a SAS that would set the srt / ResourceTypes in a different order than
             // the .NET SDK would normally create the SAS
-            string permissions = "rwdylacuptfi";
-            string services = "bqtf";
             TestAccountSasBuilder accountSasBuilder = new TestAccountSasBuilder(
                 permissions: permissions,
                 expiresOn: Recording.UtcNow.AddDays(1),
@@ -645,6 +638,19 @@ namespace Azure.Storage.Files.Shares.Tests
         }
 
         [RecordedTest]
+        [TestCase("sco")]
+        [TestCase("soc")]
+        [TestCase("cos")]
+        [TestCase("ocs")]
+        [TestCase("os")]
+        [TestCase("oc")]
+        [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2020_06_12)]
+        public async Task AccountSas_ResourceTypeOrder(string resourceType)
+        {
+            await InvokeAccountSasTest(resourceType: resourceType);
+        }
+
+        [RecordedTest]
         [TestCase("bfqt")]
         [TestCase("qftb")]
         [TestCase("tqfb")]
@@ -654,33 +660,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2020_06_12)]
         public async Task AccountSas_ServiceOrder(string services)
         {
-            // Arrange
-            await using DisposingShare test = await GetTestShareAsync();
-            string directoryName = GetNewDirectoryName();
-            string fileName = GetNewFileName();
-            ShareDirectoryClient directory = InstrumentClient(test.Share.GetDirectoryClient(directoryName));
-            await directory.CreateAsync().ConfigureAwait(false);
-            ShareFileClient file = directory.GetFileClient(fileName);
-            await file.CreateAsync(Constants.MB).ConfigureAwait(false);
-
-            // Generate a SAS that would set the srt / ResourceTypes in a different order than
-            // the .NET SDK would normally create the SAS
-            string permissions = "rwdylacuptfi";
-            string resourceTypes = "sco";
-            TestAccountSasBuilder accountSasBuilder = new TestAccountSasBuilder(
-                permissions: permissions,
-                expiresOn: Recording.UtcNow.AddDays(1),
-                services: services,
-                resourceTypes: resourceTypes);
-
-            UriBuilder blobUriBuilder = new UriBuilder(file.Uri)
-            {
-                Query = accountSasBuilder.ToTestSasQueryParameters(Tenants.GetNewSharedKeyCredentials()).ToString()
-            };
-
-            // Assert
-            ShareFileClient sasBlobClient = InstrumentClient(new ShareFileClient(blobUriBuilder.Uri, GetOptions()));
-            await sasBlobClient.GetPropertiesAsync();
+            await InvokeAccountSasTest(services: services);
         }
 
         [RecordedTest]
@@ -693,33 +673,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2020_06_12)]
         public async Task AccountSas_PermissionsOrder(string permissions)
         {
-            // Arrange
-            await using DisposingShare test = await GetTestShareAsync();
-            string directoryName = GetNewDirectoryName();
-            string fileName = GetNewFileName();
-            ShareDirectoryClient directory = InstrumentClient(test.Share.GetDirectoryClient(directoryName));
-            await directory.CreateAsync().ConfigureAwait(false);
-            ShareFileClient file = directory.GetFileClient(fileName);
-            await file.CreateAsync(Constants.MB).ConfigureAwait(false);
-
-            // Generate a SAS that would set the srt / ResourceTypes in a different order than
-            // the .NET SDK would normally create the SAS
-            string services = "bqtf";
-            string resourceTypes = "sco";
-            TestAccountSasBuilder accountSasBuilder = new TestAccountSasBuilder(
-                permissions: permissions,
-                expiresOn: Recording.UtcNow.AddDays(1),
-                services: services,
-                resourceTypes: resourceTypes);
-
-            UriBuilder blobUriBuilder = new UriBuilder(file.Uri)
-            {
-                Query = accountSasBuilder.ToTestSasQueryParameters(Tenants.GetNewSharedKeyCredentials()).ToString()
-            };
-
-            // Assert
-            ShareFileClient sasBlobClient = InstrumentClient(new ShareFileClient(blobUriBuilder.Uri, GetOptions()));
-            await sasBlobClient.GetPropertiesAsync();
+            await InvokeAccountSasTest(permissions: permissions);
         }
         #endregion
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
@@ -9,6 +9,7 @@ using Azure.Core.TestFramework;
 using Azure.Storage.Files.Shares.Models;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
+using Azure.Storage.Test.Shared;
 using Moq;
 using NUnit.Framework;
 
@@ -602,6 +603,123 @@ namespace Azure.Storage.Files.Shares.Tests
             TestHelper.AssertExpectedException(
                 () => serviceClient.GenerateAccountSasUri(sasBuilder),
                 new InvalidOperationException("SAS Uri cannot be generated. builder.Services does specify Files. builder.Services must either specify Files or specify all Services are accessible in the value."));
+        }
+
+        [RecordedTest]
+        [TestCase("sco")]
+        [TestCase("soc")]
+        [TestCase("cos")]
+        [TestCase("ocs")]
+        [TestCase("os")]
+        [TestCase("oc")]
+        [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2020_06_12)]
+        public async Task AccountSas_ResourceTypeOrder(string resourceType)
+        {
+            // Arrange
+            await using DisposingShare test = await GetTestShareAsync();
+            string directoryName = GetNewDirectoryName();
+            string fileName = GetNewFileName();
+            ShareDirectoryClient directory = InstrumentClient(test.Share.GetDirectoryClient(directoryName));
+            await directory.CreateAsync().ConfigureAwait(false);
+            ShareFileClient file = directory.GetFileClient(fileName);
+            await file.CreateAsync(Constants.MB).ConfigureAwait(false);
+
+            // Generate a SAS that would set the srt / ResourceTypes in a different order than
+            // the .NET SDK would normally create the SAS
+            string permissions = "rwdylacuptfi";
+            string services = "bqtf";
+            TestAccountSasBuilder accountSasBuilder = new TestAccountSasBuilder(
+                permissions: permissions,
+                expiresOn: Recording.UtcNow.AddDays(1),
+                services: services,
+                resourceTypes: resourceType);
+
+            UriBuilder blobUriBuilder = new UriBuilder(file.Uri)
+            {
+                Query = accountSasBuilder.ToTestSasQueryParameters(Tenants.GetNewSharedKeyCredentials()).ToString()
+            };
+
+            // Assert
+            ShareFileClient sasBlobClient = InstrumentClient(new ShareFileClient(blobUriBuilder.Uri, GetOptions()));
+            await sasBlobClient.GetPropertiesAsync();
+        }
+
+        [RecordedTest]
+        [TestCase("bfqt")]
+        [TestCase("qftb")]
+        [TestCase("tqfb")]
+        [TestCase("fqt")]
+        [TestCase("qf")]
+        [TestCase("fb")]
+        [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2020_06_12)]
+        public async Task AccountSas_ServiceOrder(string services)
+        {
+            // Arrange
+            await using DisposingShare test = await GetTestShareAsync();
+            string directoryName = GetNewDirectoryName();
+            string fileName = GetNewFileName();
+            ShareDirectoryClient directory = InstrumentClient(test.Share.GetDirectoryClient(directoryName));
+            await directory.CreateAsync().ConfigureAwait(false);
+            ShareFileClient file = directory.GetFileClient(fileName);
+            await file.CreateAsync(Constants.MB).ConfigureAwait(false);
+
+            // Generate a SAS that would set the srt / ResourceTypes in a different order than
+            // the .NET SDK would normally create the SAS
+            string permissions = "rwdylacuptfi";
+            string resourceTypes = "sco";
+            TestAccountSasBuilder accountSasBuilder = new TestAccountSasBuilder(
+                permissions: permissions,
+                expiresOn: Recording.UtcNow.AddDays(1),
+                services: services,
+                resourceTypes: resourceTypes);
+
+            UriBuilder blobUriBuilder = new UriBuilder(file.Uri)
+            {
+                Query = accountSasBuilder.ToTestSasQueryParameters(Tenants.GetNewSharedKeyCredentials()).ToString()
+            };
+
+            // Assert
+            ShareFileClient sasBlobClient = InstrumentClient(new ShareFileClient(blobUriBuilder.Uri, GetOptions()));
+            await sasBlobClient.GetPropertiesAsync();
+        }
+
+        [RecordedTest]
+        [TestCase("rwdylacuptfi")]
+        [TestCase("cuprwdylatfi")]
+        [TestCase("cudypafitrwl")]
+        [TestCase("cuprwdyla")]
+        [TestCase("rywdlcaup")]
+        [TestCase("larwdycup")]
+        [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2020_06_12)]
+        public async Task AccountSas_PermissionsOrder(string permissions)
+        {
+            // Arrange
+            await using DisposingShare test = await GetTestShareAsync();
+            string directoryName = GetNewDirectoryName();
+            string fileName = GetNewFileName();
+            ShareDirectoryClient directory = InstrumentClient(test.Share.GetDirectoryClient(directoryName));
+            await directory.CreateAsync().ConfigureAwait(false);
+            ShareFileClient file = directory.GetFileClient(fileName);
+            await file.CreateAsync(Constants.MB).ConfigureAwait(false);
+
+            // Generate a SAS that would set the srt / ResourceTypes in a different order than
+            // the .NET SDK would normally create the SAS
+            string services = "bqtf";
+            string resourceTypes = "sco";
+            TestAccountSasBuilder accountSasBuilder = new TestAccountSasBuilder(
+                permissions: permissions,
+                expiresOn: Recording.UtcNow.AddDays(1),
+                services: services,
+                resourceTypes: resourceTypes);
+
+            UriBuilder blobUriBuilder = new UriBuilder(file.Uri)
+            {
+                Query = accountSasBuilder.ToTestSasQueryParameters(Tenants.GetNewSharedKeyCredentials()).ToString()
+            };
+
+            // Assert
+            ShareFileClient sasBlobClient = InstrumentClient(new ShareFileClient(blobUriBuilder.Uri, GetOptions()));
+            await sasBlobClient.GetPropertiesAsync();
         }
         #endregion
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cudypafitrwl%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cudypafitrwl%).json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-00415489-d4e4-63d7-0121-6dec7c294392?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-052faea4590f2801fa64966de07f240a-a73e9b2d86575dc3-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "33638c4d-b319-182a-d97a-a036363229d8",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "ETag": "\u00220x8DA54108B141DCC\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "33638c4d-b319-182a-d97a-a036363229d8",
+        "x-ms-request-id": "92da6316-201a-0007-28f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-00415489-d4e4-63d7-0121-6dec7c294392/test-directory-52681897-5b67-3953-04d5-e7b13c350ab2?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c37f0cf73fb88144bc206ddc0639b9cb-23a9d485ef470aa1-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b772ed6f-3993-8712-9f20-21f559298aec",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:03 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "ETag": "\u00220x8DA54108B1F5E90\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b772ed6f-3993-8712-9f20-21f559298aec",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:05.6645264Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:05.6645264Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:05.6645264Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da6318-201a-0007-29f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-00415489-d4e4-63d7-0121-6dec7c294392/test-directory-52681897-5b67-3953-04d5-e7b13c350ab2/test-file-f09e7fc3-0fc5-4779-3171-0129af1835e6",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-1db361b9287489604845b2c279158a54-913a03a9aba3fffe-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "c1ba5d95-7ea5-cf52-ad83-a1c6e9909810",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:03 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "ETag": "\u00220x8DA54108B2B43AB\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c1ba5d95-7ea5-cf52-ad83-a1c6e9909810",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:05.7424811Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:05.7424811Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:05.7424811Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da6319-201a-0007-2af9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-00415489-d4e4-63d7-0121-6dec7c294392/test-directory-52681897-5b67-3953-04d5-e7b13c350ab2/test-file-f09e7fc3-0fc5-4779-3171-0129af1835e6?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A04Z\u0026sp=cudypafitrwl\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-6df383db8dc525da1b427452072692d6-bdc3d4271d9b2020-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "fc6069a4-c96e-2046-aed8-cea72905ce68",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "ETag": "\u00220x8DA54108B2B43AB\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "fc6069a4-c96e-2046-aed8-cea72905ce68",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:05.7424811Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:05.7424811Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:05.7424811Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da631a-201a-0007-2bf9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-00415489-d4e4-63d7-0121-6dec7c294392?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c77300804e2510e8ec89b6ab037c41a5-83826cae209c9669-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "802137dc-9b30-d5a1-fc83-1cf891d27b1c",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:04 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "802137dc-9b30-d5a1-fc83-1cf891d27b1c",
+        "x-ms-request-id": "92da631b-201a-0007-2cf9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:04.0577210-07:00",
+    "RandomSeed": "358668285",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cudypafitrwl%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cudypafitrwl%)Async.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-b6b836ee-bc0c-5f88-fb8f-c95a37e55a10?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-cec3e18cbd9cdf0db33194fca57fd525-3df981a37bbf7980-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "4d5a24bc-e1ac-77a5-fca5-f0a622edabb0",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "ETag": "\u00220x8DA54108FC2ECAC\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4d5a24bc-e1ac-77a5-fca5-f0a622edabb0",
+        "x-ms-request-id": "92da63c5-201a-0007-22f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-b6b836ee-bc0c-5f88-fb8f-c95a37e55a10/test-directory-ff732e28-35d9-73c7-f3cc-4c6fd3a1eef1?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-33a9cf3002cbbc8e91c29b76b22fc545-63d6d89963be9c48-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "9617feb6-984e-1c24-cab8-aa189f4fe855",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "ETag": "\u00220x8DA54108FCE04A9\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9617feb6-984e-1c24-cab8-aa189f4fe855",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:13.5199913Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:13.5199913Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:13.5199913Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da63c7-201a-0007-23f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-b6b836ee-bc0c-5f88-fb8f-c95a37e55a10/test-directory-ff732e28-35d9-73c7-f3cc-4c6fd3a1eef1/test-file-139e8c8e-0c8b-ba63-55c1-95778a9dc87d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-9b1b5ded0adc3143a9bc33897e7d12a1-95c9fbffe576e47b-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "8cc03a1d-3285-582f-12a1-77dd574ae60d",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "ETag": "\u00220x8DA54108FD8154E\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8cc03a1d-3285-582f-12a1-77dd574ae60d",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:13.5859534Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:13.5859534Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:13.5859534Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da63c8-201a-0007-24f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-b6b836ee-bc0c-5f88-fb8f-c95a37e55a10/test-directory-ff732e28-35d9-73c7-f3cc-4c6fd3a1eef1/test-file-139e8c8e-0c8b-ba63-55c1-95778a9dc87d?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A11Z\u0026sp=cudypafitrwl\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-d40f5c67318ce067e11952afc5540fa8-8c3e01bba4a99e15-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "65fa8a93-5b8f-d1d0-9e24-8a42347e35de",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "ETag": "\u00220x8DA54108FD8154E\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "65fa8a93-5b8f-d1d0-9e24-8a42347e35de",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:13.5859534Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:13.5859534Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:13.5859534Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da63c9-201a-0007-25f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-b6b836ee-bc0c-5f88-fb8f-c95a37e55a10?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-909581f2a471819666cf3ceb92a1a709-dd796f1a69689ac3-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "cc4a3237-8150-a37e-3309-27937c35d524",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cc4a3237-8150-a37e-3309-27937c35d524",
+        "x-ms-request-id": "92da63ca-201a-0007-26f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:11.8895729-07:00",
+    "RandomSeed": "1128171698",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cuprwdyla%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cuprwdyla%).json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-1bd099c2-ae48-7dac-71a5-1d4021586a72?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3541f1573ac2da345acda7801f21fd56-813d92a233481a15-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d2654167-bb52-5a75-18a1-f08d966b93eb",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "ETag": "\u00220x8DA54108B57FAAC\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d2654167-bb52-5a75-18a1-f08d966b93eb",
+        "x-ms-request-id": "92da631c-201a-0007-2df9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-1bd099c2-ae48-7dac-71a5-1d4021586a72/test-directory-ac2a077a-1663-0964-7d3c-e35df56a640d?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-e3b4e5dd9501fe8400ffe6a5d5f7597f-09ca3db68b4aa2a9-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "a1ede33c-b392-e2f7-e7ee-e2808ea840ee",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:04 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "ETag": "\u00220x8DA54108B62C63E\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a1ede33c-b392-e2f7-e7ee-e2808ea840ee",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:06.1062718Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:06.1062718Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:06.1062718Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da631e-201a-0007-2ef9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-1bd099c2-ae48-7dac-71a5-1d4021586a72/test-directory-ac2a077a-1663-0964-7d3c-e35df56a640d/test-file-e0d9f49f-97f3-3c20-c9e3-87bcc88efecd",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c184719a28ec896449a009f8850c20d4-33bf6c44ec184573-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "e580d97e-5ca1-a53b-d5e4-2a4b7745c234",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:04 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "ETag": "\u00220x8DA54108B6D7309\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e580d97e-5ca1-a53b-d5e4-2a4b7745c234",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:06.1762313Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:06.1762313Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:06.1762313Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da631f-201a-0007-2ff9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-1bd099c2-ae48-7dac-71a5-1d4021586a72/test-directory-ac2a077a-1663-0964-7d3c-e35df56a640d/test-file-e0d9f49f-97f3-3c20-c9e3-87bcc88efecd?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A04Z\u0026sp=cuprwdyla\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-8458c127f3fd7ef5c9cd7c2be202c286-dad8149f6807b6ab-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b4012f8a-5a27-e14d-db60-53be2989cfe9",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "ETag": "\u00220x8DA54108B6D7309\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "b4012f8a-5a27-e14d-db60-53be2989cfe9",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:06.1762313Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:06.1762313Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:06.1762313Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da6320-201a-0007-30f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-1bd099c2-ae48-7dac-71a5-1d4021586a72?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e181eefef09cfa4b8b92e03548fc6a63-038cf73780f1c8ec-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "47c04d44-0e43-c00c-19f5-e7b1e94cbf85",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:04 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "47c04d44-0e43-c00c-19f5-e7b1e94cbf85",
+        "x-ms-request-id": "92da6323-201a-0007-31f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:04.4923861-07:00",
+    "RandomSeed": "550602743",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cuprwdyla%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cuprwdyla%)Async.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-c903cb61-a3f6-27e6-0be8-29f788491d93?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-8b266b98a12778da3490b2135fb3a18c-dd64d4b649f7528a-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "a4f67e75-eb05-0028-be0d-c938ef5c091c",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "ETag": "\u00220x8DA54108FFA4844\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a4f67e75-eb05-0028-be0d-c938ef5c091c",
+        "x-ms-request-id": "92da63cc-201a-0007-27f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-c903cb61-a3f6-27e6-0be8-29f788491d93/test-directory-5b0aa96a-d9c8-d965-8d8a-d486fe2ed433?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-e97c3be84e3e6d84554dd3c49e210237-ef20a94d20799e28-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "46939639-ffd9-f2c8-1bfa-dfef56561b87",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "ETag": "\u00220x8DA54109006BF89\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "46939639-ffd9-f2c8-1bfa-dfef56561b87",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:13.8917769Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:13.8917769Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:13.8917769Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da63ce-201a-0007-28f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-c903cb61-a3f6-27e6-0be8-29f788491d93/test-directory-5b0aa96a-d9c8-d965-8d8a-d486fe2ed433/test-file-0982a9a4-7853-108d-7cd8-820fbe058998",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-34029dcf47e36be15a80fe33db86e10a-ac9c40060b0f6829-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "27d5f2d7-4372-66bf-bf5a-8ed409c845c2",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "ETag": "\u00220x8DA54109010D02C\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "27d5f2d7-4372-66bf-bf5a-8ed409c845c2",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:13.9577388Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:13.9577388Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:13.9577388Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da63d1-201a-0007-2af9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-c903cb61-a3f6-27e6-0be8-29f788491d93/test-directory-5b0aa96a-d9c8-d965-8d8a-d486fe2ed433/test-file-0982a9a4-7853-108d-7cd8-820fbe058998?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A12Z\u0026sp=cuprwdyla\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-f93209a1e7b9777c1433c7e361872013-649d381e37ab8f21-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "63180501-f481-bd14-7cb9-b5869b90b228",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "ETag": "\u00220x8DA54109010D02C\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "63180501-f481-bd14-7cb9-b5869b90b228",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:13.9577388Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:13.9577388Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:13.9577388Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da63d2-201a-0007-2bf9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-c903cb61-a3f6-27e6-0be8-29f788491d93?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fe4fcefa252004555e119b7d597de029-ef5c50d5439c220a-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "04d286c9-e1b0-0b41-7bbc-60c8d52773a1",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "04d286c9-e1b0-0b41-7bbc-60c8d52773a1",
+        "x-ms-request-id": "92da63d3-201a-0007-2cf9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:12.2586590-07:00",
+    "RandomSeed": "1011252387",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cuprwdylatfi%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cuprwdylatfi%).json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-263b608c-9d2e-baf4-3484-4f0e35e4f05e?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3e0615bf427f5ce0d9a2bac4931dd81d-6d05cf29e8322c73-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "270a74df-7f9e-ef80-cdf7-1224b300f419",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "ETag": "\u00220x8DA54108ADB89DC\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "270a74df-7f9e-ef80-cdf7-1224b300f419",
+        "x-ms-request-id": "92da6310-201a-0007-23f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-263b608c-9d2e-baf4-3484-4f0e35e4f05e/test-directory-a67d59b1-cd5f-a3dd-36dc-3d9a790bd28e?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-62e9594b403d9d13982578db1a263dee-db21b2fb28885808-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "c3e58425-33d2-e83f-99e7-ced960e1cd2f",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:03 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "ETag": "\u00220x8DA54108AE7B4FC\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c3e58425-33d2-e83f-99e7-ced960e1cd2f",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:05.2997372Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:05.2997372Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:05.2997372Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da6312-201a-0007-24f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-263b608c-9d2e-baf4-3484-4f0e35e4f05e/test-directory-a67d59b1-cd5f-a3dd-36dc-3d9a790bd28e/test-file-c02eef3e-c8d9-96bf-d886-6dfbd606abe7",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-e2edd8044a5f3de04fc090e2471b4453-6f73777a7933b656-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "52d6aa10-e721-6c15-ca4f-f442d027b1b5",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:03 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "ETag": "\u00220x8DA54108AF1ECA5\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "52d6aa10-e721-6c15-ca4f-f442d027b1b5",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:05.3666981Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:05.3666981Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:05.3666981Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da6313-201a-0007-25f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-263b608c-9d2e-baf4-3484-4f0e35e4f05e/test-directory-a67d59b1-cd5f-a3dd-36dc-3d9a790bd28e/test-file-c02eef3e-c8d9-96bf-d886-6dfbd606abe7?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A03Z\u0026sp=cuprwdylatfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-39457b86c8fd7f3274205155b9e82efe-2e93aa54ca492a39-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b5c8dc92-7a0b-490d-3f8e-a4844f22cfc8",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "ETag": "\u00220x8DA54108AF1ECA5\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "b5c8dc92-7a0b-490d-3f8e-a4844f22cfc8",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:05.3666981Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:05.3666981Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:05.3666981Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da6314-201a-0007-26f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-263b608c-9d2e-baf4-3484-4f0e35e4f05e?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a228688ae36bfd70c9a64e394f00c328-640fe688e270d629-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f3af583d-fc5e-1faa-b446-ab5c616a92fb",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:03 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f3af583d-fc5e-1faa-b446-ab5c616a92fb",
+        "x-ms-request-id": "92da6315-201a-0007-27f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:03.6691624-07:00",
+    "RandomSeed": "634478591",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cuprwdylatfi%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cuprwdylatfi%)Async.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-2e9c7e42-f222-078e-25b5-fa3172fd8e10?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-13f8109f6dfc45d755a4b3da2de6bbdd-0159f8c3525d9d1c-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "57f556a5-afc6-3c7e-2498-bc044d6fbeff",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "ETag": "\u00220x8DA54108F896E87\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "57f556a5-afc6-3c7e-2498-bc044d6fbeff",
+        "x-ms-request-id": "92da63bf-201a-0007-1df9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-2e9c7e42-f222-078e-25b5-fa3172fd8e10/test-directory-77fc5738-eea3-bdda-a347-21d2114e3ca9?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c47cc9b30547d1e47499832b62e124eb-cfe338fba16ffaeb-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "5e08135b-a2e3-01f6-0d58-95c28bbdf4cc",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "ETag": "\u00220x8DA54108F943888\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5e08135b-a2e3-01f6-0d58-95c28bbdf4cc",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:13.1412104Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:13.1412104Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:13.1412104Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da63c1-201a-0007-1ef9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-2e9c7e42-f222-078e-25b5-fa3172fd8e10/test-directory-77fc5738-eea3-bdda-a347-21d2114e3ca9/test-file-1b8ceefb-3608-a44a-e2e0-631cc8d6079d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-5b46f3191df4be9602504114fa48a4f3-e4bc0651aa5a7485-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b5c08eb5-a8cd-eeb9-e906-6527aca52bbe",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "ETag": "\u00220x8DA54108F9EE54D\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b5c08eb5-a8cd-eeb9-e906-6527aca52bbe",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:13.2111693Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:13.2111693Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:13.2111693Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da63c2-201a-0007-1ff9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-2e9c7e42-f222-078e-25b5-fa3172fd8e10/test-directory-77fc5738-eea3-bdda-a347-21d2114e3ca9/test-file-1b8ceefb-3608-a44a-e2e0-631cc8d6079d?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A11Z\u0026sp=cuprwdylatfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-94d613714469df70ca1c13cdccbd2842-c3436b0cf29e6abf-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "fc0d5f40-3ffc-98ff-ca53-474063020de0",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "ETag": "\u00220x8DA54108F9EE54D\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "fc0d5f40-3ffc-98ff-ca53-474063020de0",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:13.2111693Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:13.2111693Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:13.2111693Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da63c3-201a-0007-20f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-2e9c7e42-f222-078e-25b5-fa3172fd8e10?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-37922b333036afbf85dd7f167d4e58b6-b0e5993c5d4f2c4b-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "4de62488-2e98-03c1-e7a5-3e16b14d2ee7",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4de62488-2e98-03c1-e7a5-3e16b14d2ee7",
+        "x-ms-request-id": "92da63c4-201a-0007-21f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:11.5265383-07:00",
+    "RandomSeed": "1294614289",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%larwdycup%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%larwdycup%).json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-80eb8985-7a35-8e04-dc5a-b6aedb66d177?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-4afd57bdc330812bdb45bd009cc45723-376834691abf6f88-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "e5d2b855-918b-4b07-5199-6ce73d0ea018",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "ETag": "\u00220x8DA54108BCF8A30\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e5d2b855-918b-4b07-5199-6ce73d0ea018",
+        "x-ms-request-id": "92da632a-201a-0007-37f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-80eb8985-7a35-8e04-dc5a-b6aedb66d177/test-directory-7f1b310f-7b7e-c462-c49e-7e593d48b8b6?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b87a44503da5a66d4c456939d0bd6c1f-c737a1643d3cb172-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "8072b6e1-7db5-2384-4598-9afe2c6a70e7",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "ETag": "\u00220x8DA54108BDC2A0C\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8072b6e1-7db5-2384-4598-9afe2c6a70e7",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:06.9018124Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:06.9018124Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:06.9018124Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da632c-201a-0007-38f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-80eb8985-7a35-8e04-dc5a-b6aedb66d177/test-directory-7f1b310f-7b7e-c462-c49e-7e593d48b8b6/test-file-2259bd75-ec93-83eb-e47f-4ff854dc0ff3",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-9cdf6a0e9aef97a84e9ce49d031e4153-548e42a48cf003b7-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "9d164672-8f6a-be3e-9f89-5f70cb7dadeb",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "ETag": "\u00220x8DA54108BE7C114\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9d164672-8f6a-be3e-9f89-5f70cb7dadeb",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:06.9777684Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:06.9777684Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:06.9777684Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da632d-201a-0007-39f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-80eb8985-7a35-8e04-dc5a-b6aedb66d177/test-directory-7f1b310f-7b7e-c462-c49e-7e593d48b8b6/test-file-2259bd75-ec93-83eb-e47f-4ff854dc0ff3?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A05Z\u0026sp=larwdycup\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-a4ccb37f877ddc0f70ed44466b39f4b3-efcfa8a19bcd9e81-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "e68c6528-d253-ff7d-4c5f-7912b23c43c4",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "ETag": "\u00220x8DA54108BE7C114\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "e68c6528-d253-ff7d-4c5f-7912b23c43c4",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:06.9777684Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:06.9777684Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:06.9777684Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da632e-201a-0007-3af9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-80eb8985-7a35-8e04-dc5a-b6aedb66d177?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-373f02696369f2a728cc7f7107878248-d549b401bdcc91b0-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "66481832-c6f1-cc97-bb5f-3b307a5a1ccd",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "66481832-c6f1-cc97-bb5f-3b307a5a1ccd",
+        "x-ms-request-id": "92da632f-201a-0007-3bf9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:05.2820398-07:00",
+    "RandomSeed": "1658884302",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%larwdycup%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%larwdycup%)Async.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-2a95aa05-9e40-582c-a273-fecb031a05df?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-cc68c1d5dec3dc94fd2421918b788328-6c0dc990de50d3b5-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "adede1f5-5361-c6fe-37d2-8e3183866764",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "ETag": "\u00220x8DA5410907AFE33\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "adede1f5-5361-c6fe-37d2-8e3183866764",
+        "x-ms-request-id": "92da63da-201a-0007-32f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-2a95aa05-9e40-582c-a273-fecb031a05df/test-directory-b6c17bcd-d8f9-e3e0-925e-ce25c0f2fd3d?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b3f16101dc203a76c4352d39b66252a0-eee24e7458a945b8-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "5b8251d4-45b1-7637-fedd-cb3e5a3b4fab",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "ETag": "\u00220x8DA54109088FBAE\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5b8251d4-45b1-7637-fedd-cb3e5a3b4fab",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:14.7452846Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:14.7452846Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:14.7452846Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da63dc-201a-0007-33f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-2a95aa05-9e40-582c-a273-fecb031a05df/test-directory-b6c17bcd-d8f9-e3e0-925e-ce25c0f2fd3d/test-file-22d528af-572c-e37d-ebba-7ea593e6b3d5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-d13649d1d173e9102dd8b72f464010c6-9c7fd480d6268385-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "41d038b3-5764-6d24-42f5-e1c6419dc3c5",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "ETag": "\u00220x8DA54109093A86E\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "41d038b3-5764-6d24-42f5-e1c6419dc3c5",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:14.8152430Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:14.8152430Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:14.8152430Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da63dd-201a-0007-34f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-2a95aa05-9e40-582c-a273-fecb031a05df/test-directory-b6c17bcd-d8f9-e3e0-925e-ce25c0f2fd3d/test-file-22d528af-572c-e37d-ebba-7ea593e6b3d5?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A13Z\u0026sp=larwdycup\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-7accebe31d4cf704efdefbe000761c97-faf354d74ccda1a5-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "218ab87e-0d6a-5346-d406-03903cd360ae",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "ETag": "\u00220x8DA54109093A86E\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "218ab87e-0d6a-5346-d406-03903cd360ae",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:14.8152430Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:14.8152430Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:14.8152430Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da63de-201a-0007-35f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-2a95aa05-9e40-582c-a273-fecb031a05df?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-97ed055e766159d031298e55981fa812-5b4034d895a12595-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "89475ebb-a112-ad5a-2804-b75ebd2e7ae3",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "89475ebb-a112-ad5a-2804-b75ebd2e7ae3",
+        "x-ms-request-id": "92da63df-201a-0007-36f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:13.1217590-07:00",
+    "RandomSeed": "2146735847",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%rwdylacuptfi%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%rwdylacuptfi%).json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-68e8a4e5-f3c4-ffca-2889-0bada5d7c072?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-8fbddc94a15f6ec5d82144fad58fc2b5-51b0248dda036d53-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "38729d95-14fd-3aa3-1f75-0527fe4dee34",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:04 GMT",
+        "ETag": "\u00220x8DA54108A867171\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:04 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "38729d95-14fd-3aa3-1f75-0527fe4dee34",
+        "x-ms-request-id": "92da6308-201a-0007-1df9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-68e8a4e5-f3c4-ffca-2889-0bada5d7c072/test-directory-f1f0d202-147f-907b-502a-80ebb4025e8c?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-bbe9dd40d0c6735d441d294cc1e977b1-b22b243448863cd7-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "708b7916-e535-7ad0-5d0f-7dc79c6d4024",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:03 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:04 GMT",
+        "ETag": "\u00220x8DA54108A9DE5A7\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:04 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "708b7916-e535-7ad0-5d0f-7dc79c6d4024",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:04.8160167Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:04.8160167Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:04.8160167Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da630b-201a-0007-1ef9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-68e8a4e5-f3c4-ffca-2889-0bada5d7c072/test-directory-f1f0d202-147f-907b-502a-80ebb4025e8c/test-file-08188e9b-8764-e175-74b8-770e502cbe9a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-2a1ec5a2dfa75fc0e36bdbae3e8df07a-8c05904350d9d42c-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d7f75a32-4ea0-0464-3949-709c7e35e4b4",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:03 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:04 GMT",
+        "ETag": "\u00220x8DA54108AB08084\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:04 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d7f75a32-4ea0-0464-3949-709c7e35e4b4",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:04.9379460Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:04.9379460Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:04.9379460Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da630c-201a-0007-1ff9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-68e8a4e5-f3c4-ffca-2889-0bada5d7c072/test-directory-f1f0d202-147f-907b-502a-80ebb4025e8c/test-file-08188e9b-8764-e175-74b8-770e502cbe9a?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A03Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-eefee5f44332e87fae13c354a165f48a-e89d17b6e69cf16a-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "4194c0c2-6975-1c84-81fc-70f32144205c",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:04 GMT",
+        "ETag": "\u00220x8DA54108AB08084\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:04 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "4194c0c2-6975-1c84-81fc-70f32144205c",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:04.9379460Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:04.9379460Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:04.9379460Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da630e-201a-0007-21f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-68e8a4e5-f3c4-ffca-2889-0bada5d7c072?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0af518b3ba54acb75aaacb1510a7805f-39672ace79fd5a6f-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "bedab56f-a3a0-383e-3e49-2bba6aeb6354",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:03 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:04 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bedab56f-a3a0-383e-3e49-2bba6aeb6354",
+        "x-ms-request-id": "92da630f-201a-0007-22f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:03.2426576-07:00",
+    "RandomSeed": "1100514245",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%rwdylacuptfi%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%rwdylacuptfi%)Async.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-5101da50-54f5-3151-47b0-bd01c9eaf790?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-f1cc6b49d5af2031a415a730f164e3cc-1183ee3c429a90c4-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "292095b0-93ce-29e6-92e6-ed73d0d1fd33",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "ETag": "\u00220x8DA54108F4AE80A\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "292095b0-93ce-29e6-92e6-ed73d0d1fd33",
+        "x-ms-request-id": "92da63a7-201a-0007-17f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-5101da50-54f5-3151-47b0-bd01c9eaf790/test-directory-09c0ece3-9758-7a6b-dcff-be9eaf380900?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-748718d73ca28e6b5a2d68a22a05b4d7-31a692776f99d950-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "e345ecdd-c981-1568-2a23-d549099b9252",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "ETag": "\u00220x8DA54108F575F97\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e345ecdd-c981-1568-2a23-d549099b9252",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:12.7424407Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:12.7424407Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:12.7424407Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da63aa-201a-0007-18f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-5101da50-54f5-3151-47b0-bd01c9eaf790/test-directory-09c0ece3-9758-7a6b-dcff-be9eaf380900/test-file-3450ed2e-cdca-9dc1-330e-8dd0e88a31c1",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-35e2fa26fd7b33829334762b3a94155a-7c4723245af15870-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "fbf33294-4d45-9040-0820-1162a42e0f8d",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "ETag": "\u00220x8DA54108F642EEC\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fbf33294-4d45-9040-0820-1162a42e0f8d",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:12.8263916Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:12.8263916Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:12.8263916Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da63b3-201a-0007-19f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-5101da50-54f5-3151-47b0-bd01c9eaf790/test-directory-09c0ece3-9758-7a6b-dcff-be9eaf380900/test-file-3450ed2e-cdca-9dc1-330e-8dd0e88a31c1?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A11Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-deb77f098bd20dac2bc61aacacb8413d-40747ccfb883c1de-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d7b5e85a-97a8-7f0d-bcb4-35e2bc171047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "ETag": "\u00220x8DA54108F642EEC\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "d7b5e85a-97a8-7f0d-bcb4-35e2bc171047",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:12.8263916Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:12.8263916Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:12.8263916Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da63bd-201a-0007-1bf9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-5101da50-54f5-3151-47b0-bd01c9eaf790?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f505d28380f5ef85dab931bf692fe405-0b24f9dfc86acf65-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "bb08d88b-3878-7be5-ec82-1b4d0676535a",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bb08d88b-3878-7be5-ec82-1b4d0676535a",
+        "x-ms-request-id": "92da63be-201a-0007-1cf9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:11.1357542-07:00",
+    "RandomSeed": "2064512378",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%rywdlcaup%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%rywdlcaup%).json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-87b8627b-cb3e-eca6-3478-fb48d5271b85?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-d54e5681920f75dd2526daa1689309aa-ea0d6d47b95b6b91-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "7a67d51e-3a6e-b009-ce37-8f0af46d5d37",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "ETag": "\u00220x8DA54108B906790\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7a67d51e-3a6e-b009-ce37-8f0af46d5d37",
+        "x-ms-request-id": "92da6324-201a-0007-32f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-87b8627b-cb3e-eca6-3478-fb48d5271b85/test-directory-c7e78314-948e-423f-2b1d-220b5962b30c?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-dd51cfddc7c3adeee99efa99763893a2-0986b928b376c10d-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "e3348383-5d43-7278-6c0c-a03d0a2898ff",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:04 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "ETag": "\u00220x8DA54108B9BCF2E\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e3348383-5d43-7278-6c0c-a03d0a2898ff",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:06.4800558Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:06.4800558Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:06.4800558Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da6326-201a-0007-33f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-87b8627b-cb3e-eca6-3478-fb48d5271b85/test-directory-c7e78314-948e-423f-2b1d-220b5962b30c/test-file-ff2a10d5-a1bf-da16-2750-8917a92ca6f7",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c2dd140f53f7419f71bc765ac9304bef-61f099934c12bc06-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "26931df9-c2f7-78b4-c1bd-48333a1f7e6d",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:04 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "ETag": "\u00220x8DA54108BA73F2B\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "26931df9-c2f7-78b4-c1bd-48333a1f7e6d",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:06.5550123Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:06.5550123Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:06.5550123Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da6327-201a-0007-34f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-87b8627b-cb3e-eca6-3478-fb48d5271b85/test-directory-c7e78314-948e-423f-2b1d-220b5962b30c/test-file-ff2a10d5-a1bf-da16-2750-8917a92ca6f7?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A04Z\u0026sp=rywdlcaup\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-d86c1f3d6ef50ab150036dadda1a3b8b-834092cdc348afd9-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ed447649-7295-b307-77bd-5d74b598bf94",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "ETag": "\u00220x8DA54108BA73F2B\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "ed447649-7295-b307-77bd-5d74b598bf94",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:06.5550123Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:06.5550123Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:06.5550123Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da6328-201a-0007-35f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-87b8627b-cb3e-eca6-3478-fb48d5271b85?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d69b2d48c928c234e25ba1e9fcfdf163-4d0d11368e457778-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "c4eaa19e-90da-1bd8-4627-730bd9c6cf1e",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:04 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c4eaa19e-90da-1bd8-4627-730bd9c6cf1e",
+        "x-ms-request-id": "92da6329-201a-0007-36f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:04.8606206-07:00",
+    "RandomSeed": "401228107",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%rywdlcaup%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%rywdlcaup%)Async.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-ca022f14-6983-fcab-5157-afa53ab68177?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-36b5e81990add81217bf189a6ae5eefb-bc2c740141a449fc-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f98bcb08-1e72-2fc8-0929-f3a762f5cd79",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "ETag": "\u00220x8DA5410903B3F64\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f98bcb08-1e72-2fc8-0929-f3a762f5cd79",
+        "x-ms-request-id": "92da63d4-201a-0007-2df9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-ca022f14-6983-fcab-5157-afa53ab68177/test-directory-69fb3f50-436c-1fee-1faa-c2e045df2e7c?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-37d2f23234bc8ee4f928842d176f72af-d068e87c37e34c44-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f9ce77fa-5e58-c84f-3ae7-a29115531fb5",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "ETag": "\u00220x8DA5410904879C5\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f9ce77fa-5e58-c84f-3ae7-a29115531fb5",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:14.3225285Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:14.3225285Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:14.3225285Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da63d6-201a-0007-2ef9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-ca022f14-6983-fcab-5157-afa53ab68177/test-directory-69fb3f50-436c-1fee-1faa-c2e045df2e7c/test-file-6e9d68d8-882a-1304-c7da-2d9a0069f512",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b33d3b2a2fa4ecdf19a0cd978d04821e-40d3fc00d6995ae2-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "89a003f1-fc9b-75b9-5ab3-54f27248ae89",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "ETag": "\u00220x8DA54109052FF86\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "89a003f1-fc9b-75b9-5ab3-54f27248ae89",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:14.3914886Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:14.3914886Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:14.3914886Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da63d7-201a-0007-2ff9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-ca022f14-6983-fcab-5157-afa53ab68177/test-directory-69fb3f50-436c-1fee-1faa-c2e045df2e7c/test-file-6e9d68d8-882a-1304-c7da-2d9a0069f512?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A12Z\u0026sp=rywdlcaup\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-ac655a90afaead6a1272bbcf2547f7c2-acb7776dda2a2c53-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "12a0c12f-95b3-b81a-f796-40b04caf5045",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "ETag": "\u00220x8DA54109052FF86\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "12a0c12f-95b3-b81a-f796-40b04caf5045",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:14.3914886Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:14.3914886Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:14.3914886Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da63d8-201a-0007-30f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-ca022f14-6983-fcab-5157-afa53ab68177?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d1ca06b0c54eca6d6f855035eeb45de3-5f713d503366f938-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b1c35798-9ca8-b7d6-0a5a-b4450d160d25",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b1c35798-9ca8-b7d6-0a5a-b4450d160d25",
+        "x-ms-request-id": "92da63d9-201a-0007-31f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:12.6915169-07:00",
+    "RandomSeed": "2045559774",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%cos%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%cos%).json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-7e76b834-ce81-5044-6a3c-2ad1ae5c0673?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-e1a1a5434aff46a1cfbdb5d5228b40bf-fc49020d70e1c814-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "38f9622d-29d2-3d58-3eb5-c06aa5d2e46d",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "ETag": "\u00220x8DA54108CA02926\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "38f9622d-29d2-3d58-3eb5-c06aa5d2e46d",
+        "x-ms-request-id": "92da6358-201a-0007-62f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-7e76b834-ce81-5044-6a3c-2ad1ae5c0673/test-directory-52211bf7-a423-73b9-ae70-c8ec51b5c473?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-a2d021c7022c156c2dbccb42e17177fb-ff9bb3fb2aa09b24-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "1be24cf1-982e-290b-7b26-0f62b808720e",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "ETag": "\u00220x8DA54108CACA1AF\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1be24cf1-982e-290b-7b26-0f62b808720e",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:08.2680239Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:08.2680239Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:08.2680239Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da635a-201a-0007-63f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-7e76b834-ce81-5044-6a3c-2ad1ae5c0673/test-directory-52211bf7-a423-73b9-ae70-c8ec51b5c473/test-file-4ca48a87-cd62-faa0-42c0-ebb001a05fe3",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-7c5cfe3e389617c578099d1552b94044-92dc368d826c8a9e-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b4bf62d4-44bd-18b4-046c-f5ae5319d0a0",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "ETag": "\u00220x8DA54108CB6B24A\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b4bf62d4-44bd-18b4-046c-f5ae5319d0a0",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:08.3339850Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:08.3339850Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:08.3339850Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da635b-201a-0007-64f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-7e76b834-ce81-5044-6a3c-2ad1ae5c0673/test-directory-52211bf7-a423-73b9-ae70-c8ec51b5c473/test-file-4ca48a87-cd62-faa0-42c0-ebb001a05fe3?sv=2021-08-06\u0026ss=bqtf\u0026srt=cos\u0026se=2022-06-23T05%3A32%3A06Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-0f46404c715d5808d85231de33bc1708-317cac9c76c31a24-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "558d388c-bd48-cb50-3023-3db25defd1f4",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "ETag": "\u00220x8DA54108CB6B24A\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "558d388c-bd48-cb50-3023-3db25defd1f4",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:08.3339850Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:08.3339850Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:08.3339850Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da635c-201a-0007-65f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-7e76b834-ce81-5044-6a3c-2ad1ae5c0673?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-24f1565649ac6993413ce5893e3a6ca0-d9876a620463b924-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "1b21b887-7a8c-5657-2a85-4a0c6cb83fbd",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1b21b887-7a8c-5657-2a85-4a0c6cb83fbd",
+        "x-ms-request-id": "92da635d-201a-0007-66f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:06.6407078-07:00",
+    "RandomSeed": "432860519",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%cos%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%cos%)Async.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-f84062e3-1a4d-00bf-ed21-72aead050a49?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-381b893c3695ec199956d61f4aaceb90-c83469618ed64007-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "92db770d-edc5-72c9-5999-89c2d1af7a30",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "ETag": "\u00220x8DA5410914A8BD8\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "92db770d-edc5-72c9-5999-89c2d1af7a30",
+        "x-ms-request-id": "92da63f0-201a-0007-42f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-f84062e3-1a4d-00bf-ed21-72aead050a49/test-directory-799f2e8f-145d-5bec-b4b9-2de47c3f3853?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-335f46b20888bda24d5e333171fc069d-ea917ca33e729efd-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "3df03660-440e-1706-aaa2-073ead6a5dc9",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "ETag": "\u00220x8DA54109159253B\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3df03660-440e-1706-aaa2-073ead6a5dc9",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:16.1094971Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:16.1094971Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:16.1094971Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da63f2-201a-0007-43f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-f84062e3-1a4d-00bf-ed21-72aead050a49/test-directory-799f2e8f-145d-5bec-b4b9-2de47c3f3853/test-file-36a193d1-772a-fd83-721f-6681feebb61b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-805c8ec42e7bcb41c81ba9d974a79548-ca0dc357c9f37d77-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "c8204c29-79fa-a90c-66d8-ee57cd424a20",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "ETag": "\u00220x8DA541091655864\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c8204c29-79fa-a90c-66d8-ee57cd424a20",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:16.1894500Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:16.1894500Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:16.1894500Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da63f4-201a-0007-44f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-f84062e3-1a4d-00bf-ed21-72aead050a49/test-directory-799f2e8f-145d-5bec-b4b9-2de47c3f3853/test-file-36a193d1-772a-fd83-721f-6681feebb61b?sv=2021-08-06\u0026ss=bqtf\u0026srt=cos\u0026se=2022-06-23T05%3A32%3A14Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-d5a1585d6150aef30f9bc7fe913ed5e7-f5bf496d3823df5e-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "60147a65-9449-89ce-054c-a976b0012ed1",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "ETag": "\u00220x8DA541091655864\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "60147a65-9449-89ce-054c-a976b0012ed1",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:16.1894500Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:16.1894500Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:16.1894500Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da63f5-201a-0007-45f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-f84062e3-1a4d-00bf-ed21-72aead050a49?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1fb7e8ceef262b1b70f97e0c03b33a00-732e7db0af33cf6f-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "53f1ba5a-ea2d-8dd6-4680-a9a13c5310db",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "53f1ba5a-ea2d-8dd6-4680-a9a13c5310db",
+        "x-ms-request-id": "92da63f8-201a-0007-46f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:14.4906926-07:00",
+    "RandomSeed": "2127036397",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%oc%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%oc%).json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-57616c84-623f-ec9d-17ce-a7adc08bb041?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-fff7aa796e905c269c87f867c4355e65-f9e145edfc2fec4b-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "520885f2-0841-d7e4-b0bc-515f6c64327d",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "ETag": "\u00220x8DA54108D670591\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "520885f2-0841-d7e4-b0bc-515f6c64327d",
+        "x-ms-request-id": "92da636b-201a-0007-71f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-57616c84-623f-ec9d-17ce-a7adc08bb041/test-directory-733dcdb5-3463-240c-aa22-27b9f1692df0?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-9efcd31043bc2743cda8d0f50c34618f-6e108d351ac9f8db-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "9136618f-f8a9-58fa-cdbd-38a8a3ee1747",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "ETag": "\u00220x8DA54108D799760\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9136618f-f8a9-58fa-cdbd-38a8a3ee1747",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:09.6112480Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:09.6112480Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:09.6112480Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da636d-201a-0007-72f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-57616c84-623f-ec9d-17ce-a7adc08bb041/test-directory-733dcdb5-3463-240c-aa22-27b9f1692df0/test-file-3abbdb28-5d82-7f00-3abb-901e0d62d2cb",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-6dfd455d40e513619c9f3be5cc82cbbd-570a86cbbbda9929-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ac8e49d5-412c-5b21-f926-242cfac01a8a",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "ETag": "\u00220x8DA54108D85F19E\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ac8e49d5-412c-5b21-f926-242cfac01a8a",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:09.6922014Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:09.6922014Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:09.6922014Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da636e-201a-0007-73f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-57616c84-623f-ec9d-17ce-a7adc08bb041/test-directory-733dcdb5-3463-240c-aa22-27b9f1692df0/test-file-3abbdb28-5d82-7f00-3abb-901e0d62d2cb?sv=2021-08-06\u0026ss=bqtf\u0026srt=oc\u0026se=2022-06-23T05%3A32%3A07Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-f1a96b1943c757abb5ccbfec04fa2d88-c90f4e43011faf58-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "5ad2281e-6a5f-0e1b-3a0b-04c317dbfcb2",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "ETag": "\u00220x8DA54108D85F19E\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "5ad2281e-6a5f-0e1b-3a0b-04c317dbfcb2",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:09.6922014Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:09.6922014Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:09.6922014Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da636f-201a-0007-74f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-57616c84-623f-ec9d-17ce-a7adc08bb041?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-92a21c94f633f957da76151a14fdc7cb-31b8fc027366e136-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d10d3783-c0ed-622b-45c0-4bb8e3983c7e",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d10d3783-c0ed-622b-45c0-4bb8e3983c7e",
+        "x-ms-request-id": "92da6370-201a-0007-75f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:07.9975757-07:00",
+    "RandomSeed": "1962801618",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%oc%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%oc%)Async.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-682148bc-b782-3313-f78e-30933b9a980c?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-587f54b2892e25db8963f746026fc8ba-56fc339929a8a13a-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "9ca73d2a-fa6f-7dde-9a62-4a032e3cb6d9",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "ETag": "\u00220x8DA5410924457AC\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9ca73d2a-fa6f-7dde-9a62-4a032e3cb6d9",
+        "x-ms-request-id": "92da640a-201a-0007-53f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-682148bc-b782-3313-f78e-30933b9a980c/test-directory-9f5202f3-83bf-e4c8-6760-0f4511854bdd?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-874782fd0757506b975f38bafbcd1941-f691a3748b20199c-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d9146d16-b8d3-f6e5-65e9-7cd08a1f568a",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "ETag": "\u00220x8DA54109259F480\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d9146d16-b8d3-f6e5-65e9-7cd08a1f568a",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:17.7925248Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:17.7925248Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:17.7925248Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da640c-201a-0007-54f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-682148bc-b782-3313-f78e-30933b9a980c/test-directory-9f5202f3-83bf-e4c8-6760-0f4511854bdd/test-file-fe6955ef-fcf3-699c-23ef-f8a88ddd921c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c4c3eafa62f7344bcbfd320d61e81488-b17c4550a7842074-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "2091e483-b9c9-cd48-e7a3-7edd824a1b55",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "ETag": "\u00220x8DA541092684A43\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2091e483-b9c9-cd48-e7a3-7edd824a1b55",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:17.8864707Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:17.8864707Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:17.8864707Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da640d-201a-0007-55f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-682148bc-b782-3313-f78e-30933b9a980c/test-directory-9f5202f3-83bf-e4c8-6760-0f4511854bdd/test-file-fe6955ef-fcf3-699c-23ef-f8a88ddd921c?sv=2021-08-06\u0026ss=bqtf\u0026srt=oc\u0026se=2022-06-23T05%3A32%3A16Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-49a9455941bfe5dc3de4121d8ef57d29-eaa31bf4c94282c5-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "a64cf16a-368d-14c1-aaf1-5d49e8396dee",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "ETag": "\u00220x8DA541092684A43\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "a64cf16a-368d-14c1-aaf1-5d49e8396dee",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:17.8864707Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:17.8864707Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:17.8864707Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da640e-201a-0007-56f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-682148bc-b782-3313-f78e-30933b9a980c?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-10636c33e26c6bafde14e900884040fc-ab6d7de12cf19f04-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "9072a674-75fd-35c7-e82c-4de8c8dfc71c",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9072a674-75fd-35c7-e82c-4de8c8dfc71c",
+        "x-ms-request-id": "92da640f-201a-0007-57f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:16.1868853-07:00",
+    "RandomSeed": "994158377",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%ocs%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%ocs%).json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-30b3871c-be40-864d-56fc-0d35e1844e3a?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-0c07043036a7e18eb535a92355b75e56-37eb1242106bd635-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "99779ae1-e138-fb58-10e3-547c3fba3d98",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "ETag": "\u00220x8DA54108CE7D607\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "99779ae1-e138-fb58-10e3-547c3fba3d98",
+        "x-ms-request-id": "92da635e-201a-0007-67f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-30b3871c-be40-864d-56fc-0d35e1844e3a/test-directory-7d749eb8-2142-fc2b-d200-3c97e192d49b?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-63426ab0dc7faa0196d008ceda0dc88d-1646e70505158470-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "7ba3b80f-f566-048a-9c91-4a596a5e309a",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "ETag": "\u00220x8DA54108CF33D2F\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7ba3b80f-f566-048a-9c91-4a596a5e309a",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:08.7307567Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:08.7307567Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:08.7307567Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da6360-201a-0007-68f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-30b3871c-be40-864d-56fc-0d35e1844e3a/test-directory-7d749eb8-2142-fc2b-d200-3c97e192d49b/test-file-4753c4d9-b40d-e302-33e9-b7cccb387239",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-0438324fb4fbf937e6cc8c1cd7c1c612-694ae58893260515-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "12bd38cf-f795-75d2-bafe-75b45bad5610",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "ETag": "\u00220x8DA54108D000C82\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "12bd38cf-f795-75d2-bafe-75b45bad5610",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:08.8147074Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:08.8147074Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:08.8147074Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da6362-201a-0007-69f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-30b3871c-be40-864d-56fc-0d35e1844e3a/test-directory-7d749eb8-2142-fc2b-d200-3c97e192d49b/test-file-4753c4d9-b40d-e302-33e9-b7cccb387239?sv=2021-08-06\u0026ss=bqtf\u0026srt=ocs\u0026se=2022-06-23T05%3A32%3A07Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-80b991c5896cd83a7adcf8c25683d1e8-56b6577bc5ea5dc6-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "3189d753-1da0-9605-31b7-e2914ba1d810",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "ETag": "\u00220x8DA54108D000C82\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "3189d753-1da0-9605-31b7-e2914ba1d810",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:08.8147074Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:08.8147074Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:08.8147074Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da6363-201a-0007-6af9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-30b3871c-be40-864d-56fc-0d35e1844e3a?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-795ac2205b2f6df780f231adee860d8e-31c1964779de8720-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "8360a4e8-2423-2c6f-2712-70dd9b5c01c1",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8360a4e8-2423-2c6f-2712-70dd9b5c01c1",
+        "x-ms-request-id": "92da6364-201a-0007-6bf9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:07.1403964-07:00",
+    "RandomSeed": "2003136109",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%ocs%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%ocs%)Async.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-3064ce70-f1ae-3216-e3e3-dba44b592432?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-1881755261d0ea437f1ceb6c01e504e2-0306cf35e3646c52-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "cc25398a-0033-2569-1d3f-604a1fe03906",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "ETag": "\u00220x8DA5410919FF260\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cc25398a-0033-2569-1d3f-604a1fe03906",
+        "x-ms-request-id": "92da63f9-201a-0007-47f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-3064ce70-f1ae-3216-e3e3-dba44b592432/test-directory-c008258b-03ca-07a7-0cb9-7ef43eb1a58d?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-9f2002bdd11f6d232174a47e133e49f1-6a72ab7984536d75-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "c06fd399-27c6-34d3-2544-c211d0c7ff94",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "ETag": "\u00220x8DA541091C9148C\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c06fd399-27c6-34d3-2544-c211d0c7ff94",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:16.8430732Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:16.8430732Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:16.8430732Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da63fb-201a-0007-48f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-3064ce70-f1ae-3216-e3e3-dba44b592432/test-directory-c008258b-03ca-07a7-0cb9-7ef43eb1a58d/test-file-12195edb-5733-c4ff-fdb8-33e008778ad2",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c4f68cf1c47ec450b75f3196e9b31e5b-6c615697482386c2-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "3547c6d1-c907-590b-d9a5-410985a0b6ca",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "ETag": "\u00220x8DA541091D34C39\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3547c6d1-c907-590b-d9a5-410985a0b6ca",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:16.9100345Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:16.9100345Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:16.9100345Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da63fc-201a-0007-49f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-3064ce70-f1ae-3216-e3e3-dba44b592432/test-directory-c008258b-03ca-07a7-0cb9-7ef43eb1a58d/test-file-12195edb-5733-c4ff-fdb8-33e008778ad2?sv=2021-08-06\u0026ss=bqtf\u0026srt=ocs\u0026se=2022-06-23T05%3A32%3A15Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-0695eded84bdbec2163520563e4dbe13-fd575c97c428d000-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "0a403902-ca7f-658c-a01b-b732fd360d0b",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "ETag": "\u00220x8DA541091D34C39\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "0a403902-ca7f-658c-a01b-b732fd360d0b",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:16.9100345Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:16.9100345Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:16.9100345Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da63fd-201a-0007-4af9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-3064ce70-f1ae-3216-e3e3-dba44b592432?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b0f82bfb44350b09e681eb914a92d640-29ffbb0aa7355f56-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "4c06a108-ac60-554a-9ee3-35e59e625c5c",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4c06a108-ac60-554a-9ee3-35e59e625c5c",
+        "x-ms-request-id": "92da63fe-201a-0007-4bf9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:15.2102379-07:00",
+    "RandomSeed": "237276920",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%os%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%os%).json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-318d6faa-e66f-93e6-e54b-925c177b2bcb?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-e97e4a95f903e271636c35a84dcae3f0-ba2a36799556650c-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "8a90e8b9-df70-af88-ecb5-56ed186e0f78",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "ETag": "\u00220x8DA54108D304628\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8a90e8b9-df70-af88-ecb5-56ed186e0f78",
+        "x-ms-request-id": "92da6365-201a-0007-6cf9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-318d6faa-e66f-93e6-e54b-925c177b2bcb/test-directory-befd380e-ee6c-b197-b95b-33462502487e?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-468b14b0b6c12e69fb90b6ffa0e2856e-6f10a4a500a4336c-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "38cad76d-e0cb-6d8e-dda0-2ba9d5400ef1",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "ETag": "\u00220x8DA54108D3CBE6F\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "38cad76d-e0cb-6d8e-dda0-2ba9d5400ef1",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:09.2124783Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:09.2124783Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:09.2124783Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da6367-201a-0007-6df9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-318d6faa-e66f-93e6-e54b-925c177b2bcb/test-directory-befd380e-ee6c-b197-b95b-33462502487e/test-file-2ea3df23-a1ea-5c5b-92c2-1957a2c71a8f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c7dd11d79a5f3d0637fd78fea14e4a7c-3e994f7b2406f758-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "caea2f39-e2fc-38c3-b967-34c83d9cf511",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "ETag": "\u00220x8DA54108D46F614\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "caea2f39-e2fc-38c3-b967-34c83d9cf511",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:09.2794388Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:09.2794388Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:09.2794388Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da6368-201a-0007-6ef9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-318d6faa-e66f-93e6-e54b-925c177b2bcb/test-directory-befd380e-ee6c-b197-b95b-33462502487e/test-file-2ea3df23-a1ea-5c5b-92c2-1957a2c71a8f?sv=2021-08-06\u0026ss=bqtf\u0026srt=os\u0026se=2022-06-23T05%3A32%3A07Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-895d3e45b5e62d946cfad3545528e1ec-3629b577a43757d4-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "a56fdbf0-4355-5ef5-e0f3-24c5004c7cfd",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "ETag": "\u00220x8DA54108D46F614\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "a56fdbf0-4355-5ef5-e0f3-24c5004c7cfd",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:09.2794388Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:09.2794388Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:09.2794388Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da6369-201a-0007-6ff9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-318d6faa-e66f-93e6-e54b-925c177b2bcb?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2e9e8476205758f7094db3af47e68fb2-af09c10ac28e6874-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "62d89dc9-4f2c-8cbb-ea76-272187f63675",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "62d89dc9-4f2c-8cbb-ea76-272187f63675",
+        "x-ms-request-id": "92da636a-201a-0007-70f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:07.5803693-07:00",
+    "RandomSeed": "1574694377",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%os%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%os%)Async.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-e7d91399-51fe-3f80-4f52-804c4d5b7b59?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-66c6c47b27d00341d9c20f3dc40c1dcb-57297ca634e87419-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ab7d4912-e008-3118-3045-482a9ca3e21f",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "ETag": "\u00220x8DA541091F4BCB6\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ab7d4912-e008-3118-3045-482a9ca3e21f",
+        "x-ms-request-id": "92da63ff-201a-0007-4cf9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-e7d91399-51fe-3f80-4f52-804c4d5b7b59/test-directory-285c7172-6db6-8f68-f559-06090adb975d?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-f6a6171cf075158e77f0a1f182275087-2d3065e2f92ffc04-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "e398eaad-de69-a242-1f41-33761cbccd00",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "ETag": "\u00220x8DA541092004908\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e398eaad-de69-a242-1f41-33761cbccd00",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:17.2048648Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:17.2048648Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:17.2048648Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da6401-201a-0007-4df9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-e7d91399-51fe-3f80-4f52-804c4d5b7b59/test-directory-285c7172-6db6-8f68-f559-06090adb975d/test-file-0439b891-cfdd-1a51-f540-51acc1f4e33d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-fcb6b7e608004483c1dcc0eb8cc29691-03a752e838c9cd09-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d6fefb19-ff5b-35d3-e590-1654649b8824",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "ETag": "\u00220x8DA5410920BB8FC\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d6fefb19-ff5b-35d3-e590-1654649b8824",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:17.2798204Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:17.2798204Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:17.2798204Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da6402-201a-0007-4ef9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-e7d91399-51fe-3f80-4f52-804c4d5b7b59/test-directory-285c7172-6db6-8f68-f559-06090adb975d/test-file-0439b891-cfdd-1a51-f540-51acc1f4e33d?sv=2021-08-06\u0026ss=bqtf\u0026srt=os\u0026se=2022-06-23T05%3A32%3A15Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-73c7cc1a9feded1adc3e63b267b4b208-574c555bf19b51ad-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "205c4d00-f6bd-76a5-f5c1-fd164b73950c",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "ETag": "\u00220x8DA5410920BB8FC\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "205c4d00-f6bd-76a5-f5c1-fd164b73950c",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:17.2798204Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:17.2798204Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:17.2798204Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da6403-201a-0007-4ff9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-e7d91399-51fe-3f80-4f52-804c4d5b7b59?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a65f0ec9efc4e27aa5df0c1672081890-6e41581e165dfd7e-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "16549707-673e-2967-0fc2-1b58469600ae",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "16549707-673e-2967-0fc2-1b58469600ae",
+        "x-ms-request-id": "92da6409-201a-0007-52f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:15.5799064-07:00",
+    "RandomSeed": "186711533",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%sco%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%sco%).json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-5aba74ff-00a5-8648-6a53-b3b46483fa4c?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-a5a4a19e3fff2eacf4e88fc88c6ca745-255852a1efbde2da-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "2aeeb907-ebcb-7525-74a2-2d29335c1081",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "ETag": "\u00220x8DA54108C10CF78\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2aeeb907-ebcb-7525-74a2-2d29335c1081",
+        "x-ms-request-id": "92da6330-201a-0007-3cf9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-5aba74ff-00a5-8648-6a53-b3b46483fa4c/test-directory-97a331c3-1426-0ea7-da53-208692919040?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-772a80bc7c7af30fa216c3d3f6658612-7fc5d0ee7c241ef9-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "1cf9ec12-65b0-f4ec-b057-dab6acf94a69",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "ETag": "\u00220x8DA54108C1C0FCA\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1cf9ec12-65b0-f4ec-b057-dab6acf94a69",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:07.3205706Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:07.3205706Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:07.3205706Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da6332-201a-0007-3df9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-5aba74ff-00a5-8648-6a53-b3b46483fa4c/test-directory-97a331c3-1426-0ea7-da53-208692919040/test-file-abac172f-cf95-4b81-bc6f-68adc37033dc",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b8bb71820c9eee1d3e8a3b4899207d43-7dceba2591533fd1-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d79a858c-1776-a92c-fffe-142eb1be4718",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "ETag": "\u00220x8DA54108C277FD4\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d79a858c-1776-a92c-fffe-142eb1be4718",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:07.3955284Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:07.3955284Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:07.3955284Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da6333-201a-0007-3ef9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-5aba74ff-00a5-8648-6a53-b3b46483fa4c/test-directory-97a331c3-1426-0ea7-da53-208692919040/test-file-abac172f-cf95-4b81-bc6f-68adc37033dc?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A05Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-71fe4939cae7d7489df0216679617c1b-bb97909ec1d45a1c-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "262abdd7-735f-08f3-17ce-a7a0b88bf2e2",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "ETag": "\u00220x8DA54108C277FD4\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "262abdd7-735f-08f3-17ce-a7a0b88bf2e2",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:07.3955284Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:07.3955284Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:07.3955284Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da6334-201a-0007-3ff9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-5aba74ff-00a5-8648-6a53-b3b46483fa4c?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b3afdabb0be1bcfa50e9e5546450da98-7e61fa232e84c2fa-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f3576d88-2094-21b9-f34f-6f5893a38da5",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f3576d88-2094-21b9-f34f-6f5893a38da5",
+        "x-ms-request-id": "92da6335-201a-0007-40f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:05.7012898-07:00",
+    "RandomSeed": "339297279",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%sco%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%sco%)Async.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-fd08ce03-3e55-ccf0-8524-156c9c6cddc5?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-38af27211f8501e67b09d03edd94c5ad-abd531c658a5dda6-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "c9d85ef1-459f-7ac4-58b0-22d1b3d213ad",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "ETag": "\u00220x8DA541090C43173\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c9d85ef1-459f-7ac4-58b0-22d1b3d213ad",
+        "x-ms-request-id": "92da63e2-201a-0007-38f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-fd08ce03-3e55-ccf0-8524-156c9c6cddc5/test-directory-080721db-bad0-cbfc-1c50-bcf691a0a5ae?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-2f465d0308c0a172d7e0e82cdce0df3b-e8c1c18051ccb34b-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "bc62730a-d457-c719-fbb9-6c062811b53b",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "ETag": "\u00220x8DA541090D2CB08\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bc62730a-d457-c719-fbb9-6c062811b53b",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:15.2290056Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:15.2290056Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:15.2290056Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da63e4-201a-0007-39f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-fd08ce03-3e55-ccf0-8524-156c9c6cddc5/test-directory-080721db-bad0-cbfc-1c50-bcf691a0a5ae/test-file-3e7bf66e-1394-4e26-9bca-91eb15e0046e",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-84651f75931671aa54fbb5df72b3b818-c809b84d571f37ef-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "a1e0d9e0-477d-7617-e5ac-081541470e4f",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "ETag": "\u00220x8DA541090DE6209\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a1e0d9e0-477d-7617-e5ac-081541470e4f",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:15.3049609Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:15.3049609Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:15.3049609Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da63e5-201a-0007-3af9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-fd08ce03-3e55-ccf0-8524-156c9c6cddc5/test-directory-080721db-bad0-cbfc-1c50-bcf691a0a5ae/test-file-3e7bf66e-1394-4e26-9bca-91eb15e0046e?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A13Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-6ee0a07bf8c0a52d7352462c16cf6b0d-c300ba9a863ed5a2-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "4f269ef3-1431-04bd-3634-ac7f98c97f60",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "ETag": "\u00220x8DA541090DE6209\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "4f269ef3-1431-04bd-3634-ac7f98c97f60",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:15.3049609Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:15.3049609Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:15.3049609Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da63e6-201a-0007-3bf9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-fd08ce03-3e55-ccf0-8524-156c9c6cddc5?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1a37dd253680a621998e850ad5f55948-b77953aa40485312-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "a221e34b-bf21-421d-b3fe-03edab0cd0cb",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a221e34b-bf21-421d-b3fe-03edab0cd0cb",
+        "x-ms-request-id": "92da63e7-201a-0007-3cf9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:13.6151418-07:00",
+    "RandomSeed": "2081887555",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%soc%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%soc%).json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-0c3c09cc-555f-e242-ee7b-b568d2733aed?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-8a52cecb551aed9c1ddec13d20277af1-b862d6f5178874b0-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "092cbc23-c3c8-3bdd-7c56-d6922713f6bc",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "ETag": "\u00220x8DA54108C5C4C3F\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "092cbc23-c3c8-3bdd-7c56-d6922713f6bc",
+        "x-ms-request-id": "92da6344-201a-0007-4ff9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-0c3c09cc-555f-e242-ee7b-b568d2733aed/test-directory-e94e00ae-3160-2913-bfb4-7734eccbee15?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b41815df757e04c4de5d3fc98942b938-c93b05ff4549763f-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "aeb8c167-e0cf-7d75-dbca-7c17eb0a5d08",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "ETag": "\u00220x8DA54108C67B3A6\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "aeb8c167-e0cf-7d75-dbca-7c17eb0a5d08",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:07.8162854Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:07.8162854Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:07.8162854Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da6352-201a-0007-5cf9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-0c3c09cc-555f-e242-ee7b-b568d2733aed/test-directory-e94e00ae-3160-2913-bfb4-7734eccbee15/test-file-164479d9-3146-8425-6d49-4609ccb76082",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-47dd189e1e0575b52b47c6ae54993fd6-bb06c2918d32c590-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "0aa195f9-b1ff-53b2-364a-17bf3bc3069e",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "ETag": "\u00220x8DA54108C734AA5\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0aa195f9-b1ff-53b2-364a-17bf3bc3069e",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:07.8922405Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:07.8922405Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:07.8922405Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da6355-201a-0007-5ff9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-0c3c09cc-555f-e242-ee7b-b568d2733aed/test-directory-e94e00ae-3160-2913-bfb4-7734eccbee15/test-file-164479d9-3146-8425-6d49-4609ccb76082?sv=2021-08-06\u0026ss=bqtf\u0026srt=soc\u0026se=2022-06-23T05%3A32%3A06Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-3c71bb7e9b6a349e74837fc67dbd9d71-a32632b6792cbf9c-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "561db893-5268-a209-41ac-0ab8e3cce6d9",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "ETag": "\u00220x8DA54108C734AA5\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "561db893-5268-a209-41ac-0ab8e3cce6d9",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:07.8922405Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:07.8922405Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:07.8922405Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da6356-201a-0007-60f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-0c3c09cc-555f-e242-ee7b-b568d2733aed?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0e062d05832473186bf6289c5a2e4e38-f24c489b04676421-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "832b4db5-b0a5-5335-371d-15fc05f58869",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:06 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:07 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "832b4db5-b0a5-5335-371d-15fc05f58869",
+        "x-ms-request-id": "92da6357-201a-0007-61f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:06.2057931-07:00",
+    "RandomSeed": "633015574",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%soc%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%soc%)Async.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-21732dcd-6bac-ed72-bfaa-df8ecedc1cf0?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-d3724ffa6afd53a34f6c9a6b63b7e074-9df8e1dfb50bbe60-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "67d99a10-2a0d-0513-80ab-35500d419ce4",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "ETag": "\u00220x8DA54109105EBCF\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "67d99a10-2a0d-0513-80ab-35500d419ce4",
+        "x-ms-request-id": "92da63ea-201a-0007-3df9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-21732dcd-6bac-ed72-bfaa-df8ecedc1cf0/test-directory-3dec674f-ac43-796c-d3a1-2ac1773f1ea2?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-5f88cd9d7489b9abfddf963541d6ce2b-91875fa2d6a0b7ae-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "0b08938d-67c2-9ae1-849d-8023248d5ac9",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:13 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "ETag": "\u00220x8DA5410911B3AFE\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0b08938d-67c2-9ae1-849d-8023248d5ac9",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:15.7037310Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:15.7037310Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:15.7037310Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da63ec-201a-0007-3ef9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-21732dcd-6bac-ed72-bfaa-df8ecedc1cf0/test-directory-3dec674f-ac43-796c-d3a1-2ac1773f1ea2/test-file-347e0148-b502-4fe2-bd20-87df1e0ac4b5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-0d1668251c788d22a57c45c92e9f4065-87e35f64aa294e5f-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "8b514791-b802-e7f3-2d49-e392a3763fa0",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "ETag": "\u00220x8DA541091265CE6\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8b514791-b802-e7f3-2d49-e392a3763fa0",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:15.7766886Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:15.7766886Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:15.7766886Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da63ed-201a-0007-3ff9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-21732dcd-6bac-ed72-bfaa-df8ecedc1cf0/test-directory-3dec674f-ac43-796c-d3a1-2ac1773f1ea2/test-file-347e0148-b502-4fe2-bd20-87df1e0ac4b5?sv=2021-08-06\u0026ss=bqtf\u0026srt=soc\u0026se=2022-06-23T05%3A32%3A14Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-794bca044ebeecce55a6cdffb44828e8-26bf3874a3e1fd1d-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "dc91154f-cf3b-24c7-808a-3a12d2de7ff1",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "ETag": "\u00220x8DA541091265CE6\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "dc91154f-cf3b-24c7-808a-3a12d2de7ff1",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:15.7766886Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:15.7766886Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:15.7766886Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da63ee-201a-0007-40f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-21732dcd-6bac-ed72-bfaa-df8ecedc1cf0?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-96ba009a8a11c838fd9da47377ab7cc8-2df7cd415edc00ef-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "8e43d5d0-62e4-3664-036a-0b55ecd10443",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:14 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:15 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8e43d5d0-62e4-3664-036a-0b55ecd10443",
+        "x-ms-request-id": "92da63ef-201a-0007-41f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:14.0781738-07:00",
+    "RandomSeed": "188637321",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%bfqt%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%bfqt%).json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-e6a2d0f9-9e9d-d0a0-1833-3cfbb73c02da?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-fce53f1230cedf9239a178d51ee23396-5a35bc8cb3f100d6-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d89efe90-48a8-d5bd-2f1d-7e8143944c37",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "ETag": "\u00220x8DA54108DB7D8D7\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d89efe90-48a8-d5bd-2f1d-7e8143944c37",
+        "x-ms-request-id": "92da6371-201a-0007-76f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-e6a2d0f9-9e9d-d0a0-1833-3cfbb73c02da/test-directory-0187b47a-be2a-3b10-952d-a3f3b7b7cb8e?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-76758c8001c18a9fe7f44861b6c94f2e-55e29954447c3fbe-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "61aaef52-9229-5099-8112-fc5773dcfcdb",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "ETag": "\u00220x8DA54108DC736BC\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "61aaef52-9229-5099-8112-fc5773dcfcdb",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:10.1199548Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:10.1199548Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:10.1199548Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da6375-201a-0007-78f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-e6a2d0f9-9e9d-d0a0-1833-3cfbb73c02da/test-directory-0187b47a-be2a-3b10-952d-a3f3b7b7cb8e/test-file-b96ae2d6-2a9d-7532-04d2-4a333fb930ae",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-81f68f7c9e88b232f225c0edaf03fa6c-398a3b8ca89a5c25-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "4fe1d2b4-cf0e-cb84-151d-cfef5ed85d10",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "ETag": "\u00220x8DA54108DD20A89\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4fe1d2b4-cf0e-cb84-151d-cfef5ed85d10",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:10.1909129Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:10.1909129Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:10.1909129Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da6376-201a-0007-79f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-e6a2d0f9-9e9d-d0a0-1833-3cfbb73c02da/test-directory-0187b47a-be2a-3b10-952d-a3f3b7b7cb8e/test-file-b96ae2d6-2a9d-7532-04d2-4a333fb930ae?sv=2021-08-06\u0026ss=bfqt\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A08Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-b33ab6f521d5a8ba1a715b2d67927de4-fb0da419fcce88e1-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "a1a3c241-adfb-2dcc-70c9-f22baa9e1cd9",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "ETag": "\u00220x8DA54108DD20A89\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "a1a3c241-adfb-2dcc-70c9-f22baa9e1cd9",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:10.1909129Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:10.1909129Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:10.1909129Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da6377-201a-0007-7af9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-e6a2d0f9-9e9d-d0a0-1833-3cfbb73c02da?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-019280e562378c69c646b28cf46680de-3b8bd96bf3be6853-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "9bae06b4-bc35-b915-9b50-3e6c22032dc4",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9bae06b4-bc35-b915-9b50-3e6c22032dc4",
+        "x-ms-request-id": "92da6378-201a-0007-7bf9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:08.4963936-07:00",
+    "RandomSeed": "254588129",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%bfqt%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%bfqt%)Async.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-09087ef4-b910-7b88-bc69-bea29d61b543?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-048834627077b7b1ff7f5e7afefe7381-e6151e7f61b34268-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "e6ed5a61-1f20-7198-02d0-dc5031ebde1f",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "ETag": "\u00220x8DA54109292934A\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e6ed5a61-1f20-7198-02d0-dc5031ebde1f",
+        "x-ms-request-id": "92da6410-201a-0007-58f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-09087ef4-b910-7b88-bc69-bea29d61b543/test-directory-f5324098-44fb-df74-6816-efff198d176f?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-960b63da15416cd233cc1ff20b9aba4e-6b858eba06f94512-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "09f76cb8-9ba9-c8ac-1ee9-824f0f59a6a3",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "ETag": "\u00220x8DA5410929E1F64\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "09f76cb8-9ba9-c8ac-1ee9-824f0f59a6a3",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:18.2392676Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:18.2392676Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:18.2392676Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da6413-201a-0007-59f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-09087ef4-b910-7b88-bc69-bea29d61b543/test-directory-f5324098-44fb-df74-6816-efff198d176f/test-file-43412758-cf73-4922-73ab-341a38c5bf2e",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-ed45f207c09de740bbac295b1024e654-6d4cdb218934101c-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "cc62bf54-b6cd-9684-d39a-0431984c0c8c",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "ETag": "\u00220x8DA541092A8570B\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cc62bf54-b6cd-9684-d39a-0431984c0c8c",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:18.3062283Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:18.3062283Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:18.3062283Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da6414-201a-0007-5af9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-09087ef4-b910-7b88-bc69-bea29d61b543/test-directory-f5324098-44fb-df74-6816-efff198d176f/test-file-43412758-cf73-4922-73ab-341a38c5bf2e?sv=2021-08-06\u0026ss=bfqt\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A16Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-6ee6ec5df0c17120849c6a2ff0fe1352-1969d83c87f4e960-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "50faa7cf-daf7-a0d5-3d37-c68ff022a53f",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "ETag": "\u00220x8DA541092A8570B\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "50faa7cf-daf7-a0d5-3d37-c68ff022a53f",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:18.3062283Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:18.3062283Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:18.3062283Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da6415-201a-0007-5bf9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-09087ef4-b910-7b88-bc69-bea29d61b543?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b21f1f15ac5c2baf7e1f47534eae98f2-dff2d5d35fa44bdd-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f161fe24-bc52-8c94-0412-3094f5bbd3f5",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f161fe24-bc52-8c94-0412-3094f5bbd3f5",
+        "x-ms-request-id": "92da6416-201a-0007-5cf9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:16.6094476-07:00",
+    "RandomSeed": "397050572",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%fb%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%fb%).json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-8aed5bdd-d935-44bc-8ed1-bb053182efab?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-0792a5ab369380630291381912b7c9cc-79dde5f0f79d15bc-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d033ae32-ee12-21bb-6668-6e64297a6af3",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "ETag": "\u00220x8DA54108F0584C1\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d033ae32-ee12-21bb-6668-6e64297a6af3",
+        "x-ms-request-id": "92da639f-201a-0007-10f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-8aed5bdd-d935-44bc-8ed1-bb053182efab/test-directory-493a1058-c3de-432b-14cb-70446fe8bba8?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-e31d801a8ea7648c5085d9be62f2d6f8-2aec51a27648cf9f-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "050bc6ad-e7a7-39a4-7789-b0b2f6831732",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "ETag": "\u00220x8DA54108F124A79\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "050bc6ad-e7a7-39a4-7789-b0b2f6831732",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:12.2897017Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:12.2897017Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:12.2897017Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da63a1-201a-0007-11f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-8aed5bdd-d935-44bc-8ed1-bb053182efab/test-directory-493a1058-c3de-432b-14cb-70446fe8bba8/test-file-82d22359-1f4e-b098-992c-cda82be1f99f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c62d3131daee6e1553e2673434f06127-a1d78a55d0b20007-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "65fb4f7b-f3d6-9ff8-d041-02227f0678ff",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "ETag": "\u00220x8DA54108F1D6C6A\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "65fb4f7b-f3d6-9ff8-d041-02227f0678ff",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:12.3626602Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:12.3626602Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:12.3626602Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da63a2-201a-0007-12f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-8aed5bdd-d935-44bc-8ed1-bb053182efab/test-directory-493a1058-c3de-432b-14cb-70446fe8bba8/test-file-82d22359-1f4e-b098-992c-cda82be1f99f?sv=2021-08-06\u0026ss=fb\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A10Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-cb6820156c619272eb0d6abedb37028a-6eed7b786601cf78-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "a6368e55-b287-df5c-d71e-292b3fdaaa64",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "ETag": "\u00220x8DA54108F1D6C6A\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "a6368e55-b287-df5c-d71e-292b3fdaaa64",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:12.3626602Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:12.3626602Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:12.3626602Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da63a3-201a-0007-13f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-8aed5bdd-d935-44bc-8ed1-bb053182efab?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ccde5a20d28d55e052cf84c31588c887-570f877a84f62543-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f0ccdc6a-d2cf-2577-2c95-d4998ce42bef",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:12 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f0ccdc6a-d2cf-2577-2c95-d4998ce42bef",
+        "x-ms-request-id": "92da63a4-201a-0007-14f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:10.6686037-07:00",
+    "RandomSeed": "1461832309",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%fb%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%fb%)Async.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-9239b0b0-ce10-9888-40fc-b880fdfe257d?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-121682559ad0113528e9f70fe6a3f866-9047de6313319c5a-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "7381af29-e5f8-4e98-504f-c655116de96c",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:20 GMT",
+        "ETag": "\u00220x8DA541093C9AD51\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:20 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7381af29-e5f8-4e98-504f-c655116de96c",
+        "x-ms-request-id": "92da6431-201a-0007-72f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-9239b0b0-ce10-9888-40fc-b880fdfe257d/test-directory-31e5affc-d84a-2fda-75fe-52d01fce4fec?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-686912ab909e037ddf45a80d423f6b27-c1d17b84994e7e9e-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "bf8ad9ff-9a16-49f0-2bd3-5d68a1387490",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:20 GMT",
+        "ETag": "\u00220x8DA541093DA4135\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:20 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bf8ad9ff-9a16-49f0-2bd3-5d68a1387490",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:20.3110709Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:20.3110709Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:20.3110709Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da6433-201a-0007-73f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-9239b0b0-ce10-9888-40fc-b880fdfe257d/test-directory-31e5affc-d84a-2fda-75fe-52d01fce4fec/test-file-4e5652ca-b27c-1184-d4e1-36a1bae529d2",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-23b3d4509ad362f132b3f633292f9237-e84e75eb062c03a3-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "e1a1b4b1-6a5a-bcbb-5175-6d9aa2b2af9c",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:20 GMT",
+        "ETag": "\u00220x8DA541093E49FF1\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:20 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e1a1b4b1-6a5a-bcbb-5175-6d9aa2b2af9c",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:20.3790321Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:20.3790321Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:20.3790321Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da6434-201a-0007-74f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-9239b0b0-ce10-9888-40fc-b880fdfe257d/test-directory-31e5affc-d84a-2fda-75fe-52d01fce4fec/test-file-4e5652ca-b27c-1184-d4e1-36a1bae529d2?sv=2021-08-06\u0026ss=fb\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A18Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-7ceb40d71c5d832a76493e4d826c61ad-0f02e2117a483bff-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "edb75056-9396-6a35-c3bd-8b9a49e42783",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:20 GMT",
+        "ETag": "\u00220x8DA541093E49FF1\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:20 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "edb75056-9396-6a35-c3bd-8b9a49e42783",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:20.3790321Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:20.3790321Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:20.3790321Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da6435-201a-0007-75f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-9239b0b0-ce10-9888-40fc-b880fdfe257d?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ce0542c44465ff770982ce12a4732a49-7d24bf24dcd637a5-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "5143cce0-c1fb-4a05-37bb-5091c7d8fe76",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:20 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5143cce0-c1fb-4a05-37bb-5091c7d8fe76",
+        "x-ms-request-id": "92da6436-201a-0007-76f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:18.6864900-07:00",
+    "RandomSeed": "220294562",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%fqt%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%fqt%).json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-1245286e-0664-3f26-3fd2-6ada772bc0c2?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-18f3ffc4b237fbb3adb10b7916c56207-30283034efab9b10-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "3c7a90e6-b93c-381f-f821-8dc173c484b9",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "ETag": "\u00220x8DA54108E8173F6\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3c7a90e6-b93c-381f-f821-8dc173c484b9",
+        "x-ms-request-id": "92da6393-201a-0007-06f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-1245286e-0664-3f26-3fd2-6ada772bc0c2/test-directory-2c12291e-9a7a-5cc9-9457-4e5670fcbb30?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-bb72b746734d959f29d6499022ec4c83-9f09dabfad198237-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "042c5d65-9ccf-9b08-a393-4745f24dd8c2",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "ETag": "\u00220x8DA54108E8E87F8\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "042c5d65-9ccf-9b08-a393-4745f24dd8c2",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:11.4262008Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:11.4262008Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:11.4262008Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da6395-201a-0007-07f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-1245286e-0664-3f26-3fd2-6ada772bc0c2/test-directory-2c12291e-9a7a-5cc9-9457-4e5670fcbb30/test-file-e7f46e95-83b1-7e86-e534-a87c84d17a00",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3d33e834976d6909e776c5673282c6fb-dd01cdd9c19ed29c-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "2717ac6c-75a5-ec30-d46f-b668c93c597a",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "ETag": "\u00220x8DA54108E995BC2\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2717ac6c-75a5-ec30-d46f-b668c93c597a",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:11.4971586Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:11.4971586Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:11.4971586Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da6396-201a-0007-08f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-1245286e-0664-3f26-3fd2-6ada772bc0c2/test-directory-2c12291e-9a7a-5cc9-9457-4e5670fcbb30/test-file-e7f46e95-83b1-7e86-e534-a87c84d17a00?sv=2021-08-06\u0026ss=fqt\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A09Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-fd0d65236cefba1ee9efdef8e7566763-4c79bd0eed0de05b-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "45d92a7f-b136-661d-1edf-c082aacbbcaf",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "ETag": "\u00220x8DA54108E995BC2\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "45d92a7f-b136-661d-1edf-c082aacbbcaf",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:11.4971586Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:11.4971586Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:11.4971586Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da6397-201a-0007-09f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-1245286e-0664-3f26-3fd2-6ada772bc0c2?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2f6629f03c94f9c99ab45c380198b8ba-9f70c54d776455a4-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "9ee8b5af-1462-9344-c8a2-fe1b7186585e",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9ee8b5af-1462-9344-c8a2-fe1b7186585e",
+        "x-ms-request-id": "92da6398-201a-0007-0af9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:09.8213397-07:00",
+    "RandomSeed": "773470168",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%fqt%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%fqt%)Async.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-f11875a8-7f7d-1862-d18b-4ea1b0ea8464?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b358d940760e27d267dbc70642a4222b-dbae14aca1deb165-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "12092e1b-517f-b2f5-5821-61812412db42",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "ETag": "\u00220x8DA54109342DDC6\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "12092e1b-517f-b2f5-5821-61812412db42",
+        "x-ms-request-id": "92da6424-201a-0007-67f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-f11875a8-7f7d-1862-d18b-4ea1b0ea8464/test-directory-d1686197-8642-ab6a-606b-88294a543852?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-1a2d0ae3e0e06cf353d4e1859ac9942b-b221331968c25d0a-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "52a30fe9-588c-2661-7b19-ea95fc4f0ecc",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "ETag": "\u00220x8DA5410934DA669\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "52a30fe9-588c-2661-7b19-ea95fc4f0ecc",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:19.3896041Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:19.3896041Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:19.3896041Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da6426-201a-0007-68f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-f11875a8-7f7d-1862-d18b-4ea1b0ea8464/test-directory-d1686197-8642-ab6a-606b-88294a543852/test-file-8286d2de-71e0-4fe5-e7ad-891a9c938756",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c77eda3511d3ffcce088cc11280c75b4-05c2108bf02fdc72-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "8d318445-34f0-1fca-914f-04fdf1a49874",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "ETag": "\u00220x8DA541093593D69\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8d318445-34f0-1fca-914f-04fdf1a49874",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:19.4655593Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:19.4655593Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:19.4655593Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da6427-201a-0007-69f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-f11875a8-7f7d-1862-d18b-4ea1b0ea8464/test-directory-d1686197-8642-ab6a-606b-88294a543852/test-file-8286d2de-71e0-4fe5-e7ad-891a9c938756?sv=2021-08-06\u0026ss=fqt\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A17Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-ad9b6d7693d32276110bc5da1d2ebe32-702e95e217a3db90-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "784fcf92-811e-afdc-6791-c68eb43d10f4",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "ETag": "\u00220x8DA541093593D69\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "784fcf92-811e-afdc-6791-c68eb43d10f4",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:19.4655593Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:19.4655593Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:19.4655593Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da6428-201a-0007-6af9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-f11875a8-7f7d-1862-d18b-4ea1b0ea8464?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c944f0806a70267e50a7b59787113c28-ff711c4a22a377c0-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "226b5ae8-1f54-cd55-097e-2f8a4a987c96",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "226b5ae8-1f54-cd55-097e-2f8a4a987c96",
+        "x-ms-request-id": "92da6429-201a-0007-6bf9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:17.7659442-07:00",
+    "RandomSeed": "398667039",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%qf%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%qf%).json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-d16aa1f5-1344-b129-b24b-5899b96e347b?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-7b3b2b74f3980038a2ef6bf456ecc551-d21e72616a1fa50e-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "c2c17e27-cbda-8df3-c3c7-9d94788b6221",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "ETag": "\u00220x8DA54108EC99601\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c2c17e27-cbda-8df3-c3c7-9d94788b6221",
+        "x-ms-request-id": "92da6399-201a-0007-0bf9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-d16aa1f5-1344-b129-b24b-5899b96e347b/test-directory-8b32abd7-8243-d7c1-a711-865585aab7a9?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-175341bf7dae382676bce1ab8bef5bfa-7ba1b9d908b3dc16-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d70bf30f-2819-6574-0a55-c1abb0ef5642",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "ETag": "\u00220x8DA54108ED5E6A5\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d70bf30f-2819-6574-0a55-c1abb0ef5642",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:11.8939301Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:11.8939301Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:11.8939301Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da639b-201a-0007-0cf9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-d16aa1f5-1344-b129-b24b-5899b96e347b/test-directory-8b32abd7-8243-d7c1-a711-865585aab7a9/test-file-3a71a189-71ad-dca1-c997-d2d18064e0bf",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-49d273cf24cafba33d0d62d6eab608c4-6e68d0f5dc5dab6d-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "8dc1b98f-0959-64a6-f842-448075c7f3ce",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "ETag": "\u00220x8DA54108EE0455C\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8dc1b98f-0959-64a6-f842-448075c7f3ce",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:11.9618908Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:11.9618908Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:11.9618908Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da639c-201a-0007-0df9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-d16aa1f5-1344-b129-b24b-5899b96e347b/test-directory-8b32abd7-8243-d7c1-a711-865585aab7a9/test-file-3a71a189-71ad-dca1-c997-d2d18064e0bf?sv=2021-08-06\u0026ss=qf\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A10Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-98f83da931c3b3aa89b0d1be037286ee-2c0bf97f9e083c75-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f71b95bd-c92d-27e9-2065-20c02551dc66",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "ETag": "\u00220x8DA54108EE0455C\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "f71b95bd-c92d-27e9-2065-20c02551dc66",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:11.9618908Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:11.9618908Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:11.9618908Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da639d-201a-0007-0ef9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-d16aa1f5-1344-b129-b24b-5899b96e347b?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d1f118bf8fe33673ce8c870276230ae7-7ef4b2d09e074483-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "e0c31232-fcab-caa0-ef70-5c6fce5580cf",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e0c31232-fcab-caa0-ef70-5c6fce5580cf",
+        "x-ms-request-id": "92da639e-201a-0007-0ff9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:10.2619761-07:00",
+    "RandomSeed": "1925628851",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%qf%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%qf%)Async.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-4a4f9edd-b8fd-7d79-2f79-3d000920e2a9?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-d784fd04b9954bf2554c00fa31922ceb-032d63c8126d4bda-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "7843103f-ee2a-b94e-b550-3065905d26a4",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "ETag": "\u00220x8DA5410937ECC91\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7843103f-ee2a-b94e-b550-3065905d26a4",
+        "x-ms-request-id": "92da642a-201a-0007-6cf9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-4a4f9edd-b8fd-7d79-2f79-3d000920e2a9/test-directory-3bd59d37-3337-2272-d593-1cc52c770c9d?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-52c2a6fe12609792377193f469f83e22-bdf4af259a81ec3c-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "721b9344-2d9c-cdc6-1fec-51b7199c9871",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "ETag": "\u00220x8DA5410938B1B78\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "721b9344-2d9c-cdc6-1fec-51b7199c9871",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:19.7923704Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:19.7923704Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:19.7923704Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da642c-201a-0007-6df9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-4a4f9edd-b8fd-7d79-2f79-3d000920e2a9/test-directory-3bd59d37-3337-2272-d593-1cc52c770c9d/test-file-f8c11d4a-6add-e87e-ea7f-1ad68a632bcf",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-06a4d246cea122328ade645107e3007f-b8e2ddd0a836f04d-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f792dcf2-b948-e533-20fd-b3d0a231f201",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "ETag": "\u00220x8DA54109396B282\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f792dcf2-b948-e533-20fd-b3d0a231f201",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:19.8683266Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:19.8683266Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:19.8683266Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da642d-201a-0007-6ef9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-4a4f9edd-b8fd-7d79-2f79-3d000920e2a9/test-directory-3bd59d37-3337-2272-d593-1cc52c770c9d/test-file-f8c11d4a-6add-e87e-ea7f-1ad68a632bcf?sv=2021-08-06\u0026ss=qf\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A18Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-39ae6feb2b32076332f53026536135e8-9aa7572bd10fa96d-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "3dc5f0d4-a109-ae29-1acd-24af8510b403",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "ETag": "\u00220x8DA54109396B282\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "3dc5f0d4-a109-ae29-1acd-24af8510b403",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:19.8683266Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:19.8683266Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:19.8683266Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da642e-201a-0007-6ff9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-4a4f9edd-b8fd-7d79-2f79-3d000920e2a9?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5ba571f40a3758df925838b33176c533-e65f3e447dc6f0be-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b1fb7bf6-b56c-e6f7-0780-6a0a23e186a1",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b1fb7bf6-b56c-e6f7-0780-6a0a23e186a1",
+        "x-ms-request-id": "92da642f-201a-0007-70f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:18.1785558-07:00",
+    "RandomSeed": "1683664376",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%qftb%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%qftb%).json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-8a6b2f35-605c-8c7f-7f63-7ccce5d5e9ef?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-df653d778a926a85ac805b061d2cfb12-ce3cc188988f8231-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "1ae9bac5-42a2-ab77-375a-037fbb96a2ae",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "ETag": "\u00220x8DA54108DFB40A2\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1ae9bac5-42a2-ab77-375a-037fbb96a2ae",
+        "x-ms-request-id": "92da6379-201a-0007-7cf9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-8a6b2f35-605c-8c7f-7f63-7ccce5d5e9ef/test-directory-0cedb20d-15fb-a101-b96b-044f050f1e21?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-366f3cb3c0b2f80232ed40aebfc86303-3282a6e934f0c7e5-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "73fce23b-768f-3ec3-65e2-1d46929512c2",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "ETag": "\u00220x8DA54108E060B2E\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "73fce23b-768f-3ec3-65e2-1d46929512c2",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:10.5317166Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:10.5317166Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:10.5317166Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da637b-201a-0007-7df9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-8a6b2f35-605c-8c7f-7f63-7ccce5d5e9ef/test-directory-0cedb20d-15fb-a101-b96b-044f050f1e21/test-file-2b064783-cfeb-0a4d-efb4-826b8ff644ee",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-ff20ee326a3cc081e6a51d7e6cb2862e-dc8dc345ff6867f9-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ad2f5a0e-d0fa-f35e-e822-568db5f31d23",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "ETag": "\u00220x8DA54108E101BD1\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ad2f5a0e-d0fa-f35e-e822-568db5f31d23",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:10.5976785Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:10.5976785Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:10.5976785Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da6387-201a-0007-7ef9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-8a6b2f35-605c-8c7f-7f63-7ccce5d5e9ef/test-directory-0cedb20d-15fb-a101-b96b-044f050f1e21/test-file-2b064783-cfeb-0a4d-efb4-826b8ff644ee?sv=2021-08-06\u0026ss=qftb\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A08Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-b6c746aeb4dbdd7f0722918e6dd1a0ce-97e6fed84dc08b0f-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "38385616-6465-55c8-b7f1-6f8b0c24f919",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "ETag": "\u00220x8DA54108E101BD1\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "38385616-6465-55c8-b7f1-6f8b0c24f919",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:10.5976785Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:10.5976785Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:10.5976785Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da6388-201a-0007-7ff9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-8a6b2f35-605c-8c7f-7f63-7ccce5d5e9ef?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9dece4f96a3b83d012fa73e86f72fcbb-de4a89affab92794-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "5f770752-e4ba-d1bd-d7ba-7051ddeecb0c",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:08 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5f770752-e4ba-d1bd-d7ba-7051ddeecb0c",
+        "x-ms-request-id": "92da6389-201a-0007-80f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:08.8964828-07:00",
+    "RandomSeed": "715040817",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%qftb%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%qftb%)Async.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-4cc726e0-ab1a-eb17-1bba-ac6007bbadaa?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-d4992b533e791b1c4eed063b9eb8f7a7-77fb4e4e7b9c3f63-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "dc23adfd-bbed-8073-99fd-1e1581726583",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "ETag": "\u00220x8DA541092CB754E\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dc23adfd-bbed-8073-99fd-1e1581726583",
+        "x-ms-request-id": "92da6417-201a-0007-5df9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-4cc726e0-ab1a-eb17-1bba-ac6007bbadaa/test-directory-83c0679f-3619-8135-872d-9fb4e9977c3c?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-040356b0114bfbd9ab24781d5e992257-6f5585a15ae9abed-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "2f00e281-0a0f-ceeb-aa6c-3f93a32d41fd",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "ETag": "\u00220x8DA541092D6DA3C\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2f00e281-0a0f-ceeb-aa6c-3f93a32d41fd",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:18.6110524Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:18.6110524Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:18.6110524Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da6419-201a-0007-5ef9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-4cc726e0-ab1a-eb17-1bba-ac6007bbadaa/test-directory-83c0679f-3619-8135-872d-9fb4e9977c3c/test-file-5a625215-d098-53bd-4386-93084089183b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-7a68167bf798add5612d7227ce6fd087-3a7bb676caf2dfad-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "5d8790ef-e889-f62b-5312-5db1e2ad2349",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:16 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "ETag": "\u00220x8DA541092E3D0A2\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5d8790ef-e889-f62b-5312-5db1e2ad2349",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:18.6960034Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:18.6960034Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:18.6960034Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da641a-201a-0007-5ff9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-4cc726e0-ab1a-eb17-1bba-ac6007bbadaa/test-directory-83c0679f-3619-8135-872d-9fb4e9977c3c/test-file-5a625215-d098-53bd-4386-93084089183b?sv=2021-08-06\u0026ss=qftb\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A17Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-1cfa8a932b3abb08294598f424137550-fbc505e3ac4fbd04-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "12a3ba34-e3a5-2c73-38bb-58a3166b1165",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "ETag": "\u00220x8DA541092E3D0A2\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "12a3ba34-e3a5-2c73-38bb-58a3166b1165",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:18.6960034Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:18.6960034Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:18.6960034Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da641b-201a-0007-60f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-4cc726e0-ab1a-eb17-1bba-ac6007bbadaa?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-445b86fef023281ceded7dcb58f59de0-13c80d2bb751fd2e-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "277cb0bf-1009-7da4-e47e-7e5192a9f659",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "277cb0bf-1009-7da4-e47e-7e5192a9f659",
+        "x-ms-request-id": "92da641d-201a-0007-61f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:17.0046964-07:00",
+    "RandomSeed": "1627717241",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%tqfb%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%tqfb%).json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-db837ba9-d9ca-b286-c26f-08bdd7745452?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-842f4102909b82c692a9a4231df67e40-5a7eca2db6dc6862-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "af1e7f31-01d9-a330-61fc-3511a16d9481",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "ETag": "\u00220x8DA54108E342299\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "af1e7f31-01d9-a330-61fc-3511a16d9481",
+        "x-ms-request-id": "92da638b-201a-0007-01f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-db837ba9-d9ca-b286-c26f-08bdd7745452/test-directory-febeb092-c04f-c27d-b220-8b8507fcd336?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-86a7bd8fcc350f11bf46cec3acc68eb0-804e5043948a1aa8-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "caccfe29-3be0-ed2b-378d-fd2031b610fb",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "ETag": "\u00220x8DA54108E409A89\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "caccfe29-3be0-ed2b-378d-fd2031b610fb",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:10.9154953Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:10.9154953Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:10.9154953Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da638d-201a-0007-02f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-db837ba9-d9ca-b286-c26f-08bdd7745452/test-directory-febeb092-c04f-c27d-b220-8b8507fcd336/test-file-588cd645-a556-3079-002f-8fc6b2b6c1e2",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-4ff8667ff8585a2258bc2cd9e48e43cd-336180ed32ee8a2b-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b39d2992-f6ea-7402-250a-f7402dc13f4b",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "ETag": "\u00220x8DA54108E4CA6B0\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b39d2992-f6ea-7402-250a-f7402dc13f4b",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:10.9944496Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:10.9944496Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:10.9944496Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da638e-201a-0007-03f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-db837ba9-d9ca-b286-c26f-08bdd7745452/test-directory-febeb092-c04f-c27d-b220-8b8507fcd336/test-file-588cd645-a556-3079-002f-8fc6b2b6c1e2?sv=2021-08-06\u0026ss=tqfb\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A09Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-416df00697bb8f23a302d4050a394c4c-77e8e1dd1f570e07-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "078da8d2-5c19-6811-a560-91f9ad29ec32",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "ETag": "\u00220x8DA54108E4CA6B0\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:10 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "078da8d2-5c19-6811-a560-91f9ad29ec32",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:10.9944496Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:10.9944496Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:10.9944496Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da638f-201a-0007-04f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-db837ba9-d9ca-b286-c26f-08bdd7745452?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e60e14d2f54e73c3f1ee436125eb99f9-7e4b58f394bb576d-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "856d81c5-3734-ef31-eff0-27755467d66c",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:09 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:11 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "856d81c5-3734-ef31-eff0-27755467d66c",
+        "x-ms-request-id": "92da6390-201a-0007-05f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:09.3067313-07:00",
+    "RandomSeed": "268298569",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%tqfb%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%tqfb%)Async.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-2b26b3e7-6951-e21e-93e5-b4028e7f76eb?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-490a39708dfb64ca767367aa2eab3cd3-63e74a3e87d1f8fa-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "4191d274-0dbd-7bed-957a-2d454934f47a",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "ETag": "\u00220x8DA54109309ADAD\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4191d274-0dbd-7bed-957a-2d454934f47a",
+        "x-ms-request-id": "92da641e-201a-0007-62f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-2b26b3e7-6951-e21e-93e5-b4028e7f76eb/test-directory-5ce1211b-7b5f-76bc-991f-b96bcfc4cb33?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-80ab20c8a6c51975693dda6ba5033f58-1fec3b1846a66347-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "5375f9ae-38a6-e78d-f30e-8235944f31c4",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "ETag": "\u00220x8DA54109314C47F\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5375f9ae-38a6-e78d-f30e-8235944f31c4",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-06-22T05:32:19.0168191Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:19.0168191Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:19.0168191Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "92da6420-201a-0007-63f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-2b26b3e7-6951-e21e-93e5-b4028e7f76eb/test-directory-5ce1211b-7b5f-76bc-991f-b96bcfc4cb33/test-file-bb8ef6cf-34ed-d32e-da29-e76d44d4bd3d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-2af12861030eeeb1f98dcdd3b4d91de3-bbb6312eaf95fa67-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "4abe167d-695e-b997-9156-0171372964c5",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:18 GMT",
+        "ETag": "\u00220x8DA541093200D6A\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4abe167d-695e-b997-9156-0171372964c5",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:19.0907754Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:19.0907754Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:19.0907754Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "92da6421-201a-0007-64f9-851982000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-2b26b3e7-6951-e21e-93e5-b4028e7f76eb/test-directory-5ce1211b-7b5f-76bc-991f-b96bcfc4cb33/test-file-bb8ef6cf-34ed-d32e-da29-e76d44d4bd3d?sv=2021-08-06\u0026ss=tqfb\u0026srt=sco\u0026se=2022-06-23T05%3A32%3A17Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-89269c23cde3fe89566af4cc0f461a12-7e5515dc58a46b3e-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "7db7298f-e691-f765-e4c0-1f30d442df6e",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1048576",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "ETag": "\u00220x8DA541093200D6A\u0022",
+        "Last-Modified": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "7db7298f-e691-f765-e4c0-1f30d442df6e",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-06-22T05:32:19.0907754Z",
+        "x-ms-file-creation-time": "2022-06-22T05:32:19.0907754Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-06-22T05:32:19.0907754Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "92da6422-201a-0007-65f9-851982000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-type": "File",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-2b26b3e7-6951-e21e-93e5-b4028e7f76eb?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-387414f549d7b1d2f5333e87a4ad34e5-011c86f7e9adbb3b-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "0de19efa-e671-0334-7e44-f448db190303",
+        "x-ms-date": "Wed, 22 Jun 2022 05:32:17 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-08-06"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:32:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0de19efa-e671-0334-7e44-f448db190303",
+        "x-ms-request-id": "92da6423-201a-0007-66f9-851982000000",
+        "x-ms-version": "2021-08-06"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:32:17.3929769-07:00",
+    "RandomSeed": "1368517039",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/Azure.Storage.Queues.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Queues/tests/Azure.Storage.Queues.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="SessionRecords\" />
+    <Compile Include="$(AzureStorageSharedTestSources)..\Sas\*.cs" LinkBase="Shared\Sas" />
     <Compile Include="$(AzureStorageSharedTestSources)\**\*.cs" LinkBase="Shared" />
     <Compile Remove="$(AzureStorageSharedTestSources)\AzuriteFixture.cs" />
     <Compile Remove="$(AzureStorageSharedTestSources)\AzuriteNUnitFixture.cs" />

--- a/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
@@ -539,15 +539,10 @@ namespace Azure.Storage.Queues.Test
         #endregion
 
         #region AccountSas
-        [RecordedTest]
-        [TestCase("sco")]
-        [TestCase("soc")]
-        [TestCase("cos")]
-        [TestCase("ocs")]
-        [TestCase("cs")]
-        [TestCase("oc")]
-        [ServiceVersion(Min = QueueClientOptions.ServiceVersion.V2020_06_12)]
-        public async Task AccountSas_ResourceTypeOrder(string resourceType)
+        private async Task InvokeAccountSasTest(
+            string permissions = "rwdylacuptfi",
+            string services = "bqtf",
+            string resourceType = "sco")
         {
             // Arrange
             await using DisposingQueue test = await GetTestQueueAsync();
@@ -556,8 +551,6 @@ namespace Azure.Storage.Queues.Test
 
             // Generate a SAS that would set the srt / ResourceTypes in a different order than
             // the .NET SDK would normally create the SAS
-            string permissions = "rwdylacuptfi";
-            string services = "bqtf";
             TestAccountSasBuilder accountSasBuilder = new TestAccountSasBuilder(
                 permissions: permissions,
                 expiresOn: Recording.UtcNow.AddDays(1),
@@ -575,6 +568,19 @@ namespace Azure.Storage.Queues.Test
         }
 
         [RecordedTest]
+        [TestCase("sco")]
+        [TestCase("soc")]
+        [TestCase("cos")]
+        [TestCase("ocs")]
+        [TestCase("cs")]
+        [TestCase("oc")]
+        [ServiceVersion(Min = QueueClientOptions.ServiceVersion.V2020_06_12)]
+        public async Task AccountSas_ResourceTypeOrder(string resourceType)
+        {
+            await InvokeAccountSasTest(resourceType: resourceType);
+        }
+
+        [RecordedTest]
         [TestCase("bfqt")]
         [TestCase("qftb")]
         [TestCase("tqfb")]
@@ -584,29 +590,7 @@ namespace Azure.Storage.Queues.Test
         [ServiceVersion(Min = QueueClientOptions.ServiceVersion.V2020_06_12)]
         public async Task AccountSas_ServiceOrder(string services)
         {
-            // Arrange
-            await using DisposingQueue test = await GetTestQueueAsync();
-            QueueClient queue = test.Queue;
-            await queue.CreateAsync().ConfigureAwait(false);
-
-            // Generate a SAS that would set the srt / ResourceTypes in a different order than
-            // the .NET SDK would normally create the SAS
-            string permissions = "rwdylacuptfi";
-            string resourceTypes = "sco";
-            TestAccountSasBuilder accountSasBuilder = new TestAccountSasBuilder(
-                permissions: permissions,
-                expiresOn: Recording.UtcNow.AddDays(1),
-                services: services,
-                resourceTypes: resourceTypes);
-
-            UriBuilder blobUriBuilder = new UriBuilder(queue.Uri)
-            {
-                Query = accountSasBuilder.ToTestSasQueryParameters(Tenants.GetNewSharedKeyCredentials()).ToString()
-            };
-
-            // Assert
-            QueueClient sasBlobClient = InstrumentClient(new QueueClient(blobUriBuilder.Uri, GetOptions()));
-            await sasBlobClient.GetPropertiesAsync();
+            await InvokeAccountSasTest(services: services);
         }
 
         [RecordedTest]
@@ -619,31 +603,10 @@ namespace Azure.Storage.Queues.Test
         [ServiceVersion(Min = QueueClientOptions.ServiceVersion.V2020_06_12)]
         public async Task AccountSas_PermissionsOrder(string permissions)
         {
-            // Arrange
-            await using DisposingQueue test = await GetTestQueueAsync();
-            QueueClient queue = test.Queue;
-            await queue.CreateAsync().ConfigureAwait(false);
-
-            // Generate a SAS that would set the srt / ResourceTypes in a different order than
-            // the .NET SDK would normally create the SAS
-            string services = "bqtf";
-            string resourceTypes = "sco";
-            TestAccountSasBuilder accountSasBuilder = new TestAccountSasBuilder(
-                permissions: permissions,
-                expiresOn: Recording.UtcNow.AddDays(1),
-                services: services,
-                resourceTypes: resourceTypes);
-
-            UriBuilder blobUriBuilder = new UriBuilder(queue.Uri)
-            {
-                Query = accountSasBuilder.ToTestSasQueryParameters(Tenants.GetNewSharedKeyCredentials()).ToString()
-            };
-
-            // Assert
-            QueueClient sasBlobClient = InstrumentClient(new QueueClient(blobUriBuilder.Uri, GetOptions()));
-            await sasBlobClient.GetPropertiesAsync();
+            await InvokeAccountSasTest(permissions: permissions);
         }
         #endregion
+
         [RecordedTest]
         public void CanMockClientConstructors()
         {

--- a/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
@@ -11,6 +11,7 @@ using Azure.Storage.Queues.Models;
 using Azure.Storage.Queues.Tests;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
+using Azure.Storage.Test.Shared;
 using Moq;
 using NUnit.Framework;
 
@@ -124,11 +125,12 @@ namespace Azure.Storage.Queues.Test
             QueueServiceClient service = GetServiceClient_SharedKey();
             await using DisposingQueue test = await GetTestQueueAsync(service);
 
-            var marker = default(string);
+            var continuationToken = default(string);
             var queues = new List<QueueItem>();
-            await foreach (Page<QueueItem> page in service.GetQueuesAsync().AsPages(marker))
+            await foreach (Page<QueueItem> page in service.GetQueuesAsync().AsPages(continuationToken))
             {
                 queues.AddRange(page.Values);
+                continuationToken = page.ContinuationToken;
             }
 
             Assert.AreNotEqual(0, queues.Count);
@@ -536,6 +538,112 @@ namespace Azure.Storage.Queues.Test
         }
         #endregion
 
+        #region AccountSas
+        [RecordedTest]
+        [TestCase("sco")]
+        [TestCase("soc")]
+        [TestCase("cos")]
+        [TestCase("ocs")]
+        [TestCase("cs")]
+        [TestCase("oc")]
+        [ServiceVersion(Min = QueueClientOptions.ServiceVersion.V2020_06_12)]
+        public async Task AccountSas_ResourceTypeOrder(string resourceType)
+        {
+            // Arrange
+            await using DisposingQueue test = await GetTestQueueAsync();
+            QueueClient queue = test.Queue;
+            await queue.CreateAsync().ConfigureAwait(false);
+
+            // Generate a SAS that would set the srt / ResourceTypes in a different order than
+            // the .NET SDK would normally create the SAS
+            string permissions = "rwdylacuptfi";
+            string services = "bqtf";
+            TestAccountSasBuilder accountSasBuilder = new TestAccountSasBuilder(
+                permissions: permissions,
+                expiresOn: Recording.UtcNow.AddDays(1),
+                services: services,
+                resourceTypes: resourceType);
+
+            UriBuilder blobUriBuilder = new UriBuilder(queue.Uri)
+            {
+                Query = accountSasBuilder.ToTestSasQueryParameters(Tenants.GetNewSharedKeyCredentials()).ToString()
+            };
+
+            // Assert
+            QueueClient sasBlobClient = InstrumentClient(new QueueClient(blobUriBuilder.Uri, GetOptions()));
+            await sasBlobClient.GetPropertiesAsync();
+        }
+
+        [RecordedTest]
+        [TestCase("bfqt")]
+        [TestCase("qftb")]
+        [TestCase("tqfb")]
+        [TestCase("fqt")]
+        [TestCase("qb")]
+        [TestCase("fq")]
+        [ServiceVersion(Min = QueueClientOptions.ServiceVersion.V2020_06_12)]
+        public async Task AccountSas_ServiceOrder(string services)
+        {
+            // Arrange
+            await using DisposingQueue test = await GetTestQueueAsync();
+            QueueClient queue = test.Queue;
+            await queue.CreateAsync().ConfigureAwait(false);
+
+            // Generate a SAS that would set the srt / ResourceTypes in a different order than
+            // the .NET SDK would normally create the SAS
+            string permissions = "rwdylacuptfi";
+            string resourceTypes = "sco";
+            TestAccountSasBuilder accountSasBuilder = new TestAccountSasBuilder(
+                permissions: permissions,
+                expiresOn: Recording.UtcNow.AddDays(1),
+                services: services,
+                resourceTypes: resourceTypes);
+
+            UriBuilder blobUriBuilder = new UriBuilder(queue.Uri)
+            {
+                Query = accountSasBuilder.ToTestSasQueryParameters(Tenants.GetNewSharedKeyCredentials()).ToString()
+            };
+
+            // Assert
+            QueueClient sasBlobClient = InstrumentClient(new QueueClient(blobUriBuilder.Uri, GetOptions()));
+            await sasBlobClient.GetPropertiesAsync();
+        }
+
+        [RecordedTest]
+        [TestCase("rwdylacuptfi")]
+        [TestCase("cuprwdylatfi")]
+        [TestCase("cudypafitrwl")]
+        [TestCase("cuprwdyla")]
+        [TestCase("rywdlcaup")]
+        [TestCase("larwdycup")]
+        [ServiceVersion(Min = QueueClientOptions.ServiceVersion.V2020_06_12)]
+        public async Task AccountSas_PermissionsOrder(string permissions)
+        {
+            // Arrange
+            await using DisposingQueue test = await GetTestQueueAsync();
+            QueueClient queue = test.Queue;
+            await queue.CreateAsync().ConfigureAwait(false);
+
+            // Generate a SAS that would set the srt / ResourceTypes in a different order than
+            // the .NET SDK would normally create the SAS
+            string services = "bqtf";
+            string resourceTypes = "sco";
+            TestAccountSasBuilder accountSasBuilder = new TestAccountSasBuilder(
+                permissions: permissions,
+                expiresOn: Recording.UtcNow.AddDays(1),
+                services: services,
+                resourceTypes: resourceTypes);
+
+            UriBuilder blobUriBuilder = new UriBuilder(queue.Uri)
+            {
+                Query = accountSasBuilder.ToTestSasQueryParameters(Tenants.GetNewSharedKeyCredentials()).ToString()
+            };
+
+            // Assert
+            QueueClient sasBlobClient = InstrumentClient(new QueueClient(blobUriBuilder.Uri, GetOptions()));
+            await sasBlobClient.GetPropertiesAsync();
+        }
+        #endregion
         [RecordedTest]
         public void CanMockClientConstructors()
         {

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cudypafitrwl%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cudypafitrwl%).json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-aeeb81a8-6190-f399-c799-cb605c66fd99",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-94acbef109aa5840bcda65bbb5b23e8d-96a1fb3420341214-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "4df26c0a-c6d4-106d-913e-aed653e38530",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:04 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e839240a-f003-003b-01fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-aeeb81a8-6190-f399-c799-cb605c66fd99",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-d5648a79d771ef94323130d8588249ce-f15260fde0cb3f65-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ef567bce-b074-cec5-7798-440b84479aca",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:04 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392428-f003-003b-1dfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-aeeb81a8-6190-f399-c799-cb605c66fd99?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A03Z\u0026sp=cudypafitrwl\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-b1b7c88db101c8648c776451c29f64b2-3018ec99fcb70144-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d70865bb-958d-1cbc-9d68-a1742813f11c",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:05 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e8392462-f003-003b-57fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-aeeb81a8-6190-f399-c799-cb605c66fd99",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1d3ed773932c5d4c32f9704f9231d989-495bc9ede1f9d51f-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "1f505d7a-c33e-5a3d-8205-6fde11ce7539",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:05 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e839246c-f003-003b-61fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:03.8315688-07:00",
+    "RandomSeed": "866456205",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cudypafitrwl%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cudypafitrwl%)Async.json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-b3fdcc7b-c03e-e5f8-9706-169a7bdf2ca5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-9807d2d1fdca3eb864058937a91746a6-564c5d2c60ef6ab7-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "530aa2d9-01b3-2500-277d-d8e0b30c4057",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:12 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393133-f003-003b-65fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-b3fdcc7b-c03e-e5f8-9706-169a7bdf2ca5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-02d35be4d7cf8f09f4020b2173a1216d-e41c0983cbbd4427-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d9c1c98b-d9d5-4af2-9e6e-92d283e56ae4",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:12 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393164-f003-003b-12fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-b3fdcc7b-c03e-e5f8-9706-169a7bdf2ca5?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A11Z\u0026sp=cudypafitrwl\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-de04424174544f6aa64308ce2523e5d0-6ed8d9354024c5eb-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ea5545e9-674b-7f82-cb3c-8be9cb679b20",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:13 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e839318a-f003-003b-37fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-b3fdcc7b-c03e-e5f8-9706-169a7bdf2ca5",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-331f1807305b2b813bc409648b88d798-1039b04ee4d0b3a4-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "3ee8ab08-8090-9b99-26df-c842c60baf00",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:13 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83931b3-f003-003b-5dfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:11.8247213-07:00",
+    "RandomSeed": "2035000406",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cuprwdyla%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cuprwdyla%).json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-b6fa92cd-b445-b3ea-eb08-10870a0240ed",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b1eaa7f089789341d9ec6bc5f4abe6b8-6a7cd3a9cc11dfe4-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "29efe58f-44ac-fe7b-3c97-4d1216dff75a",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:05 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e839249e-f003-003b-12fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-b6fa92cd-b445-b3ea-eb08-10870a0240ed",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-82c389ac3e872c9cf08d04e2778b7f6a-7665398cd3b0cb29-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "24f84f9b-1712-2940-b562-eb9008163c5d",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:05 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83924ba-f003-003b-2dfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-b6fa92cd-b445-b3ea-eb08-10870a0240ed?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A04Z\u0026sp=cuprwdyla\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-a2a601705debd8d8fbbbbb3c09283dbb-e5b7e2181ef9bcf2-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "c7761f5a-d2e6-8647-8530-cad386fa6f53",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:05 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e83924dc-f003-003b-4cfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-b6fa92cd-b445-b3ea-eb08-10870a0240ed",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-95c6089ff9223657a3c74f3e91215bcf-9950cdc29c3ae030-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "e836adb3-75a0-7e77-c3c8-2b3323b6975e",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:05 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83924fd-f003-003b-6cfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:04.1435944-07:00",
+    "RandomSeed": "1470901215",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cuprwdyla%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cuprwdyla%)Async.json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-b90e3181-2503-4d6c-2480-d70f7640ca50",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-a9e7978daea97835b8f40fe293636bfc-cd950446a3fd5f0a-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "fff55416-6953-bb13-645e-867c3b198c92",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:13 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83931e8-f003-003b-12fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-b90e3181-2503-4d6c-2480-d70f7640ca50",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-0fa943866a6cd0feaa2bced2f96c886c-cef828c32dee7972-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "21f98e92-cb4a-b1fc-9017-c4db4f4c5d84",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:13 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393226-f003-003b-4bfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-b90e3181-2503-4d6c-2480-d70f7640ca50?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A12Z\u0026sp=cuprwdyla\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-828d1b09e6e643333a02300a2fc5575c-972e10ec0bc0b159-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "adea0e4d-6a20-b647-3548-7c19f9ef5c1a",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:13 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e839324f-f003-003b-71fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-b90e3181-2503-4d6c-2480-d70f7640ca50",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f001a5a28a44a0cd18a00ab24e594cac-c0ac0098a5a8d4dc-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "408d87d9-b062-bf64-ce0c-d56865fe5e9a",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:13 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e839327a-f003-003b-19fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:12.3220419-07:00",
+    "RandomSeed": "1190050800",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cuprwdylatfi%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cuprwdylatfi%).json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-162de156-faa5-bf68-a7f8-b828b1332826",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-e09fcb2618199da558e0c7b2b1975179-0367ee817f55b081-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "136ccce5-6e03-9777-b210-7dec01c181cd",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:04 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e839239e-f003-003b-1dfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-162de156-faa5-bf68-a7f8-b828b1332826",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-ae1afabf5ab5163ac565f5efb1380700-668948404a5f797c-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "e5430eca-15c6-2f22-223d-183ec2b413e5",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:04 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83923b0-f003-003b-2cfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-162de156-faa5-bf68-a7f8-b828b1332826?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A03Z\u0026sp=cuprwdylatfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-173a2c7b6871d678aa53513ad1fd7cd3-57df06929f8c14f8-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f322d218-9c7e-5506-c1d4-c065b625538b",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:04 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e83923cb-f003-003b-43fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-162de156-faa5-bf68-a7f8-b828b1332826",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-97b6db72a7dc6efb693ad661e212dd31-67fef0df10e01257-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ef26c908-2092-2767-c244-212389a15f43",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:04 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83923e4-f003-003b-5cfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:03.5074148-07:00",
+    "RandomSeed": "825694310",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cuprwdylatfi%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%cuprwdylatfi%)Async.json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-cf8257e8-a2ea-c616-6185-7bb7bb5a3d03",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-41bda3ef100b1c209537881918302b50-005a242c5d75a28e-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "0cbf4802-ba9f-c746-16d7-17f6eafe30c0",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:12 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e839309d-f003-003b-55fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-cf8257e8-a2ea-c616-6185-7bb7bb5a3d03",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-27cb88f07db7da7fc6518c8eba4671de-7b007cfd68484c46-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "73b5dca2-309a-5064-1713-597507be283f",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:12 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83930c7-f003-003b-7bfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-cf8257e8-a2ea-c616-6185-7bb7bb5a3d03?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A11Z\u0026sp=cuprwdylatfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-f533ec3e2a12ea16b6f1a9beb5f82f06-27e69523c400fc5a-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "0e54e503-bd49-8b25-74db-e348e9fdc3e3",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:12 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e83930ef-f003-003b-22fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-cf8257e8-a2ea-c616-6185-7bb7bb5a3d03",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7b18ce2794bc42210743894ab0cb28da-bf4d8f732b590d72-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "217140a3-1a6a-6ef5-64d1-a52704fbd5d8",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:12 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393106-f003-003b-38fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:11.4138950-07:00",
+    "RandomSeed": "2026032473",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%larwdycup%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%larwdycup%).json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-18997eaf-7967-1767-cfe6-70e051ac7044",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-fbc75135f166b19c1655f62b579d220f-7ee4c1d86bb5ec2e-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "172e6489-90fb-3368-5c89-b3a996c18cda",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:05 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83925d7-f003-003b-3ffa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-18997eaf-7967-1767-cfe6-70e051ac7044",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-2105a435d714b7ae48fe37007ca0d12e-10b679db5452592d-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ed56eb39-587e-8149-c287-0187f53e299c",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:06 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83925f9-f003-003b-5efa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-18997eaf-7967-1767-cfe6-70e051ac7044?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A04Z\u0026sp=larwdycup\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-dfde97d2f5e736ac4d63a421ccfc3196-5b43280be00292dd-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ab704c6a-9f6a-775c-543c-75b3b8651258",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:06 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e839263d-f003-003b-1dfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-18997eaf-7967-1767-cfe6-70e051ac7044",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8153700e8344a43e25adcc4eaf0c32db-249ecdf0126af3b1-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "a81df744-7ecd-ab31-52ce-056efe961711",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:06 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392662-f003-003b-41fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:04.9058702-07:00",
+    "RandomSeed": "1001646530",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%larwdycup%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%larwdycup%)Async.json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-ba32788d-8505-6234-ffe4-67f1142cccd9",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-710e237909e2ee0ee54090bc761f368e-feae65c8d8a7450d-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d21c9f15-8159-03a8-edff-eafe1d63fc2c",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:14 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393361-f003-003b-73fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-ba32788d-8505-6234-ffe4-67f1142cccd9",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-a658cba39a6d9a1c890d710022e6a270-afd62e79bbc5e95f-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "74db98e0-fa0f-2a7f-c71c-6e22509c15f0",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:14 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e839338c-f003-003b-1dfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-ba32788d-8505-6234-ffe4-67f1142cccd9?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A13Z\u0026sp=larwdycup\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-3f21992975fd952c71bf634891cb633c-29aa3084f15b58d8-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "851d07de-8887-a21d-3589-0d077d010240",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:14 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e83933e7-f003-003b-73fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-ba32788d-8505-6234-ffe4-67f1142cccd9",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b46f690e19e731b860cb45ce11a4b2f5-43b977db18d9100e-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "49432348-8f7f-1f68-0c52-56dd20a3ac7a",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:14 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393417-f003-003b-1ffa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:13.3518591-07:00",
+    "RandomSeed": "1249058006",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%rwdylacuptfi%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%rwdylacuptfi%).json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-feef3ce3-fb90-3e4d-8d59-c79c7551b3ee",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-28ffc4e9e40e7a2610e02b49efb663c3-f55753b5879808f5-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "159f23ea-70cd-1e29-588b-a09a4c9dcb89",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:04 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83922b1-f003-003b-41fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-feef3ce3-fb90-3e4d-8d59-c79c7551b3ee",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-19c90c798f41cbe3d5734bab52f9ee1b-ed03fe1691f31dba-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "52b25b26-9eb1-2221-e574-6ce7de84f3ce",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:04 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83922f3-f003-003b-7cfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-feef3ce3-fb90-3e4d-8d59-c79c7551b3ee?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A03Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-b276c3411b8adefd2134710301c857c1-a5645df9b495679f-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f073c1ee-78ea-bdd7-12ad-5b8bc2a68698",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:04 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e839232b-f003-003b-31fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-feef3ce3-fb90-3e4d-8d59-c79c7551b3ee",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6957540a067c1631af8bf37a6103dd4e-02d13dace90b2d28-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "1df884af-0210-f3e3-41c3-5c3195e0f8ee",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:04 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e839233a-f003-003b-40fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:03.0640235-07:00",
+    "RandomSeed": "1479851752",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%rwdylacuptfi%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%rwdylacuptfi%)Async.json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-3b2945c8-09d0-68e4-90e4-a6a5868bae0a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-6905271ab0a7b3ac312e2d0ba7eec105-87379e81e3cb8b77-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "c1dd145c-9424-1f55-a09d-a215391c40e8",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:12 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393016-f003-003b-55fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-3b2945c8-09d0-68e4-90e4-a6a5868bae0a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-dccd20e60d3c65f09e20f9d1ef876e49-3c4c9aa6215606f3-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "7249965f-ecae-32e5-0cc7-f4bbb27bdc30",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:12 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393041-f003-003b-7efa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-3b2945c8-09d0-68e4-90e4-a6a5868bae0a?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A10Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-15224ab63a5f4f12e816fa7c4d404084-502d257f6599f1a9-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "a2b57956-cdd3-9c3a-adf9-d57f388bc139",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:12 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e8393067-f003-003b-21fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-3b2945c8-09d0-68e4-90e4-a6a5868bae0a",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b88a6d026b731ae64b1986ebc1f577a1-66a064e8ed45f7d3-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "3864b088-3ac5-9f5d-0561-e041cd49f843",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:12 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393083-f003-003b-3cfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:10.9978682-07:00",
+    "RandomSeed": "1533942137",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%rywdlcaup%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%rywdlcaup%).json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-9ac6f8d9-9de9-7bb2-ce28-46abeecc0e2f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-88bd3e9c0da2f0415c341559b4cdba12-b353e13ae12615d7-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "27bae22f-1faf-9136-2291-2630404890b9",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:05 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e839253d-f003-003b-2afa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-9ac6f8d9-9de9-7bb2-ce28-46abeecc0e2f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-bdeb6e56572b36e853dfb43b0b2f6428-ea5cce1c7b728323-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "0b7c075f-e712-c080-5e68-d6989a29fb05",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:05 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392559-f003-003b-43fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-9ac6f8d9-9de9-7bb2-ce28-46abeecc0e2f?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A04Z\u0026sp=rywdlcaup\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-07e09f2c006820c4e391e8089b488ad0-f51eee49deffbf25-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "39d1b7fd-84cc-1fa6-d0d1-7cda93e07d75",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:05 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e839257a-f003-003b-63fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-9ac6f8d9-9de9-7bb2-ce28-46abeecc0e2f",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fa47efe0c1cd6b9a3d9b91714e96494d-960d10bc930a2865-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "e29a2b11-c258-9a39-0315-c7fa7021328a",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:05 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392597-f003-003b-80fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:04.4889414-07:00",
+    "RandomSeed": "858501720",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%rywdlcaup%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_PermissionsOrder(%rywdlcaup%)Async.json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-34657192-08f5-bace-82fa-ffbdc3b65ef3",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-f6b2b2caec032b76722b130a3c864aed-416170da6a48929b-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "6f383f48-07ab-438f-fd42-5a8c738bd84f",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:13 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e839329d-f003-003b-3bfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-34657192-08f5-bace-82fa-ffbdc3b65ef3",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-5c25d8d34a420a9e69415c778775575a-8a1a64f6ebd16c8e-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "83744974-ef7d-f848-952e-6789268abb84",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:13 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83932bc-f003-003b-58fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-34657192-08f5-bace-82fa-ffbdc3b65ef3?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A12Z\u0026sp=rywdlcaup\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-7e5cd8d7861fa843d150e09ea8f357a8-7647a4768bc9030a-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "2a182430-5517-d6d1-cf7c-9aba59e9ebd0",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:14 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e83932eb-f003-003b-01fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-34657192-08f5-bace-82fa-ffbdc3b65ef3",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ab59a0d1e60cc22be7e6789486ffa201-9137f39c2c4d3b64-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "015887ce-9172-9f6d-0415-c15bbb132de3",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:14 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393323-f003-003b-36fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:12.7635610-07:00",
+    "RandomSeed": "709516627",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%cos%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%cos%).json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-6eaba0d5-6d7c-3612-4efa-852b7e4b4254",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-0979fc7ca3e916ce4e712185beead650-163ed4ca16ddda54-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "140e55f1-7350-4e17-66c6-573dbc548942",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:07 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e839283a-f003-003b-80fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-6eaba0d5-6d7c-3612-4efa-852b7e4b4254",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-ce57dfd71e7dfbe12c2b3ed63037466f-451c699d0a35cd64-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "2939c4b5-2d3c-ec04-e1b7-c1499d5f523e",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:07 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e839285a-f003-003b-1efa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-6eaba0d5-6d7c-3612-4efa-852b7e4b4254?sv=2021-08-06\u0026ss=bqtf\u0026srt=cos\u0026se=2022-06-23T05%3A40%3A06Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-b023a21ce91acf5d23369f5492539b09-9326d56e4456018b-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f7885109-601b-5f05-abdf-3df525bb42a4",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:07 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e839287d-f003-003b-3ffa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-6eaba0d5-6d7c-3612-4efa-852b7e4b4254",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7ee93e287c379d093119cc5d0b7c0bfd-9b64cc4aa15ac842-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "4c40aabb-5ad7-0c23-d2d7-1d9ee81ee595",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:07 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392893-f003-003b-55fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:06.2372060-07:00",
+    "RandomSeed": "1401748069",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%cos%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%cos%)Async.json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-87dddaec-e555-8c94-44aa-f01ab2e1c610",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-5daa07352182d55a3fd74a8e733c5980-7d9eeb09c905d5bd-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "cd08c310-307e-2530-870b-87e4c00d8546",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:16 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393661-f003-003b-4ffa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-87dddaec-e555-8c94-44aa-f01ab2e1c610",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-2300f279d64fcc264246d47e0c325629-3ea29a963a890530-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ee0a4f9b-f9d9-8192-3beb-78951ad14250",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:16 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393697-f003-003b-02fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-87dddaec-e555-8c94-44aa-f01ab2e1c610?sv=2021-08-06\u0026ss=bqtf\u0026srt=cos\u0026se=2022-06-23T05%3A40%3A15Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-fafd38f3852450c6f9476bff18c86a45-4e76bff5ca34cc6a-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "7048049f-9603-366d-81d8-b078c9983054",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:16 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e83936e4-f003-003b-42fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-87dddaec-e555-8c94-44aa-f01ab2e1c610",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5bdfccfc71cc0cf1f3d9de392a9da7f1-581b16de2c98226e-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "15f5f086-d188-614c-702e-8b9072c304fe",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:16 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393701-f003-003b-5cfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:15.1442611-07:00",
+    "RandomSeed": "1021214835",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%cs%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%cs%).json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-1b98d6a0-332f-6d8a-0f65-30ed047b930c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-d7441ee38f49687caceec81bd6c4ec1d-583532cf64dce705-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "2c4b2891-9299-6224-9a05-cbfb3b95436b",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:46 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "4d2b272d-6003-0029-73fa-854b95000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-1b98d6a0-332f-6d8a-0f65-30ed047b930c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-112d8d1d9912fc9480837d61951ee97d-ee1ee4b29f947601-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "dc5cacf7-6730-9b73-ef1b-ac9e796d89e0",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:46 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "4d2b2741-6003-0029-05fa-854b95000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-1b98d6a0-332f-6d8a-0f65-30ed047b930c?sv=2021-08-06\u0026ss=bqtf\u0026srt=cs\u0026se=2022-06-23T05%3A40%3A45Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-8a860b4f2f21bddd379ee384c81aba45-883a72c88d61ab08-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "8e03f651-6639-1b3b-3045-c5cbd8dde3ff",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:46 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "4d2b274a-6003-0029-0cfa-854b95000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-1b98d6a0-332f-6d8a-0f65-30ed047b930c",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f8dd2f45969e7723c0ac0b8079c208d9-0d13eba5a8f36119-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "824cce30-fb69-dba7-152f-e515f2d034ce",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:46 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "4d2b2751-6003-0029-11fa-854b95000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:45.0629587-07:00",
+    "RandomSeed": "1113763258",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%cs%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%cs%)Async.json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-6205f7b9-7fc5-555f-f21e-d046d0554f5a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-17e66ab279ab0de158a40f7c16b07a2e-8b0e7d7720379cc4-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "c9521060-444c-41ff-bbb2-1fe8a4010828",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:46 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "4d2b2769-6003-0029-24fa-854b95000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-6205f7b9-7fc5-555f-f21e-d046d0554f5a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-11ff0cd8f080806597ae7f52a8019b9c-f845b2d463bc06a2-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "c0e5eb3f-8503-a10e-3641-bea23ad0f751",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:46 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "4d2b2779-6003-0029-2ffa-854b95000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-6205f7b9-7fc5-555f-f21e-d046d0554f5a?sv=2021-08-06\u0026ss=bqtf\u0026srt=cs\u0026se=2022-06-23T05%3A40%3A45Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-e15a339766e8bd74899bbf0d1aeaae51-4fd587f7cc6d2be1-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b8a9bc41-481b-df25-1ce4-57846dbf246c",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:46 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "4d2b2786-6003-0029-39fa-854b95000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-6205f7b9-7fc5-555f-f21e-d046d0554f5a",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-14f7109add77db0e887102e9cacc4bd4-88b92ea913744e4c-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "7e60be30-3e27-e435-005f-9d23f99ac8ef",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:46 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "4d2b2793-6003-0029-44fa-854b95000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:45.3934924-07:00",
+    "RandomSeed": "460397211",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%oc%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%oc%).json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-81e5ac81-72e8-fc3d-c4d1-0fcedaaeb88c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-59731706161279c18b74fec800bed0ee-96e43360f2a5964b-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ab03af63-e239-a99a-3ef1-603fab3c5817",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:08 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392aaa-f003-003b-52fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-81e5ac81-72e8-fc3d-c4d1-0fcedaaeb88c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-0b85568b69af652036ce5a028be7adb2-30303471e4605e61-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "2b6a0e2b-0cab-ae52-6d4b-ad414890f6b9",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:09 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392acf-f003-003b-76fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-81e5ac81-72e8-fc3d-c4d1-0fcedaaeb88c?sv=2021-08-06\u0026ss=bqtf\u0026srt=oc\u0026se=2022-06-23T05%3A40%3A07Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-5eeab985a560d792570a27c78a747e17-3ed9a53cc0e729bb-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "9d13309f-2dd1-9f6b-b80b-4d30b5f3904c",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:09 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e8392af3-f003-003b-16fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-81e5ac81-72e8-fc3d-c4d1-0fcedaaeb88c",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-79915ebc40f768198b5fc0bbb8454079-97d269750966713e-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "17a19a23-597c-d3e7-6ec6-e6d09d544a87",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:09 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392b06-f003-003b-29fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:07.8623002-07:00",
+    "RandomSeed": "1409501135",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%oc%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%oc%)Async.json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-94098266-4583-3776-3d1a-770dee0ffb75",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-2d8f29429797d86ff5d29bbad7193da7-20cdd53292e0afcd-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b2eb63cf-d354-fee4-3f71-d0d92ee0df2f",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:17 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393948-f003-003b-09fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-94098266-4583-3776-3d1a-770dee0ffb75",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-186add7b60b95edd87626aeda5fafe39-60ec2647e4c3fe85-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "8b3ee812-4824-2820-1a29-85eac6ee44d8",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:18 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393986-f003-003b-41fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-94098266-4583-3776-3d1a-770dee0ffb75?sv=2021-08-06\u0026ss=bqtf\u0026srt=oc\u0026se=2022-06-23T05%3A40%3A16Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-36b67cd420ed4f5f433aaa56ed0de284-6dde44ce9a9545eb-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "46c7e47d-53a2-530b-33a6-62966d1509cc",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:18 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e83939bb-f003-003b-75fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-94098266-4583-3776-3d1a-770dee0ffb75",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-29aa66cb40958c2d9b7d64e09a44fc56-240ee4de7454f519-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "e16cad78-fe26-bf35-bc20-bcdc28396f4e",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:18 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83939dd-f003-003b-15fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:16.9785837-07:00",
+    "RandomSeed": "634879556",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%ocs%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%ocs%).json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-4f993c9f-2817-fd5e-2a9d-7d640906292c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-161b1b1dfcf1d10c37830186b4fd200b-9d4a5b79dfe3d176-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "926f0ed5-9013-fc3a-f865-4da23d4d283e",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:07 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83928cb-f003-003b-09fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-4f993c9f-2817-fd5e-2a9d-7d640906292c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-e73dd8f6a4b2f3cd9620a87742992138-bb42f3648a90eb8a-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "fa8f424c-9797-6418-73fb-5a82555c1f93",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:07 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83928e3-f003-003b-20fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-4f993c9f-2817-fd5e-2a9d-7d640906292c?sv=2021-08-06\u0026ss=bqtf\u0026srt=ocs\u0026se=2022-06-23T05%3A40%3A06Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-7aeee0b233eef7346b3dfca6ce61f92f-79abfc7ab04c3ef3-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "fa560dd4-2dbe-72a6-8eeb-8b72752da8e0",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:07 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e8392908-f003-003b-44fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-4f993c9f-2817-fd5e-2a9d-7d640906292c",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c5001196edb1058865950780c61d2c67-cac237bf8443f3e2-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "47adc58c-2506-cad5-b580-36aec75a8e31",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:08 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e839294c-f003-003b-05fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:06.6438643-07:00",
+    "RandomSeed": "428455614",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%ocs%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%ocs%)Async.json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-e94dca74-89d5-336d-2462-8277b819b79c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-057c673ca94492ee8d67149626ea68c3-2b1a2a413bde13b5-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "11db1063-82fc-8468-04db-ebdfc651be01",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:16 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393751-f003-003b-26fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-e94dca74-89d5-336d-2462-8277b819b79c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-bc1e7ccdd0672e13a8ac39bb9e15fca6-ce5467fef4b90f77-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "a813c8a7-a63d-6a9f-e28e-026ac94d353f",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:16 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393774-f003-003b-47fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-e94dca74-89d5-336d-2462-8277b819b79c?sv=2021-08-06\u0026ss=bqtf\u0026srt=ocs\u0026se=2022-06-23T05%3A40%3A15Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-7b9f69e066fa7f9add9ca76aec6675b3-e3ebc504fd63cc71-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "fe374e14-163d-44c3-2a9c-5e7ebad7f550",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:16 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e83937af-f003-003b-80fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-e94dca74-89d5-336d-2462-8277b819b79c",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c52d9495b408ac0365eba12315e6e47b-abc7bf52cd38aed3-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "7b55e60f-3715-b401-bf55-78e41b2decf8",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:17 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83937e2-f003-003b-2efa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:15.6644909-07:00",
+    "RandomSeed": "390680577",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%sco%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%sco%).json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-fbfa8a2d-7448-10fe-5cee-c9d7ea5feabd",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3f96314e577c65cf9551731428c911d5-63815b86ece3f0b1-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "93ae8501-cc24-48f4-29d9-9f775216b3f7",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:06 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83926f0-f003-003b-4bfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-fbfa8a2d-7448-10fe-5cee-c9d7ea5feabd",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-413ed424449244aee4777a62a200c29e-3e1e333d498580fc-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "64d6a87f-57b0-8f98-5240-ee444179d576",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:06 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392709-f003-003b-62fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-fbfa8a2d-7448-10fe-5cee-c9d7ea5feabd?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A05Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-8b52150d60da54af59dd422a1d8fe899-2b0f5a5a4355cf7c-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "aaf794d3-4f40-ef46-77ee-a99913090921",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:06 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e8392730-f003-003b-06fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-fbfa8a2d-7448-10fe-5cee-c9d7ea5feabd",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d56b26efb3d968defb6f89bb7385d902-1a4f2d3586664e8f-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ac704815-2b81-b535-1844-82e6c9adeb2d",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:06 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392752-f003-003b-27fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:05.5108570-07:00",
+    "RandomSeed": "434349030",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%sco%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%sco%)Async.json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-2b2d84f8-5bec-7889-adcc-8939a507a7cc",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-07578ce6b665d15e15650b9e018c42c7-5197be37937723cf-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f053b20a-faa4-2d45-9f91-73e4dec62da3",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:14 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393458-f003-003b-60fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-2b2d84f8-5bec-7889-adcc-8939a507a7cc",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-52cc6e17f1f6c81eca77844edd38fc53-099e9c51f9d982df-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f32e3c3b-b6b4-0327-1086-8c838c46d9d7",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:14 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393474-f003-003b-7bfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-2b2d84f8-5bec-7889-adcc-8939a507a7cc?sv=2021-08-06\u0026ss=bqtf\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A13Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-b1a840c247aade302447a40c9226dc7e-e0e2703a097c0723-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "a2a9bbdb-3a97-63ee-47e4-56a2760b6d13",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:15 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e839348b-f003-003b-11fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-2b2d84f8-5bec-7889-adcc-8939a507a7cc",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6e537f368bc096e205f2a724d2b7ceff-8b196691ba91a9ac-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d0a709f6-379c-7d40-2bf0-0b29d4829118",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:15 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83934b4-f003-003b-37fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:13.8220692-07:00",
+    "RandomSeed": "40164755",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%soc%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%soc%).json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-c59c1f68-3ca8-5cd0-7300-455153243089",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3dbd904dfdfb49255dfb99294f1ba97b-51de982c321e61b6-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "6728e8a5-5dc2-ae8f-f15f-1f2874853aae",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:06 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392785-f003-003b-5afa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-c59c1f68-3ca8-5cd0-7300-455153243089",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-f1f30096f91a3b38e500bcd4ed9e7521-be31cdc13d3acd6c-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "6aac95ec-c8fb-fcc7-1b2c-ffb26cf8e115",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:07 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83927aa-f003-003b-7cfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-c59c1f68-3ca8-5cd0-7300-455153243089?sv=2021-08-06\u0026ss=bqtf\u0026srt=soc\u0026se=2022-06-23T05%3A40%3A05Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-d918b3e2701aee45b745367c6ee89c2c-20ed635f4e243b3e-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "df3b9f88-cfd8-f6b3-c4ae-cb6fc6777005",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:07 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e83927db-f003-003b-2afa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-c59c1f68-3ca8-5cd0-7300-455153243089",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8d623fb3a9aa34ffc9738fdc5293ff1a-5d2c683129a8db4a-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "cc2ad541-02bd-4f3c-1752-359a61a41947",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:07 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83927fb-f003-003b-47fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:05.8785383-07:00",
+    "RandomSeed": "1174535517",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%soc%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ResourceTypeOrder(%soc%)Async.json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-4d62195f-ff14-bddb-b94a-7035643245e0",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-fdef52ce865389bb196195b54a9ed751-d2916c8a19fdf3cc-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "69510411-ba72-b351-bf28-ae8f40c01c25",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:15 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83934fa-f003-003b-79fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-4d62195f-ff14-bddb-b94a-7035643245e0",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c97317d4335e9e7505fa5c5b0abd3c98-6dbef4ae3041f375-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "5f23e390-dbe0-986d-0c58-210eb76a56e6",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:15 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8393550-f003-003b-4dfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-4d62195f-ff14-bddb-b94a-7035643245e0?sv=2021-08-06\u0026ss=bqtf\u0026srt=soc\u0026se=2022-06-23T05%3A40%3A14Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-978248c6047957f59674eefa8b6440ff-f7357016e6f02fa6-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "5cff6f62-bc9d-e144-060f-67e4242e42b4",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:15 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e839357c-f003-003b-78fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-4d62195f-ff14-bddb-b94a-7035643245e0",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-dba2cd49775826fe13bb591e321c855d-c1f172555921da3c-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "48abc90c-f96a-a749-2dd6-7cc2de6ba69a",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:15 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e83935ad-f003-003b-27fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:14.3551966-07:00",
+    "RandomSeed": "1233966993",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%bfqt%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%bfqt%).json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-70f0f643-a0d3-9722-86ad-dd22a3b62442",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-60933c27687c158da079d6f64bfa19c1-8b36dfeb1aab14e3-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "37e95f3c-a5c8-898b-810a-9459f0534d9a",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:09 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392b3c-f003-003b-5cfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-70f0f643-a0d3-9722-86ad-dd22a3b62442",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b377ed1260feff75983763d833b5eda6-3b6ebdc24a7a79c0-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "43e6107b-edcd-627a-6274-a79774b14fd4",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:09 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392b50-f003-003b-6ffa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-70f0f643-a0d3-9722-86ad-dd22a3b62442?sv=2021-08-06\u0026ss=bfqt\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A08Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-c4999ce2bb68e9c5146146dd73efdbac-d725d9736acce5e6-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "dfddc6f2-0a6d-14cc-b0e3-87388409c73a",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:09 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e8392b63-f003-003b-02fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-70f0f643-a0d3-9722-86ad-dd22a3b62442",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0204bfe085e2551181013bea5b8e16dd-33697cc2915f419d-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ada421f2-6fd3-9d67-3210-a48fc1e78bb5",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:09 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392b77-f003-003b-16fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:08.1679783-07:00",
+    "RandomSeed": "1935404708",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%bfqt%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%bfqt%)Async.json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-847066cd-0ca8-5edf-555d-072f44c66ad7",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-88ffc5ef4829dcddb3e01c55c6c18068-6d386a3b1ad1f12f-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b3ade3d9-5c68-67f1-4372-edd3321e97b5",
+        "x-ms-date": "Wed, 22 Jun 2022 05:39:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:46 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "5faeeb7a-3003-0069-08fa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-847066cd-0ca8-5edf-555d-072f44c66ad7",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c91143e3de894866439939b4c71ddf80-5bb4e153891d6f9c-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "6056d2e4-b718-386f-af07-26e781d4aec7",
+        "x-ms-date": "Wed, 22 Jun 2022 05:39:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:46 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "5faeebad-3003-0069-36fa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-847066cd-0ca8-5edf-555d-072f44c66ad7?sv=2021-08-06\u0026ss=bfqt\u0026srt=sco\u0026se=2022-06-23T05%3A39%3A45Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-786198c973820c40498cf96dcff22c67-43843f08f258f827-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "60efbd52-36c7-e89c-e0bd-5a35d733ddea",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:46 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "5faeebc3-3003-0069-4afa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-847066cd-0ca8-5edf-555d-072f44c66ad7",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ed71ecc8e345b1354c97151c4c23e8f1-bdefa54be77f9b0f-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "c4943184-4ee4-05ff-d608-0e7213c30395",
+        "x-ms-date": "Wed, 22 Jun 2022 05:39:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:46 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "5faeebd7-3003-0069-5cfa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:39:45.2897668-07:00",
+    "RandomSeed": "814238310",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%fq%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%fq%).json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-638256e2-c015-208f-b428-ebebf12ff444",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-511bbeacf6f3225049b87ec99c043a78-1df540ac82cc9e8f-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "9884efc5-efea-943a-3653-b0b8de2c7e54",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:11 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392f42-f003-003b-11fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-638256e2-c015-208f-b428-ebebf12ff444",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3e8faffefc242f65f043013054407ffc-60a7a8e0cce3d3e1-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "0125a942-5caa-5e59-1663-f1901022806a",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:11 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392f69-f003-003b-34fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-638256e2-c015-208f-b428-ebebf12ff444?sv=2021-08-06\u0026ss=fq\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A10Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-24021de70819e7149d61b4edc5a71c27-2b474db257f9b4a7-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "3576a0c1-7c07-fda9-5d7c-259b29a91158",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:11 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e8392fa5-f003-003b-6afa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-638256e2-c015-208f-b428-ebebf12ff444",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8f905651f62f5b23e09bd45ce0755952-e03ac7d18f7c8c67-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "6fcfec38-4bab-4c62-5807-784c85a6810b",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:11 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392fe5-f003-003b-25fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:10.4939121-07:00",
+    "RandomSeed": "999235542",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%fq%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%fq%)Async.json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-c144307a-947d-cab6-c9b6-d28e186022cb",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-77d62a28ca6ef1c9dc74d4c11acee509-3ffd5b154dd8bada-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "9e6e27b2-9bcf-41f1-7311-5a3404143613",
+        "x-ms-date": "Wed, 22 Jun 2022 05:39:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:48 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "5faeedaa-3003-0069-78fa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-c144307a-947d-cab6-c9b6-d28e186022cb",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-701b15e1ae19f8b862d06ea405dc03a0-010db3e80866b96f-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f1db2c98-83f1-2ffb-ec8a-759966b474d5",
+        "x-ms-date": "Wed, 22 Jun 2022 05:39:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:48 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "5faeedc1-3003-0069-0cfa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-c144307a-947d-cab6-c9b6-d28e186022cb?sv=2021-08-06\u0026ss=fq\u0026srt=sco\u0026se=2022-06-23T05%3A39%3A47Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-1d312ce3bb02c65096483f68f01a0f10-7d9b7c1cc2ec1ba0-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d79b0d44-4539-c022-df0b-a17d39e95293",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:48 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "5faeedd2-3003-0069-1dfa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-c144307a-947d-cab6-c9b6-d28e186022cb",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-11cb96be837af24b7597b11080608315-8cd3963abcd91ad9-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "59554da6-9d18-1a9c-0066-4236ec20caba",
+        "x-ms-date": "Wed, 22 Jun 2022 05:39:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:48 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "5faeede9-3003-0069-2ffa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:39:47.0686599-07:00",
+    "RandomSeed": "601654461",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%fqt%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%fqt%).json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-a7bb1271-a0dd-ec65-2f04-4eebcc844101",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-60c657489da8382129d632983d0a0935-371c3164c4422667-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "bb056ad9-c2d4-ab1c-80a3-712b905b6888",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:10 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392d80-f003-003b-80fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-a7bb1271-a0dd-ec65-2f04-4eebcc844101",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-9c85494e48437adb81d36442466ae31a-1cafa20a3aa60a62-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "6211a46c-857e-0a2c-802b-ea0f3743144d",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:10 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392db1-f003-003b-2afa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-a7bb1271-a0dd-ec65-2f04-4eebcc844101?sv=2021-08-06\u0026ss=fqt\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A09Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-ad4d8312fb89c504e979b5eb3b9af3d5-ac420f02b4983bd7-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "ecbfc24e-0649-4109-8b85-7147dc899060",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:10 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e8392ddf-f003-003b-55fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-a7bb1271-a0dd-ec65-2f04-4eebcc844101",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-191dfd7d8585e39a7c023d157469c94d-7b5069639c8decb8-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "74c1489e-2783-4e03-ef7c-536a35f13647",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:10 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392e0c-f003-003b-7ffa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:09.5465930-07:00",
+    "RandomSeed": "1714030893",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%fqt%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%fqt%)Async.json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-ebb7ab65-5d2f-f568-77a9-e7dac3ac37bc",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-cb580469ff405711d17879917c7edb7e-2cdf368502a98dd4-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d4cf5242-94be-c8b2-38ec-0a75f93ba6ad",
+        "x-ms-date": "Wed, 22 Jun 2022 05:39:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:47 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "5faeeccf-3003-0069-40fa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-ebb7ab65-5d2f-f568-77a9-e7dac3ac37bc",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c98d4983f20acf6e922404be39448c6c-e5ed73d4e8a05fe1-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "709765cc-62dc-6cfd-303d-7297d458d0ad",
+        "x-ms-date": "Wed, 22 Jun 2022 05:39:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:47 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "5faeece1-3003-0069-51fa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-ebb7ab65-5d2f-f568-77a9-e7dac3ac37bc?sv=2021-08-06\u0026ss=fqt\u0026srt=sco\u0026se=2022-06-23T05%3A39%3A46Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-053c0dc74c014d1a6a62b8a6c39abbdc-9a6486a2eb13f6ad-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "94a81a39-35a4-bdd1-1fd3-0fd8ad71b183",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:47 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "5faeecf0-3003-0069-5ffa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-ebb7ab65-5d2f-f568-77a9-e7dac3ac37bc",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b01dd193a314d54bb1eb9f4387d01ef7-40da36a5898a42b7-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b95eaaf0-3cb0-4509-641a-07738d9476d8",
+        "x-ms-date": "Wed, 22 Jun 2022 05:39:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:47 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "5faeecfe-3003-0069-6cfa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:39:46.3108206-07:00",
+    "RandomSeed": "779353087",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%qb%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%qb%).json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-7aeb642d-3d87-a1a1-eed5-100a677aea83",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-2acbdc915c6d5f3c7a6e82548a05718c-dda3b61d26419075-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "0968b6b7-32fc-1e58-a29b-dfae3cfab9bc",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:11 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392e78-f003-003b-5ffa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-7aeb642d-3d87-a1a1-eed5-100a677aea83",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-26caa32ad772a807568a135c24096ca1-1308063aa57da97b-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b052d75e-e111-7487-b104-c3936e4a08ae",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:11 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392ea5-f003-003b-03fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-7aeb642d-3d87-a1a1-eed5-100a677aea83?sv=2021-08-06\u0026ss=qb\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A10Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-a1fc01f1421e2ff8c4c0a760f4a62218-c233516b56360c06-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "6450794d-09a7-16aa-1c55-5a8154297121",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:11 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e8392ee1-f003-003b-37fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-7aeb642d-3d87-a1a1-eed5-100a677aea83",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4335aec5ae8570b07fa01d6884076e66-c1db1f09cfeddbc4-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f546d9f9-a4f9-e706-c3da-93680f304ad0",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:11 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392f1e-f003-003b-72fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:10.0333363-07:00",
+    "RandomSeed": "2139539996",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%qb%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%qb%)Async.json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-d9286e56-a9f0-639b-6b62-9c0a5454850b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-e40f21eab64b1e099e7c0730cf7394e8-986ee4f7618c166d-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "e7684abf-7082-77fd-bfdb-e10f43d4aa02",
+        "x-ms-date": "Wed, 22 Jun 2022 05:39:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:47 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "5faeed10-3003-0069-7efa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-d9286e56-a9f0-639b-6b62-9c0a5454850b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-ea90153ef411f04c014f38f674976c4b-285a2abb77e18622-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "094b63cc-9dec-5a88-3233-37f65efcaf58",
+        "x-ms-date": "Wed, 22 Jun 2022 05:39:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:47 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "5faeed24-3003-0069-11fa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-d9286e56-a9f0-639b-6b62-9c0a5454850b?sv=2021-08-06\u0026ss=qb\u0026srt=sco\u0026se=2022-06-23T05%3A39%3A46Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-e5a34a2fa7de9b43d98bc345badd8fe2-f3b37a2781c4311c-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "e04320b5-a088-6016-5cc5-c55ac8d6b865",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:47 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "5faeed31-3003-0069-1dfa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-d9286e56-a9f0-639b-6b62-9c0a5454850b",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-565bd0410cf0d6ec808875aaa9f117d8-0db56d3ead89a143-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "3d4118d4-ceb9-a3cf-789c-fbc6d950f6a6",
+        "x-ms-date": "Wed, 22 Jun 2022 05:39:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:47 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "5faeed58-3003-0069-42fa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:39:46.6002963-07:00",
+    "RandomSeed": "296248533",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%qftb%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%qftb%).json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-46035493-f5fc-ac6d-5bca-b1231e765679",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-24b76d09fee929699285a56ebd06ffd7-5884e5bace05a14f-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "bf6b1e17-4bce-01cb-7233-d10bee189d8f",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:09 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392bf8-f003-003b-0dfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-46035493-f5fc-ac6d-5bca-b1231e765679",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-4abad09c42b73d931da73a5169fc09bc-ea22e15ab8aa122f-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "000bac01-970a-d3ab-54f2-da856aa87c1a",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:09 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392c45-f003-003b-55fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-46035493-f5fc-ac6d-5bca-b1231e765679?sv=2021-08-06\u0026ss=qftb\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A08Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-8c0ea61f030ae9dbd41a0032e7f1b156-16692c76f3f51541-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "410a746a-9c0c-fa84-1d93-2dac09c7ecf9",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:10 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e8392c6c-f003-003b-7bfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-46035493-f5fc-ac6d-5bca-b1231e765679",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2fa77ab1dab6eed8cefb86cb4d2f6983-9d66ff10e64f8366-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "f61b4f8b-3a9d-390e-47fa-fe0319b92b08",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:10 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392c91-f003-003b-1dfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:08.7881826-07:00",
+    "RandomSeed": "1091223255",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%qftb%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%qftb%)Async.json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-ba1c5f72-1c07-6579-ae57-8dee156579bc",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-779f240d4a1c916c21f2f5bfc3b24bfa-3579fcc4e03c8191-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "e251aaff-28a0-5f23-d277-88253b89041c",
+        "x-ms-date": "Wed, 22 Jun 2022 05:39:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:46 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "5faeec15-3003-0069-14fa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-ba1c5f72-1c07-6579-ae57-8dee156579bc",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-2ac07df433c56d71ac2278839269c2d9-d5444ea677eed9b9-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "6aeecd8c-9613-c01c-26a8-c592055f3a8c",
+        "x-ms-date": "Wed, 22 Jun 2022 05:39:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:46 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "5faeec2b-3003-0069-28fa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-ba1c5f72-1c07-6579-ae57-8dee156579bc?sv=2021-08-06\u0026ss=qftb\u0026srt=sco\u0026se=2022-06-23T05%3A39%3A45Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-8f72f7b211b6a5f7efc8743e6fe8e9c6-abb4b697fb113697-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "6d98ab68-999a-4009-a9b5-53635ef0de79",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:46 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "5faeec44-3003-0069-40fa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-ba1c5f72-1c07-6579-ae57-8dee156579bc",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4fe32d54de22147b36a0a034461f1887-35b8336f515b3d61-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "592a7678-ccc6-08f1-c7dd-e6a5fb4f7c38",
+        "x-ms-date": "Wed, 22 Jun 2022 05:39:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:46 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "5faeec5a-3003-0069-54fa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:39:45.6583112-07:00",
+    "RandomSeed": "1469387062",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%tqfb%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%tqfb%).json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-fc9732b7-70cd-6aed-564f-3b32759fa07d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-e6b2d15d687d6a6c042dc54cad085f80-f82ba217e1581b8d-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "c338a451-ff8d-939b-c58e-649949de8ebe",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:10 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392cca-f003-003b-53fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-fc9732b7-70cd-6aed-564f-3b32759fa07d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-715bf2b58999cfd338e4796f9561556c-1306d761eb58b5e8-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "d0e1964b-dd66-a4ef-6da7-8f4c8598a856",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:10 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392cf4-f003-003b-7bfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-fc9732b7-70cd-6aed-564f-3b32759fa07d?sv=2021-08-06\u0026ss=tqfb\u0026srt=sco\u0026se=2022-06-23T05%3A40%3A09Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-d896ab71744fac2c2aba88a3a0e777fd-d62847985ac37891-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "b24efeeb-bdfd-c857-2ac8-6f9daad84767",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:10 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "e8392d15-f003-003b-1bfa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-fc9732b7-70cd-6aed-564f-3b32759fa07d",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c2e4372572a762e6664606cff163da91-417bcf3680f43e59-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "8760bab2-f54a-ae59-bb8f-83bab8c36ca7",
+        "x-ms-date": "Wed, 22 Jun 2022 05:40:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:40:10 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e8392d3e-f003-003b-41fa-853045000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:40:09.1820298-07:00",
+    "RandomSeed": "176099231",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%tqfb%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/AccountSas_ServiceOrder(%tqfb%)Async.json
@@ -1,0 +1,119 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-42d1cffd-0c34-b579-7489-2fd163c5fd17",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-0cf6d36e7910e271a41397bbde7c51cc-0f38b443958e51ee-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "73c42366-2b8c-cf96-f8f6-b978d5f567e6",
+        "x-ms-date": "Wed, 22 Jun 2022 05:39:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:47 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "5faeec74-3003-0069-6cfa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-42d1cffd-0c34-b579-7489-2fd163c5fd17",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-a5f8cdfc9a703af9d0a03946b16e3dc2-2663b014c2946600-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "3f6a674f-8901-fe8a-29ea-dca6eb9c60d5",
+        "x-ms-date": "Wed, 22 Jun 2022 05:39:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:47 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "5faeec8a-3003-0069-80fa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-42d1cffd-0c34-b579-7489-2fd163c5fd17?sv=2021-08-06\u0026ss=tqfb\u0026srt=sco\u0026se=2022-06-23T05%3A39%3A45Z\u0026sp=rwdylacuptfi\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-a27a9b072f155ddad5c9b1b012d80f9c-9b6f8c8692a5a1a5-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "6e29978e-288b-78e5-9ea9-b3df11b66c1d",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:47 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "5faeec94-3003-0069-0afa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.queue.core.windows.net/test-queue-42d1cffd-0c34-b579-7489-2fd163c5fd17",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f0d328b2695bebe264924f4aae9f7ad9-424766c9fc289f3c-00",
+        "User-Agent": "azsdk-net-Storage.Queues/12.11.0-alpha.20220621.1 (.NET 6.0.6; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "54187636-f273-0d4a-256b-8600a91d670f",
+        "x-ms-date": "Wed, 22 Jun 2022 05:39:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 22 Jun 2022 05:39:47 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "5faeeca9-3003-0069-1efa-854cad000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-06-21T22:39:45.9677580-07:00",
+    "RandomSeed": "1005018438",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}


### PR DESCRIPTION
…types, permission types, and service types

Found a test gap where we weren't testing for ensuring that the SDK was not altering or manipulating the SAS in any form or shape. Since the SDK will generate a SAS with a fixed resource type, service type and permissions type, it was difficult to test the many different ways a customer could possibly generate a SAS with different orders of the resource type, permission types and service types.

According to the documentation for Account SAS, the storage service does not care about the order of resource type, permission types and service types.
See: https://docs.microsoft.com/en-us/rest/api/storageservices/create-account-sas#specify-the-account-sas-parameters

Not to be confused with Service SAS which does require the ordering to be correct for permissions.