### PR TITLE
Update docs links for collection read-only property init

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/AnalyzeDocumentOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/AnalyzeDocumentOptions.cs
@@ -37,7 +37,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// </para>
         /// <para>
         /// Although this collection cannot be set, it can be modified.
-        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#collection-initializers">collection initializer</see>.
+        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#object-initializers-with-collection-read-only-property-initialization">Object initializers with collection read-only property initialization</see>.
         /// </para>
         /// </summary>
         public IList<string> Pages { get; } = new List<string>();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeBusinessCardsOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeBusinessCardsOptions.cs
@@ -48,7 +48,7 @@ namespace Azure.AI.FormRecognizer
         /// </para>
         /// <para>
         /// Although this collection cannot be set, it can be modified.
-        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#collection-initializers">collection initializer</see>.
+        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#object-initializers-with-collection-read-only-property-initialization">Object initializers with collection read-only property initialization</see>.
         /// </para>
         /// </summary>
         public IList<string> Pages { get; } = new List<string>();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeContentOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeContentOptions.cs
@@ -57,7 +57,7 @@ namespace Azure.AI.FormRecognizer
         /// </para>
         /// <para>
         /// Although this collection cannot be set, it can be modified.
-        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#collection-initializers">collection initializer</see>.
+        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#object-initializers-with-collection-read-only-property-initialization">Object initializers with collection read-only property initialization</see>.
         /// </para>
         /// </summary>
         /// <remarks>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeCustomFormsOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeCustomFormsOptions.cs
@@ -42,7 +42,7 @@ namespace Azure.AI.FormRecognizer
         /// </para>
         /// <para>
         /// Although this collection cannot be set, it can be modified.
-        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#collection-initializers">collection initializer</see>.
+        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#object-initializers-with-collection-read-only-property-initialization">Object initializers with collection read-only property initialization</see>.
         /// </para>
         /// </summary>
         /// <remarks>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeIdentityDocumentsOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeIdentityDocumentsOptions.cs
@@ -42,7 +42,7 @@ namespace Azure.AI.FormRecognizer
         /// </para>
         /// <para>
         /// Although this collection cannot be set, it can be modified.
-        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#collection-initializers">collection initializer</see>.
+        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#object-initializers-with-collection-read-only-property-initialization">Object initializers with collection read-only property initialization</see>.
         /// </para>
         /// </summary>
         public IList<string> Pages { get; } = new List<string>();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeInvoicesOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeInvoicesOptions.cs
@@ -48,7 +48,7 @@ namespace Azure.AI.FormRecognizer
         /// </para>
         /// <para>
         /// Although this collection cannot be set, it can be modified.
-        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#collection-initializers">collection initializer</see>.
+        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#object-initializers-with-collection-read-only-property-initialization">Object initializers with collection read-only property initialization</see>.
         /// </para>
         /// </summary>
         public IList<string> Pages { get; } = new List<string>();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeReceiptsOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/RecognizeReceiptsOptions.cs
@@ -51,7 +51,7 @@ namespace Azure.AI.FormRecognizer
         /// </para>
         /// <para>
         /// Although this collection cannot be set, it can be modified.
-        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#collection-initializers">collection initializer</see>.
+        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#object-initializers-with-collection-read-only-property-initialization">Object initializers with collection read-only property initialization</see>.
         /// </para>
         /// </summary>
         /// <remarks>

--- a/sdk/monitor/Azure.Monitor.Query/src/LogsQueryOptions.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/LogsQueryOptions.cs
@@ -33,7 +33,13 @@ namespace Azure.Monitor.Query
         public bool IncludeVisualization { get; set; }
 
         /// <summary>
+        /// <para>
         /// Gets a list of additional workspaces names to include in the query.
+        /// </para>
+        /// <para>
+        /// Although this collection cannot be set, it can be modified.
+        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#object-initializers-with-collection-read-only-property-initialization">Object initializers with collection read-only property initialization</see>.
+        /// </para>
         /// </summary>
         public IList<string> AdditionalWorkspaces { get; } = new ChangeTrackingList<string>();
 

--- a/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryOptions.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryOptions.cs
@@ -26,7 +26,13 @@ namespace Azure.Monitor.Query
         public TimeSpan? Granularity { get; set; }
 
         /// <summary>
+        /// <para>
         /// Gets the list of metric aggregations to retrieve.
+        /// </para>
+        /// <para>
+        /// Although this collection cannot be set, it can be modified.
+        /// See <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers#object-initializers-with-collection-read-only-property-initialization">Object initializers with collection read-only property initialization</see>.
+        /// </para>
         /// </summary>
         public IList<MetricAggregationType> Aggregations { get; } = new List<MetricAggregationType>();
 


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-sdk-for-net/issues/29334

**Summary of changes**
- Update existing docs links, which referenced the wrong section of the doc
- Add the docs links to Monitor Query's Logs and Metrics query options classes