### PR TITLE
[Event Hubs] Processor Stop Tests

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientLiveTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
+using Azure.Core.Pipeline;
 using Azure.Messaging.EventHubs.Authorization;
 using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Primitives;
@@ -852,6 +853,74 @@ namespace Azure.Messaging.EventHubs.Tests
 
             await processor.StopProcessingAsync().IgnoreExceptions();
             cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventProcessorClient" /> no longer dispatches events for
+        ///   processing once it has been stopped.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProcessorClientCeasesProcessingWhenStopping()
+        {
+            // Setup the environment.
+
+            await using EventHubScope scope = await EventHubScope.CreateAsync(4);
+            var connectionString = EventHubsTestEnvironment.Instance.BuildConnectionStringForEventHub(scope.EventHubName);
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            // Publish some events
+
+            var sentCount = await SendEvents(connectionString, EventGenerator.CreateSmallEvents(400), cancellationSource.Token);
+            Assert.That(sentCount, Is.EqualTo(400), "All generated  events should have been published.");
+
+            // Attempt to read events using the longest possible TryTimeout.
+
+            var options = new EventProcessorOptions { LoadBalancingStrategy = LoadBalancingStrategy.Greedy, MaximumWaitTime = null };
+            options.RetryOptions.TryTimeout = EventHubsTestEnvironment.Instance.TestExecutionTimeLimit.Add(TimeSpan.FromSeconds(30));
+
+            var processorStopped = false;
+            var eventsProcessedAfterStop = false;
+            var readCount = 0;
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var processor = CreateProcessor(scope.ConsumerGroups.First(), connectionString, options: options);
+
+            processor.ProcessEventAsync += args =>
+            {
+                if (args.HasEvent)
+                {
+                    if (processorStopped)
+                    {
+                        eventsProcessedAfterStop = true;
+                    }
+
+                    // Set the completion source once half of our published events
+                    // have been read.
+
+                    if (++readCount >= (sentCount / 2))
+                    {
+                        completionSource.TrySetResult(true);
+                    }
+                }
+
+                return Task.CompletedTask;
+            };
+
+            processor.ProcessErrorAsync += CreateAssertingErrorHandler();
+            await processor.StartProcessingAsync(cancellationSource.Token);
+
+            // Once enough events have been confirmed to have been read, stop the processor and validate that no
+            // additional events dispatched for processing.
+
+            await completionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+            await processor.StopProcessingAsync(cancellationSource.Token);
+            processorStopped = true;
+
+            Assert.That(processor.IsRunning, Is.False, "The processor should have stopped.");
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+            Assert.That(eventsProcessedAfterStop, Is.False, "Events should not have been dispatched for processing after the processor has stopped.");
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
@@ -83,6 +83,22 @@ namespace Azure.Messaging.EventHubs.Tests
                     .GetValue(processor);
 
         /// <summary>
+        ///   Retrieves the cancellation source used for the processor's activity when running, using its private accessor.
+        /// </summary>
+        ///
+        /// <typeparam name="T">The partition type to which the processor is bound.</typeparam>
+        ///
+        /// <param name="processor">The processor instance to operate on.</param>
+        ///
+        /// <returns>The cancellation source associated with the processor's activity when running.</returns>
+        ///
+        private static CancellationTokenSource GetRunningProcessorCancellationSource<T>(EventProcessor<T> processor) where T : EventProcessorPartition, new() =>
+            (CancellationTokenSource)
+                typeof(EventProcessor<T>)
+                    .GetField("_runningProcessorCancellationSource", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .GetValue(processor);
+
+        /// <summary>
         ///   Retrieves the active set of partition processors for an event processor, using its private accessor.
         /// </summary>
         ///
@@ -99,6 +115,27 @@ namespace Azure.Messaging.EventHubs.Tests
                     .GetValue(processor);
 
         /// <summary>
+        ///   Invokes the processor infrastructure method responsible for starting a partition
+        ///   processing task, using its private accessor.
+        /// </summary>
+        ///
+        /// <typeparam name="T">The partition type to which the processor is bound.</typeparam>
+        ///
+        /// <param name="processor">The processor instance to operate on.</param>
+        /// <param name="partitionId">The identifier of the Event Hub partition whose processing should be started.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <returns><c>true</c> if the <paramref name="partitionId"/> was started; otherwise, <c>false</c>.</returns>
+        ///
+        private static bool InvokeTryStartProcessingPartition<T>(EventProcessor<T> processor,
+                                                                 string partitionId,
+                                                                 CancellationToken cancellationToken) where T : EventProcessorPartition, new() =>
+            (bool)
+                typeof(EventProcessor<T>)
+                    .GetMethod("TryStartProcessingPartition", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .Invoke(processor, new object[] { partitionId, cancellationToken });
+
+        /// <summary>
         ///   Invokes the processor infrastructure method responsible for stopping a partition
         ///   processing task, using its private accessor.
         /// </summary>
@@ -113,9 +150,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <returns><c>true</c> if the <paramref name="partitionId"/> was owned and was being processed; otherwise, <c>false</c>.</returns>
         ///
         private static Task<bool> InvokeTryStopProcessingPartitionAsync<T>(EventProcessor<T> processor,
-                                                                          string partitionId,
-                                                                          ProcessingStoppedReason reason,
-                                                                          CancellationToken cancellationToken) where T : EventProcessorPartition, new() =>
+                                                                           string partitionId,
+                                                                           ProcessingStoppedReason reason,
+                                                                           CancellationToken cancellationToken) where T : EventProcessorPartition, new() =>
             (Task<bool>)
                 typeof(EventProcessor<T>)
                     .GetMethod("TryStopProcessingPartitionAsync", BindingFlags.Instance | BindingFlags.NonPublic)


### PR DESCRIPTION
# Summary

The focus of these changes is to add additional test coverage to validate that events are not dispatched for processing once the processor's `StopAsync` method has completed.