### PR TITLE
Fix regional authority for `ClientCertificateCredential`

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/ClientCertificateCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ClientCertificateCredential.cs
@@ -159,7 +159,8 @@ namespace Azure.Identity
                          clientId,
                          certificateProvider,
                          certCredOptions?.SendCertificateChain ?? false,
-                         options);
+                         options,
+                         certCredOptions?.RegionalAuthority);
         }
 
         /// <summary>

--- a/sdk/identity/Azure.Identity/tests/ClientCertificateCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ClientCertificateCredentialTests.cs
@@ -196,7 +196,7 @@ namespace Azure.Identity.Tests
         {
             TestSetup();
             var _transport = Createx5cValidatingTransport(sendCertChain);
-            var _pipeline = new HttpPipeline(_transport, new[] {new BearerTokenAuthenticationPolicy(new MockCredential(), "scope")});
+            var _pipeline = new HttpPipeline(_transport, new[] { new BearerTokenAuthenticationPolicy(new MockCredential(), "scope") });
             var context = new TokenRequestContext(new[] { Scope }, tenantId: TenantId);
             expectedTenantId = TenantIdResolver.Resolve(TenantId, context);
             var certificatePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pfx");
@@ -216,6 +216,24 @@ namespace Azure.Identity.Tests
             var token = await credential.GetTokenAsync(context);
 
             Assert.AreEqual(token.Token, expectedToken, "Should be the expected token value");
+        }
+
+        [Test]
+        public void VerifyMsalClientRegionalAuthority()
+        {
+            RegionalAuthority?[] authorities = { null, RegionalAuthority.AutoDiscoverRegion, RegionalAuthority.USWest };
+
+            foreach (RegionalAuthority? regionalAuthority in authorities)
+            {
+                var expectedTenantId = Guid.NewGuid().ToString();
+                var expectedClientId = Guid.NewGuid().ToString();
+                var certificatePathPem = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pem");
+
+                var cred = new ClientCertificateCredential(expectedTenantId, expectedClientId, certificatePathPem,
+                    new ClientCertificateCredentialOptions() { RegionalAuthority = regionalAuthority });
+
+                Assert.AreEqual(regionalAuthority, cred.Client.RegionalAuthority);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixing support for regional authority in `ClientCertificateCredential` along with necessary unit tests.

Fixes #29454 