### PR TITLE
Add compile error to storage perf tests

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Infrastructure/BlobTest.cs
+++ b/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Infrastructure/BlobTest.cs
@@ -7,6 +7,8 @@ using Azure.Test.Perf;
 
 namespace Azure.Storage.Blobs.Perf
 {
+    test compile error
+
     public abstract class BlobTest<TOptions> : ContainerTest<TOptions> where TOptions : SizeOptions
     {
         protected string BlobName { get; } = $"Azure.Storage.Blobs.Perf.BlobTest-{Guid.NewGuid()}";


### PR DESCRIPTION
Verify if "storage - ci" pipeline catches build breaks
