### PR TITLE
Treat `AZURE_AUTHORITY_HOST` as optional

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -213,7 +213,7 @@ namespace Azure.Core.TestFramework
                         GetVariable("CLIENT_SECRET"),
                         new ClientSecretCredentialOptions()
                         {
-                             AuthorityHost = new Uri(GetVariable("AZURE_AUTHORITY_HOST"))
+                             AuthorityHost = new Uri(AuthorityHostUrl)
                         }
                     );
                 }


### PR DESCRIPTION
Resolves #29447
