### PR TITLE
[EventHubs] Remove the dependency on storage and update tests

### DIFF
--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Azure.ResourceManager.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Azure.ResourceManager.EventHubs.Tests.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\src\Azure.ResourceManager.EventHubs.csproj" />
-    <ProjectReference Include="..\..\..\storage\Azure.ResourceManager.Storage\src\Azure.ResourceManager.Storage.csproj" />
-    <ProjectReference Include="..\..\..\resources\Azure.ResourceManager.Resources\src\Azure.ResourceManager.Resources.csproj" />
     <ProjectReference Include="..\..\..\network\Azure.ResourceManager.Network\src\Azure.ResourceManager.Network.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.ResourceManager.Resources" />
     <PackageReference Include="Azure.Identity" />
   </ItemGroup>
 </Project>

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Azure.ResourceManager.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Azure.ResourceManager.EventHubs.Tests.csproj
@@ -4,7 +4,6 @@
     <ProjectReference Include="..\..\..\network\Azure.ResourceManager.Network\src\Azure.ResourceManager.Network.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.ResourceManager.Resources" />
     <PackageReference Include="Azure.Identity" />
   </ItemGroup>
 </Project>

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventhubTests/CreateEventhubWithParameter.json
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventhubTests/CreateEventhubWithParameter.json
@@ -6,34 +6,43 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-a8992aa017126344bafd81e274264b89-e4a719bbff37e142-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "421af15ff3552324ed42d930f6958dac",
+        "traceparent": "00-ea844f4b9028e24d93d8df9e5bd56cc7-bc32694464646c47-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6839885390ae787c4cb5cf45055d8b00",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "468",
+        "Content-Length": "747",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:19 GMT",
+        "Date": "Wed, 29 Jun 2022 14:49:37 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "890255a5-1a71-4704-8326-417c3f24fa70",
-        "x-ms-ratelimit-remaining-subscription-reads": "11909",
-        "x-ms-request-id": "890255a5-1a71-4704-8326-417c3f24fa70",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043320Z:890255a5-1a71-4704-8326-417c3f24fa70"
+        "x-ms-correlation-request-id": "7fb3f341-2e55-4763-8059-96130741e953",
+        "x-ms-ratelimit-remaining-subscription-reads": "11978",
+        "x-ms-request-id": "7fb3f341-2e55-4763-8059-96130741e953",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144938Z:7fb3f341-2e55-4763-8059-96130741e953"
       },
       "ResponseBody": {
         "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "authorizationSource": "RoleBased",
         "managedByTenants": [],
         "tags": {
-          "tagKey1": "tagValue1",
-          "tagKey2": "tagValue2"
+          "TagKey-9823": "TagValue-566",
+          "TagKey-3481": "TagValue-320",
+          "TagKey-4926": "TagValue-1187",
+          "TagKey-751": "TagValue-3921",
+          "TagKey-1866": "TagValue-8559",
+          "TagKey-3094": "TagValue-9190",
+          "TagKey-2449": "TagValue-9",
+          "TagKey-8379": "TagValue-164",
+          "TagKey-7470": "TagValue-2205",
+          "TagKey-4236": "TagValue-3698",
+          "TagKey-5316": "TagValue-2725"
         },
         "subscriptionId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
@@ -47,15 +56,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourcegroups/testeventhubRG-9363?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourcegroups/testeventhubRG-4207?api-version=2021-04-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "44",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0abec591b6918b851c1c8847e569ed58",
+        "traceparent": "00-e6f24334f4a3f6459eb914d3c953b605-06c2d51a12849447-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ba4ddab42fd5362b4f87c45b634ad9e8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -69,19 +79,19 @@
         "Cache-Control": "no-cache",
         "Content-Length": "258",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:20 GMT",
+        "Date": "Wed, 29 Jun 2022 14:49:40 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "74317bf7-953c-42c2-8259-7dc1fc9e0498",
-        "x-ms-ratelimit-remaining-subscription-writes": "1197",
-        "x-ms-request-id": "74317bf7-953c-42c2-8259-7dc1fc9e0498",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043320Z:74317bf7-953c-42c2-8259-7dc1fc9e0498"
+        "x-ms-correlation-request-id": "f34ee856-41c3-4571-ac69-dd61003f6ba8",
+        "x-ms-ratelimit-remaining-subscription-writes": "1196",
+        "x-ms-request-id": "f34ee856-41c3-4571-ac69-dd61003f6ba8",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144941Z:f34ee856-41c3-4571-ac69-dd61003f6ba8"
       },
       "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363",
-        "name": "testeventhubRG-9363",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207",
+        "name": "testeventhubRG-4207",
         "type": "Microsoft.Resources/resourceGroups",
         "location": "eastus2",
         "tags": {
@@ -100,33 +110,34 @@
         "Authorization": "Sanitized",
         "Content-Length": "32",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211105.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fbd8c6733bbda40473e02e7bad6a2213",
+        "traceparent": "00-c8695945c37f5a4ab5fd37bb807d0c2b-f339dc53dfc0c54f-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "db07545ade982ea95ba74bcb128aca78",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "testnamespacemgmt9103"
+        "name": "testnamespacemgmt7361"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "53",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:21 GMT",
+        "Date": "Wed, 29 Jun 2022 14:49:40 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "fbd8c6733bbda40473e02e7bad6a2213",
-        "x-ms-correlation-request-id": "9a028ed7-d23e-47ea-9446-81b5ac6f2af4",
+        "x-ms-client-request-id": "db07545ade982ea95ba74bcb128aca78",
+        "x-ms-correlation-request-id": "0d02f8ce-b166-4ab7-958c-af4208c0e438",
         "x-ms-ratelimit-remaining-subscription-writes": "1198",
-        "x-ms-request-id": "5d3be4aa-2481-4799-a2da-0e611faf09d9_M5CH3_M5CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043321Z:9a028ed7-d23e-47ea-9446-81b5ac6f2af4"
+        "x-ms-request-id": "8bfc9efe-4a15-4921-b0d1-e4478a649dc5_M4SN1_M4SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144941Z:0d02f8ce-b166-4ab7-958c-af4208c0e438"
       },
       "ResponseBody": {
         "nameAvailable": true,
@@ -135,15 +146,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361?api-version=2021-11-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "48",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211105.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0b68a6ffceeb943bb639d69cdb07d9ec",
+        "traceparent": "00-2b18b0cf3e17834882d33cb632bd9d28-13bc6b791f083440-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "5f6ecc0f7dbc0e58315e08b71de86bf5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -154,23 +166,23 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "736",
+        "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:25 GMT",
+        "Date": "Wed, 29 Jun 2022 14:49:45 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "0b68a6ffceeb943bb639d69cdb07d9ec",
-        "x-ms-correlation-request-id": "eefe3830-32c2-423f-bbdf-abf2d55af343",
-        "x-ms-ratelimit-remaining-subscription-resource-requests": "48",
-        "x-ms-request-id": "d0d03450-2e6f-4596-9e19-b82f6bb38480_M5CH3_M5CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043325Z:eefe3830-32c2-423f-bbdf-abf2d55af343"
+        "x-ms-client-request-id": "5f6ecc0f7dbc0e58315e08b71de86bf5",
+        "x-ms-correlation-request-id": "7c8d3d22-da18-4a3a-9c1f-f6eeca5b4ac9",
+        "x-ms-ratelimit-remaining-subscription-resource-requests": "49",
+        "x-ms-request-id": "febe64bd-b2a2-4d9b-8759-f35e817d5950_M4SN1_M4SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144946Z:7c8d3d22-da18-4a3a-9c1f-f6eeca5b4ac9"
       },
       "ResponseBody": {
         "sku": {
@@ -178,8 +190,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361",
+        "name": "testnamespacemgmt7361",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -190,44 +202,45 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7361",
+          "createdAt": "2022-06-29T14:49:44.563Z",
+          "updatedAt": "2022-06-29T14:49:44.563Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7361.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c2e634654c84a4358b4444846567c96b",
+        "traceparent": "00-2b18b0cf3e17834882d33cb632bd9d28-2f7324f936e13940-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "7d54e2f9896bdca4fbf9a93ad6f21173",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "736",
+        "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:26 GMT",
+        "Date": "Wed, 29 Jun 2022 14:49:46 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c2e634654c84a4358b4444846567c96b",
-        "x-ms-correlation-request-id": "e733f765-2ee0-48bd-99dd-93fca5a8f8a3",
-        "x-ms-ratelimit-remaining-subscription-reads": "11908",
-        "x-ms-request-id": "d90fa558-8cc3-462a-9e32-99cf64bbde6e_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043327Z:e733f765-2ee0-48bd-99dd-93fca5a8f8a3"
+        "x-ms-client-request-id": "7d54e2f9896bdca4fbf9a93ad6f21173",
+        "x-ms-correlation-request-id": "00351389-7de8-4365-afa8-5ecb44ea1329",
+        "x-ms-ratelimit-remaining-subscription-reads": "11977",
+        "x-ms-request-id": "d8cab852-24ee-4751-bb78-1bf0b1ab6c44_M6SN1_M6SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144947Z:00351389-7de8-4365-afa8-5ecb44ea1329"
       },
       "ResponseBody": {
         "sku": {
@@ -235,8 +248,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361",
+        "name": "testnamespacemgmt7361",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -247,44 +260,45 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7361",
+          "createdAt": "2022-06-29T14:49:44.563Z",
+          "updatedAt": "2022-06-29T14:49:44.563Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7361.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d8a242075b48b13fd2de5185b1653ea5",
+        "traceparent": "00-2b18b0cf3e17834882d33cb632bd9d28-9bef085b4b02d54c-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6d6e553b9387557fb072bb3003d02ec6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "736",
+        "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:28 GMT",
+        "Date": "Wed, 29 Jun 2022 14:49:48 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d8a242075b48b13fd2de5185b1653ea5",
-        "x-ms-correlation-request-id": "3f116a14-48dd-490a-a480-aa5b0ce595e5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11907",
-        "x-ms-request-id": "e8ebda86-54d1-40a4-aa07-a87a3b945751_M5CH3_M5CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043328Z:3f116a14-48dd-490a-a480-aa5b0ce595e5"
+        "x-ms-client-request-id": "6d6e553b9387557fb072bb3003d02ec6",
+        "x-ms-correlation-request-id": "d6b33ec3-6ddf-4045-b36f-0380242877fa",
+        "x-ms-ratelimit-remaining-subscription-reads": "11976",
+        "x-ms-request-id": "855d0a31-e92b-4828-bd00-d2389637020a_M4SN1_M4SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144948Z:d6b33ec3-6ddf-4045-b36f-0380242877fa"
       },
       "ResponseBody": {
         "sku": {
@@ -292,8 +306,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361",
+        "name": "testnamespacemgmt7361",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -304,44 +318,45 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7361",
+          "createdAt": "2022-06-29T14:49:44.563Z",
+          "updatedAt": "2022-06-29T14:49:44.563Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7361.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a73723ca16218b689f7d3b8f08502452",
+        "traceparent": "00-2b18b0cf3e17834882d33cb632bd9d28-afff064398da3c44-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "3abd0b21ed94d289ff263bff10e125b1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "736",
+        "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:29 GMT",
+        "Date": "Wed, 29 Jun 2022 14:49:50 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a73723ca16218b689f7d3b8f08502452",
-        "x-ms-correlation-request-id": "10c2f1e8-ce6c-43aa-97c5-10531433052d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11906",
-        "x-ms-request-id": "bbe6ef55-ecad-45ad-a4b7-bea73f4c7e15_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043329Z:10c2f1e8-ce6c-43aa-97c5-10531433052d"
+        "x-ms-client-request-id": "3abd0b21ed94d289ff263bff10e125b1",
+        "x-ms-correlation-request-id": "08228b08-d31a-4d39-bffa-e44c538b0c84",
+        "x-ms-ratelimit-remaining-subscription-reads": "11975",
+        "x-ms-request-id": "d0574546-eb6c-440e-b219-a1c708f8d927_M4SN1_M4SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144950Z:08228b08-d31a-4d39-bffa-e44c538b0c84"
       },
       "ResponseBody": {
         "sku": {
@@ -349,8 +364,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361",
+        "name": "testnamespacemgmt7361",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -361,44 +376,45 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7361",
+          "createdAt": "2022-06-29T14:49:44.563Z",
+          "updatedAt": "2022-06-29T14:49:44.563Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7361.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "14ceb29c966e0969f534f0a5fbb0f325",
+        "traceparent": "00-2b18b0cf3e17834882d33cb632bd9d28-4b54d28ba7bfa34c-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "8a4c067acffd667663fecdf9ce73d82b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "736",
+        "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:30 GMT",
+        "Date": "Wed, 29 Jun 2022 14:49:51 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "14ceb29c966e0969f534f0a5fbb0f325",
-        "x-ms-correlation-request-id": "190d005b-0a1d-4a09-9743-7eb268d359fb",
-        "x-ms-ratelimit-remaining-subscription-reads": "11905",
-        "x-ms-request-id": "c4e27d76-fe27-4472-b695-2781a08ba111_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043331Z:190d005b-0a1d-4a09-9743-7eb268d359fb"
+        "x-ms-client-request-id": "8a4c067acffd667663fecdf9ce73d82b",
+        "x-ms-correlation-request-id": "01e207a0-65eb-495c-86b8-54f8c6b63aaa",
+        "x-ms-ratelimit-remaining-subscription-reads": "11974",
+        "x-ms-request-id": "357bb750-c80b-4b0b-a710-4bc0cf16ee36_M4SN1_M4SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144951Z:01e207a0-65eb-495c-86b8-54f8c6b63aaa"
       },
       "ResponseBody": {
         "sku": {
@@ -406,8 +422,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361",
+        "name": "testnamespacemgmt7361",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -418,44 +434,45 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7361",
+          "createdAt": "2022-06-29T14:49:44.563Z",
+          "updatedAt": "2022-06-29T14:49:44.563Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7361.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "41b99e062230f14ada1738cb1fafa882",
+        "traceparent": "00-2b18b0cf3e17834882d33cb632bd9d28-44eaa4e46e37e64b-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ca18e3cbd6344edfcc9b6e60578045ce",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "736",
+        "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:32 GMT",
+        "Date": "Wed, 29 Jun 2022 14:49:54 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "41b99e062230f14ada1738cb1fafa882",
-        "x-ms-correlation-request-id": "6d36502b-4476-4b57-bac0-fffe5328f7ea",
-        "x-ms-ratelimit-remaining-subscription-reads": "11904",
-        "x-ms-request-id": "fdf295da-56e5-4ec9-9f8c-5bb1e0153918_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043332Z:6d36502b-4476-4b57-bac0-fffe5328f7ea"
+        "x-ms-client-request-id": "ca18e3cbd6344edfcc9b6e60578045ce",
+        "x-ms-correlation-request-id": "273ac972-4e30-4d10-a41e-00fef868754b",
+        "x-ms-ratelimit-remaining-subscription-reads": "11973",
+        "x-ms-request-id": "f44d851c-e9be-4e18-9f87-4949dd35ccb6_M10SN1_M10SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144954Z:273ac972-4e30-4d10-a41e-00fef868754b"
       },
       "ResponseBody": {
         "sku": {
@@ -463,8 +480,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361",
+        "name": "testnamespacemgmt7361",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -475,44 +492,45 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7361",
+          "createdAt": "2022-06-29T14:49:44.563Z",
+          "updatedAt": "2022-06-29T14:49:44.563Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7361.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fee9feba29973337ba2db1ec26c28fef",
+        "traceparent": "00-2b18b0cf3e17834882d33cb632bd9d28-d898d031ca303f42-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "fdb6094ca38352c89557d6951f8f048b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "736",
+        "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:33 GMT",
+        "Date": "Wed, 29 Jun 2022 14:50:00 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "fee9feba29973337ba2db1ec26c28fef",
-        "x-ms-correlation-request-id": "7d8e6456-b392-4f45-a250-c35c21f817ca",
-        "x-ms-ratelimit-remaining-subscription-reads": "11903",
-        "x-ms-request-id": "3cb5de39-0e9d-4208-8ead-60db7d75ecf0_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043333Z:7d8e6456-b392-4f45-a250-c35c21f817ca"
+        "x-ms-client-request-id": "fdb6094ca38352c89557d6951f8f048b",
+        "x-ms-correlation-request-id": "b1085c0f-38e0-4b0e-832b-a66463493bd8",
+        "x-ms-ratelimit-remaining-subscription-reads": "11972",
+        "x-ms-request-id": "96f042eb-1f04-4872-a46f-2da627669a44_M9SN1_M9SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145000Z:b1085c0f-38e0-4b0e-832b-a66463493bd8"
       },
       "ResponseBody": {
         "sku": {
@@ -520,8 +538,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361",
+        "name": "testnamespacemgmt7361",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -532,44 +550,45 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7361",
+          "createdAt": "2022-06-29T14:49:44.563Z",
+          "updatedAt": "2022-06-29T14:49:44.563Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7361.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6a89168ae3967a2268dc39565d9de946",
+        "traceparent": "00-2b18b0cf3e17834882d33cb632bd9d28-15dd1866586a1b4b-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "2d340f4d5bc9a47d27febd6160150ee3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "736",
+        "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:34 GMT",
+        "Date": "Wed, 29 Jun 2022 14:50:08 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "6a89168ae3967a2268dc39565d9de946",
-        "x-ms-correlation-request-id": "0d709070-c8cf-4d2a-b01b-983140347cd8",
-        "x-ms-ratelimit-remaining-subscription-reads": "11902",
-        "x-ms-request-id": "0d7210c4-c1d2-4fc6-812f-c97112b22ac5_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043335Z:0d709070-c8cf-4d2a-b01b-983140347cd8"
+        "x-ms-client-request-id": "2d340f4d5bc9a47d27febd6160150ee3",
+        "x-ms-correlation-request-id": "94ea3efd-5aec-4b92-a1f5-c598611a9894",
+        "x-ms-ratelimit-remaining-subscription-reads": "11971",
+        "x-ms-request-id": "efd141e1-083d-4f70-9384-565e75e82af8_M10SN1_M10SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145009Z:94ea3efd-5aec-4b92-a1f5-c598611a9894"
       },
       "ResponseBody": {
         "sku": {
@@ -577,8 +596,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361",
+        "name": "testnamespacemgmt7361",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -589,44 +608,45 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7361",
+          "createdAt": "2022-06-29T14:49:44.563Z",
+          "updatedAt": "2022-06-29T14:49:44.563Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7361.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fdeb6d8cf4c7dc8e66858602705dcb17",
+        "traceparent": "00-2b18b0cf3e17834882d33cb632bd9d28-0def7f71067c2f4b-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c5adfeb9dbbd27a81ac635dd00492e3c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "736",
+        "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:35 GMT",
+        "Date": "Wed, 29 Jun 2022 14:50:25 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "fdeb6d8cf4c7dc8e66858602705dcb17",
-        "x-ms-correlation-request-id": "2081bcd6-13fd-4788-8c2f-161855a4fa43",
-        "x-ms-ratelimit-remaining-subscription-reads": "11901",
-        "x-ms-request-id": "e41f44d1-987b-40e3-896c-a2363659493c_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043336Z:2081bcd6-13fd-4788-8c2f-161855a4fa43"
+        "x-ms-client-request-id": "c5adfeb9dbbd27a81ac635dd00492e3c",
+        "x-ms-correlation-request-id": "53876f27-d227-477f-a58e-25be359e6b5d",
+        "x-ms-ratelimit-remaining-subscription-reads": "11970",
+        "x-ms-request-id": "78be00f5-ba8e-411e-b41b-7ae0aea14e88_M9SN1_M9SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145025Z:53876f27-d227-477f-a58e-25be359e6b5d"
       },
       "ResponseBody": {
         "sku": {
@@ -634,8 +654,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361",
+        "name": "testnamespacemgmt7361",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -646,21 +666,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7361",
+          "createdAt": "2022-06-29T14:49:44.563Z",
+          "updatedAt": "2022-06-29T14:49:44.563Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7361.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "094149873e25d6ebdb6f96baf0e1d61c",
+        "traceparent": "00-2b18b0cf3e17834882d33cb632bd9d28-291817c4eec69547-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "4812e397174bf1058b11d684e567f17f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -669,7 +690,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:37 GMT",
+        "Date": "Wed, 29 Jun 2022 14:50:57 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -679,11 +700,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "094149873e25d6ebdb6f96baf0e1d61c",
-        "x-ms-correlation-request-id": "4073ab84-8954-4e80-af22-48295c29c32e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11900",
-        "x-ms-request-id": "bfdd72c0-07f1-4989-a15d-46d6a9336715_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043337Z:4073ab84-8954-4e80-af22-48295c29c32e"
+        "x-ms-client-request-id": "4812e397174bf1058b11d684e567f17f",
+        "x-ms-correlation-request-id": "3b88983e-7f6f-4218-89ea-770ec1e0a33b",
+        "x-ms-ratelimit-remaining-subscription-reads": "11969",
+        "x-ms-request-id": "dedfde99-e85a-4884-8e14-da577b06405e_M9CH3_M9CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145058Z:3b88983e-7f6f-4218-89ea-770ec1e0a33b"
       },
       "ResponseBody": {
         "sku": {
@@ -691,1490 +712,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b85f6b4492d7952887ad03105c20090a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:38 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "b85f6b4492d7952887ad03105c20090a",
-        "x-ms-correlation-request-id": "ce60218d-6f7c-4961-9e0c-94ac3ba894a9",
-        "x-ms-ratelimit-remaining-subscription-reads": "11899",
-        "x-ms-request-id": "f7b6cabe-195b-4ec3-b86e-be6b73d010b9_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043339Z:ce60218d-6f7c-4961-9e0c-94ac3ba894a9"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "14ce2211df5c4e20821521585ed3ec85",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:39 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "14ce2211df5c4e20821521585ed3ec85",
-        "x-ms-correlation-request-id": "35cad256-7447-4b52-9593-45301b5b2b75",
-        "x-ms-ratelimit-remaining-subscription-reads": "11898",
-        "x-ms-request-id": "5afd0589-c376-4ca1-88ff-1950adc08b44_M10CH3_M10CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043340Z:35cad256-7447-4b52-9593-45301b5b2b75"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "04bd69af13fdf54021ac82773ada79ba",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:41 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "04bd69af13fdf54021ac82773ada79ba",
-        "x-ms-correlation-request-id": "c4fe73cb-bb96-489f-b069-a9ae4f1811d2",
-        "x-ms-ratelimit-remaining-subscription-reads": "11897",
-        "x-ms-request-id": "68c9699f-5acd-44c0-b231-d9f6073da471_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043341Z:c4fe73cb-bb96-489f-b069-a9ae4f1811d2"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "cda88b65c11364c04a1135c270cf36b3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:42 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "cda88b65c11364c04a1135c270cf36b3",
-        "x-ms-correlation-request-id": "4f2c9548-d589-4b28-8f8f-69d7d5b98174",
-        "x-ms-ratelimit-remaining-subscription-reads": "11896",
-        "x-ms-request-id": "8809a1d1-fe75-4b33-bc6a-64f8db890a4e_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043343Z:4f2c9548-d589-4b28-8f8f-69d7d5b98174"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f3617ec10563fe0ce1d8f3b05da913a7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:44 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f3617ec10563fe0ce1d8f3b05da913a7",
-        "x-ms-correlation-request-id": "cec23f9b-8bce-4529-8435-75d172466ddc",
-        "x-ms-ratelimit-remaining-subscription-reads": "11895",
-        "x-ms-request-id": "34f9da38-a8fd-4069-8e94-1849941c57b2_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043344Z:cec23f9b-8bce-4529-8435-75d172466ddc"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d2f2679b1e2bee72a959b9ecdd7e8551",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:45 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d2f2679b1e2bee72a959b9ecdd7e8551",
-        "x-ms-correlation-request-id": "5d693ae8-d9c9-436d-b359-26e149138684",
-        "x-ms-ratelimit-remaining-subscription-reads": "11894",
-        "x-ms-request-id": "45414a79-4421-4106-8cb3-eff8e8fd04e4_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043346Z:5d693ae8-d9c9-436d-b359-26e149138684"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bcb5ce7586795f577eaaec3ace1007a1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:46 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "bcb5ce7586795f577eaaec3ace1007a1",
-        "x-ms-correlation-request-id": "9f0111ce-059d-403e-a29e-7630c2fd5b68",
-        "x-ms-ratelimit-remaining-subscription-reads": "11893",
-        "x-ms-request-id": "1c2672bd-6880-409b-a5ee-22012f5cfb41_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043347Z:9f0111ce-059d-403e-a29e-7630c2fd5b68"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "08268efe63dda3880c73490a4b202163",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:48 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "08268efe63dda3880c73490a4b202163",
-        "x-ms-correlation-request-id": "89a200cb-ff4c-4f3b-8f9f-29ab7877eb10",
-        "x-ms-ratelimit-remaining-subscription-reads": "11892",
-        "x-ms-request-id": "a90a9e46-a02e-44eb-ab74-fdf56f601efe_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043348Z:89a200cb-ff4c-4f3b-8f9f-29ab7877eb10"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8e3aa15357f3152d0f93538032371f99",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:49 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8e3aa15357f3152d0f93538032371f99",
-        "x-ms-correlation-request-id": "b9bcd6d8-2009-4694-9ca1-8d380a1a2ec0",
-        "x-ms-ratelimit-remaining-subscription-reads": "11891",
-        "x-ms-request-id": "9b9e226a-e8fb-4c26-ae7c-a58380870eaf_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043350Z:b9bcd6d8-2009-4694-9ca1-8d380a1a2ec0"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4eed18517c5811744612af063c4d145e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:50 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "4eed18517c5811744612af063c4d145e",
-        "x-ms-correlation-request-id": "a011a8a0-a2d0-451e-97ab-bae27b4f3536",
-        "x-ms-ratelimit-remaining-subscription-reads": "11890",
-        "x-ms-request-id": "2c1eac8c-67d8-4949-8972-65efbcc9cdb8_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043351Z:a011a8a0-a2d0-451e-97ab-bae27b4f3536"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2ce7888979d5a6ad6011f9490f0771d4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:52 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2ce7888979d5a6ad6011f9490f0771d4",
-        "x-ms-correlation-request-id": "7ed5fa64-23c0-49d4-b128-9ed7327166de",
-        "x-ms-ratelimit-remaining-subscription-reads": "11889",
-        "x-ms-request-id": "6b7946c8-92ed-4d21-a2c3-288e0b7af5dc_M10CH3_M10CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043352Z:7ed5fa64-23c0-49d4-b128-9ed7327166de"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "32b8b053d233d60b2d2948e1a727d8c2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:53 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "32b8b053d233d60b2d2948e1a727d8c2",
-        "x-ms-correlation-request-id": "9b769156-3372-437b-a6f9-35bce6ff136a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11888",
-        "x-ms-request-id": "2d5c1245-b542-429f-9d72-3530f342557a_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043354Z:9b769156-3372-437b-a6f9-35bce6ff136a"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a9f7f57ef350d8c36b46ed46832a013e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:54 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a9f7f57ef350d8c36b46ed46832a013e",
-        "x-ms-correlation-request-id": "01e7a302-7f81-45f0-b320-9f5eca006955",
-        "x-ms-ratelimit-remaining-subscription-reads": "11887",
-        "x-ms-request-id": "703b0d73-b417-466c-b9e8-70d574222235_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043355Z:01e7a302-7f81-45f0-b320-9f5eca006955"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8cb2daa1e194b62b7d10feac30cbfe39",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:56 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8cb2daa1e194b62b7d10feac30cbfe39",
-        "x-ms-correlation-request-id": "123fc794-8e9c-42d5-891d-88e5fb0b2a9a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11886",
-        "x-ms-request-id": "b6f075fd-beb3-4ace-adf2-4268f1693734_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043356Z:123fc794-8e9c-42d5-891d-88e5fb0b2a9a"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1acb3638c7105f84ece0c7ece4c45203",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:57 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "1acb3638c7105f84ece0c7ece4c45203",
-        "x-ms-correlation-request-id": "ecee30af-2f90-47b9-991f-bc35768e6d9e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11885",
-        "x-ms-request-id": "d421582f-2ed9-4dc2-90c4-9ddce46a2361_M10CH3_M10CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043358Z:ecee30af-2f90-47b9-991f-bc35768e6d9e"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "cc4009274c749d2dca402b3ff417a79f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:33:58 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "cc4009274c749d2dca402b3ff417a79f",
-        "x-ms-correlation-request-id": "e9fec42b-17c5-4c74-b87d-d07cf07e6131",
-        "x-ms-ratelimit-remaining-subscription-reads": "11884",
-        "x-ms-request-id": "8877f031-2e20-4c53-96e5-e6916e317b6c_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043359Z:e9fec42b-17c5-4c74-b87d-d07cf07e6131"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4c0eb447e75fd92e56529fb41a3ed1b9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:00 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "4c0eb447e75fd92e56529fb41a3ed1b9",
-        "x-ms-correlation-request-id": "c88a110a-0e06-443b-9105-80219bd8c559",
-        "x-ms-ratelimit-remaining-subscription-reads": "11883",
-        "x-ms-request-id": "c599c370-ce7b-494a-8ad1-901cc39f1518_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043400Z:c88a110a-0e06-443b-9105-80219bd8c559"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2785fbbd328becc4092d4fcf9b446ad5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:01 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2785fbbd328becc4092d4fcf9b446ad5",
-        "x-ms-correlation-request-id": "4b173517-1a6b-49bf-a3d1-915a6f802291",
-        "x-ms-ratelimit-remaining-subscription-reads": "11882",
-        "x-ms-request-id": "d6f25069-b01e-4f48-94fb-21f5446be888_M10CH3_M10CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043402Z:4b173517-1a6b-49bf-a3d1-915a6f802291"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "30a4273805b63fa4db667622ac78828b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:02 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "30a4273805b63fa4db667622ac78828b",
-        "x-ms-correlation-request-id": "41e6251b-c74e-42b1-a72f-a944ab5d446c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11881",
-        "x-ms-request-id": "94e85fff-3c66-4f8f-afc0-4f479397bcb1_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043403Z:41e6251b-c74e-42b1-a72f-a944ab5d446c"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f981726e80921514f0214331975e3d11",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:04 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f981726e80921514f0214331975e3d11",
-        "x-ms-correlation-request-id": "7875aafb-0aa0-4cfe-9510-a9d2cfaec4f2",
-        "x-ms-ratelimit-remaining-subscription-reads": "11880",
-        "x-ms-request-id": "7c6426d8-bbd3-4518-a777-b0ee7ea6bbe4_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043404Z:7875aafb-0aa0-4cfe-9510-a9d2cfaec4f2"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f37cc9e7a19ab70357454b24bba23f90",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:05 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f37cc9e7a19ab70357454b24bba23f90",
-        "x-ms-correlation-request-id": "36a7a9d2-3ac4-489f-ba01-907b17580d3d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11879",
-        "x-ms-request-id": "9b808b94-a441-4806-a77b-276877238ebb_M10CH3_M10CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043406Z:36a7a9d2-3ac4-489f-ba01-907b17580d3d"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2960c3ab71c2b843128e4094c272a87d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:06 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2960c3ab71c2b843128e4094c272a87d",
-        "x-ms-correlation-request-id": "dbf1241d-0991-4df7-a636-6122d031949b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11878",
-        "x-ms-request-id": "8543ddf3-d35e-4b3d-a0b6-90a0e0ec1c6f_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043407Z:dbf1241d-0991-4df7-a636-6122d031949b"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e33a64298ffccdf06fc9a24d34f05a4d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:08 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "e33a64298ffccdf06fc9a24d34f05a4d",
-        "x-ms-correlation-request-id": "d048f306-b405-4c30-a676-bd3e4c91097b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11877",
-        "x-ms-request-id": "0e44ac5a-c2fe-42e4-bfde-3217e4c1ba16_M10CH3_M10CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043408Z:d048f306-b405-4c30-a676-bd3e4c91097b"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d385b2e213fd764e86c3e00c616ef5e4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:09 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d385b2e213fd764e86c3e00c616ef5e4",
-        "x-ms-correlation-request-id": "32507dda-6fd4-4e20-a987-49ff9f64da22",
-        "x-ms-ratelimit-remaining-subscription-reads": "11876",
-        "x-ms-request-id": "1812b25e-422e-4e7e-b383-151211b0f156_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043410Z:32507dda-6fd4-4e20-a987-49ff9f64da22"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "57face9c5c671c94d293baf9cef68322",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:10 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "57face9c5c671c94d293baf9cef68322",
-        "x-ms-correlation-request-id": "8b52dd32-14fd-4533-855f-0b89a34ffe1d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11875",
-        "x-ms-request-id": "6b81ae02-b1d3-4499-b5f7-61c4b9a6597b_M5CH3_M5CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043411Z:8b52dd32-14fd-4533-855f-0b89a34ffe1d"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:33:24.34Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "10b2f234d4ec157f15c35c38aee46c00",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "735",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:12 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "10b2f234d4ec157f15c35c38aee46c00",
-        "x-ms-correlation-request-id": "a2ddb3cb-b968-4a1b-9dbb-f81d375081fc",
-        "x-ms-ratelimit-remaining-subscription-reads": "11874",
-        "x-ms-request-id": "5bbb1a36-4564-4003-8a48-66bff1c81151_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043413Z:a2ddb3cb-b968-4a1b-9dbb-f81d375081fc"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361",
+        "name": "testnamespacemgmt7361",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -2185,455 +724,1626 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:34:12.493Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7361",
+          "createdAt": "2022-06-29T14:49:44.563Z",
+          "updatedAt": "2022-06-29T14:50:32.233Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7361.servicebus.windows.net:443/",
           "status": "Active"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.Storage/storageAccounts/storage4657?api-version=2021-04-01",
-      "RequestMethod": "PUT",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage?api-version=2021-04-01",
+      "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "105",
-        "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.Storage/1.0.0-beta.3 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f566b0bee6031d8569006a5955a79040",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "sku": {
-          "name": "Standard_LRS"
-        },
-        "kind": "StorageV2",
-        "location": "eastus2",
-        "properties": {
-          "accessTier": "Hot"
-        }
-      },
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:17 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f566b0bee6031d8569006a5955a79040",
-        "x-ms-correlation-request-id": "fee67e2b-9213-4179-bde5-65083fbbdb93",
-        "x-ms-ratelimit-remaining-subscription-writes": "1196",
-        "x-ms-request-id": "de742304-5dbd-4ecc-b231-9253c0a7f93d",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043417Z:fee67e2b-9213-4179-bde5-65083fbbdb93"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "461024b92c1c0c302df283d315bcc01c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:17 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "461024b92c1c0c302df283d315bcc01c",
-        "x-ms-correlation-request-id": "b054d17c-d096-43a7-890e-7af688fe0b88",
-        "x-ms-ratelimit-remaining-subscription-reads": "11873",
-        "x-ms-request-id": "78f20b63-7781-47a0-954d-d541227ad0c2",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043418Z:b054d17c-d096-43a7-890e-7af688fe0b88"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0cf0f7cc45fdc6efe71710c24285c1fc",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:18 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "0cf0f7cc45fdc6efe71710c24285c1fc",
-        "x-ms-correlation-request-id": "242c581a-0b0c-47be-af2b-ec31292580a0",
-        "x-ms-ratelimit-remaining-subscription-reads": "11872",
-        "x-ms-request-id": "ccaad53d-0a9f-4a60-b16d-663b857e9252",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043419Z:242c581a-0b0c-47be-af2b-ec31292580a0"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "309f42124a979123a7628ef274f53a28",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:20 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "309f42124a979123a7628ef274f53a28",
-        "x-ms-correlation-request-id": "b0f11a03-613f-4106-a2f9-78e88fd3f4f3",
-        "x-ms-ratelimit-remaining-subscription-reads": "11871",
-        "x-ms-request-id": "23f8cd0d-9cb6-4552-8798-28152b595e16",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043420Z:b0f11a03-613f-4106-a2f9-78e88fd3f4f3"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "64338781e17c742935495e051c6ecaa7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:21 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "64338781e17c742935495e051c6ecaa7",
-        "x-ms-correlation-request-id": "4a3659ce-cc42-4c38-87a0-26369e1caa9f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11870",
-        "x-ms-request-id": "0387d585-423c-410f-9e72-26a14c783789",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043422Z:4a3659ce-cc42-4c38-87a0-26369e1caa9f"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d2c086308f1c8285d45f659bb6fc52f2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:22 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d2c086308f1c8285d45f659bb6fc52f2",
-        "x-ms-correlation-request-id": "c40e30f6-a72e-457b-8b9f-69cb84a828b2",
-        "x-ms-ratelimit-remaining-subscription-reads": "11869",
-        "x-ms-request-id": "cdac5138-88c7-4716-b43a-d9beca452fb7",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043423Z:c40e30f6-a72e-457b-8b9f-69cb84a828b2"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ba40e7dd5d513080192bfb4deb1e7438",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:24 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "ba40e7dd5d513080192bfb4deb1e7438",
-        "x-ms-correlation-request-id": "658aa241-1fea-42dc-9544-bb5b6dfa6d33",
-        "x-ms-ratelimit-remaining-subscription-reads": "11868",
-        "x-ms-request-id": "f70010b0-33ad-488e-b8a6-113a48cadb90",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043424Z:658aa241-1fea-42dc-9544-bb5b6dfa6d33"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "edc2e7976734f20c02b1901c7c8ebe39",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:25 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "edc2e7976734f20c02b1901c7c8ebe39",
-        "x-ms-correlation-request-id": "e4ce8531-b163-4655-87ef-771429e801c8",
-        "x-ms-ratelimit-remaining-subscription-reads": "11867",
-        "x-ms-request-id": "5e81daf3-c4a6-462b-ac4b-7bf0c910589b",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043426Z:e4ce8531-b163-4655-87ef-771429e801c8"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "35286cf70f2ed355058fb9f1933796b5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:26 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "35286cf70f2ed355058fb9f1933796b5",
-        "x-ms-correlation-request-id": "862d1301-d93e-49d0-86bf-46db35f1ac99",
-        "x-ms-ratelimit-remaining-subscription-reads": "11866",
-        "x-ms-request-id": "5647ef2a-725b-436b-8a50-c80cba480793",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043427Z:862d1301-d93e-49d0-86bf-46db35f1ac99"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "cf032cea643a75bdda4eb8a0cd63b48a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:28 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "cf032cea643a75bdda4eb8a0cd63b48a",
-        "x-ms-correlation-request-id": "b3a9031b-f14b-4387-b364-e3cacff635a1",
-        "x-ms-ratelimit-remaining-subscription-reads": "11865",
-        "x-ms-request-id": "1e0118fe-3ceb-4a34-9a25-f0aeb1a19eb3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043428Z:b3a9031b-f14b-4387-b364-e3cacff635a1"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7f55c26c3ff5880a91eee8a4ae1a5eca",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:29 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "7f55c26c3ff5880a91eee8a4ae1a5eca",
-        "x-ms-correlation-request-id": "39937aba-4678-4cda-b26b-9eec2605a58e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11864",
-        "x-ms-request-id": "3d79ab53-12c9-4ff1-b950-5adad02491d9",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043430Z:39937aba-4678-4cda-b26b-9eec2605a58e"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5031da1aee8a92ffaeb35adf57b505a1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:30 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5031da1aee8a92ffaeb35adf57b505a1",
-        "x-ms-correlation-request-id": "6d70ea74-1300-4572-82e1-9e1ed5b749ad",
-        "x-ms-ratelimit-remaining-subscription-reads": "11863",
-        "x-ms-request-id": "9eea9d9b-e749-4503-975b-386b190fa387",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043431Z:6d70ea74-1300-4572-82e1-9e1ed5b749ad"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d1842edb17e1abc0227b3e4b7c19c6c0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:32 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "3",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d1842edb17e1abc0227b3e4b7c19c6c0",
-        "x-ms-correlation-request-id": "79b9299d-22a8-4037-bb0e-1d6d4376e04f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11862",
-        "x-ms-request-id": "40240b79-25b0-42b2-b726-1eae2f564da4",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043432Z:79b9299d-22a8-4037-bb0e-1d6d4376e04f"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/de742304-5dbd-4ecc-b231-9253c0a7f93d?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f385edf063327dffc3c3d142e52b31dc",
+        "traceparent": "00-1c459d38db9f6944964663acc2f65776-e24878e82d19164b-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "e220dcf3cd3f66720c120326a0a3ddcf",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1329",
+        "Content-Length": "20532",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 29 Jun 2022 14:50:57 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "7ed4185f-fc48-475e-81ac-6a2727d58881",
+        "x-ms-ratelimit-remaining-subscription-reads": "11968",
+        "x-ms-request-id": "7ed4185f-fc48-475e-81ac-6a2727d58881",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145058Z:7ed4185f-fc48-475e-81ac-6a2727d58881"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage",
+        "namespace": "Microsoft.Storage",
+        "authorizations": [
+          {
+            "applicationId": "a6aa9161-5291-40bb-8c5c-923b567bee3b",
+            "roleDefinitionId": "070ab87f-0efc-4423-b18b-756f3bdb0236"
+          },
+          {
+            "applicationId": "e406a681-f3d4-42a8-90b6-c2b029497af1"
+          }
+        ],
+        "resourceTypes": [
+          {
+            "resourceType": "storageAccounts/encryptionScopes",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "deletedAccounts",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "locations/deletedAccounts",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "storageAccounts",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01",
+              "2016-01-01",
+              "2015-06-15",
+              "2015-05-01-preview"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2019-03-01-hybrid",
+                "apiVersion": "2017-10-01"
+              },
+              {
+                "profileVersion": "2017-03-09-profile",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-03-01-hybrid",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-06-01-profile",
+                "apiVersion": "2017-10-01"
+              }
+            ],
+            "zoneMappings": [
+              {
+                "location": "Australia East",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Brazil South",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Canada Central",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Central India",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Central US",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "East Asia",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "East US",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "East US 2",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "France Central",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Germany West Central",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Japan East",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Korea Central",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "North Central US",
+                "zones": []
+              },
+              {
+                "location": "North Europe",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Norway East",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "South Africa North",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "South Central US",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Southeast Asia",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Sweden Central",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Switzerland North",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "UAE North",
+                "zones": []
+              },
+              {
+                "location": "UK South",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "West Europe",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "West US 2",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "West US 3",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              }
+            ],
+            "capabilities": "CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags, SupportsLocation"
+          },
+          {
+            "resourceType": "operations",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01",
+              "2016-01-01",
+              "2015-06-15",
+              "2015-05-01-preview"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2019-03-01-hybrid",
+                "apiVersion": "2017-10-01"
+              },
+              {
+                "profileVersion": "2017-03-09-profile",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-03-01-hybrid",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-06-01-profile",
+                "apiVersion": "2017-10-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "locations/asyncoperations",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01",
+              "2016-01-01",
+              "2015-06-15",
+              "2015-05-01-preview"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2017-03-09-profile",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-03-01-hybrid",
+                "apiVersion": "2016-01-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "storageAccounts/listAccountSas",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2018-06-01-profile",
+                "apiVersion": "2017-10-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "storageAccounts/listServiceSas",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2018-06-01-profile",
+                "apiVersion": "2017-10-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "storageAccounts/blobServices",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2019-03-01-hybrid",
+                "apiVersion": "2017-10-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "storageAccounts/tableServices",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2019-03-01-hybrid",
+                "apiVersion": "2017-10-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "storageAccounts/queueServices",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2019-03-01-hybrid",
+                "apiVersion": "2017-10-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "storageAccounts/fileServices",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "locations",
+            "locations": [],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-07-01",
+              "2016-01-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2019-03-01-hybrid",
+                "apiVersion": "2017-10-01"
+              },
+              {
+                "profileVersion": "2017-03-09-profile",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-03-01-hybrid",
+                "apiVersion": "2016-01-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "locations/usages",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2017-03-09-profile",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-03-01-hybrid",
+                "apiVersion": "2016-01-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "locations/deleteVirtualNetworkOrSubnets",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-07-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "usages",
+            "locations": [],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01",
+              "2016-01-01",
+              "2015-06-15",
+              "2015-05-01-preview"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2019-03-01-hybrid",
+                "apiVersion": "2017-10-01"
+              },
+              {
+                "profileVersion": "2017-03-09-profile",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-03-01-hybrid",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-06-01-profile",
+                "apiVersion": "2017-10-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "checkNameAvailability",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01",
+              "2016-01-01",
+              "2015-06-15",
+              "2015-05-01-preview"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2019-03-01-hybrid",
+                "apiVersion": "2017-10-01"
+              },
+              {
+                "profileVersion": "2017-03-09-profile",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-03-01-hybrid",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-06-01-profile",
+                "apiVersion": "2017-10-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "locations/checkNameAvailability",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "storageAccounts/services",
+            "locations": [
+              "East US",
+              "West US",
+              "East US 2 (Stage)",
+              "West Europe",
+              "North Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "East US 2",
+              "Central US",
+              "Australia East",
+              "Australia Southeast",
+              "Brazil South",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2014-04-01"
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "storageAccounts/services/metricDefinitions",
+            "locations": [
+              "East US",
+              "West US",
+              "East US 2 (Stage)",
+              "West Europe",
+              "North Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "East US 2",
+              "Central US",
+              "Australia East",
+              "Australia Southeast",
+              "Brazil South",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2014-04-01"
+            ],
+            "capabilities": "None"
+          }
+        ],
+        "registrationState": "Registered",
+        "registrationPolicy": "RegistrationRequired"
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.Storage/storageAccounts/storage3446?api-version=2021-09-01",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "105",
         "Content-Type": "application/json",
-        "Date": "Fri, 05 Nov 2021 04:34:33 GMT",
+        "traceparent": "00-1c459d38db9f6944964663acc2f65776-ae9bd90ee7983442-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "027dca8197c6f9a1bc39ab042341b3d4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "properties": {
+          "accessTier": "Hot"
+        },
+        "kind": "StorageV2",
+        "sku": {
+          "name": "Standard_LRS"
+        },
+        "location": "eastus2"
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Content-Type": "text/plain; charset=utf-8",
+        "Date": "Wed, 29 Jun 2022 14:51:02 GMT",
+        "Expires": "-1",
+        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/4f27d9fc-69f3-47d0-b097-fcec1083785b?monitor=true\u0026api-version=2021-09-01",
+        "Pragma": "no-cache",
+        "Retry-After": "17",
+        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "027dca8197c6f9a1bc39ab042341b3d4",
+        "x-ms-correlation-request-id": "cbf1bb81-962e-4340-ac00-deaa8be06436",
+        "x-ms-ratelimit-remaining-subscription-writes": "1195",
+        "x-ms-request-id": "4f27d9fc-69f3-47d0-b097-fcec1083785b",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145102Z:cbf1bb81-962e-4340-ac00-deaa8be06436"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/4f27d9fc-69f3-47d0-b097-fcec1083785b?monitor=true\u0026api-version=2021-09-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-1c459d38db9f6944964663acc2f65776-648abaff008e8246-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "9d64b5f87c745b823a272605216d43ca",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Content-Type": "text/plain; charset=utf-8",
+        "Date": "Wed, 29 Jun 2022 14:51:02 GMT",
+        "Expires": "-1",
+        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/4f27d9fc-69f3-47d0-b097-fcec1083785b?monitor=true\u0026api-version=2021-09-01",
+        "Pragma": "no-cache",
+        "Retry-After": "17",
+        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "9d64b5f87c745b823a272605216d43ca",
+        "x-ms-correlation-request-id": "e99d653a-9c03-4264-969e-7755d876b3d8",
+        "x-ms-ratelimit-remaining-subscription-reads": "11967",
+        "x-ms-request-id": "54a0f45a-78f6-41ca-a517-c332d26a3875",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145103Z:e99d653a-9c03-4264-969e-7755d876b3d8"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/4f27d9fc-69f3-47d0-b097-fcec1083785b?monitor=true\u0026api-version=2021-09-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-1c459d38db9f6944964663acc2f65776-74ff11798b33e347-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "0b702f5e719627c2716762e4589cf8f1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "1387",
+        "Content-Type": "application/json",
+        "Date": "Wed, 29 Jun 2022 14:51:19 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f385edf063327dffc3c3d142e52b31dc",
-        "x-ms-correlation-request-id": "73b6058c-2491-4392-bd0e-a7e7b4aeef68",
-        "x-ms-ratelimit-remaining-subscription-reads": "11861",
-        "x-ms-request-id": "3818c44d-2162-4517-9af0-dd21152f6e4b",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043434Z:73b6058c-2491-4392-bd0e-a7e7b4aeef68"
+        "x-ms-client-request-id": "0b702f5e719627c2716762e4589cf8f1",
+        "x-ms-correlation-request-id": "d2a13290-0fe2-43f4-9b10-ab5cd4c66003",
+        "x-ms-ratelimit-remaining-subscription-reads": "11966",
+        "x-ms-request-id": "47e57a0d-dc80-4793-a127-550a29e0ddfa",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145120Z:d2a13290-0fe2-43f4-9b10-ab5cd4c66003"
       },
       "ResponseBody": {
         "sku": {
@@ -2641,17 +2351,19 @@
           "tier": "Standard"
         },
         "kind": "StorageV2",
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.Storage/storageAccounts/storage4657",
-        "name": "storage4657",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.Storage/storageAccounts/storage3446",
+        "name": "storage3446",
         "type": "Microsoft.Storage/storageAccounts",
         "location": "eastus2",
         "tags": {},
         "properties": {
           "keyCreationTime": {
-            "key1": "2021-11-05T04:34:16.2547953Z",
-            "key2": "2021-11-05T04:34:16.2547953Z"
+            "key1": "2022-06-29T14:51:01.4081348Z",
+            "key2": "2022-06-29T14:51:01.4081348Z"
           },
           "privateEndpointConnections": [],
+          "minimumTlsVersion": "TLS1_0",
+          "allowBlobPublicAccess": true,
           "networkAcls": {
             "bypass": "AzureServices",
             "virtualNetworkRules": [],
@@ -2664,26 +2376,26 @@
               "file": {
                 "keyType": "Account",
                 "enabled": true,
-                "lastEnabledTime": "2021-11-05T04:34:16.2547953Z"
+                "lastEnabledTime": "2022-06-29T14:51:01.4081348Z"
               },
               "blob": {
                 "keyType": "Account",
                 "enabled": true,
-                "lastEnabledTime": "2021-11-05T04:34:16.2547953Z"
+                "lastEnabledTime": "2022-06-29T14:51:01.4081348Z"
               }
             },
             "keySource": "Microsoft.Storage"
           },
           "accessTier": "Hot",
           "provisioningState": "Succeeded",
-          "creationTime": "2021-11-05T04:34:16.1454208Z",
+          "creationTime": "2022-06-29T14:51:01.2674194Z",
           "primaryEndpoints": {
-            "dfs": "https://storage4657.dfs.core.windows.net/",
-            "web": "https://storage4657.z20.web.core.windows.net/",
-            "blob": "https://storage4657.blob.core.windows.net/",
-            "queue": "https://storage4657.queue.core.windows.net/",
-            "table": "https://storage4657.table.core.windows.net/",
-            "file": "https://storage4657.file.core.windows.net/"
+            "dfs": "https://storage3446.dfs.core.windows.net/",
+            "web": "https://storage3446.z20.web.core.windows.net/",
+            "blob": "https://storage3446.blob.core.windows.net/",
+            "queue": "https://storage3446.queue.core.windows.net/",
+            "table": "https://storage3446.table.core.windows.net/",
+            "file": "https://storage3446.file.core.windows.net/"
           },
           "primaryLocation": "eastus2",
           "statusOfPrimary": "available"
@@ -2691,15 +2403,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/eventhubs/eventhub1304?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361/eventhubs/eventhub1062?api-version=2021-11-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "564",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211105.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9680c846e98d1a03862e0fb0b31695ec",
+        "traceparent": "00-c398b5677d936841b377ec46085a22df-42298fef133f5349-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "dd6e0c3d60161238b131e63452f4329e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -2715,7 +2428,7 @@
             "destination": {
               "name": "EventHubArchive.AzureBlockBlob",
               "properties": {
-                "storageAccountResourceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.Storage/storageAccounts/storage4657",
+                "storageAccountResourceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.Storage/storageAccounts/storage3446",
                 "blobContainer": "container",
                 "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}"
               }
@@ -2726,10 +2439,9 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Connection": "close",
         "Content-Length": "948",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:34:52 GMT",
+        "Date": "Wed, 29 Jun 2022 14:51:24 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -2739,23 +2451,23 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "9680c846e98d1a03862e0fb0b31695ec",
-        "x-ms-correlation-request-id": "94d8a5c2-e0f2-4414-bbc8-96bce84631dc",
-        "x-ms-ratelimit-remaining-subscription-writes": "1195",
-        "x-ms-request-id": "6ffa0cd8-fb10-43c9-88c2-176fbb2aa8d4_M10CH3_M10CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043452Z:94d8a5c2-e0f2-4414-bbc8-96bce84631dc"
+        "x-ms-client-request-id": "dd6e0c3d60161238b131e63452f4329e",
+        "x-ms-correlation-request-id": "9e58c4aa-e6b6-48e2-982a-ab25f5720c11",
+        "x-ms-ratelimit-remaining-subscription-writes": "1194",
+        "x-ms-request-id": "e125c445-cd59-42b2-9af6-2f5cec83517e_M3CH3_M3CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145124Z:9e58c4aa-e6b6-48e2-982a-ab25f5720c11"
       },
       "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/eventhubs/eventhub1304",
-        "name": "eventhub1304",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7361/eventhubs/eventhub1062",
+        "name": "eventhub1062",
         "type": "Microsoft.EventHub/Namespaces/EventHubs",
         "location": "East US 2",
         "properties": {
           "messageRetentionInDays": 4,
           "partitionCount": 4,
           "status": "Active",
-          "createdAt": "2021-11-05T04:34:41.677Z",
-          "updatedAt": "2021-11-05T04:34:51.933Z",
+          "createdAt": "2022-06-29T14:51:23.853Z",
+          "updatedAt": "2022-06-29T14:51:24.107Z",
           "partitionIds": [
             "0",
             "1",
@@ -2768,7 +2480,7 @@
             "destination": {
               "name": "EventHubArchive.AzureBlockBlob",
               "properties": {
-                "storageAccountResourceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.Storage/storageAccounts/storage4657",
+                "storageAccountResourceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.Storage/storageAccounts/storage3446",
                 "blobContainer": "container",
                 "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}"
               }
@@ -2780,12 +2492,14 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.Storage/storageAccounts/storage4657?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4207/providers/Microsoft.Storage/storageAccounts/storage3446?api-version=2021-09-01",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
+        "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.Storage/1.0.0-beta.3 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2f6aef9a6f122e77060d1e467dc6f64a",
+        "traceparent": "00-a5cefa895be0474a9d80631aee413729-9f77bff22dad644d-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "5ad2a674d7dff2873d2b0c199d039e2e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -2794,859 +2508,24 @@
         "Cache-Control": "no-cache",
         "Content-Length": "0",
         "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:35:02 GMT",
+        "Date": "Wed, 29 Jun 2022 14:51:33 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2f6aef9a6f122e77060d1e467dc6f64a",
-        "x-ms-correlation-request-id": "1015daf6-0ef8-4469-b851-99291fc23e42",
-        "x-ms-ratelimit-remaining-subscription-deletes": "14994",
-        "x-ms-request-id": "e42aa277-bba5-48e9-8fda-36e4fd4c8a75",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043503Z:1015daf6-0ef8-4469-b851-99291fc23e42"
+        "x-ms-client-request-id": "5ad2a674d7dff2873d2b0c199d039e2e",
+        "x-ms-correlation-request-id": "d31c3db4-e837-4e7b-ba5a-befd975c5bc9",
+        "x-ms-ratelimit-remaining-subscription-deletes": "14999",
+        "x-ms-request-id": "7d967501-a489-4cc5-ad48-fcbd8cb19b01",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145133Z:d31c3db4-e837-4e7b-ba5a-befd975c5bc9"
       },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211105.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "503661612945036282d9ac35f0cc0fac",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "747",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:35:03 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "503661612945036282d9ac35f0cc0fac",
-        "x-ms-correlation-request-id": "e511e509-b87a-4aeb-a77d-cb32be1f8204",
-        "x-ms-ratelimit-remaining-subscription-reads": "11912",
-        "x-ms-request-id": "cbfddccb-e53f-41d2-95f9-c111c6cfa81b_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043504Z:e511e509-b87a-4aeb-a77d-cb32be1f8204"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "sku": {
-              "name": "Standard",
-              "tier": "Standard",
-              "capacity": 1
-            },
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-            "name": "testnamespacemgmt9103",
-            "type": "Microsoft.EventHub/Namespaces",
-            "location": "East US 2",
-            "tags": {},
-            "properties": {
-              "disableLocalAuth": false,
-              "zoneRedundant": false,
-              "isAutoInflateEnabled": false,
-              "maximumThroughputUnits": 0,
-              "kafkaEnabled": true,
-              "provisioningState": "Succeeded",
-              "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-              "createdAt": "2021-11-05T04:33:24.34Z",
-              "updatedAt": "2021-11-05T04:34:12.493Z",
-              "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-              "status": "Active"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211105.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3b4b563bacc6d6d651518f7fcabd9cbf",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Date": "Fri, 05 Nov 2021 04:35:06 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "3b4b563bacc6d6d651518f7fcabd9cbf",
-        "x-ms-correlation-request-id": "1449b8b5-960f-4786-81e2-546d33aa927d",
-        "x-ms-ratelimit-remaining-subscription-deletes": "14993",
-        "x-ms-request-id": "0a9efbb7-c20c-4ffa-80ed-e6399cd36b76_M11SN1_M11SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043506Z:1449b8b5-960f-4786-81e2-546d33aa927d"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "260a71feba7bb5838b5ffef49ae339c4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:35:06 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "58",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "260a71feba7bb5838b5ffef49ae339c4",
-        "x-ms-correlation-request-id": "5e354a6c-9ace-4fd7-8c57-0e6cb13c9c9e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11911",
-        "x-ms-request-id": "fb75d67e-207f-4d85-8424-0b2775c49f14_M11SN1_M11SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043507Z:5e354a6c-9ace-4fd7-8c57-0e6cb13c9c9e"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:35:06.583Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2afeec3cbd7df6ccafdaaf60ff9d130f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:35:07 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "54",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2afeec3cbd7df6ccafdaaf60ff9d130f",
-        "x-ms-correlation-request-id": "bc76b46d-d36c-412a-af48-c5e4914b71ff",
-        "x-ms-ratelimit-remaining-subscription-reads": "11910",
-        "x-ms-request-id": "00a5d7e9-7f64-4764-a758-f3c49b5cdac5_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043508Z:bc76b46d-d36c-412a-af48-c5e4914b71ff"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:35:06.583Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5880551376b27c444299c68046b2d5a8",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:35:09 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "40",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5880551376b27c444299c68046b2d5a8",
-        "x-ms-correlation-request-id": "8be29a55-e929-4bba-8b7b-b925a22f0cc2",
-        "x-ms-ratelimit-remaining-subscription-reads": "11909",
-        "x-ms-request-id": "403de640-6429-4c3d-982a-b16723ae0bf7_M8SN1_M8SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043510Z:8be29a55-e929-4bba-8b7b-b925a22f0cc2"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:35:06.583Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d6fce82c134341bba51477a00b22b6ed",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:35:11 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "31",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d6fce82c134341bba51477a00b22b6ed",
-        "x-ms-correlation-request-id": "6a35507b-8f9a-4e26-9cb2-1b607b09b8d5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11908",
-        "x-ms-request-id": "87c15e50-bc37-4a47-a8e0-c5e2d22400b5_M5SN1_M5SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043512Z:6a35507b-8f9a-4e26-9cb2-1b607b09b8d5"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:35:06.583Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "45e0ef4be062c611a782e8e4f64baffd",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:35:13 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "54",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "45e0ef4be062c611a782e8e4f64baffd",
-        "x-ms-correlation-request-id": "2ae2de52-3da9-4071-b017-624971c8ec12",
-        "x-ms-ratelimit-remaining-subscription-reads": "11907",
-        "x-ms-request-id": "04c47c83-a374-48be-ae08-c3e7c0411fc9_M8SN1_M8SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043514Z:2ae2de52-3da9-4071-b017-624971c8ec12"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:35:06.583Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "163306053da0ffcc993fb39efea4711f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:35:14 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "46",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "163306053da0ffcc993fb39efea4711f",
-        "x-ms-correlation-request-id": "f60aef28-9a5b-46d3-9faf-c5a7ce05e289",
-        "x-ms-ratelimit-remaining-subscription-reads": "11906",
-        "x-ms-request-id": "383cc8c3-053c-48d5-845b-637906141112_M10SN1_M10SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043515Z:f60aef28-9a5b-46d3-9faf-c5a7ce05e289"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:35:06.583Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5735d8e390d14b45d6362ec02ad74a59",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:35:17 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "53",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5735d8e390d14b45d6362ec02ad74a59",
-        "x-ms-correlation-request-id": "ed72f52b-ea53-4868-811e-7d9f6eca1738",
-        "x-ms-ratelimit-remaining-subscription-reads": "11905",
-        "x-ms-request-id": "f2263b87-6b9a-487b-8c40-0d46ff2faf59_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043517Z:ed72f52b-ea53-4868-811e-7d9f6eca1738"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:35:06.583Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "049b7a649fee0e4d23e0ac232d73c703",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:35:18 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "46",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "049b7a649fee0e4d23e0ac232d73c703",
-        "x-ms-correlation-request-id": "d82756c8-3dd4-4428-91f5-1b4827d13d4e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11904",
-        "x-ms-request-id": "c4fd60e3-2a2d-447f-8650-6d6b466a8108_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043519Z:d82756c8-3dd4-4428-91f5-1b4827d13d4e"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:35:06.583Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1d00c9115816752bc0e8406a0e0bd5c1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:35:21 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "45",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "1d00c9115816752bc0e8406a0e0bd5c1",
-        "x-ms-correlation-request-id": "c5a7a74d-49e6-43c5-bbde-5ffdbaec8f08",
-        "x-ms-ratelimit-remaining-subscription-reads": "11903",
-        "x-ms-request-id": "73bd5046-b753-4afe-a891-57f48e34008f_M8SN1_M8SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043522Z:c5a7a74d-49e6-43c5-bbde-5ffdbaec8f08"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:35:06.583Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "843a59f46c0944308b2634f0e3221e63",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:35:22 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "33",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "843a59f46c0944308b2634f0e3221e63",
-        "x-ms-correlation-request-id": "47858c93-7ece-4ff8-b8d3-c9097c52c1d8",
-        "x-ms-ratelimit-remaining-subscription-reads": "11902",
-        "x-ms-request-id": "23668878-41cc-4379-8a88-7d88b61597a1_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043523Z:47858c93-7ece-4ff8-b8d3-c9097c52c1d8"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:35:06.583Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "61af2b6e2dd60c434f2543065fe20017",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:35:25 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "41",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "61af2b6e2dd60c434f2543065fe20017",
-        "x-ms-correlation-request-id": "5e7828ad-9b2b-46af-8ba3-69dc533208b8",
-        "x-ms-ratelimit-remaining-subscription-reads": "11901",
-        "x-ms-request-id": "555b9eb1-0c0c-4919-a037-ea3e9ae46d8d_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043525Z:5e7828ad-9b2b-46af-8ba3-69dc533208b8"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:35:06.583Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d42fea0b4338a4fa98bc92f0243a919e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:35:28 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "31",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d42fea0b4338a4fa98bc92f0243a919e",
-        "x-ms-correlation-request-id": "8fa80542-b610-415e-b0d6-0908e559bc6e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11900",
-        "x-ms-request-id": "2598d193-79a8-4264-ba58-becbaa4013d6_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043528Z:8fa80542-b610-415e-b0d6-0908e559bc6e"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103",
-        "name": "testnamespacemgmt9103",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9103",
-          "createdAt": "2021-11-05T04:33:24.34Z",
-          "updatedAt": "2021-11-05T04:35:06.583Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9103.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-9363/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9103/operationresults/testnamespacemgmt9103?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e3fbdcc9735cc7ea152e35e3292ae4a8",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Date": "Fri, 05 Nov 2021 04:35:30 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "e3fbdcc9735cc7ea152e35e3292ae4a8",
-        "x-ms-correlation-request-id": "cd9dc93c-35e4-438d-ba52-37e6cc638708",
-        "x-ms-ratelimit-remaining-subscription-reads": "11899",
-        "x-ms-request-id": "3fa44c6b-c9e9-468a-8cef-0a8b6d22414e_M1SN1_M1SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T043530Z:cd9dc93c-35e4-438d-ba52-37e6cc638708"
-      },
-      "ResponseBody": []
+      "ResponseBody": null
     }
   ],
   "Variables": {
-    "RandomSeed": "1552650492",
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
+    "RandomSeed": "2118807964",
     "RESOURCE_MANAGER_URL": null,
     "SUBSCRIPTION_ID": "db1ab6f0-4769-4b27-930e-01e2ef9c123c"
   }

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventhubTests/CreateEventhubWithParameterAsync.json
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventhubTests/CreateEventhubWithParameterAsync.json
@@ -6,34 +6,43 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-052f2f9d8b881c45b9065a38016dfd94-584595b1c7942242-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3369cbf374a9384ddb45a135da89d013",
+        "traceparent": "00-e7a32ad4e666364da98489287543e835-c4fc2e24923cc642-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "8cc4f96a4a789ea4e66dc8306f5eca94",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "468",
+        "Content-Length": "747",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:01 GMT",
+        "Date": "Wed, 29 Jun 2022 14:51:38 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "aee3ca5a-ba40-49e9-a984-0a5ef006babd",
-        "x-ms-ratelimit-remaining-subscription-reads": "11935",
-        "x-ms-request-id": "aee3ca5a-ba40-49e9-a984-0a5ef006babd",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044201Z:aee3ca5a-ba40-49e9-a984-0a5ef006babd"
+        "x-ms-correlation-request-id": "1da17a34-6fdb-4c4c-b4d9-283c11a8c712",
+        "x-ms-ratelimit-remaining-subscription-reads": "11965",
+        "x-ms-request-id": "1da17a34-6fdb-4c4c-b4d9-283c11a8c712",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145138Z:1da17a34-6fdb-4c4c-b4d9-283c11a8c712"
       },
       "ResponseBody": {
         "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "authorizationSource": "RoleBased",
         "managedByTenants": [],
         "tags": {
-          "tagKey1": "tagValue1",
-          "tagKey2": "tagValue2"
+          "TagKey-9823": "TagValue-566",
+          "TagKey-3481": "TagValue-320",
+          "TagKey-4926": "TagValue-1187",
+          "TagKey-751": "TagValue-3921",
+          "TagKey-1866": "TagValue-8559",
+          "TagKey-3094": "TagValue-9190",
+          "TagKey-2449": "TagValue-9",
+          "TagKey-8379": "TagValue-164",
+          "TagKey-7470": "TagValue-2205",
+          "TagKey-4236": "TagValue-3698",
+          "TagKey-5316": "TagValue-2725"
         },
         "subscriptionId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
@@ -47,15 +56,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourcegroups/testeventhubRG-4560?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourcegroups/testeventhubRG-6891?api-version=2021-04-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "44",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5e0e34f007b1972bb569198836562be1",
+        "traceparent": "00-1223864575d7ee4cbba51e3f3fbadac2-64a617f4535ea740-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "67913507966b4fe8444d2b540728aa30",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -69,19 +79,19 @@
         "Cache-Control": "no-cache",
         "Content-Length": "258",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:02 GMT",
+        "Date": "Wed, 29 Jun 2022 14:51:40 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "5c35e661-1b46-434a-8f98-0994317e8dcd",
-        "x-ms-ratelimit-remaining-subscription-writes": "1198",
-        "x-ms-request-id": "5c35e661-1b46-434a-8f98-0994317e8dcd",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044202Z:5c35e661-1b46-434a-8f98-0994317e8dcd"
+        "x-ms-correlation-request-id": "cc863934-4fdb-4138-9023-2bcfc478523c",
+        "x-ms-ratelimit-remaining-subscription-writes": "1193",
+        "x-ms-request-id": "cc863934-4fdb-4138-9023-2bcfc478523c",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145140Z:cc863934-4fdb-4138-9023-2bcfc478523c"
       },
       "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560",
-        "name": "testeventhubRG-4560",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891",
+        "name": "testeventhubRG-6891",
         "type": "Microsoft.Resources/resourceGroups",
         "location": "eastus2",
         "tags": {
@@ -100,33 +110,34 @@
         "Authorization": "Sanitized",
         "Content-Length": "32",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211105.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e64881af23cafb00f918097aa915a998",
+        "traceparent": "00-61621e45a38c574ea3accddcf369e13d-3e8dbf2429318b40-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ef9c513ef786122a21274c1654557f2e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "testnamespacemgmt8909"
+        "name": "testnamespacemgmt9092"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "53",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:02 GMT",
+        "Date": "Wed, 29 Jun 2022 14:51:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "e64881af23cafb00f918097aa915a998",
-        "x-ms-correlation-request-id": "eae7429f-8c83-4d9c-a46e-1cc48e84cb65",
-        "x-ms-ratelimit-remaining-subscription-writes": "1199",
-        "x-ms-request-id": "f831ce8e-5d04-477e-bd36-303173b6efc7_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044203Z:eae7429f-8c83-4d9c-a46e-1cc48e84cb65"
+        "x-ms-client-request-id": "ef9c513ef786122a21274c1654557f2e",
+        "x-ms-correlation-request-id": "a5b41468-307d-4ec5-bb3b-ea30870a04d5",
+        "x-ms-ratelimit-remaining-subscription-writes": "1197",
+        "x-ms-request-id": "119f9037-d293-4c05-b7c7-ecb5596b58cf_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145142Z:a5b41468-307d-4ec5-bb3b-ea30870a04d5"
       },
       "ResponseBody": {
         "nameAvailable": true,
@@ -135,15 +146,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092?api-version=2021-11-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "48",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211105.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2ba8522e41b43dc39cf40b33b0a4ef75",
+        "traceparent": "00-b153db0c07fc454a9fa9caa9e5fec74f-7c6e99356cffee4f-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "be740b55fe92dc623d34fc794ade451d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -156,21 +168,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:08 GMT",
+        "Date": "Wed, 29 Jun 2022 14:51:48 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2ba8522e41b43dc39cf40b33b0a4ef75",
-        "x-ms-correlation-request-id": "20d02a64-bac5-46b9-87c4-ee470e54ad08",
-        "x-ms-ratelimit-remaining-subscription-resource-requests": "49",
-        "x-ms-request-id": "b44e66a1-9a3c-4366-95a8-bdd3aa195a23_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044208Z:20d02a64-bac5-46b9-87c4-ee470e54ad08"
+        "x-ms-client-request-id": "be740b55fe92dc623d34fc794ade451d",
+        "x-ms-correlation-request-id": "b807d4f5-6db5-4d50-b0e2-33bdb6c4bcee",
+        "x-ms-ratelimit-remaining-subscription-resource-requests": "48",
+        "x-ms-request-id": "963b900e-73a1-4a89-8ce0-5b200df8487f_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145148Z:b807d4f5-6db5-4d50-b0e2-33bdb6c4bcee"
       },
       "ResponseBody": {
         "sku": {
@@ -178,8 +190,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092",
+        "name": "testnamespacemgmt9092",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -190,21 +202,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9092",
+          "createdAt": "2022-06-29T14:51:45.703Z",
+          "updatedAt": "2022-06-29T14:51:45.703Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt9092.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0308ef70b5836d3bbe0b4ad618cc4b54",
+        "traceparent": "00-b153db0c07fc454a9fa9caa9e5fec74f-940e881cc1f51e4d-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "1cb225ab7136401eefc0b151fab0c842",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -213,21 +226,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:10 GMT",
+        "Date": "Wed, 29 Jun 2022 14:51:51 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "0308ef70b5836d3bbe0b4ad618cc4b54",
-        "x-ms-correlation-request-id": "726d5cf0-92f0-444d-91cd-0873276d1568",
-        "x-ms-ratelimit-remaining-subscription-reads": "11934",
-        "x-ms-request-id": "9fd2bb4a-20f8-4e68-a8e2-12e049cf51d1_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044210Z:726d5cf0-92f0-444d-91cd-0873276d1568"
+        "x-ms-client-request-id": "1cb225ab7136401eefc0b151fab0c842",
+        "x-ms-correlation-request-id": "9b1c078d-b3d1-4f73-bcf9-e46fe239422b",
+        "x-ms-ratelimit-remaining-subscription-reads": "11964",
+        "x-ms-request-id": "83a7dea5-98e5-4b5e-b891-06ee27834960_M8CH3_M8CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145151Z:9b1c078d-b3d1-4f73-bcf9-e46fe239422b"
       },
       "ResponseBody": {
         "sku": {
@@ -235,8 +248,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092",
+        "name": "testnamespacemgmt9092",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -247,21 +260,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9092",
+          "createdAt": "2022-06-29T14:51:45.703Z",
+          "updatedAt": "2022-06-29T14:51:45.703Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt9092.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bf2793295a3a9ece2c971d518ad31c7f",
+        "traceparent": "00-b153db0c07fc454a9fa9caa9e5fec74f-955d6968deedc445-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "95162fe2063696378935563eb4f34104",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -270,21 +284,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:11 GMT",
+        "Date": "Wed, 29 Jun 2022 14:51:53 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "bf2793295a3a9ece2c971d518ad31c7f",
-        "x-ms-correlation-request-id": "d436e09e-238f-47db-a312-bfab9e074367",
-        "x-ms-ratelimit-remaining-subscription-reads": "11933",
-        "x-ms-request-id": "e7a784c5-b483-4549-b281-0e61605068f5_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044211Z:d436e09e-238f-47db-a312-bfab9e074367"
+        "x-ms-client-request-id": "95162fe2063696378935563eb4f34104",
+        "x-ms-correlation-request-id": "7ff0b6ce-5cf3-4524-ba62-a865f8df01fc",
+        "x-ms-ratelimit-remaining-subscription-reads": "11963",
+        "x-ms-request-id": "9c1633cf-53b8-490a-a317-74b4ffada2d6_M8CH3_M8CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145153Z:7ff0b6ce-5cf3-4524-ba62-a865f8df01fc"
       },
       "ResponseBody": {
         "sku": {
@@ -292,8 +306,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092",
+        "name": "testnamespacemgmt9092",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -304,21 +318,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9092",
+          "createdAt": "2022-06-29T14:51:45.703Z",
+          "updatedAt": "2022-06-29T14:51:45.703Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt9092.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c1c3b6e8eb9c9df2ae6d90bf454ff841",
+        "traceparent": "00-b153db0c07fc454a9fa9caa9e5fec74f-6a862066df0c5744-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "24cd0444282c8ee7a0df89370d2f43b6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -327,21 +342,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:12 GMT",
+        "Date": "Wed, 29 Jun 2022 14:51:56 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c1c3b6e8eb9c9df2ae6d90bf454ff841",
-        "x-ms-correlation-request-id": "1a5057af-a2d3-45e8-baa4-75cffa05d667",
-        "x-ms-ratelimit-remaining-subscription-reads": "11932",
-        "x-ms-request-id": "48ba823a-d847-4971-a50b-6f64fba8a2af_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044213Z:1a5057af-a2d3-45e8-baa4-75cffa05d667"
+        "x-ms-client-request-id": "24cd0444282c8ee7a0df89370d2f43b6",
+        "x-ms-correlation-request-id": "525deb4c-ffd3-4900-91d1-0af25f784451",
+        "x-ms-ratelimit-remaining-subscription-reads": "11962",
+        "x-ms-request-id": "1a8dc041-cea0-4cc2-9dac-a494a618b45c_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145156Z:525deb4c-ffd3-4900-91d1-0af25f784451"
       },
       "ResponseBody": {
         "sku": {
@@ -349,8 +364,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092",
+        "name": "testnamespacemgmt9092",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -361,21 +376,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9092",
+          "createdAt": "2022-06-29T14:51:45.703Z",
+          "updatedAt": "2022-06-29T14:51:45.703Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt9092.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8ec662164cf515192169d7eb98eae3ea",
+        "traceparent": "00-b153db0c07fc454a9fa9caa9e5fec74f-184e016bad8ff749-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6b8d088c5a23a4c1ee1c93001adf8cfb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -384,21 +400,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:14 GMT",
+        "Date": "Wed, 29 Jun 2022 14:51:58 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8ec662164cf515192169d7eb98eae3ea",
-        "x-ms-correlation-request-id": "b382922f-d85f-467d-8e47-6a6289d5f324",
-        "x-ms-ratelimit-remaining-subscription-reads": "11931",
-        "x-ms-request-id": "f05f0628-339c-45d4-a08d-d9c251a48400_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044214Z:b382922f-d85f-467d-8e47-6a6289d5f324"
+        "x-ms-client-request-id": "6b8d088c5a23a4c1ee1c93001adf8cfb",
+        "x-ms-correlation-request-id": "d3f0cb95-0458-4350-8381-917d870dab24",
+        "x-ms-ratelimit-remaining-subscription-reads": "11961",
+        "x-ms-request-id": "91df2610-e7d5-4359-9f71-6f3623446eac_M2CH3_M2CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145158Z:d3f0cb95-0458-4350-8381-917d870dab24"
       },
       "ResponseBody": {
         "sku": {
@@ -406,8 +422,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092",
+        "name": "testnamespacemgmt9092",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -418,21 +434,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9092",
+          "createdAt": "2022-06-29T14:51:45.703Z",
+          "updatedAt": "2022-06-29T14:51:45.703Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt9092.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "61eecaef8a093db7a18911cdca0e59dd",
+        "traceparent": "00-b153db0c07fc454a9fa9caa9e5fec74f-c36e693e25b99547-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f60dac7ea3e3b9164887f4577dff8859",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -441,21 +458,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:15 GMT",
+        "Date": "Wed, 29 Jun 2022 14:52:02 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "61eecaef8a093db7a18911cdca0e59dd",
-        "x-ms-correlation-request-id": "093233c3-a7c6-44e9-9d53-682738b2df2c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11930",
-        "x-ms-request-id": "e10573f8-73e7-44ff-9c17-c3957305a048_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044216Z:093233c3-a7c6-44e9-9d53-682738b2df2c"
+        "x-ms-client-request-id": "f60dac7ea3e3b9164887f4577dff8859",
+        "x-ms-correlation-request-id": "a345e07d-59bd-4a56-b10a-f310f1de2279",
+        "x-ms-ratelimit-remaining-subscription-reads": "11960",
+        "x-ms-request-id": "0ec6e66f-f4a2-4a9c-a0df-f4541dbbc94a_M8CH3_M8CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145202Z:a345e07d-59bd-4a56-b10a-f310f1de2279"
       },
       "ResponseBody": {
         "sku": {
@@ -463,8 +480,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092",
+        "name": "testnamespacemgmt9092",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -475,21 +492,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9092",
+          "createdAt": "2022-06-29T14:51:45.703Z",
+          "updatedAt": "2022-06-29T14:51:45.703Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt9092.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "273adb9f8d0d9b899dada033140604c4",
+        "traceparent": "00-b153db0c07fc454a9fa9caa9e5fec74f-50c3de543b838146-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "acb19ff1d565e9e14229351094e673c1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -498,21 +516,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:17 GMT",
+        "Date": "Wed, 29 Jun 2022 14:52:07 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "273adb9f8d0d9b899dada033140604c4",
-        "x-ms-correlation-request-id": "94404414-5e4f-4e85-818d-f25329d1fed4",
-        "x-ms-ratelimit-remaining-subscription-reads": "11929",
-        "x-ms-request-id": "0e2533e7-87f4-498a-8ae3-522adf89d66c_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044217Z:94404414-5e4f-4e85-818d-f25329d1fed4"
+        "x-ms-client-request-id": "acb19ff1d565e9e14229351094e673c1",
+        "x-ms-correlation-request-id": "d1f20f02-1212-451a-bdf7-9a22cdba3b8b",
+        "x-ms-ratelimit-remaining-subscription-reads": "11959",
+        "x-ms-request-id": "0c3ccdc3-34af-4de3-a568-e6baa9fc2ee8_M8CH3_M8CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145207Z:d1f20f02-1212-451a-bdf7-9a22cdba3b8b"
       },
       "ResponseBody": {
         "sku": {
@@ -520,8 +538,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092",
+        "name": "testnamespacemgmt9092",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -532,21 +550,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9092",
+          "createdAt": "2022-06-29T14:51:45.703Z",
+          "updatedAt": "2022-06-29T14:51:45.703Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt9092.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7ad0a58a96608c38aa88ec6c3b4c4b12",
+        "traceparent": "00-b153db0c07fc454a9fa9caa9e5fec74f-238504130212c04c-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "61b88d524d22e8d3f2d3239b666a27ef",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -555,21 +574,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:18 GMT",
+        "Date": "Wed, 29 Jun 2022 14:52:16 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "7ad0a58a96608c38aa88ec6c3b4c4b12",
-        "x-ms-correlation-request-id": "022e7f9e-80e4-4960-8cb5-a7848a131799",
-        "x-ms-ratelimit-remaining-subscription-reads": "11928",
-        "x-ms-request-id": "7ad3bbca-5384-494f-bbec-52a3d4fd881e_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044218Z:022e7f9e-80e4-4960-8cb5-a7848a131799"
+        "x-ms-client-request-id": "61b88d524d22e8d3f2d3239b666a27ef",
+        "x-ms-correlation-request-id": "8d332204-6084-485a-8bd6-8df01e68538e",
+        "x-ms-ratelimit-remaining-subscription-reads": "11958",
+        "x-ms-request-id": "915aa402-c8a4-4e2c-b70d-181e7e19fe95_M6CH3_M6CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145217Z:8d332204-6084-485a-8bd6-8df01e68538e"
       },
       "ResponseBody": {
         "sku": {
@@ -577,8 +596,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092",
+        "name": "testnamespacemgmt9092",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -589,21 +608,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9092",
+          "createdAt": "2022-06-29T14:51:45.703Z",
+          "updatedAt": "2022-06-29T14:51:45.703Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt9092.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bd4cf90fbbaf61dd4152c45bea84299a",
+        "traceparent": "00-b153db0c07fc454a9fa9caa9e5fec74f-c57dd026177b814b-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "7a0e3994e02da996cb23b3b96d052461",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -612,21 +632,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:19 GMT",
+        "Date": "Wed, 29 Jun 2022 14:52:33 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "bd4cf90fbbaf61dd4152c45bea84299a",
-        "x-ms-correlation-request-id": "67890456-51e8-462e-95d5-6a532452b51d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11927",
-        "x-ms-request-id": "ea65745d-8ea6-40f3-b8b2-04ee9a1f199e_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044220Z:67890456-51e8-462e-95d5-6a532452b51d"
+        "x-ms-client-request-id": "7a0e3994e02da996cb23b3b96d052461",
+        "x-ms-correlation-request-id": "bbd203de-19d3-478a-baa1-fbb1d9bca583",
+        "x-ms-ratelimit-remaining-subscription-reads": "11957",
+        "x-ms-request-id": "75effe0c-e0b1-4fb6-9f9b-985d6436e94e_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145234Z:bbd203de-19d3-478a-baa1-fbb1d9bca583"
       },
       "ResponseBody": {
         "sku": {
@@ -634,8 +654,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092",
+        "name": "testnamespacemgmt9092",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -646,1560 +666,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9092",
+          "createdAt": "2022-06-29T14:51:45.703Z",
+          "updatedAt": "2022-06-29T14:51:45.703Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt9092.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "24434c84df3d097da3ae7c84a01d6051",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:21 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "24434c84df3d097da3ae7c84a01d6051",
-        "x-ms-correlation-request-id": "5d7ac488-6e9e-4a53-8942-93bcb57ccc5b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11926",
-        "x-ms-request-id": "2fb2efb4-444b-4847-9502-03eb9bf7cfaf_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044221Z:5d7ac488-6e9e-4a53-8942-93bcb57ccc5b"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1b248d6247bace15c76f390dd1dca126",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:22 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "1b248d6247bace15c76f390dd1dca126",
-        "x-ms-correlation-request-id": "d37f54e3-0af6-42b0-85b9-b40fc1d91276",
-        "x-ms-ratelimit-remaining-subscription-reads": "11925",
-        "x-ms-request-id": "6b43d04d-d4fb-4250-9fb4-a0458bd46044_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044222Z:d37f54e3-0af6-42b0-85b9-b40fc1d91276"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "eee8525e26082fd57b4319003f58c024",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:23 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "eee8525e26082fd57b4319003f58c024",
-        "x-ms-correlation-request-id": "c784b34a-2fa1-4930-b7ba-891fed8c92f9",
-        "x-ms-ratelimit-remaining-subscription-reads": "11924",
-        "x-ms-request-id": "b15fe355-f42b-4bed-ae08-b5c030be07f0_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044224Z:c784b34a-2fa1-4930-b7ba-891fed8c92f9"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5df973f20e5f3cdf37755dcda67037c6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:25 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5df973f20e5f3cdf37755dcda67037c6",
-        "x-ms-correlation-request-id": "b17696c9-f269-4bcd-8630-84ef0ec0dea4",
-        "x-ms-ratelimit-remaining-subscription-reads": "11923",
-        "x-ms-request-id": "ba2b697a-8b0f-44c6-bce0-9b690fa6af1f_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044225Z:b17696c9-f269-4bcd-8630-84ef0ec0dea4"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4e25550c72343c48b8f49f772e148e6e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:26 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "4e25550c72343c48b8f49f772e148e6e",
-        "x-ms-correlation-request-id": "30dbe570-04d7-4a0a-a344-04d03e4aac51",
-        "x-ms-ratelimit-remaining-subscription-reads": "11922",
-        "x-ms-request-id": "b96340a0-c8a6-4233-abce-e000f710761e_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044227Z:30dbe570-04d7-4a0a-a344-04d03e4aac51"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5e1b14af44e350c672abb693c907890b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:28 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5e1b14af44e350c672abb693c907890b",
-        "x-ms-correlation-request-id": "a1dd8274-33f2-4de1-baf8-911769eea85d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11921",
-        "x-ms-request-id": "dcb18b90-dae5-4ea2-8e5b-274389aa29b2_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044228Z:a1dd8274-33f2-4de1-baf8-911769eea85d"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e9f3520b71337fef2abca46b6e670e23",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:29 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "e9f3520b71337fef2abca46b6e670e23",
-        "x-ms-correlation-request-id": "cb12d8d5-7682-4168-94bb-1cc2ddf9d1a9",
-        "x-ms-ratelimit-remaining-subscription-reads": "11920",
-        "x-ms-request-id": "98bef7d9-8b59-48fe-b51c-a1b1200eae8d_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044229Z:cb12d8d5-7682-4168-94bb-1cc2ddf9d1a9"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "911eeee6d955c8e38fd5db89bcb573b0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:30 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "911eeee6d955c8e38fd5db89bcb573b0",
-        "x-ms-correlation-request-id": "2d695afc-4ae6-4235-8dc4-fa9548a77abb",
-        "x-ms-ratelimit-remaining-subscription-reads": "11919",
-        "x-ms-request-id": "fa83004d-989c-4f42-befe-5d3659ca8237_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044231Z:2d695afc-4ae6-4235-8dc4-fa9548a77abb"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "db6c946ba5213d3b259b33269f5be10a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:32 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "db6c946ba5213d3b259b33269f5be10a",
-        "x-ms-correlation-request-id": "04431983-0200-4d38-8768-b319a6ebfd81",
-        "x-ms-ratelimit-remaining-subscription-reads": "11918",
-        "x-ms-request-id": "7473bb87-de6c-4980-b35d-28e42ef09887_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044232Z:04431983-0200-4d38-8768-b319a6ebfd81"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "daac939df7e832b56f2b5a5d9666c375",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:33 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "daac939df7e832b56f2b5a5d9666c375",
-        "x-ms-correlation-request-id": "81e68021-092a-4048-92c7-c5d99879d9ef",
-        "x-ms-ratelimit-remaining-subscription-reads": "11917",
-        "x-ms-request-id": "32554cba-0766-4b07-b4ac-e18839f53d02_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044234Z:81e68021-092a-4048-92c7-c5d99879d9ef"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "dafff44932fb4102b3e06cb9a5bd2833",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:35 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "dafff44932fb4102b3e06cb9a5bd2833",
-        "x-ms-correlation-request-id": "86a38497-ac8e-4722-bade-8afd370d0e28",
-        "x-ms-ratelimit-remaining-subscription-reads": "11916",
-        "x-ms-request-id": "0b6d68a3-5eea-43e9-ba2e-65096f793e51_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044235Z:86a38497-ac8e-4722-bade-8afd370d0e28"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "29ebd0f3980973c8de396cf54bdda7bf",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:36 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "29ebd0f3980973c8de396cf54bdda7bf",
-        "x-ms-correlation-request-id": "b5d4e016-7896-4b40-a285-926326b77e3e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11915",
-        "x-ms-request-id": "b51d0060-a9cb-4304-aa04-a4cb0e130d0b_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044236Z:b5d4e016-7896-4b40-a285-926326b77e3e"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "abdcbed7075b6a0f916b27078bfb8cb1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:37 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "abdcbed7075b6a0f916b27078bfb8cb1",
-        "x-ms-correlation-request-id": "9d6edabf-82c8-4c5e-9b80-26881a571a36",
-        "x-ms-ratelimit-remaining-subscription-reads": "11914",
-        "x-ms-request-id": "2debeca8-0707-4b52-8b4e-6128638cb7cf_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044238Z:9d6edabf-82c8-4c5e-9b80-26881a571a36"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c56a26029a7ab06c2b8cfbc2c60cf5d5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:39 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c56a26029a7ab06c2b8cfbc2c60cf5d5",
-        "x-ms-correlation-request-id": "49dea711-3344-4728-ab4e-30190373ca81",
-        "x-ms-ratelimit-remaining-subscription-reads": "11913",
-        "x-ms-request-id": "43fe1795-a2eb-48c8-8c27-bd70f4e42212_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044239Z:49dea711-3344-4728-ab4e-30190373ca81"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e7e1ac397ce0ecd8c180979d71c0e8e3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:40 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "e7e1ac397ce0ecd8c180979d71c0e8e3",
-        "x-ms-correlation-request-id": "8567e088-9cbe-45df-bc19-b233522d45ef",
-        "x-ms-ratelimit-remaining-subscription-reads": "11912",
-        "x-ms-request-id": "c59ae8dd-f56c-4a73-b5db-c48c63f586b5_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044240Z:8567e088-9cbe-45df-bc19-b233522d45ef"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "24f3baade2733d45522b7fcf0c4ca484",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:41 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "24f3baade2733d45522b7fcf0c4ca484",
-        "x-ms-correlation-request-id": "eb12f235-b9f6-4abf-9f62-18b90d150806",
-        "x-ms-ratelimit-remaining-subscription-reads": "11911",
-        "x-ms-request-id": "032c1009-5469-4d73-a0d9-27a950e588d5_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044242Z:eb12f235-b9f6-4abf-9f62-18b90d150806"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "dece5175a41985d14d7e03f902ce3f6b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:43 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "dece5175a41985d14d7e03f902ce3f6b",
-        "x-ms-correlation-request-id": "28bc0d64-6670-4aba-9deb-4a836a5676fc",
-        "x-ms-ratelimit-remaining-subscription-reads": "11910",
-        "x-ms-request-id": "72839bd6-e161-46da-ab5a-aeb16f04e345_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044243Z:28bc0d64-6670-4aba-9deb-4a836a5676fc"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0b1518a3d019576267a495b4fc09df74",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:44 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "0b1518a3d019576267a495b4fc09df74",
-        "x-ms-correlation-request-id": "00ecccb8-99f9-4cee-a832-7f48d4fec4a1",
-        "x-ms-ratelimit-remaining-subscription-reads": "11909",
-        "x-ms-request-id": "f48510c2-2a0e-4ff4-addf-ad277bd8f5f2_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044245Z:00ecccb8-99f9-4cee-a832-7f48d4fec4a1"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1f2713dc09f208c9e86dd7f5de4b3b83",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:46 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "1f2713dc09f208c9e86dd7f5de4b3b83",
-        "x-ms-correlation-request-id": "b7d583eb-bde6-456e-8a40-815962d93239",
-        "x-ms-ratelimit-remaining-subscription-reads": "11908",
-        "x-ms-request-id": "5447802b-e2f8-4d6d-b531-21c8dc6e558c_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044246Z:b7d583eb-bde6-456e-8a40-815962d93239"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f42b14ec9837a46bef7777750f1d8844",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:47 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f42b14ec9837a46bef7777750f1d8844",
-        "x-ms-correlation-request-id": "7f7750e0-b1fb-4685-b705-df8c9f8dfd97",
-        "x-ms-ratelimit-remaining-subscription-reads": "11907",
-        "x-ms-request-id": "7f25b1d5-5868-4a36-8187-0960b1b83a7f_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044247Z:7f7750e0-b1fb-4685-b705-df8c9f8dfd97"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ef1d8f9e20a69a784e0c23abf96d781b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:48 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "ef1d8f9e20a69a784e0c23abf96d781b",
-        "x-ms-correlation-request-id": "19fbce1e-2472-4989-83cc-7489fbe65dbe",
-        "x-ms-ratelimit-remaining-subscription-reads": "11906",
-        "x-ms-request-id": "0ada027c-c23a-4d14-bdfa-3e005a68ff88_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044249Z:19fbce1e-2472-4989-83cc-7489fbe65dbe"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e8c81169ebdd443da7832f7b9153f8cb",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:50 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "e8c81169ebdd443da7832f7b9153f8cb",
-        "x-ms-correlation-request-id": "322f8d04-b5ef-42a5-8d49-909385afff56",
-        "x-ms-ratelimit-remaining-subscription-reads": "11905",
-        "x-ms-request-id": "89573f53-3a0e-49c0-ba74-22f7f2b96c43_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044250Z:322f8d04-b5ef-42a5-8d49-909385afff56"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4f5692e44b2ecbdd9c91a52a75c0ab82",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:51 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "4f5692e44b2ecbdd9c91a52a75c0ab82",
-        "x-ms-correlation-request-id": "5665918d-52b4-4802-837e-d7ef870aec6c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11904",
-        "x-ms-request-id": "9dbb21c0-368c-4c30-a195-8ecdb84f0870_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044252Z:5665918d-52b4-4802-837e-d7ef870aec6c"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fd0c5bfea055b26652d84723f0fd08fa",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:53 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "fd0c5bfea055b26652d84723f0fd08fa",
-        "x-ms-correlation-request-id": "82469f9a-f290-4556-97e0-dc57c7bfcc91",
-        "x-ms-ratelimit-remaining-subscription-reads": "11903",
-        "x-ms-request-id": "b5f37ace-de00-4c7e-a08a-6eaafa33c263_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044253Z:82469f9a-f290-4556-97e0-dc57c7bfcc91"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "66c7571429161ded34fc4c4c4612cee7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:54 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "66c7571429161ded34fc4c4c4612cee7",
-        "x-ms-correlation-request-id": "7539a336-7531-4702-b9fd-30818b6d69a7",
-        "x-ms-ratelimit-remaining-subscription-reads": "11902",
-        "x-ms-request-id": "53a264d8-d4c9-44ef-b5f8-5118d2e170e5_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044254Z:7539a336-7531-4702-b9fd-30818b6d69a7"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "367cadd7fa4743762ba4fd5503badb9e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:55 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "367cadd7fa4743762ba4fd5503badb9e",
-        "x-ms-correlation-request-id": "2ea4e2de-4112-4ffa-a0ed-62191f87160b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11901",
-        "x-ms-request-id": "0861efb8-d820-4707-8da3-2811336d8ac9_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044256Z:2ea4e2de-4112-4ffa-a0ed-62191f87160b"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1d16aa8844f8d56c6eeec959541a6c3f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:57 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "1d16aa8844f8d56c6eeec959541a6c3f",
-        "x-ms-correlation-request-id": "9f387dcf-539b-4774-824d-af348edb3e70",
-        "x-ms-ratelimit-remaining-subscription-reads": "11900",
-        "x-ms-request-id": "526f5f90-7bfb-44ae-84ae-1950a24bf8c4_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044257Z:9f387dcf-539b-4774-824d-af348edb3e70"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:07.073Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "434b600ad28119b2e1833a722b971979",
+        "traceparent": "00-b153db0c07fc454a9fa9caa9e5fec74f-3b5fc2a5a2755444-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ef0433142746a336ccc8b991b14683d7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -2208,21 +690,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:42:58 GMT",
+        "Date": "Wed, 29 Jun 2022 14:53:06 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "434b600ad28119b2e1833a722b971979",
-        "x-ms-correlation-request-id": "e1355245-c0f0-4599-a625-f494aa3dce94",
-        "x-ms-ratelimit-remaining-subscription-reads": "11899",
-        "x-ms-request-id": "fd18ba8f-6f45-4da9-9ae6-fd605acdb2c5_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044258Z:e1355245-c0f0-4599-a625-f494aa3dce94"
+        "x-ms-client-request-id": "ef0433142746a336ccc8b991b14683d7",
+        "x-ms-correlation-request-id": "2faf0ea2-6791-42dd-9259-b7801f66a1b9",
+        "x-ms-ratelimit-remaining-subscription-reads": "11956",
+        "x-ms-request-id": "3848db8d-fa0b-43ea-b350-cf52307d2ac3_M9CH3_M9CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145306Z:2faf0ea2-6791-42dd-9259-b7801f66a1b9"
       },
       "ResponseBody": {
         "sku": {
@@ -2230,8 +712,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092",
+        "name": "testnamespacemgmt9092",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -2242,486 +724,1626 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:42:58.243Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9092",
+          "createdAt": "2022-06-29T14:51:45.703Z",
+          "updatedAt": "2022-06-29T14:52:36.007Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt9092.servicebus.windows.net:443/",
           "status": "Active"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.Storage/storageAccounts/storage8997?api-version=2021-04-01",
-      "RequestMethod": "PUT",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage?api-version=2021-04-01",
+      "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "105",
-        "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.Storage/1.0.0-beta.3 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fb9bc4adeeb04193a7c758311def1137",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "sku": {
-          "name": "Standard_LRS"
-        },
-        "kind": "StorageV2",
-        "location": "eastus2",
-        "properties": {
-          "accessTier": "Hot"
-        }
-      },
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:03 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "fb9bc4adeeb04193a7c758311def1137",
-        "x-ms-correlation-request-id": "d425120a-3f12-4201-bcaa-d7774f36b293",
-        "x-ms-ratelimit-remaining-subscription-writes": "1197",
-        "x-ms-request-id": "9a35d5b4-2965-4604-936a-291c2a0a25a0",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044304Z:d425120a-3f12-4201-bcaa-d7774f36b293"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "56a7384f43d17259b702da0a5ae7c494",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:04 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "56a7384f43d17259b702da0a5ae7c494",
-        "x-ms-correlation-request-id": "42ab58d7-c117-4c76-8eb7-8d05ae4e2b88",
-        "x-ms-ratelimit-remaining-subscription-reads": "11898",
-        "x-ms-request-id": "c9daa6fa-ef86-4e19-ad4d-ab6920a10b98",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044304Z:42ab58d7-c117-4c76-8eb7-8d05ae4e2b88"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4c6e3a290b7690890da3fe74788a47fd",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:05 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "4c6e3a290b7690890da3fe74788a47fd",
-        "x-ms-correlation-request-id": "deecb450-62ec-4365-904f-65f73a0ef193",
-        "x-ms-ratelimit-remaining-subscription-reads": "11897",
-        "x-ms-request-id": "8e2cbf2c-8c7a-478f-bbc1-dd06e9ec65e6",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044306Z:deecb450-62ec-4365-904f-65f73a0ef193"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e4e183f1bb477966f130b69543ab9d15",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:06 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "e4e183f1bb477966f130b69543ab9d15",
-        "x-ms-correlation-request-id": "74084cca-cbde-46a5-9be7-95c45fbbfb82",
-        "x-ms-ratelimit-remaining-subscription-reads": "11896",
-        "x-ms-request-id": "b36df416-07ad-41a0-8195-82ad0eee1cc5",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044307Z:74084cca-cbde-46a5-9be7-95c45fbbfb82"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c0e0e178893b445faf16482d45e5f92d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:08 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c0e0e178893b445faf16482d45e5f92d",
-        "x-ms-correlation-request-id": "82c1ce53-3e08-417f-8777-b00248de25e8",
-        "x-ms-ratelimit-remaining-subscription-reads": "11895",
-        "x-ms-request-id": "7e908eea-ddb0-4aba-af3d-86a065388827",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044308Z:82c1ce53-3e08-417f-8777-b00248de25e8"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d719dcbbdf066d4cd3f45b4554f34d62",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:09 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d719dcbbdf066d4cd3f45b4554f34d62",
-        "x-ms-correlation-request-id": "c7b93657-8ad1-4c45-a75a-44d1a87cf303",
-        "x-ms-ratelimit-remaining-subscription-reads": "11894",
-        "x-ms-request-id": "77f09945-ce0c-4471-aa7f-70849fbb6e2c",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044310Z:c7b93657-8ad1-4c45-a75a-44d1a87cf303"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "97fbe90586a967c2239c35317339340b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:10 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "97fbe90586a967c2239c35317339340b",
-        "x-ms-correlation-request-id": "b0a5712c-7c6a-46b7-9872-bd9bb4621135",
-        "x-ms-ratelimit-remaining-subscription-reads": "11893",
-        "x-ms-request-id": "89f9a7ad-a589-4fd4-8bf8-38d4d5febc80",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044311Z:b0a5712c-7c6a-46b7-9872-bd9bb4621135"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "66da8936c692990e9573ec472e1af0bb",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:12 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "66da8936c692990e9573ec472e1af0bb",
-        "x-ms-correlation-request-id": "360abc86-22bf-405f-b618-339b0dc5604b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11892",
-        "x-ms-request-id": "c5cb6d23-1d07-48d4-befa-88cdc9b02839",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044312Z:360abc86-22bf-405f-b618-339b0dc5604b"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5b28e6c962ea34841ab1b369a91bf999",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:13 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5b28e6c962ea34841ab1b369a91bf999",
-        "x-ms-correlation-request-id": "46dfafe4-318c-4e84-acdc-7ba54e561686",
-        "x-ms-ratelimit-remaining-subscription-reads": "11891",
-        "x-ms-request-id": "b3925b55-a15d-4076-8522-1f9c0673d030",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044314Z:46dfafe4-318c-4e84-acdc-7ba54e561686"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "cb0e4fbfe6193ecfda620236997b3809",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:14 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "cb0e4fbfe6193ecfda620236997b3809",
-        "x-ms-correlation-request-id": "675142f2-818c-4348-8b4e-298ea4e87af5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11890",
-        "x-ms-request-id": "9b9f34d2-9005-43d9-a782-3709748ba40a",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044315Z:675142f2-818c-4348-8b4e-298ea4e87af5"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8d677aacd910d42104a54ce113a5f07a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:16 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8d677aacd910d42104a54ce113a5f07a",
-        "x-ms-correlation-request-id": "22b3ca44-963e-42d5-8492-5bcb9bd2d3f3",
-        "x-ms-ratelimit-remaining-subscription-reads": "11889",
-        "x-ms-request-id": "b636f674-8807-4dea-a5c1-4b48d7202c7c",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044316Z:22b3ca44-963e-42d5-8492-5bcb9bd2d3f3"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "df875379250be3a216e98187604d9a9e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:17 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "17",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "df875379250be3a216e98187604d9a9e",
-        "x-ms-correlation-request-id": "52524fa9-a65d-44fe-b7be-976260627870",
-        "x-ms-ratelimit-remaining-subscription-reads": "11888",
-        "x-ms-request-id": "4082e89e-8602-4ff7-b493-48c32768b44e",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044318Z:52524fa9-a65d-44fe-b7be-976260627870"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2ebcaa786bb3e6892d3ac67399ee2b34",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:18 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "3",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2ebcaa786bb3e6892d3ac67399ee2b34",
-        "x-ms-correlation-request-id": "d50ec220-3c71-4a80-aa30-a0afa5f4b027",
-        "x-ms-ratelimit-remaining-subscription-reads": "11887",
-        "x-ms-request-id": "871e9112-b952-4b3b-ac01-b2673f0289e4",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044319Z:d50ec220-3c71-4a80-aa30-a0afa5f4b027"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "46bc887159f387fdd8847627579973b6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:19 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-        "Pragma": "no-cache",
-        "Retry-After": "3",
-        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "46bc887159f387fdd8847627579973b6",
-        "x-ms-correlation-request-id": "5af9f1b5-1020-4e8f-bbc1-0d5f34c09f0d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11886",
-        "x-ms-request-id": "68737eea-5634-4b3d-a287-2b9e59c76287",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044320Z:5af9f1b5-1020-4e8f-bbc1-0d5f34c09f0d"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/9a35d5b4-2965-4604-936a-291c2a0a25a0?monitor=true\u0026api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6868ad0bc1e80dc6caa1b1d15e2e4928",
+        "traceparent": "00-90ae4725066ed64090f82e2103e2305d-4a1564fd12589241-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "d75b7b4693f8f7720f95ff9a197becae",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1329",
+        "Content-Length": "20532",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 29 Jun 2022 14:53:06 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "ede271b7-e0e7-4086-b6b4-ad581d533d24",
+        "x-ms-ratelimit-remaining-subscription-reads": "11955",
+        "x-ms-request-id": "ede271b7-e0e7-4086-b6b4-ad581d533d24",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145307Z:ede271b7-e0e7-4086-b6b4-ad581d533d24"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage",
+        "namespace": "Microsoft.Storage",
+        "authorizations": [
+          {
+            "applicationId": "a6aa9161-5291-40bb-8c5c-923b567bee3b",
+            "roleDefinitionId": "070ab87f-0efc-4423-b18b-756f3bdb0236"
+          },
+          {
+            "applicationId": "e406a681-f3d4-42a8-90b6-c2b029497af1"
+          }
+        ],
+        "resourceTypes": [
+          {
+            "resourceType": "storageAccounts/encryptionScopes",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "deletedAccounts",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "locations/deletedAccounts",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "storageAccounts",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01",
+              "2016-01-01",
+              "2015-06-15",
+              "2015-05-01-preview"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2019-03-01-hybrid",
+                "apiVersion": "2017-10-01"
+              },
+              {
+                "profileVersion": "2017-03-09-profile",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-03-01-hybrid",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-06-01-profile",
+                "apiVersion": "2017-10-01"
+              }
+            ],
+            "zoneMappings": [
+              {
+                "location": "Australia East",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Brazil South",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Canada Central",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Central India",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Central US",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "East Asia",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "East US",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "East US 2",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "France Central",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Germany West Central",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Japan East",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Korea Central",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "North Central US",
+                "zones": []
+              },
+              {
+                "location": "North Europe",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Norway East",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "South Africa North",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "South Central US",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Southeast Asia",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Sweden Central",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "Switzerland North",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "UAE North",
+                "zones": []
+              },
+              {
+                "location": "UK South",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "West Europe",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "West US 2",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              },
+              {
+                "location": "West US 3",
+                "zones": [
+                  "2",
+                  "1",
+                  "3"
+                ]
+              }
+            ],
+            "capabilities": "CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags, SupportsLocation"
+          },
+          {
+            "resourceType": "operations",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01",
+              "2016-01-01",
+              "2015-06-15",
+              "2015-05-01-preview"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2019-03-01-hybrid",
+                "apiVersion": "2017-10-01"
+              },
+              {
+                "profileVersion": "2017-03-09-profile",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-03-01-hybrid",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-06-01-profile",
+                "apiVersion": "2017-10-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "locations/asyncoperations",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01",
+              "2016-01-01",
+              "2015-06-15",
+              "2015-05-01-preview"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2017-03-09-profile",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-03-01-hybrid",
+                "apiVersion": "2016-01-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "storageAccounts/listAccountSas",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2018-06-01-profile",
+                "apiVersion": "2017-10-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "storageAccounts/listServiceSas",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2018-06-01-profile",
+                "apiVersion": "2017-10-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "storageAccounts/blobServices",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2019-03-01-hybrid",
+                "apiVersion": "2017-10-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "storageAccounts/tableServices",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2019-03-01-hybrid",
+                "apiVersion": "2017-10-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "storageAccounts/queueServices",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2019-03-01-hybrid",
+                "apiVersion": "2017-10-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "storageAccounts/fileServices",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "locations",
+            "locations": [],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-07-01",
+              "2016-01-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2019-03-01-hybrid",
+                "apiVersion": "2017-10-01"
+              },
+              {
+                "profileVersion": "2017-03-09-profile",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-03-01-hybrid",
+                "apiVersion": "2016-01-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "locations/usages",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2017-03-09-profile",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-03-01-hybrid",
+                "apiVersion": "2016-01-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "locations/deleteVirtualNetworkOrSubnets",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-07-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "usages",
+            "locations": [],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01",
+              "2016-01-01",
+              "2015-06-15",
+              "2015-05-01-preview"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2019-03-01-hybrid",
+                "apiVersion": "2017-10-01"
+              },
+              {
+                "profileVersion": "2017-03-09-profile",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-03-01-hybrid",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-06-01-profile",
+                "apiVersion": "2017-10-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "checkNameAvailability",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-03-01-preview",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01",
+              "2016-05-01",
+              "2016-01-01",
+              "2015-06-15",
+              "2015-05-01-preview"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "apiProfiles": [
+              {
+                "profileVersion": "2019-03-01-hybrid",
+                "apiVersion": "2017-10-01"
+              },
+              {
+                "profileVersion": "2017-03-09-profile",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-03-01-hybrid",
+                "apiVersion": "2016-01-01"
+              },
+              {
+                "profileVersion": "2018-06-01-profile",
+                "apiVersion": "2017-10-01"
+              }
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "locations/checkNameAvailability",
+            "locations": [
+              "East US",
+              "East US 2",
+              "West US",
+              "West Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "Central US",
+              "North Europe",
+              "Brazil South",
+              "Australia East",
+              "Australia Southeast",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "Australia Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2021-09-01",
+              "2021-08-01",
+              "2021-06-01",
+              "2021-05-01",
+              "2021-04-01",
+              "2021-02-01",
+              "2021-01-01",
+              "2020-08-01-preview",
+              "2019-06-01",
+              "2019-04-01",
+              "2018-11-01",
+              "2018-07-01",
+              "2018-02-01",
+              "2017-10-01",
+              "2017-06-01",
+              "2016-12-01"
+            ],
+            "defaultApiVersion": "2019-06-01",
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "storageAccounts/services",
+            "locations": [
+              "East US",
+              "West US",
+              "East US 2 (Stage)",
+              "West Europe",
+              "North Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "East US 2",
+              "Central US",
+              "Australia East",
+              "Australia Southeast",
+              "Brazil South",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2014-04-01"
+            ],
+            "capabilities": "None"
+          },
+          {
+            "resourceType": "storageAccounts/services/metricDefinitions",
+            "locations": [
+              "East US",
+              "West US",
+              "East US 2 (Stage)",
+              "West Europe",
+              "North Europe",
+              "East Asia",
+              "Southeast Asia",
+              "Japan East",
+              "Japan West",
+              "North Central US",
+              "South Central US",
+              "East US 2",
+              "Central US",
+              "Australia East",
+              "Australia Southeast",
+              "Brazil South",
+              "South India",
+              "Central India",
+              "West India",
+              "Canada East",
+              "Canada Central",
+              "West US 2",
+              "West Central US",
+              "UK South",
+              "UK West",
+              "Korea Central",
+              "France Central",
+              "South Africa North",
+              "UAE North",
+              "Switzerland North",
+              "Germany West Central",
+              "Norway East",
+              "West US 3",
+              "Jio India West",
+              "Sweden Central",
+              "Korea South"
+            ],
+            "apiVersions": [
+              "2014-04-01"
+            ],
+            "capabilities": "None"
+          }
+        ],
+        "registrationState": "Registered",
+        "registrationPolicy": "RegistrationRequired"
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.Storage/storageAccounts/storage5023?api-version=2021-09-01",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "105",
         "Content-Type": "application/json",
-        "Date": "Fri, 05 Nov 2021 04:43:21 GMT",
+        "traceparent": "00-90ae4725066ed64090f82e2103e2305d-4687dc4f24aed941-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "663386c2a838026d6bae642604f8859f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "properties": {
+          "accessTier": "Hot"
+        },
+        "kind": "StorageV2",
+        "sku": {
+          "name": "Standard_LRS"
+        },
+        "location": "eastus2"
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Content-Type": "text/plain; charset=utf-8",
+        "Date": "Wed, 29 Jun 2022 14:53:11 GMT",
+        "Expires": "-1",
+        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/7987b9b8-202e-4733-b83d-2acc3e95e558?monitor=true\u0026api-version=2021-09-01",
+        "Pragma": "no-cache",
+        "Retry-After": "17",
+        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "663386c2a838026d6bae642604f8859f",
+        "x-ms-correlation-request-id": "65062d21-5188-44d4-9c62-81790422631f",
+        "x-ms-ratelimit-remaining-subscription-writes": "1192",
+        "x-ms-request-id": "7987b9b8-202e-4733-b83d-2acc3e95e558",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145311Z:65062d21-5188-44d4-9c62-81790422631f"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/7987b9b8-202e-4733-b83d-2acc3e95e558?monitor=true\u0026api-version=2021-09-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-90ae4725066ed64090f82e2103e2305d-4532f7db6e566343-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "bfefe3cd71509ec90e596c4a2e4cf317",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Content-Type": "text/plain; charset=utf-8",
+        "Date": "Wed, 29 Jun 2022 14:53:11 GMT",
+        "Expires": "-1",
+        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/7987b9b8-202e-4733-b83d-2acc3e95e558?monitor=true\u0026api-version=2021-09-01",
+        "Pragma": "no-cache",
+        "Retry-After": "17",
+        "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "bfefe3cd71509ec90e596c4a2e4cf317",
+        "x-ms-correlation-request-id": "196e5513-1869-45ad-8eea-4e463f6b75ce",
+        "x-ms-ratelimit-remaining-subscription-reads": "11954",
+        "x-ms-request-id": "6a759c9e-ef08-4220-a99c-6f3071f26f99",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145312Z:196e5513-1869-45ad-8eea-4e463f6b75ce"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage/locations/eastus2/asyncoperations/7987b9b8-202e-4733-b83d-2acc3e95e558?monitor=true\u0026api-version=2021-09-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-90ae4725066ed64090f82e2103e2305d-f7cc167db6105447-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "61be5f10615438e56b93d44170dbca61",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "1387",
+        "Content-Type": "application/json",
+        "Date": "Wed, 29 Jun 2022 14:53:28 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "6868ad0bc1e80dc6caa1b1d15e2e4928",
-        "x-ms-correlation-request-id": "67f256bf-e491-4f2e-bbba-e1ec4f2c5614",
-        "x-ms-ratelimit-remaining-subscription-reads": "11885",
-        "x-ms-request-id": "4f0913a5-824a-4a2d-8516-5023ee8d4bc7",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044321Z:67f256bf-e491-4f2e-bbba-e1ec4f2c5614"
+        "x-ms-client-request-id": "61be5f10615438e56b93d44170dbca61",
+        "x-ms-correlation-request-id": "48f46aae-d747-4394-b209-399ba5d48996",
+        "x-ms-ratelimit-remaining-subscription-reads": "11953",
+        "x-ms-request-id": "4bc2800f-6935-4919-b624-9ce579720b32",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145329Z:48f46aae-d747-4394-b209-399ba5d48996"
       },
       "ResponseBody": {
         "sku": {
@@ -2729,17 +2351,19 @@
           "tier": "Standard"
         },
         "kind": "StorageV2",
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.Storage/storageAccounts/storage8997",
-        "name": "storage8997",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.Storage/storageAccounts/storage5023",
+        "name": "storage5023",
         "type": "Microsoft.Storage/storageAccounts",
         "location": "eastus2",
         "tags": {},
         "properties": {
           "keyCreationTime": {
-            "key1": "2021-11-05T04:43:02.8855316Z",
-            "key2": "2021-11-05T04:43:02.8855316Z"
+            "key1": "2022-06-29T14:53:10.1955185Z",
+            "key2": "2022-06-29T14:53:10.1955185Z"
           },
           "privateEndpointConnections": [],
+          "minimumTlsVersion": "TLS1_0",
+          "allowBlobPublicAccess": true,
           "networkAcls": {
             "bypass": "AzureServices",
             "virtualNetworkRules": [],
@@ -2752,26 +2376,26 @@
               "file": {
                 "keyType": "Account",
                 "enabled": true,
-                "lastEnabledTime": "2021-11-05T04:43:02.8855316Z"
+                "lastEnabledTime": "2022-06-29T14:53:10.1955185Z"
               },
               "blob": {
                 "keyType": "Account",
                 "enabled": true,
-                "lastEnabledTime": "2021-11-05T04:43:02.8855316Z"
+                "lastEnabledTime": "2022-06-29T14:53:10.1955185Z"
               }
             },
             "keySource": "Microsoft.Storage"
           },
           "accessTier": "Hot",
           "provisioningState": "Succeeded",
-          "creationTime": "2021-11-05T04:43:02.7761457Z",
+          "creationTime": "2022-06-29T14:53:10.0392634Z",
           "primaryEndpoints": {
-            "dfs": "https://storage8997.dfs.core.windows.net/",
-            "web": "https://storage8997.z20.web.core.windows.net/",
-            "blob": "https://storage8997.blob.core.windows.net/",
-            "queue": "https://storage8997.queue.core.windows.net/",
-            "table": "https://storage8997.table.core.windows.net/",
-            "file": "https://storage8997.file.core.windows.net/"
+            "dfs": "https://storage5023.dfs.core.windows.net/",
+            "web": "https://storage5023.z20.web.core.windows.net/",
+            "blob": "https://storage5023.blob.core.windows.net/",
+            "queue": "https://storage5023.queue.core.windows.net/",
+            "table": "https://storage5023.table.core.windows.net/",
+            "file": "https://storage5023.file.core.windows.net/"
           },
           "primaryLocation": "eastus2",
           "statusOfPrimary": "available"
@@ -2779,15 +2403,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/eventhubs/eventhub6141?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092/eventhubs/eventhub2420?api-version=2021-11-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "564",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211105.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "91d8154cab53ad1f35562ff5618e93c6",
+        "traceparent": "00-0b671c97cb1d9740ab2af2fd369227d7-d6340901b29b8d43-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "082058174fc5ef69887b701cd1714503",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -2803,7 +2428,7 @@
             "destination": {
               "name": "EventHubArchive.AzureBlockBlob",
               "properties": {
-                "storageAccountResourceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.Storage/storageAccounts/storage8997",
+                "storageAccountResourceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.Storage/storageAccounts/storage5023",
                 "blobContainer": "container",
                 "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}"
               }
@@ -2814,9 +2439,9 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "947",
+        "Content-Length": "946",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:29 GMT",
+        "Date": "Wed, 29 Jun 2022 14:53:33 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -2826,23 +2451,23 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "91d8154cab53ad1f35562ff5618e93c6",
-        "x-ms-correlation-request-id": "491fe7bc-f312-4503-afca-cf2f2038749c",
-        "x-ms-ratelimit-remaining-subscription-writes": "1196",
-        "x-ms-request-id": "8cec8292-07f7-436f-9fb7-44b08f10afe0_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044329Z:491fe7bc-f312-4503-afca-cf2f2038749c"
+        "x-ms-client-request-id": "082058174fc5ef69887b701cd1714503",
+        "x-ms-correlation-request-id": "e23f1caa-a203-4c72-ae6d-10d63bfac59c",
+        "x-ms-ratelimit-remaining-subscription-writes": "1191",
+        "x-ms-request-id": "18d4a5e9-830a-4598-bb01-a3395ee25ac5_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145333Z:e23f1caa-a203-4c72-ae6d-10d63bfac59c"
       },
       "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/eventhubs/eventhub6141",
-        "name": "eventhub6141",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9092/eventhubs/eventhub2420",
+        "name": "eventhub2420",
         "type": "Microsoft.EventHub/Namespaces/EventHubs",
         "location": "East US 2",
         "properties": {
           "messageRetentionInDays": 4,
           "partitionCount": 4,
           "status": "Active",
-          "createdAt": "2021-11-05T04:43:28.99Z",
-          "updatedAt": "2021-11-05T04:43:29.233Z",
+          "createdAt": "2022-06-29T14:53:32.54Z",
+          "updatedAt": "2022-06-29T14:53:32.95Z",
           "partitionIds": [
             "0",
             "1",
@@ -2855,7 +2480,7 @@
             "destination": {
               "name": "EventHubArchive.AzureBlockBlob",
               "properties": {
-                "storageAccountResourceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.Storage/storageAccounts/storage8997",
+                "storageAccountResourceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.Storage/storageAccounts/storage5023",
                 "blobContainer": "container",
                 "archiveNameFormat": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}"
               }
@@ -2867,12 +2492,14 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.Storage/storageAccounts/storage8997?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6891/providers/Microsoft.Storage/storageAccounts/storage5023?api-version=2021-09-01",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
+        "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.Storage/1.0.0-beta.3 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "85ec670f4bc2c1b0ae7c52a82b28a93a",
+        "traceparent": "00-f4357981c39dbb4499aeb297cd69a4f6-541a6da1870a7d4d-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "4bd88120f950fe6bb654bd9d882d328e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -2881,979 +2508,24 @@
         "Cache-Control": "no-cache",
         "Content-Length": "0",
         "Content-Type": "text/plain; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:35 GMT",
+        "Date": "Wed, 29 Jun 2022 14:53:38 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": "Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "85ec670f4bc2c1b0ae7c52a82b28a93a",
-        "x-ms-correlation-request-id": "4663c138-ff6e-44b9-9105-b57b2d436479",
-        "x-ms-ratelimit-remaining-subscription-deletes": "14995",
-        "x-ms-request-id": "bc43bdd4-a924-4aaa-a639-fe1351abe22e",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044336Z:4663c138-ff6e-44b9-9105-b57b2d436479"
+        "x-ms-client-request-id": "4bd88120f950fe6bb654bd9d882d328e",
+        "x-ms-correlation-request-id": "a456af15-5775-481f-b0cd-0ae1b6259d4e",
+        "x-ms-ratelimit-remaining-subscription-deletes": "14998",
+        "x-ms-request-id": "d2c60909-ae77-4e50-bff8-51ce58d5dc32",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T145339Z:a456af15-5775-481f-b0cd-0ae1b6259d4e"
       },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211105.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "830b684d259b02b849bbb36b96186813",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "748",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:35 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "830b684d259b02b849bbb36b96186813",
-        "x-ms-correlation-request-id": "908f99f4-62b2-47eb-9946-2b2d7b641a07",
-        "x-ms-ratelimit-remaining-subscription-reads": "11884",
-        "x-ms-request-id": "91a62dd0-6299-45b1-8226-87cb5224e75c_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044336Z:908f99f4-62b2-47eb-9946-2b2d7b641a07"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "sku": {
-              "name": "Standard",
-              "tier": "Standard",
-              "capacity": 1
-            },
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-            "name": "testnamespacemgmt8909",
-            "type": "Microsoft.EventHub/Namespaces",
-            "location": "East US 2",
-            "tags": {},
-            "properties": {
-              "disableLocalAuth": false,
-              "zoneRedundant": false,
-              "isAutoInflateEnabled": false,
-              "maximumThroughputUnits": 0,
-              "kafkaEnabled": true,
-              "provisioningState": "Succeeded",
-              "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-              "createdAt": "2021-11-05T04:42:07.073Z",
-              "updatedAt": "2021-11-05T04:42:58.243Z",
-              "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-              "status": "Active"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211105.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c64f0a1da35d00fc6516e2d65976810c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Date": "Fri, 05 Nov 2021 04:43:37 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c64f0a1da35d00fc6516e2d65976810c",
-        "x-ms-correlation-request-id": "439b72c4-5d8e-46d4-9cc2-efb7c5c72ad7",
-        "x-ms-ratelimit-remaining-subscription-deletes": "14994",
-        "x-ms-request-id": "eae7e5f8-6788-4367-b11d-94b5c3b7cd7f_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044338Z:439b72c4-5d8e-46d4-9cc2-efb7c5c72ad7"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "208a3e14e3d9aadc6c0a1e8443e1a8d2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:38 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "40",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "208a3e14e3d9aadc6c0a1e8443e1a8d2",
-        "x-ms-correlation-request-id": "abb5f4d7-5ed5-4124-b05f-f02649a716d2",
-        "x-ms-ratelimit-remaining-subscription-reads": "11883",
-        "x-ms-request-id": "226cd457-6345-42dc-ba69-b20388d51429_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044339Z:abb5f4d7-5ed5-4124-b05f-f02649a716d2"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:43:38.24Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a1bea6396e700d8fdf65167367f56820",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:39 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "34",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a1bea6396e700d8fdf65167367f56820",
-        "x-ms-correlation-request-id": "3e5fd43e-7dae-4d44-98a1-f27f090fc9de",
-        "x-ms-ratelimit-remaining-subscription-reads": "11882",
-        "x-ms-request-id": "52dc7738-c5a0-4d78-9514-914b8e4557e2_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044340Z:3e5fd43e-7dae-4d44-98a1-f27f090fc9de"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:43:38.24Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1ac24bec60ecc93318fd8d78f1a7a5ce",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:40 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "40",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "1ac24bec60ecc93318fd8d78f1a7a5ce",
-        "x-ms-correlation-request-id": "448e15e9-ecd3-48f9-9457-71d271e80b6c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11881",
-        "x-ms-request-id": "61c2a683-a191-4109-8516-75b34c446315_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044341Z:448e15e9-ecd3-48f9-9457-71d271e80b6c"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:43:38.24Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f1cc69418986a526af7d4173cc694276",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:42 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "54",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f1cc69418986a526af7d4173cc694276",
-        "x-ms-correlation-request-id": "d5d88d6d-4c5c-4b20-8550-4261fad5ecd0",
-        "x-ms-ratelimit-remaining-subscription-reads": "11880",
-        "x-ms-request-id": "71666fa3-cf7f-4db1-a81f-b606dcec0189_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044343Z:d5d88d6d-4c5c-4b20-8550-4261fad5ecd0"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:43:38.24Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f898fea28e1fd9e673f58873e1171b37",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:43 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "35",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f898fea28e1fd9e673f58873e1171b37",
-        "x-ms-correlation-request-id": "6bbf8825-bfc8-40ff-8771-6b089b79d1cb",
-        "x-ms-ratelimit-remaining-subscription-reads": "11879",
-        "x-ms-request-id": "57bebf07-d175-4e12-b647-9e2f7f667677_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044344Z:6bbf8825-bfc8-40ff-8771-6b089b79d1cb"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:43:38.24Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fd3248bf76286299251c6b6f1fc0fcaf",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:45 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "56",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "fd3248bf76286299251c6b6f1fc0fcaf",
-        "x-ms-correlation-request-id": "4d9f3e5f-9a2e-4fb1-b3e9-10f9c32bd49b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11878",
-        "x-ms-request-id": "3c6ec2e9-376a-4591-913a-19d6027207fa_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044346Z:4d9f3e5f-9a2e-4fb1-b3e9-10f9c32bd49b"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:43:38.24Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f3d616baad0fb2ae83f37d9100b3c497",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:46 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "42",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f3d616baad0fb2ae83f37d9100b3c497",
-        "x-ms-correlation-request-id": "15089646-6ff3-4c7a-97b0-96f0e57bf9f4",
-        "x-ms-ratelimit-remaining-subscription-reads": "11877",
-        "x-ms-request-id": "434294da-74da-4d8e-ab73-0f057ece0c0c_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044347Z:15089646-6ff3-4c7a-97b0-96f0e57bf9f4"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:43:38.24Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "84b30a6145362b4e6535d2032276bab3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:47 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "59",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "84b30a6145362b4e6535d2032276bab3",
-        "x-ms-correlation-request-id": "aba0ac57-bb4a-40a3-85d0-740dccd22502",
-        "x-ms-ratelimit-remaining-subscription-reads": "11876",
-        "x-ms-request-id": "2c3e2e7b-a9fa-4cee-a575-2a2a1db6f32a_M3CH3_M3CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044348Z:aba0ac57-bb4a-40a3-85d0-740dccd22502"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:43:38.24Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "cab8d9f828401127997f7a35f9076272",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:49 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "30",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "cab8d9f828401127997f7a35f9076272",
-        "x-ms-correlation-request-id": "fb08cce1-4194-4a99-bd8d-8e6334213d63",
-        "x-ms-ratelimit-remaining-subscription-reads": "11875",
-        "x-ms-request-id": "5048222d-d313-4e4e-8f06-fbc56886280c_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044350Z:fb08cce1-4194-4a99-bd8d-8e6334213d63"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:43:38.24Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "140ed357780c7578c8ab8edadbab900c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:50 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "56",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "140ed357780c7578c8ab8edadbab900c",
-        "x-ms-correlation-request-id": "13399a01-469f-42d8-9d68-c6d37a7b34a0",
-        "x-ms-ratelimit-remaining-subscription-reads": "11874",
-        "x-ms-request-id": "c211de6f-6a3f-44cc-94b1-c9e0922fe310_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044351Z:13399a01-469f-42d8-9d68-c6d37a7b34a0"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:43:38.24Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2698ca39f9fa3857e2a1eab6ca18315d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Connection": "close",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:51 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "54",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2698ca39f9fa3857e2a1eab6ca18315d",
-        "x-ms-correlation-request-id": "48f4412d-b038-4e64-9a87-75086e3f40a0",
-        "x-ms-ratelimit-remaining-subscription-reads": "11873",
-        "x-ms-request-id": "f6b3c7ee-04b9-480b-a102-97fc6e0f310a_M3CH3_M3CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044352Z:48f4412d-b038-4e64-9a87-75086e3f40a0"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:43:38.24Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4fab60d3a56880a6604302959a4d36ed",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Connection": "close",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:55 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "55",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "4fab60d3a56880a6604302959a4d36ed",
-        "x-ms-correlation-request-id": "ac6048a7-ca70-4d8b-a04f-ff392a15d924",
-        "x-ms-ratelimit-remaining-subscription-reads": "11995",
-        "x-ms-request-id": "2458b0d5-5722-43df-8d0d-48366ab2b721_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044355Z:ac6048a7-ca70-4d8b-a04f-ff392a15d924"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:43:38.24Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2efb6def3b6f5d777cd5326b8dc2aaaf",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:57 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "34",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2efb6def3b6f5d777cd5326b8dc2aaaf",
-        "x-ms-correlation-request-id": "57e428ae-ca2a-4c69-8fc9-783c0ccb2074",
-        "x-ms-ratelimit-remaining-subscription-reads": "11997",
-        "x-ms-request-id": "36a34d1d-de12-4235-9b3b-78a616e46391_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044358Z:57e428ae-ca2a-4c69-8fc9-783c0ccb2074"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:43:38.24Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7b063079400094a32318c6b7f7c19d94",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 05 Nov 2021 04:43:59 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "37",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "7b063079400094a32318c6b7f7c19d94",
-        "x-ms-correlation-request-id": "3479f5b3-f662-4304-a83f-e9d49bef95c0",
-        "x-ms-ratelimit-remaining-subscription-reads": "11996",
-        "x-ms-request-id": "f3a21da5-8b35-45a9-8491-dba37c8064b2_M1SN1_M1SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044400Z:3479f5b3-f662-4304-a83f-e9d49bef95c0"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909",
-        "name": "testnamespacemgmt8909",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8909",
-          "createdAt": "2021-11-05T04:42:07.073Z",
-          "updatedAt": "2021-11-05T04:43:38.24Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8909.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4560/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8909/operationresults/testnamespacemgmt8909?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5dc6fc6a021d97eee84dd292723bf29e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Date": "Fri, 05 Nov 2021 04:44:01 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5dc6fc6a021d97eee84dd292723bf29e",
-        "x-ms-correlation-request-id": "a9fb3026-64ee-424f-926a-2dd229a629f5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11995",
-        "x-ms-request-id": "72c05709-835e-4ef7-a37a-1820fd41174d_M5SN1_M5SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211105T044401Z:a9fb3026-64ee-424f-926a-2dd229a629f5"
-      },
-      "ResponseBody": []
+      "ResponseBody": null
     }
   ],
   "Variables": {
-    "RandomSeed": "1667228216",
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
+    "RandomSeed": "508967873",
     "RESOURCE_MANAGER_URL": null,
     "SUBSCRIPTION_ID": "db1ab6f0-4769-4b27-930e-01e2ef9c123c"
   }

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/PrivateEndpointConnectionTests/GetAllPrivateEndpointConnection.json
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/PrivateEndpointConnectionTests/GetAllPrivateEndpointConnection.json
@@ -6,34 +6,43 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-e2e2f3050ee48a4683ce5472649c057d-7f71decb530c9241-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "88987356c7d71dc9b55556989987bced",
+        "traceparent": "00-ffcd44374b5eea4eb76570c0ac76f7e3-9991cf40189f474e-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "9740704f707f5cb3887dd484c0508dc0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "468",
+        "Content-Length": "747",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:38:51 GMT",
+        "Date": "Wed, 29 Jun 2022 14:25:27 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "d68e10f0-6214-4995-abba-bda3f1e6e714",
-        "x-ms-ratelimit-remaining-subscription-reads": "11944",
-        "x-ms-request-id": "d68e10f0-6214-4995-abba-bda3f1e6e714",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063851Z:d68e10f0-6214-4995-abba-bda3f1e6e714"
+        "x-ms-correlation-request-id": "e489a28a-d156-4e76-acbb-f71a36d14bd7",
+        "x-ms-ratelimit-remaining-subscription-reads": "11999",
+        "x-ms-request-id": "e489a28a-d156-4e76-acbb-f71a36d14bd7",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142527Z:e489a28a-d156-4e76-acbb-f71a36d14bd7"
       },
       "ResponseBody": {
         "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "authorizationSource": "RoleBased",
         "managedByTenants": [],
         "tags": {
-          "tagKey1": "tagValue1",
-          "tagKey2": "tagValue2"
+          "TagKey-9823": "TagValue-566",
+          "TagKey-3481": "TagValue-320",
+          "TagKey-4926": "TagValue-1187",
+          "TagKey-751": "TagValue-3921",
+          "TagKey-1866": "TagValue-8559",
+          "TagKey-3094": "TagValue-9190",
+          "TagKey-2449": "TagValue-9",
+          "TagKey-8379": "TagValue-164",
+          "TagKey-7470": "TagValue-2205",
+          "TagKey-4236": "TagValue-3698",
+          "TagKey-5316": "TagValue-2725"
         },
         "subscriptionId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
@@ -47,15 +56,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourcegroups/testeventhubRG-6758?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourcegroups/testeventhubRG-8189?api-version=2021-04-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "44",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e9d0eccff17d41a27f3b2ed77a3054af",
+        "traceparent": "00-6fded01ad71a174a82aa0a00c966f84a-bb3aec6e97c63c43-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "42019a0d135db7cd347fad23082f3bc0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -69,19 +79,19 @@
         "Cache-Control": "no-cache",
         "Content-Length": "258",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:38:52 GMT",
+        "Date": "Wed, 29 Jun 2022 14:25:29 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "18a6d35c-aeb5-40fe-a729-874152564758",
-        "x-ms-ratelimit-remaining-subscription-writes": "1196",
-        "x-ms-request-id": "18a6d35c-aeb5-40fe-a729-874152564758",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063852Z:18a6d35c-aeb5-40fe-a729-874152564758"
+        "x-ms-correlation-request-id": "3290218e-44b8-4f13-b981-c5d9dd0658c5",
+        "x-ms-ratelimit-remaining-subscription-writes": "1199",
+        "x-ms-request-id": "3290218e-44b8-4f13-b981-c5d9dd0658c5",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142530Z:3290218e-44b8-4f13-b981-c5d9dd0658c5"
       },
       "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758",
-        "name": "testeventhubRG-6758",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189",
+        "name": "testeventhubRG-8189",
         "type": "Microsoft.Resources/resourceGroups",
         "location": "eastus2",
         "tags": {
@@ -100,19 +110,20 @@
         "Authorization": "Sanitized",
         "Content-Length": "32",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d8b7803602f7a270da111f69a75b5133",
+        "traceparent": "00-3915418bc42f544a8eee2e8eaa35c35e-1903c5bb210a414b-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "d55d6ed8a836d8ccdf41e1dd6e353768",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "testnamespacemgmt9756"
+        "name": "testnamespacemgmt6239"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "53",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:38:53 GMT",
+        "Date": "Wed, 29 Jun 2022 14:25:29 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -122,11 +133,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d8b7803602f7a270da111f69a75b5133",
-        "x-ms-correlation-request-id": "f29c177b-9b53-4f3b-89d6-6db10d29472d",
+        "x-ms-client-request-id": "d55d6ed8a836d8ccdf41e1dd6e353768",
+        "x-ms-correlation-request-id": "feefb378-974a-4af8-ab16-9526a9878e73",
         "x-ms-ratelimit-remaining-subscription-writes": "1199",
-        "x-ms-request-id": "e34477c8-4abf-498c-b1d4-39e513670d6b_M3CH3_M3CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063854Z:f29c177b-9b53-4f3b-89d6-6db10d29472d"
+        "x-ms-request-id": "7137d30f-617f-4200-9cdc-0161d51f6900_M6CH3_M6CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142530Z:feefb378-974a-4af8-ab16-9526a9878e73"
       },
       "ResponseBody": {
         "nameAvailable": true,
@@ -135,15 +146,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239?api-version=2021-11-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "48",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "677f449ed9dff68247588c9a453a2401",
+        "traceparent": "00-f91d2f7ae10161418b3b4e9702a9c995-f4eb76c016ebdb47-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "9da653aef2c0725de04bf005387f4d98",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -156,7 +168,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:38:57 GMT",
+        "Date": "Wed, 29 Jun 2022 14:25:37 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -166,11 +178,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "677f449ed9dff68247588c9a453a2401",
-        "x-ms-correlation-request-id": "e741975b-a0f6-4c7f-84c6-a93200bbb64e",
-        "x-ms-ratelimit-remaining-subscription-resource-requests": "48",
-        "x-ms-request-id": "954181f8-99d3-464b-bf5b-1197265776ca_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063858Z:e741975b-a0f6-4c7f-84c6-a93200bbb64e"
+        "x-ms-client-request-id": "9da653aef2c0725de04bf005387f4d98",
+        "x-ms-correlation-request-id": "817dba64-5d31-4620-9f3b-4f2575dae798",
+        "x-ms-ratelimit-remaining-subscription-resource-requests": "49",
+        "x-ms-request-id": "0dfc1b44-9e6a-40dd-af5f-029980268a87_M0CH3_M0CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142537Z:817dba64-5d31-4620-9f3b-4f2575dae798"
       },
       "ResponseBody": {
         "sku": {
@@ -178,8 +190,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239",
+        "name": "testnamespacemgmt6239",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -190,21 +202,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6239",
+          "createdAt": "2022-06-29T14:25:36.277Z",
+          "updatedAt": "2022-06-29T14:25:36.277Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6239.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ebdca4dd48d55cb8fdc1919e75d65da0",
+        "traceparent": "00-f91d2f7ae10161418b3b4e9702a9c995-ac99b7c215c4c84b-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "db5abb752295e6c310ebf4ebb7c79f5f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -213,7 +226,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:00 GMT",
+        "Date": "Wed, 29 Jun 2022 14:25:37 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -223,752 +236,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "ebdca4dd48d55cb8fdc1919e75d65da0",
-        "x-ms-correlation-request-id": "9471c5d2-e450-484a-bd37-3bb00a3d52fb",
-        "x-ms-ratelimit-remaining-subscription-reads": "11943",
-        "x-ms-request-id": "10dcddbd-6bce-48c3-a0cf-ae287a7a888a_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063900Z:9471c5d2-e450-484a-bd37-3bb00a3d52fb"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a5801dec150acbfd6b95079936a2726f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:01 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a5801dec150acbfd6b95079936a2726f",
-        "x-ms-correlation-request-id": "f5a5245f-996b-4556-9115-f4c30194aff7",
-        "x-ms-ratelimit-remaining-subscription-reads": "11942",
-        "x-ms-request-id": "ded399e1-2775-411e-9e1f-1dae29c787e5_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063902Z:f5a5245f-996b-4556-9115-f4c30194aff7"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a1bdac80395ea02c49f43d7342397489",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:03 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a1bdac80395ea02c49f43d7342397489",
-        "x-ms-correlation-request-id": "4d7d11d1-669b-4a64-84bd-fa4a20bab0c6",
-        "x-ms-ratelimit-remaining-subscription-reads": "11941",
-        "x-ms-request-id": "1f73afa1-a3a6-4764-9953-26659f4e99c6_M0CH3_M0CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063903Z:4d7d11d1-669b-4a64-84bd-fa4a20bab0c6"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "66f202e93257c7d6a7117f40401f265b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:05 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "66f202e93257c7d6a7117f40401f265b",
-        "x-ms-correlation-request-id": "d4986072-3bbe-4f92-bc68-f444a1469581",
-        "x-ms-ratelimit-remaining-subscription-reads": "11940",
-        "x-ms-request-id": "e4b16302-89a4-443c-81c2-bf801de9d8c9_M11CH3_M11CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063906Z:d4986072-3bbe-4f92-bc68-f444a1469581"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c91e214fbb18b341f1df5b15d8898832",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:07 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c91e214fbb18b341f1df5b15d8898832",
-        "x-ms-correlation-request-id": "5fc97e71-f464-4385-b5a9-913d47dc35fd",
-        "x-ms-ratelimit-remaining-subscription-reads": "11939",
-        "x-ms-request-id": "294c70a5-7463-48a8-a5db-e968662d712a_M10CH3_M10CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063908Z:5fc97e71-f464-4385-b5a9-913d47dc35fd"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "34b07e200caf4d17d6f6fa4db9eb602a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:10 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "34b07e200caf4d17d6f6fa4db9eb602a",
-        "x-ms-correlation-request-id": "49530470-8649-422c-8fa5-2673dad9b3ff",
-        "x-ms-ratelimit-remaining-subscription-reads": "11938",
-        "x-ms-request-id": "41892d9a-cb0a-4628-863c-360bcbe57195_M3CH3_M3CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063910Z:49530470-8649-422c-8fa5-2673dad9b3ff"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2024e2ceab1b2d70c03e7577d7c0ee1d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:12 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2024e2ceab1b2d70c03e7577d7c0ee1d",
-        "x-ms-correlation-request-id": "6e0d6eec-9f94-49f1-b2d5-51f2999eb5df",
-        "x-ms-ratelimit-remaining-subscription-reads": "11937",
-        "x-ms-request-id": "54a16096-072a-4215-a31d-e0d83e5cecef_M3CH3_M3CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063913Z:6e0d6eec-9f94-49f1-b2d5-51f2999eb5df"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c11f4d88f16e42ab0ad0f222c1f3fa05",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:13 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c11f4d88f16e42ab0ad0f222c1f3fa05",
-        "x-ms-correlation-request-id": "2a8b609e-c12c-4325-a021-44c04f9b659e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11936",
-        "x-ms-request-id": "2545a809-6858-47fc-a5bf-8ae7498e92ea_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063914Z:2a8b609e-c12c-4325-a021-44c04f9b659e"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f547317f686575160d83737197a07616",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:16 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f547317f686575160d83737197a07616",
-        "x-ms-correlation-request-id": "c7e55402-7c25-40de-8bc1-b93a13f0dabe",
-        "x-ms-ratelimit-remaining-subscription-reads": "11935",
-        "x-ms-request-id": "a21f2be9-14c3-4144-b0d3-3ee3d3a2139c_M3CH3_M3CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063917Z:c7e55402-7c25-40de-8bc1-b93a13f0dabe"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6bc5dd079eccdcbb36e1164ab84d6bcc",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:18 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "6bc5dd079eccdcbb36e1164ab84d6bcc",
-        "x-ms-correlation-request-id": "7ba682df-86d9-41fc-a10d-de794ed11214",
-        "x-ms-ratelimit-remaining-subscription-reads": "11934",
-        "x-ms-request-id": "918640a6-af5d-44ae-bf0e-2531572e19d1_M11CH3_M11CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063919Z:7ba682df-86d9-41fc-a10d-de794ed11214"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a5f86f44f9791fb736aab4eb7e3aab69",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:19 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a5f86f44f9791fb736aab4eb7e3aab69",
-        "x-ms-correlation-request-id": "f015fbed-febc-4f22-839c-bd875ff8b7f7",
-        "x-ms-ratelimit-remaining-subscription-reads": "11933",
-        "x-ms-request-id": "fb1c9ad2-0178-43b0-aab0-8b050ac9f03b_M7CH3_M7CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063920Z:f015fbed-febc-4f22-839c-bd875ff8b7f7"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e41bdc5a8f2ee039766abe8352ccbcc0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:22 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "e41bdc5a8f2ee039766abe8352ccbcc0",
-        "x-ms-correlation-request-id": "c31e949e-707b-42ef-a45c-cd7388bdd996",
-        "x-ms-ratelimit-remaining-subscription-reads": "11932",
-        "x-ms-request-id": "2e949825-2329-4e77-88de-204da9be1d83_M11CH3_M11CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063923Z:c31e949e-707b-42ef-a45c-cd7388bdd996"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "272da617d1a80d9d25a53421eacf5efc",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:26 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "272da617d1a80d9d25a53421eacf5efc",
-        "x-ms-correlation-request-id": "d7bb905e-a226-497f-afbc-2b9fcd7603dd",
-        "x-ms-ratelimit-remaining-subscription-reads": "11999",
-        "x-ms-request-id": "36701f9c-f080-46c3-ba4a-aabaf9f018b7_M0CH3_M0CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063927Z:d7bb905e-a226-497f-afbc-2b9fcd7603dd"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "dcf0ac368632b49e36172f0e3a33cd6a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:27 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "dcf0ac368632b49e36172f0e3a33cd6a",
-        "x-ms-correlation-request-id": "9b80ab42-8221-42e4-8748-5ff24698690b",
+        "x-ms-client-request-id": "db5abb752295e6c310ebf4ebb7c79f5f",
+        "x-ms-correlation-request-id": "6e46a97b-b164-4280-9a38-0c602d0150fc",
         "x-ms-ratelimit-remaining-subscription-reads": "11998",
-        "x-ms-request-id": "b28420c6-2266-4471-87cd-1f9cb5c07dee_M10CH3_M10CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063928Z:9b80ab42-8221-42e4-8748-5ff24698690b"
+        "x-ms-request-id": "c43c4ec3-ca6c-4764-a057-2b9a5adff6ff_M3CH3_M3CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142538Z:6e46a97b-b164-4280-9a38-0c602d0150fc"
       },
       "ResponseBody": {
         "sku": {
@@ -976,8 +248,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239",
+        "name": "testnamespacemgmt6239",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -988,21 +260,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6239",
+          "createdAt": "2022-06-29T14:25:36.277Z",
+          "updatedAt": "2022-06-29T14:25:36.277Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6239.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d7d3f4ee830c89c13f0dbf895a17f6a6",
+        "traceparent": "00-f91d2f7ae10161418b3b4e9702a9c995-60598b47a4fd6946-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "311a48f318bda6057db46955748b8607",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -1011,7 +284,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:29 GMT",
+        "Date": "Wed, 29 Jun 2022 14:25:40 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1021,11 +294,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d7d3f4ee830c89c13f0dbf895a17f6a6",
-        "x-ms-correlation-request-id": "70aab2a2-8936-45f8-822d-bcfe7317104d",
+        "x-ms-client-request-id": "311a48f318bda6057db46955748b8607",
+        "x-ms-correlation-request-id": "f8e36d64-4549-4c3d-9d67-bf4e7778b171",
         "x-ms-ratelimit-remaining-subscription-reads": "11997",
-        "x-ms-request-id": "c9967b21-35db-4b18-aa3c-6aa693ddf681_M7CH3_M7CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063930Z:70aab2a2-8936-45f8-822d-bcfe7317104d"
+        "x-ms-request-id": "7e959649-e9b3-48f6-a051-321ff6c67eed_M10CH3_M10CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142541Z:f8e36d64-4549-4c3d-9d67-bf4e7778b171"
       },
       "ResponseBody": {
         "sku": {
@@ -1033,8 +306,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239",
+        "name": "testnamespacemgmt6239",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -1045,21 +318,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6239",
+          "createdAt": "2022-06-29T14:25:36.277Z",
+          "updatedAt": "2022-06-29T14:25:36.277Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6239.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a54dc10ce0db918d0878f090a18ed3f1",
+        "traceparent": "00-f91d2f7ae10161418b3b4e9702a9c995-a78861a68ffc1949-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "7d8fa6857225a00379920e7613eb3a6d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -1068,7 +342,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:30 GMT",
+        "Date": "Wed, 29 Jun 2022 14:25:42 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1078,11 +352,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a54dc10ce0db918d0878f090a18ed3f1",
-        "x-ms-correlation-request-id": "bfe0807f-707d-4b46-ae77-94a5ad6fe4d9",
+        "x-ms-client-request-id": "7d8fa6857225a00379920e7613eb3a6d",
+        "x-ms-correlation-request-id": "3c969b5f-ca58-476a-b981-ca569a01380d",
         "x-ms-ratelimit-remaining-subscription-reads": "11996",
-        "x-ms-request-id": "d9fc1e12-4885-4da9-b4bd-06dc9064824f_M7CH3_M7CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063931Z:bfe0807f-707d-4b46-ae77-94a5ad6fe4d9"
+        "x-ms-request-id": "1c351b4c-0c46-4f2c-865d-3cae8b845a68_M10CH3_M10CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142542Z:3c969b5f-ca58-476a-b981-ca569a01380d"
       },
       "ResponseBody": {
         "sku": {
@@ -1090,8 +364,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239",
+        "name": "testnamespacemgmt6239",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -1102,21 +376,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6239",
+          "createdAt": "2022-06-29T14:25:36.277Z",
+          "updatedAt": "2022-06-29T14:25:36.277Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6239.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f633cad787fbb2efea679c24c7155a1f",
+        "traceparent": "00-f91d2f7ae10161418b3b4e9702a9c995-d4ce8f49e7e5ca43-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a3de1dca93bf5d8cb5b35ee1b96d7184",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -1125,7 +400,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:31 GMT",
+        "Date": "Wed, 29 Jun 2022 14:25:43 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1135,11 +410,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f633cad787fbb2efea679c24c7155a1f",
-        "x-ms-correlation-request-id": "551175ff-8f9a-486f-8cfd-f1e66b71792a",
+        "x-ms-client-request-id": "a3de1dca93bf5d8cb5b35ee1b96d7184",
+        "x-ms-correlation-request-id": "27bfbc77-13f1-4fdd-bb9b-b093b580ba5a",
         "x-ms-ratelimit-remaining-subscription-reads": "11995",
-        "x-ms-request-id": "6ac4462b-32bb-4ee2-85ee-af03e56a3f4f_M7CH3_M7CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063932Z:551175ff-8f9a-486f-8cfd-f1e66b71792a"
+        "x-ms-request-id": "27ec811d-ad51-4da8-995e-1a0c83dc6536_M10CH3_M10CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142544Z:27bfbc77-13f1-4fdd-bb9b-b093b580ba5a"
       },
       "ResponseBody": {
         "sku": {
@@ -1147,8 +422,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239",
+        "name": "testnamespacemgmt6239",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -1159,21 +434,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6239",
+          "createdAt": "2022-06-29T14:25:36.277Z",
+          "updatedAt": "2022-06-29T14:25:36.277Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6239.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7802882027e60e8f6642cf949330e7b0",
+        "traceparent": "00-f91d2f7ae10161418b3b4e9702a9c995-ae98c0ec278cd24e-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "1165ed652137813a447ab72b0a8f9291",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -1182,7 +458,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:33 GMT",
+        "Date": "Wed, 29 Jun 2022 14:25:46 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1192,11 +468,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "7802882027e60e8f6642cf949330e7b0",
-        "x-ms-correlation-request-id": "9c6fa0d5-e4d2-4dad-8715-c58262941100",
+        "x-ms-client-request-id": "1165ed652137813a447ab72b0a8f9291",
+        "x-ms-correlation-request-id": "e5c2d07f-c444-47cc-967d-ec007b214fe1",
         "x-ms-ratelimit-remaining-subscription-reads": "11994",
-        "x-ms-request-id": "16995a49-a0f0-4aa5-ab9e-2e59dcd6304a_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063934Z:9c6fa0d5-e4d2-4dad-8715-c58262941100"
+        "x-ms-request-id": "c605762d-4fcf-49ce-9a63-6458d873d3bb_M9CH3_M9CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142547Z:e5c2d07f-c444-47cc-967d-ec007b214fe1"
       },
       "ResponseBody": {
         "sku": {
@@ -1204,8 +480,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239",
+        "name": "testnamespacemgmt6239",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -1216,21 +492,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6239",
+          "createdAt": "2022-06-29T14:25:36.277Z",
+          "updatedAt": "2022-06-29T14:25:36.277Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6239.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "90b1cd3a00e484aad19bbb734369caf3",
+        "traceparent": "00-f91d2f7ae10161418b3b4e9702a9c995-caf7263fe36f7540-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "568bfb79e2adf2471932c8711322e60c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -1239,7 +516,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:34 GMT",
+        "Date": "Wed, 29 Jun 2022 14:25:51 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1249,11 +526,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "90b1cd3a00e484aad19bbb734369caf3",
-        "x-ms-correlation-request-id": "525d1f86-1e0a-476b-a400-c6f99e26ee0a",
+        "x-ms-client-request-id": "568bfb79e2adf2471932c8711322e60c",
+        "x-ms-correlation-request-id": "f28062b0-4771-4852-acc7-c6b1aa4e4ee9",
         "x-ms-ratelimit-remaining-subscription-reads": "11993",
-        "x-ms-request-id": "44bf9c40-8bf5-4ea1-8d7b-8c2fe9884e56_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063935Z:525d1f86-1e0a-476b-a400-c6f99e26ee0a"
+        "x-ms-request-id": "618112ef-cdfd-4f0e-aae5-a198deb84212_M3CH3_M3CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142551Z:f28062b0-4771-4852-acc7-c6b1aa4e4ee9"
       },
       "ResponseBody": {
         "sku": {
@@ -1261,8 +538,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239",
+        "name": "testnamespacemgmt6239",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -1273,21 +550,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6239",
+          "createdAt": "2022-06-29T14:25:36.277Z",
+          "updatedAt": "2022-06-29T14:25:36.277Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6239.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1870d11d5a8caf0b3a2590b9b75b1fb9",
+        "traceparent": "00-f91d2f7ae10161418b3b4e9702a9c995-5d710c650292504a-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "261189202886a836e35d5e45dc615326",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -1296,7 +574,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:35 GMT",
+        "Date": "Wed, 29 Jun 2022 14:26:01 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1306,11 +584,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "1870d11d5a8caf0b3a2590b9b75b1fb9",
-        "x-ms-correlation-request-id": "37370e2e-e6fe-4400-916c-0109dd6e2922",
+        "x-ms-client-request-id": "261189202886a836e35d5e45dc615326",
+        "x-ms-correlation-request-id": "33c4476a-e1cc-467b-80e9-52b714c8607d",
         "x-ms-ratelimit-remaining-subscription-reads": "11992",
-        "x-ms-request-id": "134b4fc9-2922-498b-9b43-6458a611f100_M7CH3_M7CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063936Z:37370e2e-e6fe-4400-916c-0109dd6e2922"
+        "x-ms-request-id": "084dc916-45f9-499a-bcf4-dd92eb2f7663_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142601Z:33c4476a-e1cc-467b-80e9-52b714c8607d"
       },
       "ResponseBody": {
         "sku": {
@@ -1318,8 +596,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239",
+        "name": "testnamespacemgmt6239",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -1330,21 +608,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6239",
+          "createdAt": "2022-06-29T14:25:36.277Z",
+          "updatedAt": "2022-06-29T14:25:36.277Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6239.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f9eaeb80ca63203bde7da64b6c1bcafc",
+        "traceparent": "00-f91d2f7ae10161418b3b4e9702a9c995-9959d4b8ac5be348-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "be67cc211ae283d7a673f80559c86d22",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -1353,7 +632,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:38 GMT",
+        "Date": "Wed, 29 Jun 2022 14:26:17 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1363,11 +642,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f9eaeb80ca63203bde7da64b6c1bcafc",
-        "x-ms-correlation-request-id": "298da27c-7d2a-4751-94ac-7aef52a6b972",
+        "x-ms-client-request-id": "be67cc211ae283d7a673f80559c86d22",
+        "x-ms-correlation-request-id": "da850722-f6a5-4018-8862-01998dc479b8",
         "x-ms-ratelimit-remaining-subscription-reads": "11991",
-        "x-ms-request-id": "bfba58fe-afb3-4c0f-9eba-de72884aa097_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063938Z:298da27c-7d2a-4751-94ac-7aef52a6b972"
+        "x-ms-request-id": "1d6e86ab-86c1-461f-b649-22e19ccdc867_M2CH3_M2CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142618Z:da850722-f6a5-4018-8862-01998dc479b8"
       },
       "ResponseBody": {
         "sku": {
@@ -1375,8 +654,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239",
+        "name": "testnamespacemgmt6239",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -1387,21 +666,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6239",
+          "createdAt": "2022-06-29T14:25:36.277Z",
+          "updatedAt": "2022-06-29T14:25:36.277Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6239.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c176dc77cec0df24c20255bf70f0cd76",
+        "traceparent": "00-f91d2f7ae10161418b3b4e9702a9c995-01912e89f335724d-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "800aab946c7e500bc4e2734f830115b7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -1410,7 +690,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:39 GMT",
+        "Date": "Wed, 29 Jun 2022 14:26:50 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1420,11 +700,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c176dc77cec0df24c20255bf70f0cd76",
-        "x-ms-correlation-request-id": "70be7540-4de1-4ae4-ba94-47c8e00bf74b",
+        "x-ms-client-request-id": "800aab946c7e500bc4e2734f830115b7",
+        "x-ms-correlation-request-id": "9fab9f6f-aef3-40d3-930b-40b51b6ddb96",
         "x-ms-ratelimit-remaining-subscription-reads": "11990",
-        "x-ms-request-id": "0774ecaf-a01b-494d-8f92-9a7f29d3a43a_M7CH3_M7CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063939Z:70be7540-4de1-4ae4-ba94-47c8e00bf74b"
+        "x-ms-request-id": "c8d6e4aa-5598-4112-944a-e6ee8c7a8eb6_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142651Z:9fab9f6f-aef3-40d3-930b-40b51b6ddb96"
       },
       "ResponseBody": {
         "sku": {
@@ -1432,8 +712,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239",
+        "name": "testnamespacemgmt6239",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -1444,21 +724,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6239",
+          "createdAt": "2022-06-29T14:25:36.277Z",
+          "updatedAt": "2022-06-29T14:25:36.277Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6239.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "57f3017bd17f538f964f3a0eb4bf431f",
+        "traceparent": "00-f91d2f7ae10161418b3b4e9702a9c995-3713893e7b8f6d4a-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "4750a2df27bb052ab28d7f1230304f1b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -1467,7 +748,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:40 GMT",
+        "Date": "Wed, 29 Jun 2022 14:27:23 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1477,11 +758,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "57f3017bd17f538f964f3a0eb4bf431f",
-        "x-ms-correlation-request-id": "447e5066-1b2a-496f-9b12-2db59e92fd6f",
+        "x-ms-client-request-id": "4750a2df27bb052ab28d7f1230304f1b",
+        "x-ms-correlation-request-id": "7711f294-5815-4c74-a0c5-7496ec9ed8c2",
         "x-ms-ratelimit-remaining-subscription-reads": "11989",
-        "x-ms-request-id": "4c3d685d-5f01-4660-8bc0-d6cc90a3242f_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063940Z:447e5066-1b2a-496f-9b12-2db59e92fd6f"
+        "x-ms-request-id": "144e934c-6bb3-402e-9b18-3f9f1384bef3_M9CH3_M9CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142724Z:7711f294-5815-4c74-a0c5-7496ec9ed8c2"
       },
       "ResponseBody": {
         "sku": {
@@ -1489,8 +770,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239",
+        "name": "testnamespacemgmt6239",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -1501,21 +782,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6239",
+          "createdAt": "2022-06-29T14:25:36.277Z",
+          "updatedAt": "2022-06-29T14:25:36.277Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6239.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "db42935a5de4b1f9c60a3660757bb0ed",
+        "traceparent": "00-f91d2f7ae10161418b3b4e9702a9c995-12620969326f9949-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "30b13cf0d257b4a8c116f9ffa78700a4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -1524,7 +806,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:42 GMT",
+        "Date": "Wed, 29 Jun 2022 14:27:56 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1534,11 +816,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "db42935a5de4b1f9c60a3660757bb0ed",
-        "x-ms-correlation-request-id": "b066d242-e90a-4910-b1a2-cd47a4c6f26e",
+        "x-ms-client-request-id": "30b13cf0d257b4a8c116f9ffa78700a4",
+        "x-ms-correlation-request-id": "7ed49f4c-2f38-406e-9a03-a710c9a42431",
         "x-ms-ratelimit-remaining-subscription-reads": "11988",
-        "x-ms-request-id": "be362eb0-8940-40a2-a73d-be9219bc58be_M7CH3_M7CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063942Z:b066d242-e90a-4910-b1a2-cd47a4c6f26e"
+        "x-ms-request-id": "728591fd-c44d-489c-9420-29f70f15183e_M6CH3_M6CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142756Z:7ed49f4c-2f38-406e-9a03-a710c9a42431"
       },
       "ResponseBody": {
         "sku": {
@@ -1546,8 +828,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239",
+        "name": "testnamespacemgmt6239",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -1558,21 +840,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6239",
+          "createdAt": "2022-06-29T14:25:36.277Z",
+          "updatedAt": "2022-06-29T14:25:36.277Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6239.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6acf2fb07327a67d4c232b7093162b02",
+        "traceparent": "00-f91d2f7ae10161418b3b4e9702a9c995-8ae578478d409e49-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b726405d25776c678104cef0ecf82094",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -1581,21 +864,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:43 GMT",
+        "Date": "Wed, 29 Jun 2022 14:28:28 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "6acf2fb07327a67d4c232b7093162b02",
-        "x-ms-correlation-request-id": "9675bc36-b0f4-409e-a481-e6455c61b763",
+        "x-ms-client-request-id": "b726405d25776c678104cef0ecf82094",
+        "x-ms-correlation-request-id": "8570fc1b-a9a8-407a-837e-09890cd8db7a",
         "x-ms-ratelimit-remaining-subscription-reads": "11987",
-        "x-ms-request-id": "e5d0a0bb-1093-471b-8efe-ae6520399a92_M7CH3_M7CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063943Z:9675bc36-b0f4-409e-a481-e6455c61b763"
+        "x-ms-request-id": "cfecd9e3-c657-4786-ad63-f4bfd476f554_M0SN1_M0SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142829Z:8570fc1b-a9a8-407a-837e-09890cd8db7a"
       },
       "ResponseBody": {
         "sku": {
@@ -1603,8 +886,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239",
+        "name": "testnamespacemgmt6239",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -1615,21 +898,80 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:38:56.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6239",
+          "createdAt": "2022-06-29T14:25:36.277Z",
+          "updatedAt": "2022-06-29T14:25:36.277Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6239.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "dc6436bff1ae1e92084190749a2fde1a",
+        "traceparent": "00-f91d2f7ae10161418b3b4e9702a9c995-f4356ed5cbd44e44-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "465f5793e5500c60fa9c86a42d2a5e2a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "738",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 29 Jun 2022 14:29:02 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/SN1",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "465f5793e5500c60fa9c86a42d2a5e2a",
+        "x-ms-correlation-request-id": "c02978c9-931d-4e0e-8af5-89a70d3cbaa8",
+        "x-ms-ratelimit-remaining-subscription-reads": "11986",
+        "x-ms-request-id": "3c117074-04cb-4810-acca-c44d5988ae42_M8SN1_M8SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142902Z:c02978c9-931d-4e0e-8af5-89a70d3cbaa8"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239",
+        "name": "testnamespacemgmt6239",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6239",
+          "createdAt": "2022-06-29T14:25:36.277Z",
+          "updatedAt": "2022-06-29T14:25:36.277Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6239.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-f91d2f7ae10161418b3b4e9702a9c995-de3f7560e5cd1945-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f0b5db8d970acaa3d544af5304b7c8c8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -1638,21 +980,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:44 GMT",
+        "Date": "Wed, 29 Jun 2022 14:29:35 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "dc6436bff1ae1e92084190749a2fde1a",
-        "x-ms-correlation-request-id": "9fc24681-acbd-437e-987d-b74bbfad3cc0",
-        "x-ms-ratelimit-remaining-subscription-reads": "11986",
-        "x-ms-request-id": "7e6601a6-1043-405a-8b6d-e9f0afad4d11_M7CH3_M7CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063944Z:9fc24681-acbd-437e-987d-b74bbfad3cc0"
+        "x-ms-client-request-id": "f0b5db8d970acaa3d544af5304b7c8c8",
+        "x-ms-correlation-request-id": "6fb84b54-8352-4bf0-b3e0-0ebeeb3ab28f",
+        "x-ms-ratelimit-remaining-subscription-reads": "11985",
+        "x-ms-request-id": "a52ae8d3-da04-4652-a3d0-fbeba445f6de_M2SN1_M2SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142935Z:6fb84b54-8352-4bf0-b3e0-0ebeeb3ab28f"
       },
       "ResponseBody": {
         "sku": {
@@ -1660,8 +1002,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239",
+        "name": "testnamespacemgmt6239",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -1672,24 +1014,25 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:39:43.977Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6239",
+          "createdAt": "2022-06-29T14:25:36.277Z",
+          "updatedAt": "2022-06-29T14:29:07.617Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6239.servicebus.windows.net:443/",
           "status": "Active"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/virtualNetworks/vnet-9802?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.Network/virtualNetworks/vnet-3299?api-version=2021-02-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "261",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.Network/1.0.0-beta.3 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f0845e4df7d815e69b8fc031881db0df",
+        "traceparent": "00-87199d2768f8604191cab673e9d65962-c21f23492da1184d-00",
+        "User-Agent": "azsdk-net-ResourceManager.Network/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "28506b6554b9e07819bcdb9fc23f56a6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -1720,11 +1063,11 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Azure-AsyncNotification": "Enabled",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/35df5e18-2cb8-4061-a9af-16ae0a405561?api-version=2021-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/4c62dc58-4a1a-4b3f-9fe3-b1a0d99774c7?api-version=2021-02-01",
         "Cache-Control": "no-cache",
         "Content-Length": "1339",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:53 GMT",
+        "Date": "Wed, 29 Jun 2022 14:29:39 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "3",
@@ -1734,62 +1077,61 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "c7a7e135-b335-4d03-916e-1242ae322462",
-        "x-ms-client-request-id": "f0845e4df7d815e69b8fc031881db0df",
-        "x-ms-correlation-request-id": "e1307193-a036-46ff-9a8d-1ffc424caf86",
-        "x-ms-ratelimit-remaining-subscription-writes": "1199",
-        "x-ms-request-id": "35df5e18-2cb8-4061-a9af-16ae0a405561",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063953Z:e1307193-a036-46ff-9a8d-1ffc424caf86"
+        "x-ms-arm-service-request-id": "cb1a8de9-3368-49c7-bf82-e7f32302cbc9",
+        "x-ms-client-request-id": "28506b6554b9e07819bcdb9fc23f56a6",
+        "x-ms-correlation-request-id": "166184e1-6af5-4616-b599-db70c51c71fc",
+        "x-ms-ratelimit-remaining-subscription-writes": "1198",
+        "x-ms-request-id": "4c62dc58-4a1a-4b3f-9fe3-b1a0d99774c7",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142939Z:166184e1-6af5-4616-b599-db70c51c71fc"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022name\u0022: \u0022vnet-9802\u0022,\r\n",
-        "  \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/virtualNetworks/vnet-9802\u0022,\r\n",
-        "  \u0022etag\u0022: \u0022W/\\\u00229cd959ed-00ef-43cc-a4ca-747777d3e0e1\\\u0022\u0022,\r\n",
-        "  \u0022type\u0022: \u0022Microsoft.Network/virtualNetworks\u0022,\r\n",
-        "  \u0022location\u0022: \u0022westus2\u0022,\r\n",
-        "  \u0022properties\u0022: {\r\n",
-        "    \u0022provisioningState\u0022: \u0022Updating\u0022,\r\n",
-        "    \u0022resourceGuid\u0022: \u0022b8df8dec-7ed0-41e9-b1c4-103f22b49bb5\u0022,\r\n",
-        "    \u0022addressSpace\u0022: {\r\n",
-        "      \u0022addressPrefixes\u0022: [\r\n",
-        "        \u002210.0.0.0/16\u0022\r\n",
-        "      ]\r\n",
-        "    },\r\n",
-        "    \u0022dhcpOptions\u0022: {\r\n",
-        "      \u0022dnsServers\u0022: [\r\n",
-        "        \u002210.1.1.1\u0022,\r\n",
-        "        \u002210.1.2.4\u0022\r\n",
-        "      ]\r\n",
-        "    },\r\n",
-        "    \u0022subnets\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022name\u0022: \u0022default\u0022,\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/virtualNetworks/vnet-9802/subnets/default\u0022,\r\n",
-        "        \u0022etag\u0022: \u0022W/\\\u00229cd959ed-00ef-43cc-a4ca-747777d3e0e1\\\u0022\u0022,\r\n",
-        "        \u0022properties\u0022: {\r\n",
-        "          \u0022provisioningState\u0022: \u0022Updating\u0022,\r\n",
-        "          \u0022addressPrefix\u0022: \u002210.0.1.0/24\u0022,\r\n",
-        "          \u0022delegations\u0022: [],\r\n",
-        "          \u0022privateEndpointNetworkPolicies\u0022: \u0022Disabled\u0022,\r\n",
-        "          \u0022privateLinkServiceNetworkPolicies\u0022: \u0022Enabled\u0022\r\n",
-        "        },\r\n",
-        "        \u0022type\u0022: \u0022Microsoft.Network/virtualNetworks/subnets\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022virtualNetworkPeerings\u0022: [],\r\n",
-        "    \u0022enableDdosProtection\u0022: false\r\n",
-        "  }\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "name": "vnet-3299",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.Network/virtualNetworks/vnet-3299",
+        "etag": "W/\u0022cf7a5f2c-ab7a-4450-84b9-04b5aad55b62\u0022",
+        "type": "Microsoft.Network/virtualNetworks",
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Updating",
+          "resourceGuid": "c60fe045-bcad-4a56-bd4c-4a5c5b67508c",
+          "addressSpace": {
+            "addressPrefixes": [
+              "10.0.0.0/16"
+            ]
+          },
+          "dhcpOptions": {
+            "dnsServers": [
+              "10.1.1.1",
+              "10.1.2.4"
+            ]
+          },
+          "subnets": [
+            {
+              "name": "default",
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.Network/virtualNetworks/vnet-3299/subnets/default",
+              "etag": "W/\u0022cf7a5f2c-ab7a-4450-84b9-04b5aad55b62\u0022",
+              "properties": {
+                "provisioningState": "Updating",
+                "addressPrefix": "10.0.1.0/24",
+                "delegations": [],
+                "privateEndpointNetworkPolicies": "Disabled",
+                "privateLinkServiceNetworkPolicies": "Enabled"
+              },
+              "type": "Microsoft.Network/virtualNetworks/subnets"
+            }
+          ],
+          "virtualNetworkPeerings": [],
+          "enableDdosProtection": false
+        }
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/35df5e18-2cb8-4061-a9af-16ae0a405561?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/4c62dc58-4a1a-4b3f-9fe3-b1a0d99774c7?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b746d11112a73ee67dc71261d1ec8024",
+        "traceparent": "00-87199d2768f8604191cab673e9d65962-ede98587deb68845-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "bfc7aebe020e87d43d0ff1dbc82a1205",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -1798,7 +1140,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "29",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:53 GMT",
+        "Date": "Wed, 29 Jun 2022 14:29:39 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1807,26 +1149,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "34fc4fe3-b022-41fe-9ceb-db6f32841630",
-        "x-ms-client-request-id": "b746d11112a73ee67dc71261d1ec8024",
-        "x-ms-correlation-request-id": "2f975b8e-0a59-4cec-9178-c0c1e1917d6e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11985",
-        "x-ms-request-id": "0573a500-cde1-4347-9cc5-68df9fc3d8ff",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063953Z:2f975b8e-0a59-4cec-9178-c0c1e1917d6e"
+        "x-ms-arm-service-request-id": "54d821d9-2140-413b-92d9-8f676d7d9a38",
+        "x-ms-client-request-id": "bfc7aebe020e87d43d0ff1dbc82a1205",
+        "x-ms-correlation-request-id": "8c2c9422-a5ae-4bb0-b319-1132bf046f94",
+        "x-ms-ratelimit-remaining-subscription-reads": "11984",
+        "x-ms-request-id": "aa387d3b-e7ef-45db-9549-48fab7091437",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142940Z:8c2c9422-a5ae-4bb0-b319-1132bf046f94"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022Succeeded\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "Succeeded"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/virtualNetworks/vnet-9802?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.Network/virtualNetworks/vnet-3299?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8d6595df039f0ecb9fe63f7611040c8f",
+        "traceparent": "00-87199d2768f8604191cab673e9d65962-4e60803595d0be4b-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "5560ac5884b7dcc66f9c92474842d311",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -1835,8 +1176,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1341",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:54 GMT",
-        "ETag": "W/\u002223c1740d-30a2-4149-9e8c-ec24dea03aec\u0022",
+        "Date": "Wed, 29 Jun 2022 14:29:40 GMT",
+        "ETag": "W/\u0022feed82c1-c8ea-428d-8af6-03f37397f036\u0022",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1845,74 +1186,73 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "08dae20c-e4b8-4b0a-951e-b4a8f9fe1843",
-        "x-ms-client-request-id": "8d6595df039f0ecb9fe63f7611040c8f",
-        "x-ms-correlation-request-id": "3e7295a8-c65b-46db-9c6c-49e4f83dd25c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11984",
-        "x-ms-request-id": "a44d5a27-9369-4894-b429-93bb66f47b9c",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063954Z:3e7295a8-c65b-46db-9c6c-49e4f83dd25c"
+        "x-ms-arm-service-request-id": "26732763-5116-4ab1-ad1d-210389afc411",
+        "x-ms-client-request-id": "5560ac5884b7dcc66f9c92474842d311",
+        "x-ms-correlation-request-id": "b86813cf-3f96-4548-ae12-bb81de44388c",
+        "x-ms-ratelimit-remaining-subscription-reads": "11983",
+        "x-ms-request-id": "f01868c9-26c8-40d6-b1ce-df519a5b225e",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142940Z:b86813cf-3f96-4548-ae12-bb81de44388c"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022name\u0022: \u0022vnet-9802\u0022,\r\n",
-        "  \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/virtualNetworks/vnet-9802\u0022,\r\n",
-        "  \u0022etag\u0022: \u0022W/\\\u002223c1740d-30a2-4149-9e8c-ec24dea03aec\\\u0022\u0022,\r\n",
-        "  \u0022type\u0022: \u0022Microsoft.Network/virtualNetworks\u0022,\r\n",
-        "  \u0022location\u0022: \u0022westus2\u0022,\r\n",
-        "  \u0022properties\u0022: {\r\n",
-        "    \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "    \u0022resourceGuid\u0022: \u0022b8df8dec-7ed0-41e9-b1c4-103f22b49bb5\u0022,\r\n",
-        "    \u0022addressSpace\u0022: {\r\n",
-        "      \u0022addressPrefixes\u0022: [\r\n",
-        "        \u002210.0.0.0/16\u0022\r\n",
-        "      ]\r\n",
-        "    },\r\n",
-        "    \u0022dhcpOptions\u0022: {\r\n",
-        "      \u0022dnsServers\u0022: [\r\n",
-        "        \u002210.1.1.1\u0022,\r\n",
-        "        \u002210.1.2.4\u0022\r\n",
-        "      ]\r\n",
-        "    },\r\n",
-        "    \u0022subnets\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022name\u0022: \u0022default\u0022,\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/virtualNetworks/vnet-9802/subnets/default\u0022,\r\n",
-        "        \u0022etag\u0022: \u0022W/\\\u002223c1740d-30a2-4149-9e8c-ec24dea03aec\\\u0022\u0022,\r\n",
-        "        \u0022properties\u0022: {\r\n",
-        "          \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "          \u0022addressPrefix\u0022: \u002210.0.1.0/24\u0022,\r\n",
-        "          \u0022delegations\u0022: [],\r\n",
-        "          \u0022privateEndpointNetworkPolicies\u0022: \u0022Disabled\u0022,\r\n",
-        "          \u0022privateLinkServiceNetworkPolicies\u0022: \u0022Enabled\u0022\r\n",
-        "        },\r\n",
-        "        \u0022type\u0022: \u0022Microsoft.Network/virtualNetworks/subnets\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022virtualNetworkPeerings\u0022: [],\r\n",
-        "    \u0022enableDdosProtection\u0022: false\r\n",
-        "  }\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "name": "vnet-3299",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.Network/virtualNetworks/vnet-3299",
+        "etag": "W/\u0022feed82c1-c8ea-428d-8af6-03f37397f036\u0022",
+        "type": "Microsoft.Network/virtualNetworks",
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "resourceGuid": "c60fe045-bcad-4a56-bd4c-4a5c5b67508c",
+          "addressSpace": {
+            "addressPrefixes": [
+              "10.0.0.0/16"
+            ]
+          },
+          "dhcpOptions": {
+            "dnsServers": [
+              "10.1.1.1",
+              "10.1.2.4"
+            ]
+          },
+          "subnets": [
+            {
+              "name": "default",
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.Network/virtualNetworks/vnet-3299/subnets/default",
+              "etag": "W/\u0022feed82c1-c8ea-428d-8af6-03f37397f036\u0022",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "addressPrefix": "10.0.1.0/24",
+                "delegations": [],
+                "privateEndpointNetworkPolicies": "Disabled",
+                "privateLinkServiceNetworkPolicies": "Enabled"
+              },
+              "type": "Microsoft.Network/virtualNetworks/subnets"
+            }
+          ],
+          "virtualNetworkPeerings": [],
+          "enableDdosProtection": false
+        }
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/privateEndpoints/pe-6794?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.Network/privateEndpoints/pe-5576?api-version=2021-02-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "733",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.Network/1.0.0-beta.3 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f8d6b620223700bb990c2b5dcbc4e1c1",
+        "traceparent": "00-9fe8714c3d0bab4e9d9d5fb78ec997a0-b85b10d6775be14d-00",
+        "User-Agent": "azsdk-net-ResourceManager.Network/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "967814e1a198898d06209820ea6a5f05",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "location": "westus2",
         "properties": {
           "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.Network/virtualNetworks/vnet-3299/subnets/default",
             "name": "default",
             "type": "Microsoft.Network/virtualNetworks/subnets",
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/virtualNetworks/vnet-9802/subnets/default",
             "properties": {
               "addressPrefix": "10.0.1.0/24",
               "delegations": [],
@@ -1922,9 +1262,9 @@
           },
           "manualPrivateLinkServiceConnections": [
             {
-              "name": "pec1197",
+              "name": "pec1009",
               "properties": {
-                "privateLinkServiceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
+                "privateLinkServiceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239",
                 "groupIds": [
                   "namespace"
                 ],
@@ -1937,11 +1277,11 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Azure-AsyncNotification": "Enabled",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/4afbbff9-229f-4403-8dfe-304fdf756f41?api-version=2021-02-01",
         "Cache-Control": "no-cache",
         "Content-Length": "1958",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:59 GMT",
+        "Date": "Wed, 29 Jun 2022 14:29:44 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
@@ -1951,65 +1291,64 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "0cdd522c-dc70-40de-a1d5-09243ca29ae2",
-        "x-ms-client-request-id": "f8d6b620223700bb990c2b5dcbc4e1c1",
-        "x-ms-correlation-request-id": "dda279e1-35da-4b7f-85f3-c093079026f2",
-        "x-ms-ratelimit-remaining-subscription-writes": "1198",
-        "x-ms-request-id": "33df434b-4bef-427e-9b18-d31882c576ca",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T063959Z:dda279e1-35da-4b7f-85f3-c093079026f2"
+        "x-ms-arm-service-request-id": "4f9309a4-bd27-4154-8085-7db49a51c597",
+        "x-ms-client-request-id": "967814e1a198898d06209820ea6a5f05",
+        "x-ms-correlation-request-id": "bef780c4-2fd8-4a3b-850a-57a9b244d304",
+        "x-ms-ratelimit-remaining-subscription-writes": "1197",
+        "x-ms-request-id": "4afbbff9-229f-4403-8dfe-304fdf756f41",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142945Z:bef780c4-2fd8-4a3b-850a-57a9b244d304"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022name\u0022: \u0022pe-6794\u0022,\r\n",
-        "  \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/privateEndpoints/pe-6794\u0022,\r\n",
-        "  \u0022etag\u0022: \u0022W/\\\u002247c2ec7e-6a66-4e15-933d-c8e30f1f9b79\\\u0022\u0022,\r\n",
-        "  \u0022type\u0022: \u0022Microsoft.Network/privateEndpoints\u0022,\r\n",
-        "  \u0022location\u0022: \u0022westus2\u0022,\r\n",
-        "  \u0022properties\u0022: {\r\n",
-        "    \u0022provisioningState\u0022: \u0022Updating\u0022,\r\n",
-        "    \u0022resourceGuid\u0022: \u0022c8cbffac-e1ba-4bde-b22c-07cc72405d46\u0022,\r\n",
-        "    \u0022privateLinkServiceConnections\u0022: [],\r\n",
-        "    \u0022manualPrivateLinkServiceConnections\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022name\u0022: \u0022pec1197\u0022,\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/privateEndpoints/pe-6794/manualPrivateLinkServiceConnections/pec1197\u0022,\r\n",
-        "        \u0022etag\u0022: \u0022W/\\\u002247c2ec7e-6a66-4e15-933d-c8e30f1f9b79\\\u0022\u0022,\r\n",
-        "        \u0022properties\u0022: {\r\n",
-        "          \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "          \u0022privateLinkServiceId\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756\u0022,\r\n",
-        "          \u0022groupIds\u0022: [\r\n",
-        "            \u0022namespace\u0022\r\n",
-        "          ],\r\n",
-        "          \u0022requestMessage\u0022: \u0022SDK test\u0022,\r\n",
-        "          \u0022privateLinkServiceConnectionState\u0022: {\r\n",
-        "            \u0022status\u0022: \u0022Pending\u0022,\r\n",
-        "            \u0022description\u0022: \u0022SDK test\u0022,\r\n",
-        "            \u0022actionsRequired\u0022: \u0022None\u0022\r\n",
-        "          }\r\n",
-        "        },\r\n",
-        "        \u0022type\u0022: \u0022Microsoft.Network/privateEndpoints/manualPrivateLinkServiceConnections\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022subnet\u0022: {\r\n",
-        "      \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/virtualNetworks/vnet-9802/subnets/default\u0022\r\n",
-        "    },\r\n",
-        "    \u0022networkInterfaces\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/networkInterfaces/pe-6794.nic.db67e56f-e401-4e3c-bac3-8512aa0056a1\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022customDnsConfigs\u0022: []\r\n",
-        "  }\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "name": "pe-5576",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.Network/privateEndpoints/pe-5576",
+        "etag": "W/\u00228e0bacba-b5cd-4f92-9ed0-4327ce62ca89\u0022",
+        "type": "Microsoft.Network/privateEndpoints",
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Updating",
+          "resourceGuid": "da0e7734-4b93-4ffe-bdd8-327f80eee100",
+          "privateLinkServiceConnections": [],
+          "manualPrivateLinkServiceConnections": [
+            {
+              "name": "pec1009",
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.Network/privateEndpoints/pe-5576/manualPrivateLinkServiceConnections/pec1009",
+              "etag": "W/\u00228e0bacba-b5cd-4f92-9ed0-4327ce62ca89\u0022",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateLinkServiceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239",
+                "groupIds": [
+                  "namespace"
+                ],
+                "requestMessage": "SDK test",
+                "privateLinkServiceConnectionState": {
+                  "status": "Pending",
+                  "description": "SDK test",
+                  "actionsRequired": "None"
+                }
+              },
+              "type": "Microsoft.Network/privateEndpoints/manualPrivateLinkServiceConnections"
+            }
+          ],
+          "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.Network/virtualNetworks/vnet-3299/subnets/default"
+          },
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.Network/networkInterfaces/pe-5576.nic.9d8222b7-ba6f-4b50-bed5-d47ffde6d02c"
+            }
+          ],
+          "customDnsConfigs": []
+        }
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/4afbbff9-229f-4403-8dfe-304fdf756f41?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "cacc56efe74d435dd29f69bee2421a7b",
+        "traceparent": "00-9fe8714c3d0bab4e9d9d5fb78ec997a0-12f8f43b380a7941-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "fd49c160c18dbe14c72d7ea5444eb128",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -2018,7 +1357,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "30",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:39:59 GMT",
+        "Date": "Wed, 29 Jun 2022 14:29:44 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
@@ -2028,64 +1367,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "65878a98-5409-4413-8ab2-e741087a5125",
-        "x-ms-client-request-id": "cacc56efe74d435dd29f69bee2421a7b",
-        "x-ms-correlation-request-id": "901a33cd-3236-442d-bb7e-62cb0ec4039e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11983",
-        "x-ms-request-id": "10877b50-0c96-4424-9364-50f8b021143a",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064000Z:901a33cd-3236-442d-bb7e-62cb0ec4039e"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "98014f95e2e912d4af9fe0764f4bd21f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:01 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "20",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "51af8d80-50cb-4e99-b372-c8c6c36937b5",
-        "x-ms-client-request-id": "98014f95e2e912d4af9fe0764f4bd21f",
-        "x-ms-correlation-request-id": "95be5bd1-9521-47c3-92dc-0b1841df6b09",
+        "x-ms-arm-service-request-id": "494da21c-3da3-41f0-8f15-2cea81c7d34d",
+        "x-ms-client-request-id": "fd49c160c18dbe14c72d7ea5444eb128",
+        "x-ms-correlation-request-id": "c336ebae-3ca0-445f-a580-147c94f6222e",
         "x-ms-ratelimit-remaining-subscription-reads": "11982",
-        "x-ms-request-id": "dac25204-a6dd-476a-8b50-186044369b66",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064001Z:95be5bd1-9521-47c3-92dc-0b1841df6b09"
+        "x-ms-request-id": "934146d7-d6de-4a55-917d-ec22735ac6a5",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142945Z:c336ebae-3ca0-445f-a580-147c94f6222e"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "InProgress"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/4afbbff9-229f-4403-8dfe-304fdf756f41?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "756ea85016f71b741662bd07a44754d6",
+        "traceparent": "00-9fe8714c3d0bab4e9d9d5fb78ec997a0-61b0f95055df1c48-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "736542e78d68a8ea2c8d472632004b0b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -2094,7 +1394,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "30",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:02 GMT",
+        "Date": "Wed, 29 Jun 2022 14:29:55 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "20",
@@ -2104,26 +1404,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "af2f81b6-2d17-4e0c-80dc-211eed2bd0b0",
-        "x-ms-client-request-id": "756ea85016f71b741662bd07a44754d6",
-        "x-ms-correlation-request-id": "c1abb352-691a-4704-88f3-f71461af59d6",
+        "x-ms-arm-service-request-id": "37219e8d-24fb-4824-a21c-68eff6ee6e7e",
+        "x-ms-client-request-id": "736542e78d68a8ea2c8d472632004b0b",
+        "x-ms-correlation-request-id": "6cf888ad-a974-41c8-88db-b3c9adc20bb2",
         "x-ms-ratelimit-remaining-subscription-reads": "11981",
-        "x-ms-request-id": "09ee0634-c8e8-4a5a-8ec4-ea09a9f295e6",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064002Z:c1abb352-691a-4704-88f3-f71461af59d6"
+        "x-ms-request-id": "9c8089a2-45c2-4ff8-a565-3a20bf4ead8d",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T142955Z:6cf888ad-a974-41c8-88db-b3c9adc20bb2"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "InProgress"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/4afbbff9-229f-4403-8dfe-304fdf756f41?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ddda57a623780c9981ba1bae07e6f386",
+        "traceparent": "00-9fe8714c3d0bab4e9d9d5fb78ec997a0-e58ce80e3082244c-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "29c0b8e362201a784bea24efba42a600",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -2132,1603 +1431,46 @@
         "Cache-Control": "no-cache",
         "Content-Length": "30",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:03 GMT",
+        "Date": "Wed, 29 Jun 2022 14:30:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "40",
+        "Retry-After": "20",
         "Server": [
           "Microsoft-HTTPAPI/2.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "f0a9434e-b31a-4123-853c-ffc9b035cf2e",
-        "x-ms-client-request-id": "ddda57a623780c9981ba1bae07e6f386",
-        "x-ms-correlation-request-id": "105a3de9-a074-48d5-a379-fabdb0a6cb12",
+        "x-ms-arm-service-request-id": "3a14015e-76ee-4d4d-9317-98e4b3d41211",
+        "x-ms-client-request-id": "29c0b8e362201a784bea24efba42a600",
+        "x-ms-correlation-request-id": "1bfe98bc-29f0-4569-a41a-3b3878fcda22",
         "x-ms-ratelimit-remaining-subscription-reads": "11980",
-        "x-ms-request-id": "e83aa964-19ba-462c-9675-b595ea3de24d",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064003Z:105a3de9-a074-48d5-a379-fabdb0a6cb12"
+        "x-ms-request-id": "9301db3f-14d4-45e2-88be-0dfba3089100",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143016Z:1bfe98bc-29f0-4569-a41a-3b3878fcda22"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "InProgress"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/4afbbff9-229f-4403-8dfe-304fdf756f41?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3a6d4acca5d37e83dbe6818625cd6d67",
+        "Connection": "close",
+        "traceparent": "00-9fe8714c3d0bab4e9d9d5fb78ec997a0-cf9b57c5aef23d45-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "fba646c0c995d277d7a1d0007aee8cc7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:05 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "40",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "8964726b-31a2-4db6-ad68-a2c15cd5abef",
-        "x-ms-client-request-id": "3a6d4acca5d37e83dbe6818625cd6d67",
-        "x-ms-correlation-request-id": "4f1245cc-c68b-459c-b07f-8aa94a8f6d8d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11979",
-        "x-ms-request-id": "6c171187-39b0-4eae-af1c-e33d918c6868",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064005Z:4f1245cc-c68b-459c-b07f-8aa94a8f6d8d"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f7d0094af5702da70f62f33dfbc6142f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:06 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "80",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "ccdc50cf-72ca-429d-a4fd-927977dfb9e9",
-        "x-ms-client-request-id": "f7d0094af5702da70f62f33dfbc6142f",
-        "x-ms-correlation-request-id": "3533c708-a273-445b-974a-00ebb73a0133",
-        "x-ms-ratelimit-remaining-subscription-reads": "11978",
-        "x-ms-request-id": "1307ba68-3937-4169-af58-14cee1572f5b",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064006Z:3533c708-a273-445b-974a-00ebb73a0133"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "593a366e1ad90002d45b0291a112e7b4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:07 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "80",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "225837f4-1dcd-4d0f-bb5d-7d1c03494aa4",
-        "x-ms-client-request-id": "593a366e1ad90002d45b0291a112e7b4",
-        "x-ms-correlation-request-id": "6e43fdb5-b533-4de4-ae83-cdc9faaaed49",
-        "x-ms-ratelimit-remaining-subscription-reads": "11977",
-        "x-ms-request-id": "9697c825-a23b-4e1c-8864-f95711dc1b69",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064007Z:6e43fdb5-b533-4de4-ae83-cdc9faaaed49"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fd63b34cfc16d616a2402a71b1468315",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:08 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "160",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "f597a964-26b5-4f4c-a634-20df528d1a4c",
-        "x-ms-client-request-id": "fd63b34cfc16d616a2402a71b1468315",
-        "x-ms-correlation-request-id": "29fbeff4-5dd1-4fda-a37a-10536363ad53",
-        "x-ms-ratelimit-remaining-subscription-reads": "11976",
-        "x-ms-request-id": "896988c9-db0f-4f83-91c5-61c0b5c457dd",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064009Z:29fbeff4-5dd1-4fda-a37a-10536363ad53"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ee1752d113922f8d07cf2314f3158bfd",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:10 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "160",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "7a98fe4f-c7e0-4d4c-ac1a-3e490b501b8d",
-        "x-ms-client-request-id": "ee1752d113922f8d07cf2314f3158bfd",
-        "x-ms-correlation-request-id": "ca47a6a9-546f-445a-8d67-617c4f4da554",
-        "x-ms-ratelimit-remaining-subscription-reads": "11975",
-        "x-ms-request-id": "12606631-e8b6-408a-a97d-bd5294eaf876",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064010Z:ca47a6a9-546f-445a-8d67-617c4f4da554"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "47f03f7a166272192064b799f0904f8e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:11 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "7dba57fb-402e-4813-bf72-491b30e2966a",
-        "x-ms-client-request-id": "47f03f7a166272192064b799f0904f8e",
-        "x-ms-correlation-request-id": "9ce1a0f8-bf7c-4288-ad54-840016d97c82",
-        "x-ms-ratelimit-remaining-subscription-reads": "11974",
-        "x-ms-request-id": "57fd04c1-e6d8-47e2-93c7-aa29b015dbe6",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064012Z:9ce1a0f8-bf7c-4288-ad54-840016d97c82"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4fc0ecd8f8fa38212634f646d801e38d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:13 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "dc0c2c41-8a30-4bbf-9fa2-c94e5d7b9d17",
-        "x-ms-client-request-id": "4fc0ecd8f8fa38212634f646d801e38d",
-        "x-ms-correlation-request-id": "0659e587-c729-44a9-87f6-78c327057b4f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11973",
-        "x-ms-request-id": "8c85f8f9-8dea-4ab8-8303-914302d18e32",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064013Z:0659e587-c729-44a9-87f6-78c327057b4f"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "72f62db43b55bab338a5cd2e5cf33f76",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:14 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "e6186211-cdc5-4c68-b4d4-0b613e27e7a7",
-        "x-ms-client-request-id": "72f62db43b55bab338a5cd2e5cf33f76",
-        "x-ms-correlation-request-id": "57c3aec8-5652-4050-9eb3-1a79fb211dda",
-        "x-ms-ratelimit-remaining-subscription-reads": "11972",
-        "x-ms-request-id": "80c73a13-b389-4a49-ae28-cf4c173e9ca3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064014Z:57c3aec8-5652-4050-9eb3-1a79fb211dda"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "063c95803c5582021db8212e20d2991e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:15 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "51b3f1ab-f501-4864-8ae7-ae543038afee",
-        "x-ms-client-request-id": "063c95803c5582021db8212e20d2991e",
-        "x-ms-correlation-request-id": "e77e2d35-55d6-489f-a454-7b4f4f491d8c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11971",
-        "x-ms-request-id": "4a4dd5e5-6b99-4c95-ad93-96e996df470f",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064016Z:e77e2d35-55d6-489f-a454-7b4f4f491d8c"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c2e52980dc999d39390516552bf2db32",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:17 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "f9db8f24-448d-4e30-9245-bf0fa1ca1b3a",
-        "x-ms-client-request-id": "c2e52980dc999d39390516552bf2db32",
-        "x-ms-correlation-request-id": "8e17c85a-3afb-4cbd-ac19-fe4e9cdc0e52",
-        "x-ms-ratelimit-remaining-subscription-reads": "11970",
-        "x-ms-request-id": "739c1fdf-75df-4546-aa86-3082fc81bb25",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064017Z:8e17c85a-3afb-4cbd-ac19-fe4e9cdc0e52"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "43c67ff4ddc578372a74549c19859966",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:18 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "776be4e3-5f8d-44dd-aff6-c6775979ddc6",
-        "x-ms-client-request-id": "43c67ff4ddc578372a74549c19859966",
-        "x-ms-correlation-request-id": "e271e309-da2b-41c3-82ed-bcff552f9d99",
-        "x-ms-ratelimit-remaining-subscription-reads": "11969",
-        "x-ms-request-id": "75cf815f-e8ce-44fb-8f8d-b1fff6b6ecdd",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064018Z:e271e309-da2b-41c3-82ed-bcff552f9d99"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "32aeaf0b7c0ea3dc5b9fcd5025ac562a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:19 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "15039fe0-9b83-4a23-bc45-ea2f37123876",
-        "x-ms-client-request-id": "32aeaf0b7c0ea3dc5b9fcd5025ac562a",
-        "x-ms-correlation-request-id": "f0e65c73-6a4c-4321-83cd-f633da6fd409",
-        "x-ms-ratelimit-remaining-subscription-reads": "11968",
-        "x-ms-request-id": "2b81bdaf-9000-411d-9378-f8cadbee031a",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064019Z:f0e65c73-6a4c-4321-83cd-f633da6fd409"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a139efdc550ba359f26d9724879c83b4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:20 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "1ac7a0ee-84a3-4618-9992-4dabacbc5dd3",
-        "x-ms-client-request-id": "a139efdc550ba359f26d9724879c83b4",
-        "x-ms-correlation-request-id": "8a1f6939-5555-4e38-8b16-796d1dad1643",
-        "x-ms-ratelimit-remaining-subscription-reads": "11967",
-        "x-ms-request-id": "ab2c4171-bead-44ea-b43d-d200b82628e1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064021Z:8a1f6939-5555-4e38-8b16-796d1dad1643"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7c49af6ba8447823a222e72610e7527e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:22 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "4c072125-d74b-4dff-9fba-2795a7706c59",
-        "x-ms-client-request-id": "7c49af6ba8447823a222e72610e7527e",
-        "x-ms-correlation-request-id": "5cd44a73-4c0d-4829-8c3c-ddda7fa26231",
-        "x-ms-ratelimit-remaining-subscription-reads": "11966",
-        "x-ms-request-id": "af260330-ba39-4e27-b836-d507701d0a62",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064022Z:5cd44a73-4c0d-4829-8c3c-ddda7fa26231"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2ac0291ef84cb55b550b40a1e4b81cbf",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:23 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "a1d2ee5f-d6a1-4292-a625-4551dba2a975",
-        "x-ms-client-request-id": "2ac0291ef84cb55b550b40a1e4b81cbf",
-        "x-ms-correlation-request-id": "94450437-970d-4844-ab61-b4e62fed1f43",
-        "x-ms-ratelimit-remaining-subscription-reads": "11965",
-        "x-ms-request-id": "61364058-945c-4f77-9fc0-139c6b21b579",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064023Z:94450437-970d-4844-ab61-b4e62fed1f43"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "75e4181cda6233e6cbc0fee86e32920a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:24 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "ca344f22-6662-40de-be33-f9e43b372cfd",
-        "x-ms-client-request-id": "75e4181cda6233e6cbc0fee86e32920a",
-        "x-ms-correlation-request-id": "f4a983ff-b1fd-4c82-95f1-36afc601eea0",
-        "x-ms-ratelimit-remaining-subscription-reads": "11964",
-        "x-ms-request-id": "2784a494-a3a9-4bb3-baf2-db125b9243d8",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064025Z:f4a983ff-b1fd-4c82-95f1-36afc601eea0"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5e06191a58db726854942639678294ea",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:26 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "1ef47721-fd89-4cb8-a6fe-dccb3334c15a",
-        "x-ms-client-request-id": "5e06191a58db726854942639678294ea",
-        "x-ms-correlation-request-id": "d82764de-c4c6-422d-920b-d80f526ba880",
-        "x-ms-ratelimit-remaining-subscription-reads": "11963",
-        "x-ms-request-id": "613d2be1-40b6-424c-a8a1-e061a4b4e59c",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064026Z:d82764de-c4c6-422d-920b-d80f526ba880"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f70a2806dd03431b438c5f8bfa724723",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:27 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "a6f50e2e-2756-4171-b22d-3ca1aa65a264",
-        "x-ms-client-request-id": "f70a2806dd03431b438c5f8bfa724723",
-        "x-ms-correlation-request-id": "a12aeaf6-6d9b-405b-8eb3-ecb95757935c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11962",
-        "x-ms-request-id": "6d4ee570-e706-44ab-86b8-04d8d2429b0b",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064027Z:a12aeaf6-6d9b-405b-8eb3-ecb95757935c"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ca863678beb1c4e3b07120ceb4adcc48",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:28 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "70ba3772-180b-4b27-a5ff-5ea6c4d1cf1c",
-        "x-ms-client-request-id": "ca863678beb1c4e3b07120ceb4adcc48",
-        "x-ms-correlation-request-id": "7fcd9d52-820e-4d93-ab14-42e97ad41be5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11961",
-        "x-ms-request-id": "f690c90f-2957-47c5-9da2-af862c2905ca",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064029Z:7fcd9d52-820e-4d93-ab14-42e97ad41be5"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "45e2132b9b283d07fec31a4ff8dc78e2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:29 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "a20ceea3-d773-48c5-9660-2ed3556069f6",
-        "x-ms-client-request-id": "45e2132b9b283d07fec31a4ff8dc78e2",
-        "x-ms-correlation-request-id": "7ba9a621-d15e-4362-b154-0645204fc048",
-        "x-ms-ratelimit-remaining-subscription-reads": "11960",
-        "x-ms-request-id": "324f7aa0-a882-492d-b290-a2e97b73ddac",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064030Z:7ba9a621-d15e-4362-b154-0645204fc048"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "31c0024cc9fb483944464691bc4c8e96",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:31 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "b8e0eb85-b524-4414-aa31-4c4809f75b95",
-        "x-ms-client-request-id": "31c0024cc9fb483944464691bc4c8e96",
-        "x-ms-correlation-request-id": "648b5686-e454-4050-8714-8d1b946f837a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11959",
-        "x-ms-request-id": "e02619bf-175f-4785-91b5-08e034ce024b",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064031Z:648b5686-e454-4050-8714-8d1b946f837a"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e65f17c00190ddfb2f49cbeea394cbd4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:32 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "eaa39fde-b5a8-4c28-a139-e197b7a1f60c",
-        "x-ms-client-request-id": "e65f17c00190ddfb2f49cbeea394cbd4",
-        "x-ms-correlation-request-id": "28d730db-0129-4a9a-8ca6-f05e1a7526bb",
-        "x-ms-ratelimit-remaining-subscription-reads": "11958",
-        "x-ms-request-id": "210316a3-a453-45ff-b53e-cbeaa8bad670",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064032Z:28d730db-0129-4a9a-8ca6-f05e1a7526bb"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b1813ef99aec624cda9901e1547581b2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:33 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "820c8b83-311f-4b21-9c8b-3de424d609d1",
-        "x-ms-client-request-id": "b1813ef99aec624cda9901e1547581b2",
-        "x-ms-correlation-request-id": "5078f1b9-5631-49f6-b56d-e3c7c5f9cca5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11957",
-        "x-ms-request-id": "7514510a-bb44-4dbd-93af-82c44a4fac9a",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064034Z:5078f1b9-5631-49f6-b56d-e3c7c5f9cca5"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e08f8434927c4b5207e302b2fe4aa5b0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:35 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "cbe2cfa7-e324-43bf-ae7d-13b1eded3213",
-        "x-ms-client-request-id": "e08f8434927c4b5207e302b2fe4aa5b0",
-        "x-ms-correlation-request-id": "d5436b0b-bbf3-4927-8efe-fb006cd50bc5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11956",
-        "x-ms-request-id": "a681a11a-be96-4ab9-a490-68862054d17d",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064035Z:d5436b0b-bbf3-4927-8efe-fb006cd50bc5"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7d97727adcca25a9cafd0bf6001988b9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:36 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "b4c6463a-cfec-41f7-8cfd-6ddb88bd4011",
-        "x-ms-client-request-id": "7d97727adcca25a9cafd0bf6001988b9",
-        "x-ms-correlation-request-id": "c1545126-dba9-4d07-acbd-d73abc7e2aec",
-        "x-ms-ratelimit-remaining-subscription-reads": "11955",
-        "x-ms-request-id": "aa206dd2-d7a1-469e-a523-3eb90dd2f84a",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064037Z:c1545126-dba9-4d07-acbd-d73abc7e2aec"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1eb919c8eb046757ec36a908989a638f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:38 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "ac9e6003-6f9c-4687-8d53-3f8fed7a77a9",
-        "x-ms-client-request-id": "1eb919c8eb046757ec36a908989a638f",
-        "x-ms-correlation-request-id": "024fa715-5154-4f3c-a113-0f02b61f9bd6",
-        "x-ms-ratelimit-remaining-subscription-reads": "11954",
-        "x-ms-request-id": "69314fd7-d7c6-4d40-98b6-9fc47872a44e",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064038Z:024fa715-5154-4f3c-a113-0f02b61f9bd6"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e16750f404dd57e7da69167e865b4aee",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:39 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "4f9a9030-fb76-4616-8098-dbe3ddeb9e04",
-        "x-ms-client-request-id": "e16750f404dd57e7da69167e865b4aee",
-        "x-ms-correlation-request-id": "c01fcdb9-2c92-4300-a39a-68c6e584ffec",
-        "x-ms-ratelimit-remaining-subscription-reads": "11953",
-        "x-ms-request-id": "54666429-c7da-4e35-92df-f165d5a9c366",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064039Z:c01fcdb9-2c92-4300-a39a-68c6e584ffec"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e5e9485b86918fac1a30909432a18c2f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:40 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "d491659e-b574-48f1-9b17-32ead77cc9c4",
-        "x-ms-client-request-id": "e5e9485b86918fac1a30909432a18c2f",
-        "x-ms-correlation-request-id": "03bd3a76-87cf-4ab1-b972-9f1b8d67e197",
-        "x-ms-ratelimit-remaining-subscription-reads": "11952",
-        "x-ms-request-id": "f23a63d3-e438-456c-9e03-9fe87cd8a499",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064041Z:03bd3a76-87cf-4ab1-b972-9f1b8d67e197"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b0017b9aa6b1c3db3161439ad5d9e090",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:42 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "4f0cc0e4-946c-436a-a9fb-d30d410b97d9",
-        "x-ms-client-request-id": "b0017b9aa6b1c3db3161439ad5d9e090",
-        "x-ms-correlation-request-id": "8f9e272d-9482-4f9d-bb6d-bbbd06d32b6a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11951",
-        "x-ms-request-id": "3f6c9429-3cf9-4bfd-a3d8-2a4f0d5ed893",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064042Z:8f9e272d-9482-4f9d-bb6d-bbbd06d32b6a"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "50adbbec7eb06dfea4d8c7ad73532439",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:43 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "65dd13cc-913c-401a-8760-86081edeb2b1",
-        "x-ms-client-request-id": "50adbbec7eb06dfea4d8c7ad73532439",
-        "x-ms-correlation-request-id": "633db535-766f-441b-85f7-5565d082ca3c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11950",
-        "x-ms-request-id": "031517e4-3e6c-4889-b5a8-9a6dc7600883",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064043Z:633db535-766f-441b-85f7-5565d082ca3c"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0ae4e6dd995ab43d6d25b32f4311ba41",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:44 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "94eab9cf-8e2d-41d3-8e62-bd09ed31e1bf",
-        "x-ms-client-request-id": "0ae4e6dd995ab43d6d25b32f4311ba41",
-        "x-ms-correlation-request-id": "d43b5ae8-de34-42ff-9599-ce1d1e15a6c4",
-        "x-ms-ratelimit-remaining-subscription-reads": "11949",
-        "x-ms-request-id": "1bfbaf8f-bb64-43d1-bafe-77aec9f5ac98",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064045Z:d43b5ae8-de34-42ff-9599-ce1d1e15a6c4"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "77a800503cf41b7e7d940cd9df2e50de",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:45 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "73c9a184-0a52-4424-84a5-8698a4ff2f49",
-        "x-ms-client-request-id": "77a800503cf41b7e7d940cd9df2e50de",
-        "x-ms-correlation-request-id": "16d55b22-cf0a-48da-ae1c-75ec3ca95332",
-        "x-ms-ratelimit-remaining-subscription-reads": "11948",
-        "x-ms-request-id": "2f5f989b-a7e3-49da-a698-effd5380f62f",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064046Z:16d55b22-cf0a-48da-ae1c-75ec3ca95332"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "eebd0a3cd5f452367ef8e38bcace2a93",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:47 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "362b8e54-467b-47c3-a235-e0d6c5fb7dd4",
-        "x-ms-client-request-id": "eebd0a3cd5f452367ef8e38bcace2a93",
-        "x-ms-correlation-request-id": "bb6d07c3-b875-4163-817d-3b15577c4516",
-        "x-ms-ratelimit-remaining-subscription-reads": "11947",
-        "x-ms-request-id": "de531e71-7d25-4b01-8aca-a33f4aca7997",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064047Z:bb6d07c3-b875-4163-817d-3b15577c4516"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "735d851eadaaa04568c88dc68d63d53e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:48 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "9c49f78e-64eb-469c-83d8-aa24ba972847",
-        "x-ms-client-request-id": "735d851eadaaa04568c88dc68d63d53e",
-        "x-ms-correlation-request-id": "81489463-a4f4-406f-8a94-8a397f96d039",
-        "x-ms-ratelimit-remaining-subscription-reads": "11946",
-        "x-ms-request-id": "972dd2f4-3cba-4b64-9892-75621f4b2bb7",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064049Z:81489463-a4f4-406f-8a94-8a397f96d039"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "38f3d4d5cb537a4dc956f9fc59f350ae",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:49 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "3dac8036-a9de-4604-8622-83e906a03eab",
-        "x-ms-client-request-id": "38f3d4d5cb537a4dc956f9fc59f350ae",
-        "x-ms-correlation-request-id": "5b2bc293-5b5a-4553-afad-445b2097adc2",
-        "x-ms-ratelimit-remaining-subscription-reads": "11945",
-        "x-ms-request-id": "8dd5a947-a63b-455c-a064-fbf85414f7f9",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064050Z:5b2bc293-5b5a-4553-afad-445b2097adc2"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5aba7869ddd18f33c51d862b4770c41a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:51 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "9ac7349f-57ff-4d15-849b-19adba753d70",
-        "x-ms-client-request-id": "5aba7869ddd18f33c51d862b4770c41a",
-        "x-ms-correlation-request-id": "f3145280-f109-42bb-89ce-3a2fb6eeb69c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11944",
-        "x-ms-request-id": "23250149-85cb-4f3d-b46e-7ff6e4dd86df",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064051Z:f3145280-f109-42bb-89ce-3a2fb6eeb69c"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f6b5a422f1db523f37e2a954b3494674",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:52 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "ca863d05-89ca-4c91-9016-c361f4d12c11",
-        "x-ms-client-request-id": "f6b5a422f1db523f37e2a954b3494674",
-        "x-ms-correlation-request-id": "d0175f6a-d87b-4ee8-8ef6-7c22c19624f9",
-        "x-ms-ratelimit-remaining-subscription-reads": "11943",
-        "x-ms-request-id": "e14efa3d-76a4-4aae-8d4f-027d6d7aa707",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064052Z:d0175f6a-d87b-4ee8-8ef6-7c22c19624f9"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "155cdf777ba9f86da063733644213259",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:53 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "f2ae9ce2-ae60-4e23-8a76-340c62fc86c0",
-        "x-ms-client-request-id": "155cdf777ba9f86da063733644213259",
-        "x-ms-correlation-request-id": "2251f264-da9b-46ce-a750-a91de85772d7",
-        "x-ms-ratelimit-remaining-subscription-reads": "11942",
-        "x-ms-request-id": "96d61e4f-fa8a-45f0-b1c5-c7f4e1c2b849",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064054Z:2251f264-da9b-46ce-a750-a91de85772d7"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b5d9df915a3d77d2396822ee33dfdb7b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:54 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "29edfae4-ca62-446b-ae2c-f80276090bd8",
-        "x-ms-client-request-id": "b5d9df915a3d77d2396822ee33dfdb7b",
-        "x-ms-correlation-request-id": "f6e92cb8-6fdc-482b-af60-d16d785a5be9",
-        "x-ms-ratelimit-remaining-subscription-reads": "11941",
-        "x-ms-request-id": "b0e3e3f0-1dfc-424d-858a-e22a4e2b8b0b",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064055Z:f6e92cb8-6fdc-482b-af60-d16d785a5be9"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "68b312d6af13a77136bd55787e090d15",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:56 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "285e6bf6-be61-4c91-83bd-3bcee91bd770",
-        "x-ms-client-request-id": "68b312d6af13a77136bd55787e090d15",
-        "x-ms-correlation-request-id": "400c854f-c538-4251-a6ac-ec0506a43349",
-        "x-ms-ratelimit-remaining-subscription-reads": "11940",
-        "x-ms-request-id": "84d9d207-9f9b-4d92-8e96-8ef10b66e0e7",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064056Z:400c854f-c538-4251-a6ac-ec0506a43349"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d4c24fb0916f1d360ce5db40587fc4c1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:57 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "78a8747b-9ca6-40e6-9cca-590aaf457163",
-        "x-ms-client-request-id": "d4c24fb0916f1d360ce5db40587fc4c1",
-        "x-ms-correlation-request-id": "54fe0432-eda1-440d-ac8f-88bf1e0dedff",
-        "x-ms-ratelimit-remaining-subscription-reads": "11939",
-        "x-ms-request-id": "57c8e7cb-5e8d-45da-9573-231b8a719fd5",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064058Z:54fe0432-eda1-440d-ac8f-88bf1e0dedff"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/33df434b-4bef-427e-9b18-d31882c576ca?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "325ff787c96ee2466e317e80055af930",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
+        "Connection": "close",
         "Content-Length": "29",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:58 GMT",
+        "Date": "Wed, 29 Jun 2022 14:30:36 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -3737,26 +1479,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "1eff422e-105b-4de1-8712-65216cab1d8d",
-        "x-ms-client-request-id": "325ff787c96ee2466e317e80055af930",
-        "x-ms-correlation-request-id": "f90df234-646e-4124-ad2f-0a22fd5a302c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11938",
-        "x-ms-request-id": "a45f5419-07b8-4e22-8a9e-863595a00240",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064059Z:f90df234-646e-4124-ad2f-0a22fd5a302c"
+        "x-ms-arm-service-request-id": "09ca0322-68a4-4f5d-b574-799c912ae1bf",
+        "x-ms-client-request-id": "fba646c0c995d277d7a1d0007aee8cc7",
+        "x-ms-correlation-request-id": "b50d8b7d-53cf-4f8c-9a9e-30917692dbfa",
+        "x-ms-ratelimit-remaining-subscription-reads": "11979",
+        "x-ms-request-id": "6b17bb27-ef35-4d5a-bfdf-2f76766703a8",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143037Z:b50d8b7d-53cf-4f8c-9a9e-30917692dbfa"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022Succeeded\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "Succeeded"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/privateEndpoints/pe-6794?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.Network/privateEndpoints/pe-5576?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e43d0c5a071c450bdb965c2dd3304eb7",
+        "traceparent": "00-9fe8714c3d0bab4e9d9d5fb78ec997a0-77d1366787616f48-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "8bc173e2888e8507ca4a287e68faedea",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -3765,8 +1506,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1959",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:59 GMT",
-        "ETag": "W/\u00221e93dde9-1463-4fe7-bee5-0a88ec8a3179\u0022",
+        "Date": "Wed, 29 Jun 2022 14:30:38 GMT",
+        "ETag": "W/\u0022ba0a7ec4-5b23-4523-8c60-506265b1637f\u0022",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -3775,66 +1516,65 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "d37828ff-95f6-4c50-a855-9e1dd1d8cdd7",
-        "x-ms-client-request-id": "e43d0c5a071c450bdb965c2dd3304eb7",
-        "x-ms-correlation-request-id": "b85cb3cf-b3df-422c-a298-02896ac515d9",
-        "x-ms-ratelimit-remaining-subscription-reads": "11937",
-        "x-ms-request-id": "446f2b58-e6da-4ec4-8528-631af6c55bcf",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064059Z:b85cb3cf-b3df-422c-a298-02896ac515d9"
+        "x-ms-arm-service-request-id": "74e38967-dc38-4117-8e2d-485e59deec77",
+        "x-ms-client-request-id": "8bc173e2888e8507ca4a287e68faedea",
+        "x-ms-correlation-request-id": "3caa6fa2-3104-465b-833b-247b88f30c95",
+        "x-ms-ratelimit-remaining-subscription-reads": "11996",
+        "x-ms-request-id": "fe62dd3a-ee93-4059-b298-e36c6d9fa784",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143039Z:3caa6fa2-3104-465b-833b-247b88f30c95"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022name\u0022: \u0022pe-6794\u0022,\r\n",
-        "  \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/privateEndpoints/pe-6794\u0022,\r\n",
-        "  \u0022etag\u0022: \u0022W/\\\u00221e93dde9-1463-4fe7-bee5-0a88ec8a3179\\\u0022\u0022,\r\n",
-        "  \u0022type\u0022: \u0022Microsoft.Network/privateEndpoints\u0022,\r\n",
-        "  \u0022location\u0022: \u0022westus2\u0022,\r\n",
-        "  \u0022properties\u0022: {\r\n",
-        "    \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "    \u0022resourceGuid\u0022: \u0022c8cbffac-e1ba-4bde-b22c-07cc72405d46\u0022,\r\n",
-        "    \u0022privateLinkServiceConnections\u0022: [],\r\n",
-        "    \u0022manualPrivateLinkServiceConnections\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022name\u0022: \u0022pec1197\u0022,\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/privateEndpoints/pe-6794/manualPrivateLinkServiceConnections/pec1197\u0022,\r\n",
-        "        \u0022etag\u0022: \u0022W/\\\u00221e93dde9-1463-4fe7-bee5-0a88ec8a3179\\\u0022\u0022,\r\n",
-        "        \u0022properties\u0022: {\r\n",
-        "          \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "          \u0022privateLinkServiceId\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756\u0022,\r\n",
-        "          \u0022groupIds\u0022: [\r\n",
-        "            \u0022namespace\u0022\r\n",
-        "          ],\r\n",
-        "          \u0022requestMessage\u0022: \u0022SDK test\u0022,\r\n",
-        "          \u0022privateLinkServiceConnectionState\u0022: {\r\n",
-        "            \u0022status\u0022: \u0022Pending\u0022,\r\n",
-        "            \u0022description\u0022: \u0022SDK test\u0022,\r\n",
-        "            \u0022actionsRequired\u0022: \u0022None\u0022\r\n",
-        "          }\r\n",
-        "        },\r\n",
-        "        \u0022type\u0022: \u0022Microsoft.Network/privateEndpoints/manualPrivateLinkServiceConnections\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022subnet\u0022: {\r\n",
-        "      \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/virtualNetworks/vnet-9802/subnets/default\u0022\r\n",
-        "    },\r\n",
-        "    \u0022networkInterfaces\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/networkInterfaces/pe-6794.nic.db67e56f-e401-4e3c-bac3-8512aa0056a1\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022customDnsConfigs\u0022: []\r\n",
-        "  }\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "name": "pe-5576",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.Network/privateEndpoints/pe-5576",
+        "etag": "W/\u0022ba0a7ec4-5b23-4523-8c60-506265b1637f\u0022",
+        "type": "Microsoft.Network/privateEndpoints",
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "resourceGuid": "da0e7734-4b93-4ffe-bdd8-327f80eee100",
+          "privateLinkServiceConnections": [],
+          "manualPrivateLinkServiceConnections": [
+            {
+              "name": "pec1009",
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.Network/privateEndpoints/pe-5576/manualPrivateLinkServiceConnections/pec1009",
+              "etag": "W/\u0022ba0a7ec4-5b23-4523-8c60-506265b1637f\u0022",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateLinkServiceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239",
+                "groupIds": [
+                  "namespace"
+                ],
+                "requestMessage": "SDK test",
+                "privateLinkServiceConnectionState": {
+                  "status": "Pending",
+                  "description": "SDK test",
+                  "actionsRequired": "None"
+                }
+              },
+              "type": "Microsoft.Network/privateEndpoints/manualPrivateLinkServiceConnections"
+            }
+          ],
+          "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.Network/virtualNetworks/vnet-3299/subnets/default"
+          },
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.Network/networkInterfaces/pe-5576.nic.9d8222b7-ba6f-4b50-bed5-d47ffde6d02c"
+            }
+          ],
+          "customDnsConfigs": []
+        }
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239/privateEndpointConnections?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "86f093f9daa9e6a709e0653e12b617b1",
+        "traceparent": "00-21398a84f2cd0c448d1f20de8d26afad-e96d22705faac946-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "eb6646e64f591a7640ed517f9178a05c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -3843,7 +1583,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "689",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:59 GMT",
+        "Date": "Wed, 29 Jun 2022 14:30:40 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -3853,23 +1593,23 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "86f093f9daa9e6a709e0653e12b617b1",
-        "x-ms-correlation-request-id": "4a47e408-5972-4697-849c-33590f98e041",
-        "x-ms-ratelimit-remaining-subscription-reads": "11936",
-        "x-ms-request-id": "219b2a48-a031-41d9-bfd7-df194011f4f4_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064059Z:4a47e408-5972-4697-849c-33590f98e041"
+        "x-ms-client-request-id": "eb6646e64f591a7640ed517f9178a05c",
+        "x-ms-correlation-request-id": "8a2f7dba-2d6a-4ed3-a040-0fd54c5a0fd9",
+        "x-ms-ratelimit-remaining-subscription-reads": "11995",
+        "x-ms-request-id": "e0876376-48c2-49e6-85dc-d81b80107f59_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143041Z:8a2f7dba-2d6a-4ed3-a040-0fd54c5a0fd9"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca",
-            "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6239/privateEndpointConnections/0ea10d7d-a0fe-4371-a4d0-51436ddbfe54",
+            "name": "0ea10d7d-a0fe-4371-a4d0-51436ddbfe54",
             "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
             "location": "East US 2",
             "properties": {
               "provisioningState": "Succeeded",
               "privateEndpoint": {
-                "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/privateEndpoints/pe-6794"
+                "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-8189/providers/Microsoft.Network/privateEndpoints/pe-5576"
               },
               "privateLinkServiceConnectionState": {
                 "status": "Pending",
@@ -3882,1719 +1622,11 @@
           }
         ]
       }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4ce6abece04180a5eb1a57d76c180f3e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "689",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:40:59 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "4ce6abece04180a5eb1a57d76c180f3e",
-        "x-ms-correlation-request-id": "35f4d810-bbad-4757-b2ec-43e9fef4b9aa",
-        "x-ms-ratelimit-remaining-subscription-reads": "11935",
-        "x-ms-request-id": "3dcee13d-7d24-4167-afbf-72ea91204899_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064100Z:35f4d810-bbad-4757-b2ec-43e9fef4b9aa"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca",
-            "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-            "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-            "location": "East US 2",
-            "properties": {
-              "provisioningState": "Succeeded",
-              "privateEndpoint": {
-                "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/privateEndpoints/pe-6794"
-              },
-              "privateLinkServiceConnectionState": {
-                "status": "Pending",
-                "description": "SDK test"
-              },
-              "groupIds": [
-                "namespace"
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7287c6e2726a7f866456da3ca1cd3225",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com:443/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Date": "Fri, 19 Nov 2021 06:41:00 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "7287c6e2726a7f866456da3ca1cd3225",
-        "x-ms-correlation-request-id": "efcf04a0-6165-4f5c-b2c8-8f168882cf9d",
-        "x-ms-ratelimit-remaining-subscription-deletes": "14999",
-        "x-ms-request-id": "b2461a1f-b35f-4341-a4a1-14b25de5eaad_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064100Z:efcf04a0-6165-4f5c-b2c8-8f168882cf9d"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4b5b27d0a52f79462567e7ea0569de1e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "463",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:00 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "4b5b27d0a52f79462567e7ea0569de1e",
-        "x-ms-correlation-request-id": "38e7f600-41a7-428c-bf19-c49ad13d3aec",
-        "x-ms-ratelimit-remaining-subscription-reads": "11934",
-        "x-ms-request-id": "7313b69a-7907-4c5e-b40f-51cd7ad6673a_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064101Z:38e7f600-41a7-428c-bf19-c49ad13d3aec"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:41:00.65Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c15931e8e7d7e0f4506d84fad7f7fb94",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "463",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:01 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c15931e8e7d7e0f4506d84fad7f7fb94",
-        "x-ms-correlation-request-id": "87d24006-a09a-405d-85ae-4d1552c3e752",
-        "x-ms-ratelimit-remaining-subscription-reads": "11933",
-        "x-ms-request-id": "3bfe261b-e9c7-402b-9a76-0eabae80fccd_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064102Z:87d24006-a09a-405d-85ae-4d1552c3e752"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:41:00.65Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7a6be9dde672d8f664c702e11a8c1383",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "463",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:03 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "7a6be9dde672d8f664c702e11a8c1383",
-        "x-ms-correlation-request-id": "77616337-2b5e-4330-be1a-2a34a162787d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11932",
-        "x-ms-request-id": "3a671cde-56c1-4162-9852-79fe933b9db7_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064103Z:77616337-2b5e-4330-be1a-2a34a162787d"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:41:00.65Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "51a67c91b876e919327bfbc1204ca22d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "463",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:04 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "51a67c91b876e919327bfbc1204ca22d",
-        "x-ms-correlation-request-id": "578d8fdc-5fc5-4908-98b0-dfc8f371da2c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11931",
-        "x-ms-request-id": "085e6a7a-2afb-4f74-a1d1-9deb2a4c3a0e_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064105Z:578d8fdc-5fc5-4908-98b0-dfc8f371da2c"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:41:00.65Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1c0d536b64fe02ab3b805d0fe513c5c4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "463",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:05 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "1c0d536b64fe02ab3b805d0fe513c5c4",
-        "x-ms-correlation-request-id": "a3af5f76-01e0-4d27-8c6b-dd016c67d03d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11930",
-        "x-ms-request-id": "ac1009a8-e4de-4b1e-85be-763f00528869_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064106Z:a3af5f76-01e0-4d27-8c6b-dd016c67d03d"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:41:00.65Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5b68015aa950251dcf8247f7ea35b817",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "463",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:07 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5b68015aa950251dcf8247f7ea35b817",
-        "x-ms-correlation-request-id": "5f523fba-da79-4245-8e5b-bf61ea674bbd",
-        "x-ms-ratelimit-remaining-subscription-reads": "11929",
-        "x-ms-request-id": "ad1e3f3b-54bb-40fe-8098-c71f85775a7e_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064107Z:5f523fba-da79-4245-8e5b-bf61ea674bbd"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:41:00.65Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c776d425f77f2c85d0a416f65a0a031f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "463",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:08 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c776d425f77f2c85d0a416f65a0a031f",
-        "x-ms-correlation-request-id": "23c6a6fe-5bbe-456a-8772-ec15a0b077d4",
-        "x-ms-ratelimit-remaining-subscription-reads": "11928",
-        "x-ms-request-id": "85fec933-08dd-4a53-81cd-8c0df3ecbd5b_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064109Z:23c6a6fe-5bbe-456a-8772-ec15a0b077d4"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:41:00.65Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1f6637b547e3c2dd35e84c7b1db41705",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "463",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:10 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "1f6637b547e3c2dd35e84c7b1db41705",
-        "x-ms-correlation-request-id": "fce74e18-1893-473d-9a28-2b7cdea49de0",
-        "x-ms-ratelimit-remaining-subscription-reads": "11927",
-        "x-ms-request-id": "e0be5f7d-563d-457b-a8f3-a094499194b2_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064110Z:fce74e18-1893-473d-9a28-2b7cdea49de0"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:41:00.65Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "10ea46c8fe9c62457b3b8aab9327cac5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "463",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:11 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "10ea46c8fe9c62457b3b8aab9327cac5",
-        "x-ms-correlation-request-id": "3a807d13-92fb-4e66-941c-6abf74d2be71",
-        "x-ms-ratelimit-remaining-subscription-reads": "11926",
-        "x-ms-request-id": "a586d59e-dbf3-4bba-a856-50e72808e83f_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064112Z:3a807d13-92fb-4e66-941c-6abf74d2be71"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:41:11.64Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b341277e98cedd33f7b39296aa090f1b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "460",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:12 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "b341277e98cedd33f7b39296aa090f1b",
-        "x-ms-correlation-request-id": "34d839f9-4e25-4a25-87f6-e4a4df5b2e42",
-        "x-ms-ratelimit-remaining-subscription-reads": "11925",
-        "x-ms-request-id": "840c5573-0412-438b-8bdd-3f0314ca2cad_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064113Z:34d839f9-4e25-4a25-87f6-e4a4df5b2e42"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca/operationStatus/8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-        "status": "Succeeded",
-        "startTime": "0001-01-01T00:00:00",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "142e108df31fb782f104a3a7bc312f0d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Date": "Fri, 19 Nov 2021 06:41:14 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "142e108df31fb782f104a3a7bc312f0d",
-        "x-ms-correlation-request-id": "03d45d1e-66cc-4c70-a41a-67ab5086b2f3",
-        "x-ms-ratelimit-remaining-subscription-deletes": "14998",
-        "x-ms-request-id": "2599b880-6322-4e14-9c2a-2ea9fdccc044_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064115Z:03d45d1e-66cc-4c70-a41a-67ab5086b2f3"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "821e6e2cb6f98ba6a58ac1caf58b21c5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1490",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:14 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "48",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "821e6e2cb6f98ba6a58ac1caf58b21c5",
-        "x-ms-correlation-request-id": "9b640f83-5c33-4042-b7a7-f36eeb9a07c5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11924",
-        "x-ms-request-id": "f990631f-d6bb-4fb6-ab87-3d6d24c4cff0_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064115Z:9b640f83-5c33-4042-b7a7-f36eeb9a07c5"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/privateEndpoints/pe-6794"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:41:14.853Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "237984841a0b2aa8d9fe0112d9994b43",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1490",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:16 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "55",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "237984841a0b2aa8d9fe0112d9994b43",
-        "x-ms-correlation-request-id": "97e599a0-e92f-4de8-a72b-a9172c3632ac",
-        "x-ms-ratelimit-remaining-subscription-reads": "11923",
-        "x-ms-request-id": "fb5fcff0-2de1-43f6-b77b-0eddc0a561a8_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064116Z:97e599a0-e92f-4de8-a72b-a9172c3632ac"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/privateEndpoints/pe-6794"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:41:14.853Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4e7b314bac136614e17150e8a16d3a86",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1490",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:17 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "42",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "4e7b314bac136614e17150e8a16d3a86",
-        "x-ms-correlation-request-id": "4e751372-313c-401f-9158-c9c53db7601b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11922",
-        "x-ms-request-id": "286dee97-e577-4ccf-af87-25944354c199_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064118Z:4e751372-313c-401f-9158-c9c53db7601b"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/privateEndpoints/pe-6794"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:41:14.853Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e76453eb95341166c5f4a9fab593b10b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1490",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:18 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "37",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "e76453eb95341166c5f4a9fab593b10b",
-        "x-ms-correlation-request-id": "775923cf-f0b8-49a4-938d-bc10f661e58f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11921",
-        "x-ms-request-id": "3280c25d-6e1c-47e3-8187-ace4e73ad732_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064119Z:775923cf-f0b8-49a4-938d-bc10f661e58f"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/privateEndpoints/pe-6794"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:41:14.853Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c37e7e3fd210d7b26f12429acac0886b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1490",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:20 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "32",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c37e7e3fd210d7b26f12429acac0886b",
-        "x-ms-correlation-request-id": "8e13b3bd-36ed-41ba-80d3-e029f11b781b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11920",
-        "x-ms-request-id": "237747d8-703b-44cb-8b59-6fc67062dca6_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064120Z:8e13b3bd-36ed-41ba-80d3-e029f11b781b"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/privateEndpoints/pe-6794"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:41:14.853Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "85267bc46335b60eca6a891f0319b14d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1490",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:21 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "45",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "85267bc46335b60eca6a891f0319b14d",
-        "x-ms-correlation-request-id": "e7444105-18a6-4ee9-8d4d-85d48f3c169c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11919",
-        "x-ms-request-id": "766956c3-0946-41d0-80db-e025a0f30e7e_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064122Z:e7444105-18a6-4ee9-8d4d-85d48f3c169c"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/privateEndpoints/pe-6794"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:41:14.853Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "23a944c076ee1976a18c782252cc4605",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1490",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:22 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "44",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "23a944c076ee1976a18c782252cc4605",
-        "x-ms-correlation-request-id": "86479245-4471-4fda-8eeb-8853271f933e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11918",
-        "x-ms-request-id": "f3ebe504-99af-4b37-b0c8-c9a527fce79b_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064123Z:86479245-4471-4fda-8eeb-8853271f933e"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/privateEndpoints/pe-6794"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:41:14.853Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3a363d6b2b6cdcd66fc7f9a54993d456",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1490",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:24 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "30",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "3a363d6b2b6cdcd66fc7f9a54993d456",
-        "x-ms-correlation-request-id": "019fa9ef-2d01-4aea-a309-3eca17afe768",
-        "x-ms-ratelimit-remaining-subscription-reads": "11917",
-        "x-ms-request-id": "ac387a0c-122b-4839-99e7-de771e50a691_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064124Z:019fa9ef-2d01-4aea-a309-3eca17afe768"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/privateEndpoints/pe-6794"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:41:14.853Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "85d9f46164174d7d040de4a9ebec63fe",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1490",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:25 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "34",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "85d9f46164174d7d040de4a9ebec63fe",
-        "x-ms-correlation-request-id": "90d9a1c6-f11a-499b-8d51-8f54c43c67ab",
-        "x-ms-ratelimit-remaining-subscription-reads": "11916",
-        "x-ms-request-id": "88fa0ed4-3055-4f2f-87ce-5f01e29fe137_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064126Z:90d9a1c6-f11a-499b-8d51-8f54c43c67ab"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/privateEndpoints/pe-6794"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:41:14.853Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c6b3832377e294e06ecdb4267dd0cf0d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1490",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:26 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "39",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c6b3832377e294e06ecdb4267dd0cf0d",
-        "x-ms-correlation-request-id": "0d2d4502-1858-48da-a689-5fad243522aa",
-        "x-ms-ratelimit-remaining-subscription-reads": "11915",
-        "x-ms-request-id": "c9bfb87c-680c-43ef-b814-02e5969f722c_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064127Z:0d2d4502-1858-48da-a689-5fad243522aa"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756/privateEndpointConnections/8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "name": "8fdda82a-62e1-4222-ba23-3b4936800aca",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.Network/privateEndpoints/pe-6794"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:41:14.853Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5ec022b7c0f207eec0e9355f462cf082",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:28 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "33",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5ec022b7c0f207eec0e9355f462cf082",
-        "x-ms-correlation-request-id": "f23a21b8-73c1-401c-a16b-57e40bd42197",
-        "x-ms-ratelimit-remaining-subscription-reads": "11914",
-        "x-ms-request-id": "60cc5823-b23b-4075-9346-701c95690ebd_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064128Z:f23a21b8-73c1-401c-a16b-57e40bd42197"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:41:14.853Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c582fa640ee0e97313451749b056cf34",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:29 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "55",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c582fa640ee0e97313451749b056cf34",
-        "x-ms-correlation-request-id": "8ca66a38-9913-47d0-badd-44d9ad78d059",
-        "x-ms-ratelimit-remaining-subscription-reads": "11913",
-        "x-ms-request-id": "2230f7e5-7b4f-4052-942e-8f729e8967be_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064130Z:8ca66a38-9913-47d0-badd-44d9ad78d059"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:41:14.853Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c9f1d63d052b620b95ac06f942814d41",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:30 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "33",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c9f1d63d052b620b95ac06f942814d41",
-        "x-ms-correlation-request-id": "55588b21-94dd-47ee-87d8-60e2e5e0ab9a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11912",
-        "x-ms-request-id": "5e684a54-e880-4036-976d-a84f225b2115_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064131Z:55588b21-94dd-47ee-87d8-60e2e5e0ab9a"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:41:14.853Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "82c231dc0a4da92daed74aada9a4576a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:32 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "30",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "82c231dc0a4da92daed74aada9a4576a",
-        "x-ms-correlation-request-id": "2ee11044-4689-4616-a608-5f9e216a8db2",
-        "x-ms-ratelimit-remaining-subscription-reads": "11911",
-        "x-ms-request-id": "db88f6cd-9a5d-42e3-b541-3336c36ab570_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064133Z:2ee11044-4689-4616-a608-5f9e216a8db2"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:41:14.853Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "70210019273b5e56ef202f340779a792",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:33 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "32",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "70210019273b5e56ef202f340779a792",
-        "x-ms-correlation-request-id": "d98e542a-ab44-43db-ab6a-f4051516067c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11910",
-        "x-ms-request-id": "9565f18b-478b-406c-a707-1063567ff6c6_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064134Z:d98e542a-ab44-43db-ab6a-f4051516067c"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:41:14.853Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7e6dd5f74d9333e6a9471a54ba5eb8f1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:34 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "43",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "7e6dd5f74d9333e6a9471a54ba5eb8f1",
-        "x-ms-correlation-request-id": "95d3a554-a10c-4b61-b2c7-b6c685f4dc2f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11909",
-        "x-ms-request-id": "78c48635-d1e5-43fe-a957-bcf936da0cf1_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064135Z:95d3a554-a10c-4b61-b2c7-b6c685f4dc2f"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756",
-        "name": "testnamespacemgmt9756",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9756",
-          "createdAt": "2021-11-19T06:38:56.707Z",
-          "updatedAt": "2021-11-19T06:41:14.853Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt9756.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6758/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9756/operationresults/testnamespacemgmt9756?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "41e09c54dd5fb406da63932ddaf9a134",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Date": "Fri, 19 Nov 2021 06:41:36 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "41e09c54dd5fb406da63932ddaf9a134",
-        "x-ms-correlation-request-id": "4128eea3-777c-4acd-957c-b4e634b2d558",
-        "x-ms-ratelimit-remaining-subscription-reads": "11908",
-        "x-ms-request-id": "60db9be9-9ce4-426c-b01d-39d45ce3f4d7_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064136Z:4128eea3-777c-4acd-957c-b4e634b2d558"
-      },
-      "ResponseBody": []
     }
   ],
   "Variables": {
-    "RandomSeed": "2005307007",
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
+    "RandomSeed": "1299083552",
     "RESOURCE_MANAGER_URL": null,
     "SUBSCRIPTION_ID": "db1ab6f0-4769-4b27-930e-01e2ef9c123c"
   }

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/PrivateEndpointConnectionTests/GetAllPrivateEndpointConnectionAsync.json
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/PrivateEndpointConnectionTests/GetAllPrivateEndpointConnectionAsync.json
@@ -6,34 +6,43 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-d41a9ca87d1bfe458bb35537c8a32c7d-e8e554b324364e46-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b1f41399e6f0a145717ee58f929d5ff0",
+        "traceparent": "00-adc77e91e50eca4fb5d1b3baf943e06a-ab5672f8aae12c40-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "7ab47669fc594df1517a236594884193",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "468",
+        "Content-Length": "747",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:27 GMT",
+        "Date": "Wed, 29 Jun 2022 14:33:57 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "2f657ce0-adb3-4910-8660-6a598c558cb5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11921",
-        "x-ms-request-id": "2f657ce0-adb3-4910-8660-6a598c558cb5",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064627Z:2f657ce0-adb3-4910-8660-6a598c558cb5"
+        "x-ms-correlation-request-id": "fc9456c4-035d-4344-90be-bdc2592c4671",
+        "x-ms-ratelimit-remaining-subscription-reads": "11999",
+        "x-ms-request-id": "fc9456c4-035d-4344-90be-bdc2592c4671",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143357Z:fc9456c4-035d-4344-90be-bdc2592c4671"
       },
       "ResponseBody": {
         "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "authorizationSource": "RoleBased",
         "managedByTenants": [],
         "tags": {
-          "tagKey1": "tagValue1",
-          "tagKey2": "tagValue2"
+          "TagKey-9823": "TagValue-566",
+          "TagKey-3481": "TagValue-320",
+          "TagKey-4926": "TagValue-1187",
+          "TagKey-751": "TagValue-3921",
+          "TagKey-1866": "TagValue-8559",
+          "TagKey-3094": "TagValue-9190",
+          "TagKey-2449": "TagValue-9",
+          "TagKey-8379": "TagValue-164",
+          "TagKey-7470": "TagValue-2205",
+          "TagKey-4236": "TagValue-3698",
+          "TagKey-5316": "TagValue-2725"
         },
         "subscriptionId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
@@ -47,15 +56,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourcegroups/testeventhubRG-2742?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourcegroups/testeventhubRG-1063?api-version=2021-04-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "44",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ee007561954618c8c53c4c0cce3834ec",
+        "traceparent": "00-1132639afb1b0f40b8edd08666ab7b7d-aafe5b95450d6346-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "7193060363866ffea710cbb0e15766cb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -69,19 +79,19 @@
         "Cache-Control": "no-cache",
         "Content-Length": "258",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:27 GMT",
+        "Date": "Wed, 29 Jun 2022 14:34:00 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "7aae5147-8dd5-4be3-a337-4c3165191f21",
-        "x-ms-ratelimit-remaining-subscription-writes": "1194",
-        "x-ms-request-id": "7aae5147-8dd5-4be3-a337-4c3165191f21",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064628Z:7aae5147-8dd5-4be3-a337-4c3165191f21"
+        "x-ms-correlation-request-id": "efbe45e1-1595-4248-b96b-fdc8b83df861",
+        "x-ms-ratelimit-remaining-subscription-writes": "1199",
+        "x-ms-request-id": "efbe45e1-1595-4248-b96b-fdc8b83df861",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143400Z:efbe45e1-1595-4248-b96b-fdc8b83df861"
       },
       "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742",
-        "name": "testeventhubRG-2742",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063",
+        "name": "testeventhubRG-1063",
         "type": "Microsoft.Resources/resourceGroups",
         "location": "eastus2",
         "tags": {
@@ -100,33 +110,34 @@
         "Authorization": "Sanitized",
         "Content-Length": "32",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "badc649fdd848a43b7c8a520f4369775",
+        "traceparent": "00-3f498818fe111d4787aa4a2fef6c09ba-d7e777b6be648d41-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "be133a1d6334c86671eb5829cfe1eb76",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "testnamespacemgmt2712"
+        "name": "testnamespacemgmt4395"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "53",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:28 GMT",
+        "Date": "Wed, 29 Jun 2022 14:34:00 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "badc649fdd848a43b7c8a520f4369775",
-        "x-ms-correlation-request-id": "8d6cb65b-5a55-4f1a-86fa-85894527d3f2",
-        "x-ms-ratelimit-remaining-subscription-writes": "1197",
-        "x-ms-request-id": "083b6364-4efd-45d0-8ffd-872a3281410c_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064629Z:8d6cb65b-5a55-4f1a-86fa-85894527d3f2"
+        "x-ms-client-request-id": "be133a1d6334c86671eb5829cfe1eb76",
+        "x-ms-correlation-request-id": "b793c2a8-4591-4254-be3d-97041e9cf963",
+        "x-ms-ratelimit-remaining-subscription-writes": "1199",
+        "x-ms-request-id": "de758955-b9dd-470a-8183-e0627ac8fd7f_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143401Z:b793c2a8-4591-4254-be3d-97041e9cf963"
       },
       "ResponseBody": {
         "nameAvailable": true,
@@ -135,15 +146,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395?api-version=2021-11-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "48",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9b70b894538e2c7d982aaaf994a346b1",
+        "traceparent": "00-0715a6c716d0324eb1055d2c7a16e73a-5421bfc65700a646-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a0137855e3e4b6120bb1ec269c6f22bd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -156,21 +168,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:32 GMT",
+        "Date": "Wed, 29 Jun 2022 14:34:07 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "9b70b894538e2c7d982aaaf994a346b1",
-        "x-ms-correlation-request-id": "0eb49fd4-d0a6-4bb5-8721-a60964bcaf8c",
-        "x-ms-ratelimit-remaining-subscription-resource-requests": "47",
-        "x-ms-request-id": "66ec47f7-b0d6-4865-9711-7a5f884097e2_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064633Z:0eb49fd4-d0a6-4bb5-8721-a60964bcaf8c"
+        "x-ms-client-request-id": "a0137855e3e4b6120bb1ec269c6f22bd",
+        "x-ms-correlation-request-id": "2ecbfc6e-b29e-40b7-b56a-198201827606",
+        "x-ms-ratelimit-remaining-subscription-resource-requests": "49",
+        "x-ms-request-id": "3bdedbf1-b8c6-4ff2-9f97-97f9103da2b4_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143408Z:2ecbfc6e-b29e-40b7-b56a-198201827606"
       },
       "ResponseBody": {
         "sku": {
@@ -178,8 +190,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395",
+        "name": "testnamespacemgmt4395",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -190,21 +202,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4395",
+          "createdAt": "2022-06-29T14:34:06.397Z",
+          "updatedAt": "2022-06-29T14:34:06.397Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4395.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7f3996b450c34c6de6b022593349f514",
+        "traceparent": "00-0715a6c716d0324eb1055d2c7a16e73a-852b1cb844c87b48-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "df8c3adf2a533ac3275cb28377402b01",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -213,21 +226,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:35 GMT",
+        "Date": "Wed, 29 Jun 2022 14:34:08 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "7f3996b450c34c6de6b022593349f514",
-        "x-ms-correlation-request-id": "2c82ebbc-004d-4835-b66f-c933c79baaf3",
-        "x-ms-ratelimit-remaining-subscription-reads": "11920",
-        "x-ms-request-id": "12ffd008-4232-4791-9bb4-88fbb79e4580_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064636Z:2c82ebbc-004d-4835-b66f-c933c79baaf3"
+        "x-ms-client-request-id": "df8c3adf2a533ac3275cb28377402b01",
+        "x-ms-correlation-request-id": "3b519e56-25a4-444d-9a41-7f6c0fc66449",
+        "x-ms-ratelimit-remaining-subscription-reads": "11998",
+        "x-ms-request-id": "284d0b8f-b5cd-4ff7-8054-ae334f35489f_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143409Z:3b519e56-25a4-444d-9a41-7f6c0fc66449"
       },
       "ResponseBody": {
         "sku": {
@@ -235,8 +248,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395",
+        "name": "testnamespacemgmt4395",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -247,21 +260,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4395",
+          "createdAt": "2022-06-29T14:34:06.397Z",
+          "updatedAt": "2022-06-29T14:34:06.397Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4395.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5d7df3829d380461dbd8de29c4b108a0",
+        "traceparent": "00-0715a6c716d0324eb1055d2c7a16e73a-c6000c539ee0114f-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "e28e9ac8e575e9f6a970743bcd9a10c5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -270,21 +284,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:36 GMT",
+        "Date": "Wed, 29 Jun 2022 14:34:10 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5d7df3829d380461dbd8de29c4b108a0",
-        "x-ms-correlation-request-id": "c750e12c-37f8-4880-a9cb-a70597966e02",
-        "x-ms-ratelimit-remaining-subscription-reads": "11919",
-        "x-ms-request-id": "d06aa391-6408-4640-9430-dcf558df7da2_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064637Z:c750e12c-37f8-4880-a9cb-a70597966e02"
+        "x-ms-client-request-id": "e28e9ac8e575e9f6a970743bcd9a10c5",
+        "x-ms-correlation-request-id": "c892fb96-6c37-4ac3-8e9b-53debc40fedf",
+        "x-ms-ratelimit-remaining-subscription-reads": "11997",
+        "x-ms-request-id": "eb1489c2-ff9d-4107-8350-e84c24697a4b_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143411Z:c892fb96-6c37-4ac3-8e9b-53debc40fedf"
       },
       "ResponseBody": {
         "sku": {
@@ -292,8 +306,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395",
+        "name": "testnamespacemgmt4395",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -304,21 +318,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4395",
+          "createdAt": "2022-06-29T14:34:06.397Z",
+          "updatedAt": "2022-06-29T14:34:06.397Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4395.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fd44a359c66952ed29b113636e836373",
+        "traceparent": "00-0715a6c716d0324eb1055d2c7a16e73a-1c00d2ad68399e49-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6246bcd843e36f6a2931df23b94b2aeb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -327,21 +342,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:37 GMT",
+        "Date": "Wed, 29 Jun 2022 14:34:12 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "fd44a359c66952ed29b113636e836373",
-        "x-ms-correlation-request-id": "f7785be5-e12a-4031-82aa-c6005d09a512",
-        "x-ms-ratelimit-remaining-subscription-reads": "11918",
-        "x-ms-request-id": "fe967da0-8a20-4075-b2cd-edffcaef9b92_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064638Z:f7785be5-e12a-4031-82aa-c6005d09a512"
+        "x-ms-client-request-id": "6246bcd843e36f6a2931df23b94b2aeb",
+        "x-ms-correlation-request-id": "974b7d24-37f5-4a44-8482-88aba0098603",
+        "x-ms-ratelimit-remaining-subscription-reads": "11996",
+        "x-ms-request-id": "a3ec0969-821e-4e10-97b4-550c82b0a388_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143413Z:974b7d24-37f5-4a44-8482-88aba0098603"
       },
       "ResponseBody": {
         "sku": {
@@ -349,8 +364,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395",
+        "name": "testnamespacemgmt4395",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -361,21 +376,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4395",
+          "createdAt": "2022-06-29T14:34:06.397Z",
+          "updatedAt": "2022-06-29T14:34:06.397Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4395.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2f4a796f737a17ce3534a4eb71438735",
+        "traceparent": "00-0715a6c716d0324eb1055d2c7a16e73a-f1c41997ffd9ad41-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "0baf147df6b7fab943a236e2b6886c8d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -384,21 +400,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:39 GMT",
+        "Date": "Wed, 29 Jun 2022 14:34:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2f4a796f737a17ce3534a4eb71438735",
-        "x-ms-correlation-request-id": "d903e7a0-a81c-4f99-8d67-3faf7958f593",
-        "x-ms-ratelimit-remaining-subscription-reads": "11917",
-        "x-ms-request-id": "dc8ccbc9-76ad-4784-a8c7-772730e7b3ea_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064640Z:d903e7a0-a81c-4f99-8d67-3faf7958f593"
+        "x-ms-client-request-id": "0baf147df6b7fab943a236e2b6886c8d",
+        "x-ms-correlation-request-id": "8aff7839-478c-4ae3-95a1-ebae8e812ba7",
+        "x-ms-ratelimit-remaining-subscription-reads": "11995",
+        "x-ms-request-id": "55a7479f-334a-44ac-b490-0d4ecd7388d9_M10CH3_M10CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143415Z:8aff7839-478c-4ae3-95a1-ebae8e812ba7"
       },
       "ResponseBody": {
         "sku": {
@@ -406,8 +422,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395",
+        "name": "testnamespacemgmt4395",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -418,21 +434,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4395",
+          "createdAt": "2022-06-29T14:34:06.397Z",
+          "updatedAt": "2022-06-29T14:34:06.397Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4395.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8fff81a7f805bbab062a338689fd9657",
+        "traceparent": "00-0715a6c716d0324eb1055d2c7a16e73a-4a12991e0f5a1241-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "baaaed4cc9fa851d301fb84305d3305d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -441,21 +458,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:40 GMT",
+        "Date": "Wed, 29 Jun 2022 14:34:17 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8fff81a7f805bbab062a338689fd9657",
-        "x-ms-correlation-request-id": "15d0108c-4b84-4849-a204-d5a9e6b3f3ca",
-        "x-ms-ratelimit-remaining-subscription-reads": "11916",
-        "x-ms-request-id": "f2aa109f-17de-49ad-956f-fb4b89598a13_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064641Z:15d0108c-4b84-4849-a204-d5a9e6b3f3ca"
+        "x-ms-client-request-id": "baaaed4cc9fa851d301fb84305d3305d",
+        "x-ms-correlation-request-id": "9f196871-2c8a-432a-a422-7bf16a47f9b1",
+        "x-ms-ratelimit-remaining-subscription-reads": "11994",
+        "x-ms-request-id": "05ee0b23-0d57-409c-8004-e513f0a50f5b_M10CH3_M10CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143418Z:9f196871-2c8a-432a-a422-7bf16a47f9b1"
       },
       "ResponseBody": {
         "sku": {
@@ -463,8 +480,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395",
+        "name": "testnamespacemgmt4395",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -475,21 +492,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4395",
+          "createdAt": "2022-06-29T14:34:06.397Z",
+          "updatedAt": "2022-06-29T14:34:06.397Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4395.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4bba6a74d966e525d52cc7342202e0e5",
+        "traceparent": "00-0715a6c716d0324eb1055d2c7a16e73a-bdd53d6fe433b94c-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b9bd884605ebe20e034b1e410c88b9a1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -498,21 +516,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:41 GMT",
+        "Date": "Wed, 29 Jun 2022 14:34:22 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "4bba6a74d966e525d52cc7342202e0e5",
-        "x-ms-correlation-request-id": "9d4128cb-d372-4e20-82ad-095c8fdfedee",
-        "x-ms-ratelimit-remaining-subscription-reads": "11915",
-        "x-ms-request-id": "6b4d3f99-927d-4509-91b2-f481a0aadd28_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064642Z:9d4128cb-d372-4e20-82ad-095c8fdfedee"
+        "x-ms-client-request-id": "b9bd884605ebe20e034b1e410c88b9a1",
+        "x-ms-correlation-request-id": "25fff7ef-c7df-4c6b-a995-d990adba6d52",
+        "x-ms-ratelimit-remaining-subscription-reads": "11993",
+        "x-ms-request-id": "a953f149-e35f-4ce3-ae20-a5ca5ec5e9b2_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143423Z:25fff7ef-c7df-4c6b-a995-d990adba6d52"
       },
       "ResponseBody": {
         "sku": {
@@ -520,8 +538,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395",
+        "name": "testnamespacemgmt4395",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -532,21 +550,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4395",
+          "createdAt": "2022-06-29T14:34:06.397Z",
+          "updatedAt": "2022-06-29T14:34:06.397Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4395.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ecbcdd2ad484766ece8e284f40478e37",
+        "traceparent": "00-0715a6c716d0324eb1055d2c7a16e73a-384f9caa6d548448-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "cbd651c570a1b3f0f629db983d75f470",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -555,21 +574,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:43 GMT",
+        "Date": "Wed, 29 Jun 2022 14:34:30 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "ecbcdd2ad484766ece8e284f40478e37",
-        "x-ms-correlation-request-id": "df9b34c7-efeb-41cf-aa32-cd0f40740de6",
-        "x-ms-ratelimit-remaining-subscription-reads": "11914",
-        "x-ms-request-id": "ee17f8b8-bb75-4605-84f8-82e1b4018a63_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064644Z:df9b34c7-efeb-41cf-aa32-cd0f40740de6"
+        "x-ms-client-request-id": "cbd651c570a1b3f0f629db983d75f470",
+        "x-ms-correlation-request-id": "10249984-1291-4281-9a59-d5e3784f5eae",
+        "x-ms-ratelimit-remaining-subscription-reads": "11992",
+        "x-ms-request-id": "0e57e50e-c06f-431b-aeaf-9ffcc147dbf7_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143431Z:10249984-1291-4281-9a59-d5e3784f5eae"
       },
       "ResponseBody": {
         "sku": {
@@ -577,8 +596,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395",
+        "name": "testnamespacemgmt4395",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -589,21 +608,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4395",
+          "createdAt": "2022-06-29T14:34:06.397Z",
+          "updatedAt": "2022-06-29T14:34:06.397Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4395.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "07764c9e3b89cecf5b19bad830769904",
+        "traceparent": "00-0715a6c716d0324eb1055d2c7a16e73a-b3cb4c0d5840b744-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "2e9cd971b2ca46a2dfc7b7afabdc79a7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -612,21 +632,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:44 GMT",
+        "Date": "Wed, 29 Jun 2022 14:34:48 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "07764c9e3b89cecf5b19bad830769904",
-        "x-ms-correlation-request-id": "a5a8eb45-c700-428f-a3ad-02cdcbc457ce",
-        "x-ms-ratelimit-remaining-subscription-reads": "11913",
-        "x-ms-request-id": "ba411e69-4867-4033-a563-7215ff7504d4_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064645Z:a5a8eb45-c700-428f-a3ad-02cdcbc457ce"
+        "x-ms-client-request-id": "2e9cd971b2ca46a2dfc7b7afabdc79a7",
+        "x-ms-correlation-request-id": "3b15eadf-1542-44d8-81fb-403ac4f51138",
+        "x-ms-ratelimit-remaining-subscription-reads": "11991",
+        "x-ms-request-id": "06e72f51-4563-427e-bc2e-fe3761453c7a_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143448Z:3b15eadf-1542-44d8-81fb-403ac4f51138"
       },
       "ResponseBody": {
         "sku": {
@@ -634,8 +654,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395",
+        "name": "testnamespacemgmt4395",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -646,21 +666,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4395",
+          "createdAt": "2022-06-29T14:34:06.397Z",
+          "updatedAt": "2022-06-29T14:34:06.397Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4395.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ab5c4d49aa41a0d3fc437dd8b0d6a58e",
+        "traceparent": "00-0715a6c716d0324eb1055d2c7a16e73a-57d2e518e1554a4e-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b37e166664fcd6bc970ac3c12a76a48d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -669,21 +690,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:45 GMT",
+        "Date": "Wed, 29 Jun 2022 14:35:22 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "ab5c4d49aa41a0d3fc437dd8b0d6a58e",
-        "x-ms-correlation-request-id": "a8d3c58e-e3a9-44a0-8595-7fe42519fef5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11912",
-        "x-ms-request-id": "6dd0f27a-43eb-4000-a460-de3e45201087_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064646Z:a8d3c58e-e3a9-44a0-8595-7fe42519fef5"
+        "x-ms-client-request-id": "b37e166664fcd6bc970ac3c12a76a48d",
+        "x-ms-correlation-request-id": "9d1a8f6c-f466-4a30-99ca-c4b9d8b75b64",
+        "x-ms-ratelimit-remaining-subscription-reads": "11990",
+        "x-ms-request-id": "a2d5bbf1-b1ac-479e-b286-e97d51f573fa_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143523Z:9d1a8f6c-f466-4a30-99ca-c4b9d8b75b64"
       },
       "ResponseBody": {
         "sku": {
@@ -691,8 +712,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395",
+        "name": "testnamespacemgmt4395",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -703,21 +724,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4395",
+          "createdAt": "2022-06-29T14:34:06.397Z",
+          "updatedAt": "2022-06-29T14:34:06.397Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4395.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d696909ed98bee5c0eed906a1a964658",
+        "traceparent": "00-0715a6c716d0324eb1055d2c7a16e73a-9ec0eaba77a74546-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "33cfad568bec12d7af8fecd9b8410819",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -726,21 +748,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:47 GMT",
+        "Date": "Wed, 29 Jun 2022 14:35:56 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d696909ed98bee5c0eed906a1a964658",
-        "x-ms-correlation-request-id": "9aa20d92-9e22-4bbf-a777-a8f14a5bc94c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11911",
-        "x-ms-request-id": "63ca489d-ee1e-44f1-b4b4-d124e9a52d6c_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064648Z:9aa20d92-9e22-4bbf-a777-a8f14a5bc94c"
+        "x-ms-client-request-id": "33cfad568bec12d7af8fecd9b8410819",
+        "x-ms-correlation-request-id": "12da3217-778a-442b-b134-7fd974b98ef4",
+        "x-ms-ratelimit-remaining-subscription-reads": "11989",
+        "x-ms-request-id": "c8fc59b2-8742-4fa2-91ba-543f7b8d8d8b_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143556Z:12da3217-778a-442b-b134-7fd974b98ef4"
       },
       "ResponseBody": {
         "sku": {
@@ -748,8 +770,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395",
+        "name": "testnamespacemgmt4395",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -760,21 +782,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4395",
+          "createdAt": "2022-06-29T14:34:06.397Z",
+          "updatedAt": "2022-06-29T14:34:06.397Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4395.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f20524f4e2eaf4f678d50a46bef61e85",
+        "traceparent": "00-0715a6c716d0324eb1055d2c7a16e73a-b20c20e699578f48-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "273133b040f70d741dc696bfefe01c69",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -783,21 +806,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:48 GMT",
+        "Date": "Wed, 29 Jun 2022 14:36:28 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f20524f4e2eaf4f678d50a46bef61e85",
-        "x-ms-correlation-request-id": "24325f2c-f5af-49fa-840c-a3b5c352a320",
-        "x-ms-ratelimit-remaining-subscription-reads": "11910",
-        "x-ms-request-id": "e89e48e1-d68f-44da-aa11-2fca67f3516e_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064649Z:24325f2c-f5af-49fa-840c-a3b5c352a320"
+        "x-ms-client-request-id": "273133b040f70d741dc696bfefe01c69",
+        "x-ms-correlation-request-id": "e703158e-6caa-4c53-8f37-10e10d7ce43c",
+        "x-ms-ratelimit-remaining-subscription-reads": "11988",
+        "x-ms-request-id": "518c2d90-c9a7-4404-a4ed-15aa2d560e75_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143628Z:e703158e-6caa-4c53-8f37-10e10d7ce43c"
       },
       "ResponseBody": {
         "sku": {
@@ -805,8 +828,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395",
+        "name": "testnamespacemgmt4395",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -817,21 +840,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4395",
+          "createdAt": "2022-06-29T14:34:06.397Z",
+          "updatedAt": "2022-06-29T14:34:06.397Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4395.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a0392b74c3df7078f16e9c5319698665",
+        "traceparent": "00-0715a6c716d0324eb1055d2c7a16e73a-7892c43b1413ef42-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "fd592922460ddbbb3f6b046c78e21d55",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -840,21 +864,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:50 GMT",
+        "Date": "Wed, 29 Jun 2022 14:37:00 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a0392b74c3df7078f16e9c5319698665",
-        "x-ms-correlation-request-id": "a98c95a5-ef2d-42db-a8f8-b3dc78fcb82a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11909",
-        "x-ms-request-id": "fe9123ba-c88e-4fdc-8c7d-febdc53ae039_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064651Z:a98c95a5-ef2d-42db-a8f8-b3dc78fcb82a"
+        "x-ms-client-request-id": "fd592922460ddbbb3f6b046c78e21d55",
+        "x-ms-correlation-request-id": "6aac334b-8ffa-4445-bd39-9348f66339f9",
+        "x-ms-ratelimit-remaining-subscription-reads": "11987",
+        "x-ms-request-id": "47c48f55-32f5-4243-9afc-8278e3e34594_M6CH3_M6CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143701Z:6aac334b-8ffa-4445-bd39-9348f66339f9"
       },
       "ResponseBody": {
         "sku": {
@@ -862,8 +886,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395",
+        "name": "testnamespacemgmt4395",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -874,21 +898,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4395",
+          "createdAt": "2022-06-29T14:34:06.397Z",
+          "updatedAt": "2022-06-29T14:34:06.397Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4395.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8be324fdb3d0bba39aa25eb5cf152f18",
+        "traceparent": "00-0715a6c716d0324eb1055d2c7a16e73a-30adc7f52f8f6b43-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f611a9027d44159639c11626f41723cf",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -897,21 +922,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:51 GMT",
+        "Date": "Wed, 29 Jun 2022 14:37:34 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8be324fdb3d0bba39aa25eb5cf152f18",
-        "x-ms-correlation-request-id": "e5e1d0af-31d0-4f19-867f-741383e6b8d2",
-        "x-ms-ratelimit-remaining-subscription-reads": "11908",
-        "x-ms-request-id": "c85785b4-e3db-40b5-8c7f-87c2cb03817b_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064652Z:e5e1d0af-31d0-4f19-867f-741383e6b8d2"
+        "x-ms-client-request-id": "f611a9027d44159639c11626f41723cf",
+        "x-ms-correlation-request-id": "95bb3097-de61-4789-85c3-94eadeb387d0",
+        "x-ms-ratelimit-remaining-subscription-reads": "11986",
+        "x-ms-request-id": "5cc30eea-e684-4fbf-a574-de9ea5117915_M6CH3_M6CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143734Z:95bb3097-de61-4789-85c3-94eadeb387d0"
       },
       "ResponseBody": {
         "sku": {
@@ -919,8 +944,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395",
+        "name": "testnamespacemgmt4395",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -931,1161 +956,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4395",
+          "createdAt": "2022-06-29T14:34:06.397Z",
+          "updatedAt": "2022-06-29T14:34:06.397Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4395.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "eef50acfa55c3178ab95007c46a2da0e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:53 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "eef50acfa55c3178ab95007c46a2da0e",
-        "x-ms-correlation-request-id": "c840f6ef-b8dc-43c6-8ca6-b0e413168f9e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11907",
-        "x-ms-request-id": "57580d56-d6c5-4339-85ba-b9891dcf762e_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064653Z:c840f6ef-b8dc-43c6-8ca6-b0e413168f9e"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9948a44f9212c1b5877d063d64c3a0db",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:55 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "9948a44f9212c1b5877d063d64c3a0db",
-        "x-ms-correlation-request-id": "3fc4f265-cc30-45bb-b1d4-25e28ac545ce",
-        "x-ms-ratelimit-remaining-subscription-reads": "11906",
-        "x-ms-request-id": "8f4dcd06-367e-4350-a61b-9347d1f44bde_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064655Z:3fc4f265-cc30-45bb-b1d4-25e28ac545ce"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0e83843e98735709acb2e03ab22775f7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:56 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "0e83843e98735709acb2e03ab22775f7",
-        "x-ms-correlation-request-id": "3c5cd6a2-f595-441b-b824-926fbb3c437e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11905",
-        "x-ms-request-id": "1e028ee1-3d57-4744-be0b-cffa5558423a_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064656Z:3c5cd6a2-f595-441b-b824-926fbb3c437e"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2a664fc795cc3d05553466de9f3bcce8",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:57 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2a664fc795cc3d05553466de9f3bcce8",
-        "x-ms-correlation-request-id": "498f67a0-1265-484c-b193-8c5e19f40eed",
-        "x-ms-ratelimit-remaining-subscription-reads": "11904",
-        "x-ms-request-id": "4e20f43d-f98a-4189-9ed7-fd8329c07eef_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064657Z:498f67a0-1265-484c-b193-8c5e19f40eed"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c13e24f4cb1eb79a9bf1ed60b17a0e60",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:46:59 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c13e24f4cb1eb79a9bf1ed60b17a0e60",
-        "x-ms-correlation-request-id": "3090b754-d29c-4758-9559-f87bb0beab3b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11903",
-        "x-ms-request-id": "31f28d21-0fc5-4851-a8fd-20613cd82abc_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064659Z:3090b754-d29c-4758-9559-f87bb0beab3b"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "14750e08765ca80e7e46b93e312ab771",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:00 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "14750e08765ca80e7e46b93e312ab771",
-        "x-ms-correlation-request-id": "3a522a9d-12ff-4559-9f1a-e26679aed601",
-        "x-ms-ratelimit-remaining-subscription-reads": "11902",
-        "x-ms-request-id": "7c7e57e6-6765-4948-913c-eb0fb0eac4f8_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064700Z:3a522a9d-12ff-4559-9f1a-e26679aed601"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8d46f7e5b3e9fbd9b5af8edba8a58bda",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:01 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8d46f7e5b3e9fbd9b5af8edba8a58bda",
-        "x-ms-correlation-request-id": "1c718676-3012-4e20-8ce9-3142cdd87bca",
-        "x-ms-ratelimit-remaining-subscription-reads": "11901",
-        "x-ms-request-id": "9550190d-1cf1-430f-a468-c6cc1877ac0f_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064701Z:1c718676-3012-4e20-8ce9-3142cdd87bca"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "91d60626b7c57d8b159543d8125b8670",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:03 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "91d60626b7c57d8b159543d8125b8670",
-        "x-ms-correlation-request-id": "e7277706-bb92-457d-8eee-b4336f771c7e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11900",
-        "x-ms-request-id": "c5d98a5a-3713-4277-abef-60913e7ff54c_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064703Z:e7277706-bb92-457d-8eee-b4336f771c7e"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ba7b7c3980345476357a5fade833ffd9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:04 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "ba7b7c3980345476357a5fade833ffd9",
-        "x-ms-correlation-request-id": "853a8c26-4f6a-4a42-8138-8f4b2ce4fa42",
-        "x-ms-ratelimit-remaining-subscription-reads": "11899",
-        "x-ms-request-id": "d5ac1508-7ca8-4056-9d7b-87f8cd6e158a_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064704Z:853a8c26-4f6a-4a42-8138-8f4b2ce4fa42"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2a18deba26542dab6cc877537000e859",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:05 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2a18deba26542dab6cc877537000e859",
-        "x-ms-correlation-request-id": "76f4422f-261c-4a80-b987-8190e83c0331",
-        "x-ms-ratelimit-remaining-subscription-reads": "11898",
-        "x-ms-request-id": "6a37148b-1eb0-4a02-9165-d851270199ae_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064705Z:76f4422f-261c-4a80-b987-8190e83c0331"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2ba11d28d129a5a68f815c4a58de95e2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:07 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2ba11d28d129a5a68f815c4a58de95e2",
-        "x-ms-correlation-request-id": "7f221a57-8fc5-4b45-99d9-54438856f67e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11897",
-        "x-ms-request-id": "2da785aa-5962-480c-baea-1aa0104c540d_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064707Z:7f221a57-8fc5-4b45-99d9-54438856f67e"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "341e69955b43131cd04d4d6c0923e434",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:08 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "341e69955b43131cd04d4d6c0923e434",
-        "x-ms-correlation-request-id": "cd259839-82d8-4f26-9526-d55f16a48bed",
-        "x-ms-ratelimit-remaining-subscription-reads": "11896",
-        "x-ms-request-id": "0b10a561-70aa-4663-bc57-2a7e0d54704a_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064708Z:cd259839-82d8-4f26-9526-d55f16a48bed"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ca840591d491e8af38739ad3ca60d58d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:09 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "ca840591d491e8af38739ad3ca60d58d",
-        "x-ms-correlation-request-id": "32a9d7d1-1267-4058-ab6a-9a94c81ed142",
-        "x-ms-ratelimit-remaining-subscription-reads": "11895",
-        "x-ms-request-id": "5eba369a-0add-4bee-87c7-119bbc519dfe_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064710Z:32a9d7d1-1267-4058-ab6a-9a94c81ed142"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "06bd9532b4e2cd16018e5bdc83399c6c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:11 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "06bd9532b4e2cd16018e5bdc83399c6c",
-        "x-ms-correlation-request-id": "76478c29-9766-4edf-b3cb-01b205e07d1c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11894",
-        "x-ms-request-id": "1ec865c6-faef-48c3-bc71-4db5005b4981_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064711Z:76478c29-9766-4edf-b3cb-01b205e07d1c"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "52b9279ccb59c151b936fccfc049496f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:12 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "52b9279ccb59c151b936fccfc049496f",
-        "x-ms-correlation-request-id": "3ecf4fc8-ca9c-49b1-a313-22f5edf5c972",
-        "x-ms-ratelimit-remaining-subscription-reads": "11893",
-        "x-ms-request-id": "695d9d45-fb2f-4cfc-8fa9-d69c0b02e7eb_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064712Z:3ecf4fc8-ca9c-49b1-a313-22f5edf5c972"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "733ac078dd65dc52efb7c90379d364fe",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:13 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "733ac078dd65dc52efb7c90379d364fe",
-        "x-ms-correlation-request-id": "705696ac-b051-4e57-a51f-1801eabde3b8",
-        "x-ms-ratelimit-remaining-subscription-reads": "11892",
-        "x-ms-request-id": "b71921d3-f3b8-4213-b3fa-40ee37526926_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064714Z:705696ac-b051-4e57-a51f-1801eabde3b8"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a2362dd683a7673444fb4dacb8460cb8",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:15 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a2362dd683a7673444fb4dacb8460cb8",
-        "x-ms-correlation-request-id": "0c703dfa-65da-4909-9531-43c02b058405",
-        "x-ms-ratelimit-remaining-subscription-reads": "11891",
-        "x-ms-request-id": "0450f8c3-d268-44d2-8f4c-474419737400_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064715Z:0c703dfa-65da-4909-9531-43c02b058405"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c364eb4528ffbf06d5dc62a2014d48e6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:16 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c364eb4528ffbf06d5dc62a2014d48e6",
-        "x-ms-correlation-request-id": "d7a928d5-8922-4194-a59b-5842e95218dc",
-        "x-ms-ratelimit-remaining-subscription-reads": "11890",
-        "x-ms-request-id": "ac4474a6-1e47-4776-b8f2-b1d780451076_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064716Z:d7a928d5-8922-4194-a59b-5842e95218dc"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "92f9fdd1a612f5c88bd22f6a90a623a8",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:17 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "92f9fdd1a612f5c88bd22f6a90a623a8",
-        "x-ms-correlation-request-id": "b7aa96b1-259a-48e3-aa54-8bc2604bb49b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11889",
-        "x-ms-request-id": "d04d3377-b272-4d9d-b05f-9919d6e267aa_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064718Z:b7aa96b1-259a-48e3-aa54-8bc2604bb49b"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8dbd10aaa06fadfe2677cdca209265f6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:19 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8dbd10aaa06fadfe2677cdca209265f6",
-        "x-ms-correlation-request-id": "8586288c-f95e-406e-9f51-806f7180b749",
-        "x-ms-ratelimit-remaining-subscription-reads": "11888",
-        "x-ms-request-id": "2b455403-2309-4740-b959-1e8b0c8ec304_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064719Z:8586288c-f95e-406e-9f51-806f7180b749"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:46:32.127Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bbda67b2794d9ea5226e382df99c2e2f",
+        "traceparent": "00-0715a6c716d0324eb1055d2c7a16e73a-1bfe894eb1fced45-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "8fb683730ae8690c7756e78b3c08943a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -2094,21 +980,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:20 GMT",
+        "Date": "Wed, 29 Jun 2022 14:38:06 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "bbda67b2794d9ea5226e382df99c2e2f",
-        "x-ms-correlation-request-id": "f26b8d68-b508-4ee4-93e7-dc8140c62efe",
-        "x-ms-ratelimit-remaining-subscription-reads": "11887",
-        "x-ms-request-id": "2a783fa4-3e52-4d9f-a58c-6c6a90dd5abf_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064720Z:f26b8d68-b508-4ee4-93e7-dc8140c62efe"
+        "x-ms-client-request-id": "8fb683730ae8690c7756e78b3c08943a",
+        "x-ms-correlation-request-id": "b40276ff-c1be-4057-b784-015e37c3f605",
+        "x-ms-ratelimit-remaining-subscription-reads": "11985",
+        "x-ms-request-id": "a77dcb66-8932-4f57-81b4-ee8abc47b3b6_M6CH3_M6CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143807Z:b40276ff-c1be-4057-b784-015e37c3f605"
       },
       "ResponseBody": {
         "sku": {
@@ -2116,8 +1002,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395",
+        "name": "testnamespacemgmt4395",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -2128,24 +1014,25 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:47:20.413Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4395",
+          "createdAt": "2022-06-29T14:34:06.397Z",
+          "updatedAt": "2022-06-29T14:37:37.817Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4395.servicebus.windows.net:443/",
           "status": "Active"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/virtualNetworks/vnet-93?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.Network/virtualNetworks/vnet-7959?api-version=2021-02-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "261",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.Network/1.0.0-beta.3 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "90f1f7ba76baff314b6c9ad9fdd5f96d",
+        "traceparent": "00-bf854b53546596459a9f92aefa9689b7-9927deba025fe741-00",
+        "User-Agent": "azsdk-net-ResourceManager.Network/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ce45bd40242593a543c44b3095e62748",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -2176,11 +1063,11 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Azure-AsyncNotification": "Enabled",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/ccd593e7-3ac3-4e43-84e0-f0877bd99a04?api-version=2021-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/22171ee5-251a-402f-bb53-b06f3f79fd70?api-version=2021-02-01",
         "Cache-Control": "no-cache",
-        "Content-Length": "1333",
+        "Content-Length": "1339",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:23 GMT",
+        "Date": "Wed, 29 Jun 2022 14:38:10 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "3",
@@ -2190,100 +1077,61 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "f47c15a1-ce45-49e9-800b-92c4498faea4",
-        "x-ms-client-request-id": "90f1f7ba76baff314b6c9ad9fdd5f96d",
-        "x-ms-correlation-request-id": "3b319a14-e361-4111-85b1-7cb549b801c7",
-        "x-ms-ratelimit-remaining-subscription-writes": "1193",
-        "x-ms-request-id": "ccd593e7-3ac3-4e43-84e0-f0877bd99a04",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064724Z:3b319a14-e361-4111-85b1-7cb549b801c7"
+        "x-ms-arm-service-request-id": "7fe22802-b157-40d4-a885-d54c6ff3ffc4",
+        "x-ms-client-request-id": "ce45bd40242593a543c44b3095e62748",
+        "x-ms-correlation-request-id": "69132b0c-8338-4abe-a8f2-5c01ceca15eb",
+        "x-ms-ratelimit-remaining-subscription-writes": "1198",
+        "x-ms-request-id": "22171ee5-251a-402f-bb53-b06f3f79fd70",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143811Z:69132b0c-8338-4abe-a8f2-5c01ceca15eb"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022name\u0022: \u0022vnet-93\u0022,\r\n",
-        "  \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/virtualNetworks/vnet-93\u0022,\r\n",
-        "  \u0022etag\u0022: \u0022W/\\\u00225a5da7d1-623f-4d8c-a683-e728aaa8c388\\\u0022\u0022,\r\n",
-        "  \u0022type\u0022: \u0022Microsoft.Network/virtualNetworks\u0022,\r\n",
-        "  \u0022location\u0022: \u0022westus2\u0022,\r\n",
-        "  \u0022properties\u0022: {\r\n",
-        "    \u0022provisioningState\u0022: \u0022Updating\u0022,\r\n",
-        "    \u0022resourceGuid\u0022: \u00229a6a5de5-09f6-4a7f-8af4-c380f39b6995\u0022,\r\n",
-        "    \u0022addressSpace\u0022: {\r\n",
-        "      \u0022addressPrefixes\u0022: [\r\n",
-        "        \u002210.0.0.0/16\u0022\r\n",
-        "      ]\r\n",
-        "    },\r\n",
-        "    \u0022dhcpOptions\u0022: {\r\n",
-        "      \u0022dnsServers\u0022: [\r\n",
-        "        \u002210.1.1.1\u0022,\r\n",
-        "        \u002210.1.2.4\u0022\r\n",
-        "      ]\r\n",
-        "    },\r\n",
-        "    \u0022subnets\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022name\u0022: \u0022default\u0022,\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/virtualNetworks/vnet-93/subnets/default\u0022,\r\n",
-        "        \u0022etag\u0022: \u0022W/\\\u00225a5da7d1-623f-4d8c-a683-e728aaa8c388\\\u0022\u0022,\r\n",
-        "        \u0022properties\u0022: {\r\n",
-        "          \u0022provisioningState\u0022: \u0022Updating\u0022,\r\n",
-        "          \u0022addressPrefix\u0022: \u002210.0.1.0/24\u0022,\r\n",
-        "          \u0022delegations\u0022: [],\r\n",
-        "          \u0022privateEndpointNetworkPolicies\u0022: \u0022Disabled\u0022,\r\n",
-        "          \u0022privateLinkServiceNetworkPolicies\u0022: \u0022Enabled\u0022\r\n",
-        "        },\r\n",
-        "        \u0022type\u0022: \u0022Microsoft.Network/virtualNetworks/subnets\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022virtualNetworkPeerings\u0022: [],\r\n",
-        "    \u0022enableDdosProtection\u0022: false\r\n",
-        "  }\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "name": "vnet-7959",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.Network/virtualNetworks/vnet-7959",
+        "etag": "W/\u00227ef489b2-54fa-40a5-b66c-87354076f13f\u0022",
+        "type": "Microsoft.Network/virtualNetworks",
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Updating",
+          "resourceGuid": "bbacb658-2567-4073-aaa1-a5545e15e26e",
+          "addressSpace": {
+            "addressPrefixes": [
+              "10.0.0.0/16"
+            ]
+          },
+          "dhcpOptions": {
+            "dnsServers": [
+              "10.1.1.1",
+              "10.1.2.4"
+            ]
+          },
+          "subnets": [
+            {
+              "name": "default",
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.Network/virtualNetworks/vnet-7959/subnets/default",
+              "etag": "W/\u00227ef489b2-54fa-40a5-b66c-87354076f13f\u0022",
+              "properties": {
+                "provisioningState": "Updating",
+                "addressPrefix": "10.0.1.0/24",
+                "delegations": [],
+                "privateEndpointNetworkPolicies": "Disabled",
+                "privateLinkServiceNetworkPolicies": "Enabled"
+              },
+              "type": "Microsoft.Network/virtualNetworks/subnets"
+            }
+          ],
+          "virtualNetworkPeerings": [],
+          "enableDdosProtection": false
+        }
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/ccd593e7-3ac3-4e43-84e0-f0877bd99a04?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/22171ee5-251a-402f-bb53-b06f3f79fd70?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9a65119e6674f0f8a9bb010d0ac52499",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:24 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "37bc5291-4b23-4252-ab50-94894e2c622e",
-        "x-ms-client-request-id": "9a65119e6674f0f8a9bb010d0ac52499",
-        "x-ms-correlation-request-id": "73cbb8e2-5784-44b4-a7c3-7bf723da545c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11886",
-        "x-ms-request-id": "f260cbfb-53c4-4053-9692-c6ca3e7595e2",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064724Z:73cbb8e2-5784-44b4-a7c3-7bf723da545c"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/ccd593e7-3ac3-4e43-84e0-f0877bd99a04?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e5c0bf3f63055e50c786704f76c92d97",
+        "traceparent": "00-bf854b53546596459a9f92aefa9689b7-d1d14ef900f94942-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "59b37ddb00de5e4d11fba445c039e26f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -2292,7 +1140,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "29",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:25 GMT",
+        "Date": "Wed, 29 Jun 2022 14:38:11 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -2301,36 +1149,35 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "f3c84b33-cc9e-4996-87e2-88f06dad1e13",
-        "x-ms-client-request-id": "e5c0bf3f63055e50c786704f76c92d97",
-        "x-ms-correlation-request-id": "876a4d57-684a-4456-aa66-b2707cde80f5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11885",
-        "x-ms-request-id": "1c702b1b-2b8b-4751-8f14-8d013199be4c",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064725Z:876a4d57-684a-4456-aa66-b2707cde80f5"
+        "x-ms-arm-service-request-id": "a36e955a-a82d-4867-9e4d-6548115869be",
+        "x-ms-client-request-id": "59b37ddb00de5e4d11fba445c039e26f",
+        "x-ms-correlation-request-id": "23799434-94f3-4066-adb6-924632ecc38d",
+        "x-ms-ratelimit-remaining-subscription-reads": "11984",
+        "x-ms-request-id": "f61fe296-2aa4-4747-87b4-090a4b6dcfb3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143812Z:23799434-94f3-4066-adb6-924632ecc38d"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022Succeeded\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "Succeeded"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/virtualNetworks/vnet-93?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.Network/virtualNetworks/vnet-7959?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ec3a52e25e6fd3f8be3822ad59226059",
+        "traceparent": "00-bf854b53546596459a9f92aefa9689b7-524e862846c42949-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "0f0843bf0fa0d31ac5a827a6370e886b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1335",
+        "Content-Length": "1341",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:25 GMT",
-        "ETag": "W/\u00221325fb0e-fe52-46b1-a0e7-f8a6818bdd30\u0022",
+        "Date": "Wed, 29 Jun 2022 14:38:12 GMT",
+        "ETag": "W/\u00221e8f0813-040f-47b2-9000-7559607dc1e8\u0022",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -2339,74 +1186,73 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "bb4a5fff-4a06-4f58-8eb8-e6f21ff6125d",
-        "x-ms-client-request-id": "ec3a52e25e6fd3f8be3822ad59226059",
-        "x-ms-correlation-request-id": "14e03206-eaba-4faa-bd35-f6009131f9cc",
-        "x-ms-ratelimit-remaining-subscription-reads": "11884",
-        "x-ms-request-id": "dbc6f307-0809-4796-9868-c60a6de67213",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064725Z:14e03206-eaba-4faa-bd35-f6009131f9cc"
+        "x-ms-arm-service-request-id": "f7b21dc3-87b3-4000-a868-dd140cee9393",
+        "x-ms-client-request-id": "0f0843bf0fa0d31ac5a827a6370e886b",
+        "x-ms-correlation-request-id": "48bec4e7-460c-46be-bbf6-56ca25e15f43",
+        "x-ms-ratelimit-remaining-subscription-reads": "11983",
+        "x-ms-request-id": "c18cbabf-d39b-4824-9fda-59554ebe3429",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143813Z:48bec4e7-460c-46be-bbf6-56ca25e15f43"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022name\u0022: \u0022vnet-93\u0022,\r\n",
-        "  \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/virtualNetworks/vnet-93\u0022,\r\n",
-        "  \u0022etag\u0022: \u0022W/\\\u00221325fb0e-fe52-46b1-a0e7-f8a6818bdd30\\\u0022\u0022,\r\n",
-        "  \u0022type\u0022: \u0022Microsoft.Network/virtualNetworks\u0022,\r\n",
-        "  \u0022location\u0022: \u0022westus2\u0022,\r\n",
-        "  \u0022properties\u0022: {\r\n",
-        "    \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "    \u0022resourceGuid\u0022: \u00229a6a5de5-09f6-4a7f-8af4-c380f39b6995\u0022,\r\n",
-        "    \u0022addressSpace\u0022: {\r\n",
-        "      \u0022addressPrefixes\u0022: [\r\n",
-        "        \u002210.0.0.0/16\u0022\r\n",
-        "      ]\r\n",
-        "    },\r\n",
-        "    \u0022dhcpOptions\u0022: {\r\n",
-        "      \u0022dnsServers\u0022: [\r\n",
-        "        \u002210.1.1.1\u0022,\r\n",
-        "        \u002210.1.2.4\u0022\r\n",
-        "      ]\r\n",
-        "    },\r\n",
-        "    \u0022subnets\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022name\u0022: \u0022default\u0022,\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/virtualNetworks/vnet-93/subnets/default\u0022,\r\n",
-        "        \u0022etag\u0022: \u0022W/\\\u00221325fb0e-fe52-46b1-a0e7-f8a6818bdd30\\\u0022\u0022,\r\n",
-        "        \u0022properties\u0022: {\r\n",
-        "          \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "          \u0022addressPrefix\u0022: \u002210.0.1.0/24\u0022,\r\n",
-        "          \u0022delegations\u0022: [],\r\n",
-        "          \u0022privateEndpointNetworkPolicies\u0022: \u0022Disabled\u0022,\r\n",
-        "          \u0022privateLinkServiceNetworkPolicies\u0022: \u0022Enabled\u0022\r\n",
-        "        },\r\n",
-        "        \u0022type\u0022: \u0022Microsoft.Network/virtualNetworks/subnets\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022virtualNetworkPeerings\u0022: [],\r\n",
-        "    \u0022enableDdosProtection\u0022: false\r\n",
-        "  }\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "name": "vnet-7959",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.Network/virtualNetworks/vnet-7959",
+        "etag": "W/\u00221e8f0813-040f-47b2-9000-7559607dc1e8\u0022",
+        "type": "Microsoft.Network/virtualNetworks",
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "resourceGuid": "bbacb658-2567-4073-aaa1-a5545e15e26e",
+          "addressSpace": {
+            "addressPrefixes": [
+              "10.0.0.0/16"
+            ]
+          },
+          "dhcpOptions": {
+            "dnsServers": [
+              "10.1.1.1",
+              "10.1.2.4"
+            ]
+          },
+          "subnets": [
+            {
+              "name": "default",
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.Network/virtualNetworks/vnet-7959/subnets/default",
+              "etag": "W/\u00221e8f0813-040f-47b2-9000-7559607dc1e8\u0022",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "addressPrefix": "10.0.1.0/24",
+                "delegations": [],
+                "privateEndpointNetworkPolicies": "Disabled",
+                "privateLinkServiceNetworkPolicies": "Enabled"
+              },
+              "type": "Microsoft.Network/virtualNetworks/subnets"
+            }
+          ],
+          "virtualNetworkPeerings": [],
+          "enableDdosProtection": false
+        }
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.Network/privateEndpoints/pe-643?api-version=2021-02-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "731",
+        "Content-Length": "733",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.Network/1.0.0-beta.3 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a4f411283a4206c1d3eef5a87adf8e6a",
+        "traceparent": "00-540ee7985c721347a513cf31782bb68d-d884bcb499735e4d-00",
+        "User-Agent": "azsdk-net-ResourceManager.Network/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ce331854336996ab1992c8b2dc6d9c7d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "location": "westus2",
         "properties": {
           "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.Network/virtualNetworks/vnet-7959/subnets/default",
             "name": "default",
             "type": "Microsoft.Network/virtualNetworks/subnets",
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/virtualNetworks/vnet-93/subnets/default",
             "properties": {
               "addressPrefix": "10.0.1.0/24",
               "delegations": [],
@@ -2416,9 +1262,9 @@
           },
           "manualPrivateLinkServiceConnections": [
             {
-              "name": "pec4151",
+              "name": "pec5830",
               "properties": {
-                "privateLinkServiceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
+                "privateLinkServiceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395",
                 "groupIds": [
                   "namespace"
                 ],
@@ -2431,11 +1277,11 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Azure-AsyncNotification": "Enabled",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/e1ad56b9-3642-470c-970e-53e7659df543?api-version=2021-02-01",
         "Cache-Control": "no-cache",
-        "Content-Length": "1956",
+        "Content-Length": "1954",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:32 GMT",
+        "Date": "Wed, 29 Jun 2022 14:38:17 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
@@ -2445,65 +1291,64 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "e2f06173-ae5d-4960-ae1d-42709eabe850",
-        "x-ms-client-request-id": "a4f411283a4206c1d3eef5a87adf8e6a",
-        "x-ms-correlation-request-id": "4348cdde-c19d-4b32-b66b-a1213c636b63",
-        "x-ms-ratelimit-remaining-subscription-writes": "1192",
-        "x-ms-request-id": "d0dbe635-040a-4777-b2e7-a26c9f85ba4c",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064732Z:4348cdde-c19d-4b32-b66b-a1213c636b63"
+        "x-ms-arm-service-request-id": "cd9a31ad-5170-46aa-a685-ff702c67eba9",
+        "x-ms-client-request-id": "ce331854336996ab1992c8b2dc6d9c7d",
+        "x-ms-correlation-request-id": "33e28466-9bdd-4435-918a-18479aca147b",
+        "x-ms-ratelimit-remaining-subscription-writes": "1197",
+        "x-ms-request-id": "e1ad56b9-3642-470c-970e-53e7659df543",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143817Z:33e28466-9bdd-4435-918a-18479aca147b"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022name\u0022: \u0022pe-2293\u0022,\r\n",
-        "  \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293\u0022,\r\n",
-        "  \u0022etag\u0022: \u0022W/\\\u0022d4384fc4-733f-4731-a522-171671ed2aab\\\u0022\u0022,\r\n",
-        "  \u0022type\u0022: \u0022Microsoft.Network/privateEndpoints\u0022,\r\n",
-        "  \u0022location\u0022: \u0022westus2\u0022,\r\n",
-        "  \u0022properties\u0022: {\r\n",
-        "    \u0022provisioningState\u0022: \u0022Updating\u0022,\r\n",
-        "    \u0022resourceGuid\u0022: \u00229689aaf7-d595-4c72-8aa1-c75e896fd54f\u0022,\r\n",
-        "    \u0022privateLinkServiceConnections\u0022: [],\r\n",
-        "    \u0022manualPrivateLinkServiceConnections\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022name\u0022: \u0022pec4151\u0022,\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293/manualPrivateLinkServiceConnections/pec4151\u0022,\r\n",
-        "        \u0022etag\u0022: \u0022W/\\\u0022d4384fc4-733f-4731-a522-171671ed2aab\\\u0022\u0022,\r\n",
-        "        \u0022properties\u0022: {\r\n",
-        "          \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "          \u0022privateLinkServiceId\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712\u0022,\r\n",
-        "          \u0022groupIds\u0022: [\r\n",
-        "            \u0022namespace\u0022\r\n",
-        "          ],\r\n",
-        "          \u0022requestMessage\u0022: \u0022SDK test\u0022,\r\n",
-        "          \u0022privateLinkServiceConnectionState\u0022: {\r\n",
-        "            \u0022status\u0022: \u0022Pending\u0022,\r\n",
-        "            \u0022description\u0022: \u0022SDK test\u0022,\r\n",
-        "            \u0022actionsRequired\u0022: \u0022None\u0022\r\n",
-        "          }\r\n",
-        "        },\r\n",
-        "        \u0022type\u0022: \u0022Microsoft.Network/privateEndpoints/manualPrivateLinkServiceConnections\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022subnet\u0022: {\r\n",
-        "      \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/virtualNetworks/vnet-93/subnets/default\u0022\r\n",
-        "    },\r\n",
-        "    \u0022networkInterfaces\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/networkInterfaces/pe-2293.nic.e4491372-95da-40c5-84ac-4e3672f2b650\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022customDnsConfigs\u0022: []\r\n",
-        "  }\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "name": "pe-643",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.Network/privateEndpoints/pe-643",
+        "etag": "W/\u002247b2723d-e3f5-42e6-874d-1d35a3d74b2a\u0022",
+        "type": "Microsoft.Network/privateEndpoints",
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Updating",
+          "resourceGuid": "e0e8e6bf-c4ce-4b67-af80-dcf8b0ec5ad6",
+          "privateLinkServiceConnections": [],
+          "manualPrivateLinkServiceConnections": [
+            {
+              "name": "pec5830",
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.Network/privateEndpoints/pe-643/manualPrivateLinkServiceConnections/pec5830",
+              "etag": "W/\u002247b2723d-e3f5-42e6-874d-1d35a3d74b2a\u0022",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateLinkServiceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395",
+                "groupIds": [
+                  "namespace"
+                ],
+                "requestMessage": "SDK test",
+                "privateLinkServiceConnectionState": {
+                  "status": "Pending",
+                  "description": "SDK test",
+                  "actionsRequired": "None"
+                }
+              },
+              "type": "Microsoft.Network/privateEndpoints/manualPrivateLinkServiceConnections"
+            }
+          ],
+          "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.Network/virtualNetworks/vnet-7959/subnets/default"
+          },
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.Network/networkInterfaces/pe-643.nic.ba4d8756-862d-4370-85a3-332f50432e9a"
+            }
+          ],
+          "customDnsConfigs": []
+        }
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/e1ad56b9-3642-470c-970e-53e7659df543?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1ca010093da2000f2b688b0add16be42",
+        "traceparent": "00-540ee7985c721347a513cf31782bb68d-d7925a3818c90c4a-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "cae5a2b1f13cd4d9640af5870a13cbb9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -2512,7 +1357,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "30",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:32 GMT",
+        "Date": "Wed, 29 Jun 2022 14:38:18 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
@@ -2522,26 +1367,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "d650198c-9a6f-4265-b6f2-f2b922b9b008",
-        "x-ms-client-request-id": "1ca010093da2000f2b688b0add16be42",
-        "x-ms-correlation-request-id": "55e804b7-14f0-4303-9a86-8a00bcfce67f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11883",
-        "x-ms-request-id": "3aabb8d7-59e0-4493-94e0-b445b910ad4b",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064733Z:55e804b7-14f0-4303-9a86-8a00bcfce67f"
+        "x-ms-arm-service-request-id": "7cca41dc-0bd0-4231-8ca3-abd58b14f319",
+        "x-ms-client-request-id": "cae5a2b1f13cd4d9640af5870a13cbb9",
+        "x-ms-correlation-request-id": "7b0f5d35-e5f4-4441-980a-6884e3c738df",
+        "x-ms-ratelimit-remaining-subscription-reads": "11982",
+        "x-ms-request-id": "a67cd0e6-bc5e-4c92-97ca-5a4552a5bc42",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143818Z:7b0f5d35-e5f4-4441-980a-6884e3c738df"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "InProgress"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/e1ad56b9-3642-470c-970e-53e7659df543?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a7f7ee1e0dcf483b4a077d75fa1e012f",
+        "traceparent": "00-540ee7985c721347a513cf31782bb68d-ac0e4bad0ad76a46-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "bf38b90a729b8891b55239335a046f16",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -2550,7 +1394,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "30",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:34 GMT",
+        "Date": "Wed, 29 Jun 2022 14:38:28 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "20",
@@ -2560,26 +1404,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "62545803-abf3-408c-8f6a-021157b99d8e",
-        "x-ms-client-request-id": "a7f7ee1e0dcf483b4a077d75fa1e012f",
-        "x-ms-correlation-request-id": "77805195-8ce8-4d68-9d97-2e51e8f313fe",
-        "x-ms-ratelimit-remaining-subscription-reads": "11882",
-        "x-ms-request-id": "27e68608-554d-491c-bc29-37b43d7a0bef",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064734Z:77805195-8ce8-4d68-9d97-2e51e8f313fe"
+        "x-ms-arm-service-request-id": "2fc7265d-caa3-47b5-becf-a760b72b5434",
+        "x-ms-client-request-id": "bf38b90a729b8891b55239335a046f16",
+        "x-ms-correlation-request-id": "62a0cfcf-ccc9-45a3-8949-091cd5e6bb8a",
+        "x-ms-ratelimit-remaining-subscription-reads": "11981",
+        "x-ms-request-id": "11713e24-d78b-4b39-9d29-ca2695581e80",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143828Z:62a0cfcf-ccc9-45a3-8949-091cd5e6bb8a"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "InProgress"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/e1ad56b9-3642-470c-970e-53e7659df543?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "699fdec8713fedc7a98a0dc255bc0f10",
+        "traceparent": "00-540ee7985c721347a513cf31782bb68d-2bfa1c19ceac1b49-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "3a008e1ed188e440eefbbc82d6dad580",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -2588,7 +1431,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "30",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:35 GMT",
+        "Date": "Wed, 29 Jun 2022 14:38:49 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "20",
@@ -2598,833 +1441,36 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "5a1d41ce-9155-460c-bb4c-0c06c527d278",
-        "x-ms-client-request-id": "699fdec8713fedc7a98a0dc255bc0f10",
-        "x-ms-correlation-request-id": "b47d5bfe-ea2d-476b-8af0-45021008cc2b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11881",
-        "x-ms-request-id": "100c2cda-06c9-4379-b10d-ec835c3d5bab",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064735Z:b47d5bfe-ea2d-476b-8af0-45021008cc2b"
+        "x-ms-arm-service-request-id": "6b51c41e-84d8-4ee6-be47-b81fb9e567d8",
+        "x-ms-client-request-id": "3a008e1ed188e440eefbbc82d6dad580",
+        "x-ms-correlation-request-id": "befbcb9c-2ce2-40a6-9198-228846341e95",
+        "x-ms-ratelimit-remaining-subscription-reads": "11980",
+        "x-ms-request-id": "4065756d-fc4b-4f3a-bed6-a2e2ddea9640",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143849Z:befbcb9c-2ce2-40a6-9198-228846341e95"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "InProgress"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/e1ad56b9-3642-470c-970e-53e7659df543?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1684fd0e7eacfb47d458d19bc09a050c",
+        "Connection": "close",
+        "traceparent": "00-540ee7985c721347a513cf31782bb68d-5f7eef3409a39343-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6d9c1f6ab3ca3e9e105c15eab7a67a60",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:36 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "40",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "faedd1c9-21a8-43e0-9adb-1baa8f6da129",
-        "x-ms-client-request-id": "1684fd0e7eacfb47d458d19bc09a050c",
-        "x-ms-correlation-request-id": "44527022-198c-49f7-893e-56f67d93a25a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11880",
-        "x-ms-request-id": "7be6991b-bc06-439d-ac83-b040648987cd",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064736Z:44527022-198c-49f7-893e-56f67d93a25a"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ff425c675477ad032609fd450079f38e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:37 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "40",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "57b5a087-889b-4b59-a8a4-6ee3b947f2a2",
-        "x-ms-client-request-id": "ff425c675477ad032609fd450079f38e",
-        "x-ms-correlation-request-id": "79651078-8d6b-46a7-adc9-33483b6855d1",
-        "x-ms-ratelimit-remaining-subscription-reads": "11879",
-        "x-ms-request-id": "0d4f5787-99e4-499c-8c7b-b9cb3996f8be",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064738Z:79651078-8d6b-46a7-adc9-33483b6855d1"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fc666cf7ea9a498296a395e7a02c2d0f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:39 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "80",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "bd654c43-93d1-4a3f-b37e-7abc3ab5e6ed",
-        "x-ms-client-request-id": "fc666cf7ea9a498296a395e7a02c2d0f",
-        "x-ms-correlation-request-id": "2dfef5c3-6ae8-4c25-b9be-d52d4f7960e5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11878",
-        "x-ms-request-id": "566f4eaa-0b1d-440f-a6d9-6ab8f599b22b",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064739Z:2dfef5c3-6ae8-4c25-b9be-d52d4f7960e5"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f95b00840f79ba99fad6f0a38002fb5a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:40 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "80",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "104e39af-7719-4f14-9f60-0b8c6ae9eeee",
-        "x-ms-client-request-id": "f95b00840f79ba99fad6f0a38002fb5a",
-        "x-ms-correlation-request-id": "e29bd97a-a1a6-4df6-b084-4998d69ea72a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11877",
-        "x-ms-request-id": "3914ace5-7358-4f96-b176-4c664e60b7a1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064741Z:e29bd97a-a1a6-4df6-b084-4998d69ea72a"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "53a3436408337c72d9f869d3be1c0dfa",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:42 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "160",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "d71b7428-0777-4fa4-8d30-678f674f3443",
-        "x-ms-client-request-id": "53a3436408337c72d9f869d3be1c0dfa",
-        "x-ms-correlation-request-id": "fdf9ebf6-be73-40b1-86ec-c4948db8129c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11876",
-        "x-ms-request-id": "6fb4d95a-5a3e-4a44-942a-e51ad4e754fa",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064742Z:fdf9ebf6-be73-40b1-86ec-c4948db8129c"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ffc0eedcf91ee814d3ab02c3fadec894",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:43 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "1fff9ad7-dbf3-4d38-aa2d-464ef11421e5",
-        "x-ms-client-request-id": "ffc0eedcf91ee814d3ab02c3fadec894",
-        "x-ms-correlation-request-id": "a2e9e359-bad1-43ee-81d1-95c831985635",
-        "x-ms-ratelimit-remaining-subscription-reads": "11875",
-        "x-ms-request-id": "5fa404ff-87a8-42cc-847d-92ff3a71f876",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064743Z:a2e9e359-bad1-43ee-81d1-95c831985635"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5c823aa7d9887bdb8dde1f80a6c5fbde",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:44 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "439b41bd-3d88-4384-9c5c-958d55365ddc",
-        "x-ms-client-request-id": "5c823aa7d9887bdb8dde1f80a6c5fbde",
-        "x-ms-correlation-request-id": "334868fc-1e59-41b8-9c3d-1cdf3ad8073d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11874",
-        "x-ms-request-id": "e81137f2-6a6d-4b96-982a-0494281d3891",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064745Z:334868fc-1e59-41b8-9c3d-1cdf3ad8073d"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "92c7f5c9fb416a3c2ebb7f8706af82fb",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:46 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "90a7a39d-febc-41be-a87f-f76f85ef02f7",
-        "x-ms-client-request-id": "92c7f5c9fb416a3c2ebb7f8706af82fb",
-        "x-ms-correlation-request-id": "5cd17911-215d-4e90-83e0-41cb0c7da882",
-        "x-ms-ratelimit-remaining-subscription-reads": "11873",
-        "x-ms-request-id": "657afa8a-96cb-4942-9cb5-514ef1561eb1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064746Z:5cd17911-215d-4e90-83e0-41cb0c7da882"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "842cd42fb09902721344713fda93420e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:47 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "82c45374-9edd-495e-956f-2fd48516c352",
-        "x-ms-client-request-id": "842cd42fb09902721344713fda93420e",
-        "x-ms-correlation-request-id": "b8e84106-d578-488e-a3e3-329c6231a5cd",
-        "x-ms-ratelimit-remaining-subscription-reads": "11872",
-        "x-ms-request-id": "b2955d03-bb11-4167-9be9-6514bfe1fbd3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064747Z:b8e84106-d578-488e-a3e3-329c6231a5cd"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "05f924b03616ab52fe172ecc595375de",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:48 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "f8cf6824-4676-41d8-a9ef-043dc2f598de",
-        "x-ms-client-request-id": "05f924b03616ab52fe172ecc595375de",
-        "x-ms-correlation-request-id": "1c5d2a8d-661c-4abd-9c6f-f99a999bc96b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11871",
-        "x-ms-request-id": "82c68319-3a85-45da-ab9e-01d0e1158bc9",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064748Z:1c5d2a8d-661c-4abd-9c6f-f99a999bc96b"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d151235c7798194483c57efc8afc909a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:49 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "fb23cdd9-d332-400b-9879-1da841c8f5b3",
-        "x-ms-client-request-id": "d151235c7798194483c57efc8afc909a",
-        "x-ms-correlation-request-id": "a692b559-8d66-4f72-9cf2-126e84daa280",
-        "x-ms-ratelimit-remaining-subscription-reads": "11870",
-        "x-ms-request-id": "224db2fe-9527-4466-ae79-297b4322d5cc",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064750Z:a692b559-8d66-4f72-9cf2-126e84daa280"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e2d771797db6f8e48280858282a5a8bf",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:50 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "bb2b6de2-05f8-4076-ac36-98879b914261",
-        "x-ms-client-request-id": "e2d771797db6f8e48280858282a5a8bf",
-        "x-ms-correlation-request-id": "daf47175-991e-4833-97a0-a32640369006",
-        "x-ms-ratelimit-remaining-subscription-reads": "11869",
-        "x-ms-request-id": "1e226c76-67c3-4d1d-bd45-0b94cbc8ad19",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064751Z:daf47175-991e-4833-97a0-a32640369006"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b7e393cf71423875dfe08151b8562101",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:52 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "1a55edba-b469-43fd-a674-b60593b5c6de",
-        "x-ms-client-request-id": "b7e393cf71423875dfe08151b8562101",
-        "x-ms-correlation-request-id": "89fd033f-73af-4e8c-b4db-aae5d7cf35b3",
-        "x-ms-ratelimit-remaining-subscription-reads": "11868",
-        "x-ms-request-id": "bc9ac869-3b93-4ed4-a002-191f864f0692",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064752Z:89fd033f-73af-4e8c-b4db-aae5d7cf35b3"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e8539387927cdf283f584e18f1c296dd",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:53 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "c102be06-3bd1-4439-b713-3550a02b63b7",
-        "x-ms-client-request-id": "e8539387927cdf283f584e18f1c296dd",
-        "x-ms-correlation-request-id": "bdd07a0a-6bed-4ae2-9fa6-7001db63f737",
-        "x-ms-ratelimit-remaining-subscription-reads": "11867",
-        "x-ms-request-id": "8f50e848-604e-48db-a8cf-d9a1bf393311",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064754Z:bdd07a0a-6bed-4ae2-9fa6-7001db63f737"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f62cbf1cd8190758fb9e02d5fb92402c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:54 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "d9492ca4-a5ee-4673-9083-b1bc232ceaf4",
-        "x-ms-client-request-id": "f62cbf1cd8190758fb9e02d5fb92402c",
-        "x-ms-correlation-request-id": "6789a5c5-c0f6-4072-91cb-2f6dcb3d0f5a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11866",
-        "x-ms-request-id": "e40fcdf0-3591-4faf-901e-9b1808b969de",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064755Z:6789a5c5-c0f6-4072-91cb-2f6dcb3d0f5a"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "eefa845ebf513d426b0478ea225c471d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:56 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "810d3819-a204-4a36-a518-d6c29f0d1f26",
-        "x-ms-client-request-id": "eefa845ebf513d426b0478ea225c471d",
-        "x-ms-correlation-request-id": "cfd0ac30-8ebf-4b71-b0eb-89ba2899baa5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11865",
-        "x-ms-request-id": "10686e36-9dbc-4f16-993a-2665e85a5f9b",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064757Z:cfd0ac30-8ebf-4b71-b0eb-89ba2899baa5"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f834a4492a29aee83b4bedde8f52e3ac",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:57 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "84642223-cf22-4d7f-bfeb-faae458ffb2d",
-        "x-ms-client-request-id": "f834a4492a29aee83b4bedde8f52e3ac",
-        "x-ms-correlation-request-id": "5a2c2a72-2d57-4c1d-9f2e-3cb26abf3ecc",
-        "x-ms-ratelimit-remaining-subscription-reads": "11864",
-        "x-ms-request-id": "0432aef5-b630-48b4-80f1-4c8e39180102",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064758Z:5a2c2a72-2d57-4c1d-9f2e-3cb26abf3ecc"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6dba2217a7c75d8b7cef8b14606de59e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:47:59 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "8db17199-ebae-4627-a965-e3d0dd708ced",
-        "x-ms-client-request-id": "6dba2217a7c75d8b7cef8b14606de59e",
-        "x-ms-correlation-request-id": "bc59a815-8285-466c-9093-3fb6cec37881",
-        "x-ms-ratelimit-remaining-subscription-reads": "11863",
-        "x-ms-request-id": "e5acaa7e-371e-4aea-8e47-89b3fa661e7a",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064759Z:bc59a815-8285-466c-9093-3fb6cec37881"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "578ce557485d33029b4cb306d264ad18",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:00 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "1900cfe1-c68e-44c4-87e3-314b9a14bb23",
-        "x-ms-client-request-id": "578ce557485d33029b4cb306d264ad18",
-        "x-ms-correlation-request-id": "558878a9-b571-4339-a615-23ab6ec27b40",
-        "x-ms-ratelimit-remaining-subscription-reads": "11862",
-        "x-ms-request-id": "c43a10b4-015e-4ffd-952c-e5a965c1d77d",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064800Z:558878a9-b571-4339-a615-23ab6ec27b40"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ffd3cb20d9a2a15518d77b3a9fd34dcd",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:01 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "7070028f-5b38-4f09-8954-788953164234",
-        "x-ms-client-request-id": "ffd3cb20d9a2a15518d77b3a9fd34dcd",
-        "x-ms-correlation-request-id": "e287888e-6b96-4040-a2a6-47e186d91975",
-        "x-ms-ratelimit-remaining-subscription-reads": "11861",
-        "x-ms-request-id": "a966b201-ed5e-42be-8ca0-9ad29f42c828",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064802Z:e287888e-6b96-4040-a2a6-47e186d91975"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a9864f668cc6cf4e2086d27bf3858b17",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:02 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "3e571046-d496-4d06-b840-c1c0a14f8adf",
-        "x-ms-client-request-id": "a9864f668cc6cf4e2086d27bf3858b17",
-        "x-ms-correlation-request-id": "5a476531-b943-429b-ab62-c6ba7d00aa05",
-        "x-ms-ratelimit-remaining-subscription-reads": "11860",
-        "x-ms-request-id": "ff643760-2b27-48ed-a59c-9c22228312aa",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064803Z:5a476531-b943-429b-ab62-c6ba7d00aa05"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d0dbe635-040a-4777-b2e7-a26c9f85ba4c?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "94f47241e59a7dfb90ea3f86ccc894c7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
+        "Connection": "close",
         "Content-Length": "29",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:04 GMT",
+        "Date": "Wed, 29 Jun 2022 14:39:09 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -3433,36 +1479,35 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "1b493a6c-6a81-4fe0-8720-1ae8f5546b7e",
-        "x-ms-client-request-id": "94f47241e59a7dfb90ea3f86ccc894c7",
-        "x-ms-correlation-request-id": "ced0320a-709b-4f91-8f5a-0815ce84f1fc",
-        "x-ms-ratelimit-remaining-subscription-reads": "11859",
-        "x-ms-request-id": "c58b486c-6e0f-4fb3-82bb-f2e943df1fc0",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064804Z:ced0320a-709b-4f91-8f5a-0815ce84f1fc"
+        "x-ms-arm-service-request-id": "6ce3783d-2f97-4b3f-ad70-9bf79ea3e4d4",
+        "x-ms-client-request-id": "6d9c1f6ab3ca3e9e105c15eab7a67a60",
+        "x-ms-correlation-request-id": "cc6477d0-d1bc-4d62-9f2a-3019cb458866",
+        "x-ms-ratelimit-remaining-subscription-reads": "11979",
+        "x-ms-request-id": "c8adccd8-6b91-48ce-b448-0a538b867f36",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143910Z:cc6477d0-d1bc-4d62-9f2a-3019cb458866"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022Succeeded\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "Succeeded"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.Network/privateEndpoints/pe-643?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "839fe6fe04de93527d04df1c07daad92",
+        "traceparent": "00-540ee7985c721347a513cf31782bb68d-ad880c6c23c53e42-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "7c69de9a911338317853d19fb60fb2da",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1957",
+        "Content-Length": "1955",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:04 GMT",
-        "ETag": "W/\u0022fe46a588-cb13-4cfe-9f97-b3e857ba1164\u0022",
+        "Date": "Wed, 29 Jun 2022 14:39:11 GMT",
+        "ETag": "W/\u00229f9dba32-9f8c-4d19-9282-d3c514142ca8\u0022",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -3471,75 +1516,74 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "a178947f-9b2d-4fdf-8fcd-25eb1c478c18",
-        "x-ms-client-request-id": "839fe6fe04de93527d04df1c07daad92",
-        "x-ms-correlation-request-id": "d0d225f0-dc9c-42e2-ad78-f9769ff71c22",
-        "x-ms-ratelimit-remaining-subscription-reads": "11858",
-        "x-ms-request-id": "88a77f1c-e76c-4037-baf8-5154bc48b60c",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064805Z:d0d225f0-dc9c-42e2-ad78-f9769ff71c22"
+        "x-ms-arm-service-request-id": "7c1599af-c338-49bf-a647-bd07cfec8a37",
+        "x-ms-client-request-id": "7c69de9a911338317853d19fb60fb2da",
+        "x-ms-correlation-request-id": "6ffa2e4f-163b-403d-ae58-8cbd4e47c5d2",
+        "x-ms-ratelimit-remaining-subscription-reads": "11999",
+        "x-ms-request-id": "be821d1e-de88-496e-8778-6aed14290436",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143911Z:6ffa2e4f-163b-403d-ae58-8cbd4e47c5d2"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022name\u0022: \u0022pe-2293\u0022,\r\n",
-        "  \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293\u0022,\r\n",
-        "  \u0022etag\u0022: \u0022W/\\\u0022fe46a588-cb13-4cfe-9f97-b3e857ba1164\\\u0022\u0022,\r\n",
-        "  \u0022type\u0022: \u0022Microsoft.Network/privateEndpoints\u0022,\r\n",
-        "  \u0022location\u0022: \u0022westus2\u0022,\r\n",
-        "  \u0022properties\u0022: {\r\n",
-        "    \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "    \u0022resourceGuid\u0022: \u00229689aaf7-d595-4c72-8aa1-c75e896fd54f\u0022,\r\n",
-        "    \u0022privateLinkServiceConnections\u0022: [],\r\n",
-        "    \u0022manualPrivateLinkServiceConnections\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022name\u0022: \u0022pec4151\u0022,\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293/manualPrivateLinkServiceConnections/pec4151\u0022,\r\n",
-        "        \u0022etag\u0022: \u0022W/\\\u0022fe46a588-cb13-4cfe-9f97-b3e857ba1164\\\u0022\u0022,\r\n",
-        "        \u0022properties\u0022: {\r\n",
-        "          \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "          \u0022privateLinkServiceId\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712\u0022,\r\n",
-        "          \u0022groupIds\u0022: [\r\n",
-        "            \u0022namespace\u0022\r\n",
-        "          ],\r\n",
-        "          \u0022requestMessage\u0022: \u0022SDK test\u0022,\r\n",
-        "          \u0022privateLinkServiceConnectionState\u0022: {\r\n",
-        "            \u0022status\u0022: \u0022Pending\u0022,\r\n",
-        "            \u0022description\u0022: \u0022SDK test\u0022,\r\n",
-        "            \u0022actionsRequired\u0022: \u0022None\u0022\r\n",
-        "          }\r\n",
-        "        },\r\n",
-        "        \u0022type\u0022: \u0022Microsoft.Network/privateEndpoints/manualPrivateLinkServiceConnections\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022subnet\u0022: {\r\n",
-        "      \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/virtualNetworks/vnet-93/subnets/default\u0022\r\n",
-        "    },\r\n",
-        "    \u0022networkInterfaces\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/networkInterfaces/pe-2293.nic.e4491372-95da-40c5-84ac-4e3672f2b650\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022customDnsConfigs\u0022: []\r\n",
-        "  }\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "name": "pe-643",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.Network/privateEndpoints/pe-643",
+        "etag": "W/\u00229f9dba32-9f8c-4d19-9282-d3c514142ca8\u0022",
+        "type": "Microsoft.Network/privateEndpoints",
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "resourceGuid": "e0e8e6bf-c4ce-4b67-af80-dcf8b0ec5ad6",
+          "privateLinkServiceConnections": [],
+          "manualPrivateLinkServiceConnections": [
+            {
+              "name": "pec5830",
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.Network/privateEndpoints/pe-643/manualPrivateLinkServiceConnections/pec5830",
+              "etag": "W/\u00229f9dba32-9f8c-4d19-9282-d3c514142ca8\u0022",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateLinkServiceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395",
+                "groupIds": [
+                  "namespace"
+                ],
+                "requestMessage": "SDK test",
+                "privateLinkServiceConnectionState": {
+                  "status": "Pending",
+                  "description": "SDK test",
+                  "actionsRequired": "None"
+                }
+              },
+              "type": "Microsoft.Network/privateEndpoints/manualPrivateLinkServiceConnections"
+            }
+          ],
+          "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.Network/virtualNetworks/vnet-7959/subnets/default"
+          },
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.Network/networkInterfaces/pe-643.nic.ba4d8756-862d-4370-85a3-332f50432e9a"
+            }
+          ],
+          "customDnsConfigs": []
+        }
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395/privateEndpointConnections?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2cf8634cb8df8032530819db4dc70257",
+        "traceparent": "00-74c7b084f8b1534d95884fcc62ae3c37-6185f030bf658943-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "3ac8b97d01676b4cefc1292cbc562d48",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "689",
+        "Content-Length": "688",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:04 GMT",
+        "Date": "Wed, 29 Jun 2022 14:39:11 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -3549,23 +1593,23 @@
         "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2cf8634cb8df8032530819db4dc70257",
-        "x-ms-correlation-request-id": "da2ad4a0-78bd-42de-aa25-d963d9bf6e5b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11857",
-        "x-ms-request-id": "63657b02-ba48-47d9-a6c6-b622974f3ab9_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064805Z:da2ad4a0-78bd-42de-aa25-d963d9bf6e5b"
+        "x-ms-client-request-id": "3ac8b97d01676b4cefc1292cbc562d48",
+        "x-ms-correlation-request-id": "b9a3fa7f-50a1-4236-8d7d-5bc788dfcc55",
+        "x-ms-ratelimit-remaining-subscription-reads": "11998",
+        "x-ms-request-id": "035b8974-bc49-448c-994f-b4ad76cda628_M3SN1_M3SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T143912Z:b9a3fa7f-50a1-4236-8d7d-5bc788dfcc55"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-            "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4395/privateEndpointConnections/db5ac28c-0bd7-43aa-84ea-82f645d62652",
+            "name": "db5ac28c-0bd7-43aa-84ea-82f645d62652",
             "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
             "location": "East US 2",
             "properties": {
               "provisioningState": "Succeeded",
               "privateEndpoint": {
-                "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293"
+                "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-1063/providers/Microsoft.Network/privateEndpoints/pe-643"
               },
               "privateLinkServiceConnectionState": {
                 "status": "Pending",
@@ -3578,1961 +1622,11 @@
           }
         ]
       }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0d7c0af208e53d391f60179606df76b5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "689",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:05 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "0d7c0af208e53d391f60179606df76b5",
-        "x-ms-correlation-request-id": "27f3d8f4-33aa-4b13-a906-e913dd84d5cb",
-        "x-ms-ratelimit-remaining-subscription-reads": "11856",
-        "x-ms-request-id": "4c7df808-9750-4e81-9338-4e799197aa77_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064805Z:27f3d8f4-33aa-4b13-a906-e913dd84d5cb"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-            "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-            "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-            "location": "East US 2",
-            "properties": {
-              "provisioningState": "Succeeded",
-              "privateEndpoint": {
-                "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293"
-              },
-              "privateLinkServiceConnectionState": {
-                "status": "Pending",
-                "description": "SDK test"
-              },
-              "groupIds": [
-                "namespace"
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6839ac3c67d045e8b31f2fd5ea7646b5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com:443/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Date": "Fri, 19 Nov 2021 06:48:05 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "6839ac3c67d045e8b31f2fd5ea7646b5",
-        "x-ms-correlation-request-id": "87d4786b-2862-4490-b3c7-484dabf4aa94",
-        "x-ms-ratelimit-remaining-subscription-deletes": "14996",
-        "x-ms-request-id": "db3978dd-4785-4e9a-95d5-3bd1d7076880_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064806Z:87d4786b-2862-4490-b3c7-484dabf4aa94"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a09f64919a8e8a87223759c6d86453a8",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "464",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:06 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a09f64919a8e8a87223759c6d86453a8",
-        "x-ms-correlation-request-id": "49d97750-e205-4428-bf36-fa375ff27bf2",
-        "x-ms-ratelimit-remaining-subscription-reads": "11855",
-        "x-ms-request-id": "a6b3c407-8c7e-452a-a159-ac7160105c41_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064806Z:49d97750-e205-4428-bf36-fa375ff27bf2"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:48:06.213Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7d9561197ab59b57fff53e155a69a317",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "464",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:07 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "7d9561197ab59b57fff53e155a69a317",
-        "x-ms-correlation-request-id": "7e005365-265a-447c-b833-636f2471df8d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11854",
-        "x-ms-request-id": "8803e95c-5c14-4e5b-a60b-eececfbcce33_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064808Z:7e005365-265a-447c-b833-636f2471df8d"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:48:06.213Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8643bba5a5d76727019fd92746e66bc5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "464",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:08 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8643bba5a5d76727019fd92746e66bc5",
-        "x-ms-correlation-request-id": "da19b13e-58f3-4d5c-96fc-df5797ae2758",
-        "x-ms-ratelimit-remaining-subscription-reads": "11853",
-        "x-ms-request-id": "671710b5-956f-4068-b4e4-702309c61c20_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064809Z:da19b13e-58f3-4d5c-96fc-df5797ae2758"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:48:06.213Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3f656467fc0717be0c03a0985b7130b9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "464",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:10 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "3f656467fc0717be0c03a0985b7130b9",
-        "x-ms-correlation-request-id": "09481e3e-307e-472e-9695-dd48695fd892",
-        "x-ms-ratelimit-remaining-subscription-reads": "11852",
-        "x-ms-request-id": "92274c9b-5e1b-4273-b6e8-decb5ee047ce_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064810Z:09481e3e-307e-472e-9695-dd48695fd892"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:48:06.213Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1c214293cc2174d13a2d7c16a0305519",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "464",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:11 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "1c214293cc2174d13a2d7c16a0305519",
-        "x-ms-correlation-request-id": "78be2739-26aa-42ce-84f5-27bd1ab07d64",
-        "x-ms-ratelimit-remaining-subscription-reads": "11851",
-        "x-ms-request-id": "48008688-8fff-4e12-a1c2-6d78bde77355_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064812Z:78be2739-26aa-42ce-84f5-27bd1ab07d64"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:48:06.213Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f6ad78896404a810fd2c79d3048e0b8f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "464",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:13 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f6ad78896404a810fd2c79d3048e0b8f",
-        "x-ms-correlation-request-id": "f2d9bb03-8ba5-48b1-b3cd-3e8a359349f5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11850",
-        "x-ms-request-id": "a8a8e06b-9868-48f6-af9c-c6700d93ede9_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064813Z:f2d9bb03-8ba5-48b1-b3cd-3e8a359349f5"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:48:06.213Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0493206f4fc59ba492f105d980a776dc",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "464",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:14 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "0493206f4fc59ba492f105d980a776dc",
-        "x-ms-correlation-request-id": "f4afed3d-f11a-4457-941e-f1d3a48845b1",
-        "x-ms-ratelimit-remaining-subscription-reads": "11849",
-        "x-ms-request-id": "337a2076-bbbd-4565-b9a0-55ead7e6aeaa_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064815Z:f4afed3d-f11a-4457-941e-f1d3a48845b1"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:48:06.213Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e20e87ae3ac42eb531781ef553fd6fab",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "464",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:15 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "e20e87ae3ac42eb531781ef553fd6fab",
-        "x-ms-correlation-request-id": "0ff93010-96a6-4208-9507-2640b7621799",
-        "x-ms-ratelimit-remaining-subscription-reads": "11848",
-        "x-ms-request-id": "711d15e4-317c-4910-aa8e-2a3401bf2189_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064816Z:0ff93010-96a6-4208-9507-2640b7621799"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:48:06.213Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "80a7ed22509c3953d41263135e372856",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "464",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:17 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "80a7ed22509c3953d41263135e372856",
-        "x-ms-correlation-request-id": "ef850fd9-58cc-4e39-828f-4fb80f3a6301",
-        "x-ms-ratelimit-remaining-subscription-reads": "11847",
-        "x-ms-request-id": "1e2d8fec-cdd8-4ae7-8f7e-3d8a005c1f98_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064817Z:ef850fd9-58cc-4e39-828f-4fb80f3a6301"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:48:06.213Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7d259cb5288034ca6b65d34c31af4795",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "464",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:18 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "7d259cb5288034ca6b65d34c31af4795",
-        "x-ms-correlation-request-id": "1dab9bc4-67d4-4be3-a37d-50f9b16c055d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11846",
-        "x-ms-request-id": "74c24373-43b4-4895-92a1-612650a069cb_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064819Z:1dab9bc4-67d4-4be3-a37d-50f9b16c055d"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:48:06.213Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "93b65981f5005d4033d40eb2d6a2cffa",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "464",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:19 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "93b65981f5005d4033d40eb2d6a2cffa",
-        "x-ms-correlation-request-id": "500752a9-fff2-461e-ab54-8e79f4370223",
-        "x-ms-ratelimit-remaining-subscription-reads": "11845",
-        "x-ms-request-id": "f15405b6-7208-4e14-9dbd-223209e278dd_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064820Z:500752a9-fff2-461e-ab54-8e79f4370223"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:48:06.213Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b63fc850f1d8f92b227215377d070825",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "463",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:21 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "b63fc850f1d8f92b227215377d070825",
-        "x-ms-correlation-request-id": "f7459158-2b0c-4cec-b3ca-43e1735cabdd",
-        "x-ms-ratelimit-remaining-subscription-reads": "11844",
-        "x-ms-request-id": "4f29650a-9d8a-4495-bc79-5696c0953003_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064822Z:f7459158-2b0c-4cec-b3ca-43e1735cabdd"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:48:21.32Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0591ceca9580bf565cc749ab1a185ec9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "460",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:22 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "0591ceca9580bf565cc749ab1a185ec9",
-        "x-ms-correlation-request-id": "f3e41e96-91ed-4844-b6d2-c52dd029971e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11843",
-        "x-ms-request-id": "4eee1b97-6efe-4a65-b4bc-2ef1af52d21d_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064823Z:f3e41e96-91ed-4844-b6d2-c52dd029971e"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c/operationStatus/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-        "status": "Succeeded",
-        "startTime": "0001-01-01T00:00:00",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "68fcd995916f90bd2ebd708de008e02c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Date": "Fri, 19 Nov 2021 06:48:24 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "68fcd995916f90bd2ebd708de008e02c",
-        "x-ms-correlation-request-id": "0b14edab-00b9-42a2-b758-d8668a2502e1",
-        "x-ms-ratelimit-remaining-subscription-deletes": "14995",
-        "x-ms-request-id": "6cf09583-d077-4ad3-8270-68b47e2e992a_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064825Z:0b14edab-00b9-42a2-b758-d8668a2502e1"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a3a14b149f0a39b51000d6c324c8de53",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:24 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "43",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a3a14b149f0a39b51000d6c324c8de53",
-        "x-ms-correlation-request-id": "2cc78780-6dbd-44c7-82c4-c0b9ecb5efec",
-        "x-ms-ratelimit-remaining-subscription-reads": "11842",
-        "x-ms-request-id": "c3d3fd2c-3ba0-4b5e-a185-8ae7cd9f1f2f_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064825Z:2cc78780-6dbd-44c7-82c4-c0b9ecb5efec"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:48:24.97Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "31de1ce75530cab85f41f6f037ace7ae",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:26 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "39",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "31de1ce75530cab85f41f6f037ace7ae",
-        "x-ms-correlation-request-id": "4224ea73-14df-481c-9081-824975b36296",
-        "x-ms-ratelimit-remaining-subscription-reads": "11841",
-        "x-ms-request-id": "8ead44c2-8dd9-4182-b564-444304724756_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064827Z:4224ea73-14df-481c-9081-824975b36296"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:48:24.97Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "957967de3c662c2132aef70ff4b696a9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:27 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "56",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "957967de3c662c2132aef70ff4b696a9",
-        "x-ms-correlation-request-id": "38190409-7a5a-4aeb-bf94-5ef9e1ec1d8a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11840",
-        "x-ms-request-id": "557934c1-e6ad-467f-b94d-5ce60e53f211_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064828Z:38190409-7a5a-4aeb-bf94-5ef9e1ec1d8a"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:48:24.97Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8b2906a0ada1bed993d744c9a8c50264",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:28 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "35",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8b2906a0ada1bed993d744c9a8c50264",
-        "x-ms-correlation-request-id": "fda5966e-a979-4ab6-9950-67ef9e0a172d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11839",
-        "x-ms-request-id": "c6e047b5-39aa-412d-bed1-e305631e0672_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064829Z:fda5966e-a979-4ab6-9950-67ef9e0a172d"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:48:24.97Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bde52819494eaaecfbb2ff815ea8d6a8",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:30 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "58",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "bde52819494eaaecfbb2ff815ea8d6a8",
-        "x-ms-correlation-request-id": "27451166-6b38-40b3-a3ca-35657fdba5b8",
-        "x-ms-ratelimit-remaining-subscription-reads": "11838",
-        "x-ms-request-id": "a40e6a36-5d2d-4e29-97b9-03e8722183a1_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064831Z:27451166-6b38-40b3-a3ca-35657fdba5b8"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:48:24.97Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "304f4dab5c83300c8dbb028ff858836c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:31 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "50",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "304f4dab5c83300c8dbb028ff858836c",
-        "x-ms-correlation-request-id": "eb0a5669-92d3-4a09-8e32-e64b924d1d75",
-        "x-ms-ratelimit-remaining-subscription-reads": "11837",
-        "x-ms-request-id": "d1e02ac9-8338-428c-8581-732dd62e8ab8_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064832Z:eb0a5669-92d3-4a09-8e32-e64b924d1d75"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:48:24.97Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "cbf693acd9d1565a197f90eead5760ea",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:32 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "58",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "cbf693acd9d1565a197f90eead5760ea",
-        "x-ms-correlation-request-id": "14b073b1-edc3-42d0-a722-d6d7a6dcfba3",
-        "x-ms-ratelimit-remaining-subscription-reads": "11836",
-        "x-ms-request-id": "3013a295-b151-46e2-86cf-bf6ada39da00_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064833Z:14b073b1-edc3-42d0-a722-d6d7a6dcfba3"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:48:24.97Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5b1e9b01d175bce01cb42f93475db1a2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:35 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "49",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5b1e9b01d175bce01cb42f93475db1a2",
-        "x-ms-correlation-request-id": "6cc070e3-b110-4fd2-89f4-2b4e0e294bc0",
-        "x-ms-ratelimit-remaining-subscription-reads": "11835",
-        "x-ms-request-id": "fae0a1f6-d059-4f54-beb8-1e0471744602_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064835Z:6cc070e3-b110-4fd2-89f4-2b4e0e294bc0"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:48:24.97Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "cad5922f0ab1d1d7f2f91704cc1d8236",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:36 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "39",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "cad5922f0ab1d1d7f2f91704cc1d8236",
-        "x-ms-correlation-request-id": "0545796f-f64f-46df-a515-75863ff67473",
-        "x-ms-ratelimit-remaining-subscription-reads": "11834",
-        "x-ms-request-id": "7eda10c5-1078-4245-a3ad-9e1701f8a9f9_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064836Z:0545796f-f64f-46df-a515-75863ff67473"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:48:24.97Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5d8e175a273adaf7b23aaf1da9c70fbb",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:37 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "38",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5d8e175a273adaf7b23aaf1da9c70fbb",
-        "x-ms-correlation-request-id": "40abfcdb-f083-44c1-a1b3-8a1102cae8ab",
-        "x-ms-ratelimit-remaining-subscription-reads": "11833",
-        "x-ms-request-id": "e775ce27-56bf-4b6b-b695-cdd812542f2c_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064837Z:40abfcdb-f083-44c1-a1b3-8a1102cae8ab"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:48:24.97Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1bbfedcd9582f639c44c697cbadcf0fe",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:39 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "38",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "1bbfedcd9582f639c44c697cbadcf0fe",
-        "x-ms-correlation-request-id": "007fb95b-a409-4ec9-8320-44dcdc577163",
-        "x-ms-ratelimit-remaining-subscription-reads": "11832",
-        "x-ms-request-id": "153a245c-452a-4267-b951-0bcfd64d4827_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064839Z:007fb95b-a409-4ec9-8320-44dcdc577163"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:48:24.97Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3038f93154cf08689bfa17775bba272b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:40 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "57",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "3038f93154cf08689bfa17775bba272b",
-        "x-ms-correlation-request-id": "9914e945-ea1b-4aa5-aec4-1d88f9bb6e71",
-        "x-ms-ratelimit-remaining-subscription-reads": "11831",
-        "x-ms-request-id": "cb15a3c1-b848-49d5-b783-1c07a437d82a_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064840Z:9914e945-ea1b-4aa5-aec4-1d88f9bb6e71"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:48:24.97Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "de375be9675ec4b3de9799edbe7a20d6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:41 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "53",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "de375be9675ec4b3de9799edbe7a20d6",
-        "x-ms-correlation-request-id": "cbe27538-40a8-40fc-ab13-77422add7900",
-        "x-ms-ratelimit-remaining-subscription-reads": "11830",
-        "x-ms-request-id": "c6bf9d64-4dc4-45dc-95bc-d265289cc36d_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064841Z:cbe27538-40a8-40fc-ab13-77422add7900"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712/privateEndpointConnections/f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "name": "f62ddc74-4dc1-490c-9cad-544d607a3f7c",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.Network/privateEndpoints/pe-2293"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:48:24.97Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b0ecb049df8e78ec85b77f877ec19b09",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:43 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "36",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "b0ecb049df8e78ec85b77f877ec19b09",
-        "x-ms-correlation-request-id": "cd835386-26b1-437a-a6c8-2eeecdbc6d74",
-        "x-ms-ratelimit-remaining-subscription-reads": "11829",
-        "x-ms-request-id": "41be38c6-59a1-461a-a844-6610e2a57e69_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064843Z:cd835386-26b1-437a-a6c8-2eeecdbc6d74"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:48:24.97Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5e923e2412a5c9a045735137bb7b4920",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:44 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "36",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5e923e2412a5c9a045735137bb7b4920",
-        "x-ms-correlation-request-id": "5c1e08e7-f530-419b-9242-cd85fc245a32",
-        "x-ms-ratelimit-remaining-subscription-reads": "11828",
-        "x-ms-request-id": "d1f864cb-45d5-49a5-ac7a-b09a6c7fe270_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064844Z:5c1e08e7-f530-419b-9242-cd85fc245a32"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:48:24.97Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "aa2e41da77ce0a9c6ebf59a7e82c461c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:45 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "32",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "aa2e41da77ce0a9c6ebf59a7e82c461c",
-        "x-ms-correlation-request-id": "db391350-d8a9-4168-b2c0-a09bfa32cf36",
-        "x-ms-ratelimit-remaining-subscription-reads": "11827",
-        "x-ms-request-id": "76d6c333-8e3a-49ee-883d-d05715563e98_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064845Z:db391350-d8a9-4168-b2c0-a09bfa32cf36"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:48:24.97Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "80c88ffcc1e7373110226b1a8db4bc09",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "737",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:47 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "55",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "80c88ffcc1e7373110226b1a8db4bc09",
-        "x-ms-correlation-request-id": "a518bde3-9666-4f63-9fee-cbd0e595ec4d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11826",
-        "x-ms-request-id": "52a9393f-897b-41ab-8b34-70f0379ba67c_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064847Z:a518bde3-9666-4f63-9fee-cbd0e595ec4d"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712",
-        "name": "testnamespacemgmt2712",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2712",
-          "createdAt": "2021-11-19T06:46:32.127Z",
-          "updatedAt": "2021-11-19T06:48:24.97Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2712.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2742/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2712/operationresults/testnamespacemgmt2712?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3dad5e6df093ad3ba188f0e5b9f8e118",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Date": "Fri, 19 Nov 2021 06:48:48 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "3dad5e6df093ad3ba188f0e5b9f8e118",
-        "x-ms-correlation-request-id": "7a671537-8fec-4d3f-ab7c-744e93fc0d16",
-        "x-ms-ratelimit-remaining-subscription-reads": "11825",
-        "x-ms-request-id": "dd3953aa-9e85-4a0d-b1dd-bf9ffef7b5c0_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064848Z:7a671537-8fec-4d3f-ab7c-744e93fc0d16"
-      },
-      "ResponseBody": []
     }
   ],
   "Variables": {
-    "RandomSeed": "2040489989",
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
+    "RandomSeed": "118087468",
     "RESOURCE_MANAGER_URL": null,
     "SUBSCRIPTION_ID": "db1ab6f0-4769-4b27-930e-01e2ef9c123c"
   }

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionDelete.json
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionDelete.json
@@ -6,34 +6,43 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f4d71f8c07d7794397e021e04e6f8169-a8c82e9084bd854d-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "500c44615966f673a1c42f3301139727",
+        "traceparent": "00-52fe7e40f894484b8026fe9543a83c27-36ee689d39aaa641-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "d64cc44c23f49e3589e0a2a97a5fd5d5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "468",
+        "Content-Length": "747",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:42 GMT",
+        "Date": "Wed, 29 Jun 2022 14:40:09 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "06fc750e-60fc-4734-a692-904c8841750f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11997",
-        "x-ms-request-id": "06fc750e-60fc-4734-a692-904c8841750f",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064143Z:06fc750e-60fc-4734-a692-904c8841750f"
+        "x-ms-correlation-request-id": "e51b7a2f-9b7c-4f36-8653-ee75b1178dc8",
+        "x-ms-ratelimit-remaining-subscription-reads": "11994",
+        "x-ms-request-id": "e51b7a2f-9b7c-4f36-8653-ee75b1178dc8",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144009Z:e51b7a2f-9b7c-4f36-8653-ee75b1178dc8"
       },
       "ResponseBody": {
         "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "authorizationSource": "RoleBased",
         "managedByTenants": [],
         "tags": {
-          "tagKey1": "tagValue1",
-          "tagKey2": "tagValue2"
+          "TagKey-9823": "TagValue-566",
+          "TagKey-3481": "TagValue-320",
+          "TagKey-4926": "TagValue-1187",
+          "TagKey-751": "TagValue-3921",
+          "TagKey-1866": "TagValue-8559",
+          "TagKey-3094": "TagValue-9190",
+          "TagKey-2449": "TagValue-9",
+          "TagKey-8379": "TagValue-164",
+          "TagKey-7470": "TagValue-2205",
+          "TagKey-4236": "TagValue-3698",
+          "TagKey-5316": "TagValue-2725"
         },
         "subscriptionId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
@@ -47,15 +56,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourcegroups/testeventhubRG-3912?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourcegroups/testeventhubRG-791?api-version=2021-04-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "44",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "58d5120c37a357557439d7d527fae492",
+        "traceparent": "00-c020c28e7284dd409865a18f88a3f553-e23b7245e6804147-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c0ba2e28f713f73440ebb5e09cea1168",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -67,21 +77,21 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "258",
+        "Content-Length": "256",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:43 GMT",
+        "Date": "Wed, 29 Jun 2022 14:40:13 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "b48bea05-c8c2-4eda-ad29-4355be0e9446",
+        "x-ms-correlation-request-id": "0f862f9a-4485-4321-bf87-fe10c3122c06",
         "x-ms-ratelimit-remaining-subscription-writes": "1199",
-        "x-ms-request-id": "b48bea05-c8c2-4eda-ad29-4355be0e9446",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064144Z:b48bea05-c8c2-4eda-ad29-4355be0e9446"
+        "x-ms-request-id": "0f862f9a-4485-4321-bf87-fe10c3122c06",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144013Z:0f862f9a-4485-4321-bf87-fe10c3122c06"
       },
       "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912",
-        "name": "testeventhubRG-3912",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791",
+        "name": "testeventhubRG-791",
         "type": "Microsoft.Resources/resourceGroups",
         "location": "eastus2",
         "tags": {
@@ -100,19 +110,20 @@
         "Authorization": "Sanitized",
         "Content-Length": "32",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "48d190602a0681b3e3bab78a8edad14e",
+        "traceparent": "00-c8a9608e44e24e489a4a6fa387866993-a646ad37876faa45-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "fde6b897cbc2b19e951a904384120f13",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "testnamespacemgmt2792"
+        "name": "testnamespacemgmt5307"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "53",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:44 GMT",
+        "Date": "Wed, 29 Jun 2022 14:40:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -122,11 +133,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "48d190602a0681b3e3bab78a8edad14e",
-        "x-ms-correlation-request-id": "76319818-37b4-4eb2-8a4c-e898c36d65af",
+        "x-ms-client-request-id": "fde6b897cbc2b19e951a904384120f13",
+        "x-ms-correlation-request-id": "76cbe00e-cba3-4be0-abe9-84ac7776ca42",
         "x-ms-ratelimit-remaining-subscription-writes": "1199",
-        "x-ms-request-id": "16e77b2a-aa2c-4d4a-ae65-11d9a95c51b1_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064145Z:76319818-37b4-4eb2-8a4c-e898c36d65af"
+        "x-ms-request-id": "cd433559-0f10-458f-b2c6-8db23487ad60_M2CH3_M2CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144015Z:76cbe00e-cba3-4be0-abe9-84ac7776ca42"
       },
       "ResponseBody": {
         "nameAvailable": true,
@@ -135,15 +146,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307?api-version=2021-11-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "48",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "055dee26bd47b70df9f21f9c2079ca4a",
+        "traceparent": "00-b9a30253d167404fa8eddac8368f77a0-dce449e1aa17ea4c-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "449f50c139bf18cddfb3387fbdedf590",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -154,9 +166,9 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "738",
+        "Content-Length": "735",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:53 GMT",
+        "Date": "Wed, 29 Jun 2022 14:40:22 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -166,11 +178,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "055dee26bd47b70df9f21f9c2079ca4a",
-        "x-ms-correlation-request-id": "f118b18c-379d-4377-94a5-9ad20654da6c",
+        "x-ms-client-request-id": "449f50c139bf18cddfb3387fbdedf590",
+        "x-ms-correlation-request-id": "153d91d8-45bd-4c9f-8e95-7e07c84e36c6",
         "x-ms-ratelimit-remaining-subscription-resource-requests": "49",
-        "x-ms-request-id": "f0fdb200-1d94-4554-8efc-51ff34b8d0c3_M8CH3_M8CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064153Z:f118b18c-379d-4377-94a5-9ad20654da6c"
+        "x-ms-request-id": "9afb90c9-a1fc-4127-98ec-6493c1638fee_M2CH3_M2CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144022Z:153d91d8-45bd-4c9f-8e95-7e07c84e36c6"
       },
       "ResponseBody": {
         "sku": {
@@ -178,8 +190,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307",
+        "name": "testnamespacemgmt5307",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -190,30 +202,31 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5307",
+          "createdAt": "2022-06-29T14:40:21.28Z",
+          "updatedAt": "2022-06-29T14:40:21.28Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5307.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0c0186068d86a25f831a4f140a176069",
+        "traceparent": "00-b9a30253d167404fa8eddac8368f77a0-e9469395d4d3994e-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "9adacda523715db8ebce1e0e921ef3a7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "738",
+        "Content-Length": "735",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:55 GMT",
+        "Date": "Wed, 29 Jun 2022 14:40:24 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -223,182 +236,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "0c0186068d86a25f831a4f140a176069",
-        "x-ms-correlation-request-id": "ec6e8ae5-1a78-4064-9fa2-c2fb3ad03bf2",
-        "x-ms-ratelimit-remaining-subscription-reads": "11996",
-        "x-ms-request-id": "f838dda6-96f8-48a7-afda-1a92f345a30b_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064155Z:ec6e8ae5-1a78-4064-9fa2-c2fb3ad03bf2"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "34ea6cf0ca273ff8e876e370fc90192c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:56 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "34ea6cf0ca273ff8e876e370fc90192c",
-        "x-ms-correlation-request-id": "3534f15d-3033-4287-8785-146939ca4fc0",
-        "x-ms-ratelimit-remaining-subscription-reads": "11995",
-        "x-ms-request-id": "a02d362c-93de-4797-a4ef-dc7aa1ca5963_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064156Z:3534f15d-3033-4287-8785-146939ca4fc0"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9996c00cbe7813c3fa10833b97f2dd0a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:41:57 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "9996c00cbe7813c3fa10833b97f2dd0a",
-        "x-ms-correlation-request-id": "3b849f97-19cc-4708-8586-3d9057c4df70",
-        "x-ms-ratelimit-remaining-subscription-reads": "11994",
-        "x-ms-request-id": "e3896212-c272-47fa-a0fd-515dd170360e_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064157Z:3b849f97-19cc-4708-8586-3d9057c4df70"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "308c5676b0e23b378ec12310a9efa5f2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:00 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "308c5676b0e23b378ec12310a9efa5f2",
-        "x-ms-correlation-request-id": "91a85038-701c-4b6d-8362-b328ac89125a",
+        "x-ms-client-request-id": "9adacda523715db8ebce1e0e921ef3a7",
+        "x-ms-correlation-request-id": "539c10e8-0c84-4739-b3ef-536760cde99f",
         "x-ms-ratelimit-remaining-subscription-reads": "11993",
-        "x-ms-request-id": "2e6ed395-9475-4215-a80a-ed98dc3163d1_M10CH3_M10CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064200Z:91a85038-701c-4b6d-8362-b328ac89125a"
+        "x-ms-request-id": "117c3899-0aa5-4e26-b06a-13cdaef1961e_M11CH3_M11CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144024Z:539c10e8-0c84-4739-b3ef-536760cde99f"
       },
       "ResponseBody": {
         "sku": {
@@ -406,8 +248,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307",
+        "name": "testnamespacemgmt5307",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -418,30 +260,31 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5307",
+          "createdAt": "2022-06-29T14:40:21.28Z",
+          "updatedAt": "2022-06-29T14:40:21.28Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5307.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4a072300c78032f1a8d6391647bca8f6",
+        "traceparent": "00-b9a30253d167404fa8eddac8368f77a0-f54870009f2cbe42-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "82020025f34a1d24e93c28b0bbf0742b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "738",
+        "Content-Length": "735",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:01 GMT",
+        "Date": "Wed, 29 Jun 2022 14:40:27 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -451,11 +294,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "4a072300c78032f1a8d6391647bca8f6",
-        "x-ms-correlation-request-id": "c38bd4af-a1b9-4817-aef4-0acb70e8aff6",
+        "x-ms-client-request-id": "82020025f34a1d24e93c28b0bbf0742b",
+        "x-ms-correlation-request-id": "47e8aa1f-8348-4b91-a98c-774be44c324b",
         "x-ms-ratelimit-remaining-subscription-reads": "11992",
-        "x-ms-request-id": "6393f88d-c06a-46ab-a6cb-455be01f4d68_M10CH3_M10CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064201Z:c38bd4af-a1b9-4817-aef4-0acb70e8aff6"
+        "x-ms-request-id": "7fd538f4-4ae8-4c8e-8992-f3e24f465bee_M3CH3_M3CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144027Z:47e8aa1f-8348-4b91-a98c-774be44c324b"
       },
       "ResponseBody": {
         "sku": {
@@ -463,8 +306,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307",
+        "name": "testnamespacemgmt5307",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -475,30 +318,31 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5307",
+          "createdAt": "2022-06-29T14:40:21.28Z",
+          "updatedAt": "2022-06-29T14:40:21.28Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5307.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a6f9d898e9045b49895a0bb69ab3690b",
+        "traceparent": "00-b9a30253d167404fa8eddac8368f77a0-281de2f34f5bfa49-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f0d95ff85b131d1e496a31208658d0fd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "738",
+        "Content-Length": "735",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:03 GMT",
+        "Date": "Wed, 29 Jun 2022 14:40:30 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -508,11 +352,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a6f9d898e9045b49895a0bb69ab3690b",
-        "x-ms-correlation-request-id": "7f20535a-9e33-4366-8b16-67e1c94f781d",
+        "x-ms-client-request-id": "f0d95ff85b131d1e496a31208658d0fd",
+        "x-ms-correlation-request-id": "fc92fde8-8390-4cbc-99c7-bc2b641eb87b",
         "x-ms-ratelimit-remaining-subscription-reads": "11991",
-        "x-ms-request-id": "db43e797-9222-4399-8b7f-c3c427d5602c_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064203Z:7f20535a-9e33-4366-8b16-67e1c94f781d"
+        "x-ms-request-id": "0b316895-7023-4d52-92da-209cde85016b_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144030Z:fc92fde8-8390-4cbc-99c7-bc2b641eb87b"
       },
       "ResponseBody": {
         "sku": {
@@ -520,8 +364,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307",
+        "name": "testnamespacemgmt5307",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -532,30 +376,31 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5307",
+          "createdAt": "2022-06-29T14:40:21.28Z",
+          "updatedAt": "2022-06-29T14:40:21.28Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5307.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "743b906b92eaaf89645a870b7720f3d1",
+        "traceparent": "00-b9a30253d167404fa8eddac8368f77a0-dbcbe471e7e8d743-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a3b7d61a38b1b28ea8bdb035fa07a2fa",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "738",
+        "Content-Length": "735",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:06 GMT",
+        "Date": "Wed, 29 Jun 2022 14:40:32 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -565,11 +410,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "743b906b92eaaf89645a870b7720f3d1",
-        "x-ms-correlation-request-id": "00f3e069-9d3d-469b-8092-51c3e3445f7b",
+        "x-ms-client-request-id": "a3b7d61a38b1b28ea8bdb035fa07a2fa",
+        "x-ms-correlation-request-id": "d02dabcd-50cb-44e1-b335-f5bd707b29ba",
         "x-ms-ratelimit-remaining-subscription-reads": "11990",
-        "x-ms-request-id": "dab731cf-9fb3-4ef9-a6e3-f638fd06b781_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064206Z:00f3e069-9d3d-469b-8092-51c3e3445f7b"
+        "x-ms-request-id": "060dedb3-8e0a-4c06-ac52-e8e14a95a0d5_M3CH3_M3CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144033Z:d02dabcd-50cb-44e1-b335-f5bd707b29ba"
       },
       "ResponseBody": {
         "sku": {
@@ -577,8 +422,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307",
+        "name": "testnamespacemgmt5307",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -589,30 +434,31 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5307",
+          "createdAt": "2022-06-29T14:40:21.28Z",
+          "updatedAt": "2022-06-29T14:40:21.28Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5307.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d0772d19fff517eed9abc126bb3b97f5",
+        "traceparent": "00-b9a30253d167404fa8eddac8368f77a0-4aa87556ec9cea4e-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "3315f2590244c994e1e439e0c1049691",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "738",
+        "Content-Length": "735",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:08 GMT",
+        "Date": "Wed, 29 Jun 2022 14:40:35 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -622,11 +468,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d0772d19fff517eed9abc126bb3b97f5",
-        "x-ms-correlation-request-id": "26f9241b-3dd6-4690-8501-054f9f630f36",
+        "x-ms-client-request-id": "3315f2590244c994e1e439e0c1049691",
+        "x-ms-correlation-request-id": "d3953d53-1824-4b5a-adeb-fddc6fb7d052",
         "x-ms-ratelimit-remaining-subscription-reads": "11989",
-        "x-ms-request-id": "63eee11d-b424-4b6a-9020-00000657daf5_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064208Z:26f9241b-3dd6-4690-8501-054f9f630f36"
+        "x-ms-request-id": "60f327ee-a2e6-43f3-8438-3c53425e7dc3_M3CH3_M3CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144035Z:d3953d53-1824-4b5a-adeb-fddc6fb7d052"
       },
       "ResponseBody": {
         "sku": {
@@ -634,8 +480,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307",
+        "name": "testnamespacemgmt5307",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -646,30 +492,31 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5307",
+          "createdAt": "2022-06-29T14:40:21.28Z",
+          "updatedAt": "2022-06-29T14:40:21.28Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5307.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b7ab2e6c3481060b4f4941a9613de468",
+        "traceparent": "00-b9a30253d167404fa8eddac8368f77a0-f67926845359384c-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "e5962b6bd138bf79d1274856aae92341",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "738",
+        "Content-Length": "735",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:09 GMT",
+        "Date": "Wed, 29 Jun 2022 14:40:40 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -679,11 +526,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "b7ab2e6c3481060b4f4941a9613de468",
-        "x-ms-correlation-request-id": "5de7620b-d415-4c69-8167-8aed7b88192c",
+        "x-ms-client-request-id": "e5962b6bd138bf79d1274856aae92341",
+        "x-ms-correlation-request-id": "2a589339-5bd6-436d-84de-153c8d68d7b8",
         "x-ms-ratelimit-remaining-subscription-reads": "11988",
-        "x-ms-request-id": "867d9080-edeb-4942-8356-d959769f138e_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064210Z:5de7620b-d415-4c69-8167-8aed7b88192c"
+        "x-ms-request-id": "3f1f8df6-2983-4f3e-8ed3-d180fc0f6450_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144041Z:2a589339-5bd6-436d-84de-153c8d68d7b8"
       },
       "ResponseBody": {
         "sku": {
@@ -691,8 +538,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307",
+        "name": "testnamespacemgmt5307",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -703,30 +550,31 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5307",
+          "createdAt": "2022-06-29T14:40:21.28Z",
+          "updatedAt": "2022-06-29T14:40:21.28Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5307.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6c9d3a67993b6b15a1249b3fd163f429",
+        "traceparent": "00-b9a30253d167404fa8eddac8368f77a0-b4a46cbf3936db4e-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "93c636c79d4218b841edc1cdffaef1a4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "738",
+        "Content-Length": "735",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:12 GMT",
+        "Date": "Wed, 29 Jun 2022 14:40:50 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -736,11 +584,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "6c9d3a67993b6b15a1249b3fd163f429",
-        "x-ms-correlation-request-id": "f2711d8e-f588-4fc5-9c93-1e3a8ce3f76b",
+        "x-ms-client-request-id": "93c636c79d4218b841edc1cdffaef1a4",
+        "x-ms-correlation-request-id": "2e10b766-1d9b-4537-82c2-830597793180",
         "x-ms-ratelimit-remaining-subscription-reads": "11987",
-        "x-ms-request-id": "09f9098b-d979-42ad-96cd-542fce6d75b6_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064212Z:f2711d8e-f588-4fc5-9c93-1e3a8ce3f76b"
+        "x-ms-request-id": "3abf0224-3070-4221-9bc6-7fbb92985951_M7CH3_M7CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144051Z:2e10b766-1d9b-4537-82c2-830597793180"
       },
       "ResponseBody": {
         "sku": {
@@ -748,8 +596,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307",
+        "name": "testnamespacemgmt5307",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -760,30 +608,31 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5307",
+          "createdAt": "2022-06-29T14:40:21.28Z",
+          "updatedAt": "2022-06-29T14:40:21.28Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5307.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "489f91c23b74e54f227181acbe45b59b",
+        "traceparent": "00-b9a30253d167404fa8eddac8368f77a0-964261d15efd8c4b-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "cfc91f26bc7188c27956621dba3e1ff7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "738",
+        "Content-Length": "735",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:13 GMT",
+        "Date": "Wed, 29 Jun 2022 14:41:09 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -793,11 +642,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "489f91c23b74e54f227181acbe45b59b",
-        "x-ms-correlation-request-id": "134cc11d-25db-4e29-89da-de7b613455bd",
+        "x-ms-client-request-id": "cfc91f26bc7188c27956621dba3e1ff7",
+        "x-ms-correlation-request-id": "189889f1-e69b-4406-8d05-99bc9b6d71e6",
         "x-ms-ratelimit-remaining-subscription-reads": "11986",
-        "x-ms-request-id": "10480984-5639-4fa0-be72-4e4b398e6b1b_M11CH3_M11CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064213Z:134cc11d-25db-4e29-89da-de7b613455bd"
+        "x-ms-request-id": "322ea6fc-135e-4bd0-a1fd-a6ab4ca467a5_M0CH3_M0CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144109Z:189889f1-e69b-4406-8d05-99bc9b6d71e6"
       },
       "ResponseBody": {
         "sku": {
@@ -805,8 +654,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307",
+        "name": "testnamespacemgmt5307",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -817,30 +666,31 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5307",
+          "createdAt": "2022-06-29T14:40:21.28Z",
+          "updatedAt": "2022-06-29T14:40:21.28Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5307.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "81be58c72b9ed3ba1840165c98cc34eb",
+        "traceparent": "00-b9a30253d167404fa8eddac8368f77a0-4638d47338e60344-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "8a18f7c1023dce4e727da34b0facbf22",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "738",
+        "Content-Length": "735",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:14 GMT",
+        "Date": "Wed, 29 Jun 2022 14:41:42 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -850,11 +700,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "81be58c72b9ed3ba1840165c98cc34eb",
-        "x-ms-correlation-request-id": "708d8c08-129f-4ff0-97e1-e8944d42386f",
+        "x-ms-client-request-id": "8a18f7c1023dce4e727da34b0facbf22",
+        "x-ms-correlation-request-id": "4ed35a1d-a679-474d-a721-76d7f422eae5",
         "x-ms-ratelimit-remaining-subscription-reads": "11985",
-        "x-ms-request-id": "6cedce46-d518-4370-bc72-2c606c644462_M7CH3_M7CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064215Z:708d8c08-129f-4ff0-97e1-e8944d42386f"
+        "x-ms-request-id": "3b3b1016-4464-4568-8972-ae6b566edaaf_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144143Z:4ed35a1d-a679-474d-a721-76d7f422eae5"
       },
       "ResponseBody": {
         "sku": {
@@ -862,8 +712,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307",
+        "name": "testnamespacemgmt5307",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -874,30 +724,31 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5307",
+          "createdAt": "2022-06-29T14:40:21.28Z",
+          "updatedAt": "2022-06-29T14:40:21.28Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5307.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d0e717559b9e2bf3eab749c91869ad5c",
+        "traceparent": "00-b9a30253d167404fa8eddac8368f77a0-271094a3f6bd8a4b-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "8b2fa435531f0bcf743e1aec3b9a5d03",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "738",
+        "Content-Length": "735",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:16 GMT",
+        "Date": "Wed, 29 Jun 2022 14:42:17 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -907,11 +758,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d0e717559b9e2bf3eab749c91869ad5c",
-        "x-ms-correlation-request-id": "adb58bad-9ebf-46fc-94fb-57b86b76baf7",
+        "x-ms-client-request-id": "8b2fa435531f0bcf743e1aec3b9a5d03",
+        "x-ms-correlation-request-id": "ba273438-9a74-42db-8221-456bbaa3a0ca",
         "x-ms-ratelimit-remaining-subscription-reads": "11984",
-        "x-ms-request-id": "04234a51-7ecb-4d27-82f7-34b8fb400792_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064216Z:adb58bad-9ebf-46fc-94fb-57b86b76baf7"
+        "x-ms-request-id": "2767770a-bef6-416a-b886-a27167504a23_M7CH3_M7CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144217Z:ba273438-9a74-42db-8221-456bbaa3a0ca"
       },
       "ResponseBody": {
         "sku": {
@@ -919,8 +770,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307",
+        "name": "testnamespacemgmt5307",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -931,44 +782,45 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5307",
+          "createdAt": "2022-06-29T14:40:21.28Z",
+          "updatedAt": "2022-06-29T14:40:21.28Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5307.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7878ff6f73a5968ad7cb2f3425f24c56",
+        "traceparent": "00-b9a30253d167404fa8eddac8368f77a0-81b603a7b4f86a4c-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "080bcace67952366d1fb5cf3187678cc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "738",
+        "Content-Length": "735",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:17 GMT",
+        "Date": "Wed, 29 Jun 2022 14:42:50 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "7878ff6f73a5968ad7cb2f3425f24c56",
-        "x-ms-correlation-request-id": "c26cb63d-84d0-40e2-b685-dbc70c585432",
+        "x-ms-client-request-id": "080bcace67952366d1fb5cf3187678cc",
+        "x-ms-correlation-request-id": "77828c62-accc-4a2f-a06c-e4c11ee19dbb",
         "x-ms-ratelimit-remaining-subscription-reads": "11983",
-        "x-ms-request-id": "77962306-06b5-4bb5-a5a5-277c45d535d8_M0CH3_M0CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064217Z:c26cb63d-84d0-40e2-b685-dbc70c585432"
+        "x-ms-request-id": "4c6443d1-ad4f-4ea3-84a6-c1070673d2b4_M0SN1_M0SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144250Z:77828c62-accc-4a2f-a06c-e4c11ee19dbb"
       },
       "ResponseBody": {
         "sku": {
@@ -976,8 +828,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307",
+        "name": "testnamespacemgmt5307",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -988,44 +840,45 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5307",
+          "createdAt": "2022-06-29T14:40:21.28Z",
+          "updatedAt": "2022-06-29T14:40:21.28Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5307.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a656953ce55d2bfc659296e6e2f0bbaf",
+        "traceparent": "00-b9a30253d167404fa8eddac8368f77a0-458b44867cc16c49-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "16e83f96930e6dd7270d15ffe86192d7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "738",
+        "Content-Length": "734",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:18 GMT",
+        "Date": "Wed, 29 Jun 2022 14:43:24 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a656953ce55d2bfc659296e6e2f0bbaf",
-        "x-ms-correlation-request-id": "cf5cdfcf-0b23-4aea-b41e-71b2b984d7df",
+        "x-ms-client-request-id": "16e83f96930e6dd7270d15ffe86192d7",
+        "x-ms-correlation-request-id": "687bfb9e-cbf7-49a8-8b75-ec2658b2a5e3",
         "x-ms-ratelimit-remaining-subscription-reads": "11982",
-        "x-ms-request-id": "ffd64417-8eec-4c64-a6b8-cc5598db5008_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064219Z:cf5cdfcf-0b23-4aea-b41e-71b2b984d7df"
+        "x-ms-request-id": "f39445e1-286d-46c9-b67b-c0eca21710c9_M10SN1_M10SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144324Z:687bfb9e-cbf7-49a8-8b75-ec2658b2a5e3"
       },
       "ResponseBody": {
         "sku": {
@@ -1033,692 +886,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "99edba92bc54e2468d51f8d36cbf06f7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:20 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "99edba92bc54e2468d51f8d36cbf06f7",
-        "x-ms-correlation-request-id": "8d934bf8-a3d3-4f1a-ab6f-c6b30a1e7d3f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11981",
-        "x-ms-request-id": "90ab8bc0-cc9a-496d-8c75-99aed68e9fff_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064220Z:8d934bf8-a3d3-4f1a-ab6f-c6b30a1e7d3f"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "828df26b071289fe034c1312dca4b4e6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:22 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "828df26b071289fe034c1312dca4b4e6",
-        "x-ms-correlation-request-id": "a8f8a60f-e12b-4f22-8c00-1c4286b623a0",
-        "x-ms-ratelimit-remaining-subscription-reads": "11980",
-        "x-ms-request-id": "369432fc-abe3-46e1-93a4-0dec1c948ba7_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064222Z:a8f8a60f-e12b-4f22-8c00-1c4286b623a0"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6aa28010b30580024f74180cec29bfa5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:23 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "6aa28010b30580024f74180cec29bfa5",
-        "x-ms-correlation-request-id": "8bc1d548-d9d0-4a83-8b27-f2c757707f77",
-        "x-ms-ratelimit-remaining-subscription-reads": "11979",
-        "x-ms-request-id": "f4654e17-267f-4fea-99ec-def187e89c17_M5CH3_M5CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064224Z:8bc1d548-d9d0-4a83-8b27-f2c757707f77"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ef7b9e8c38638b9cbb639507a83305e9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:25 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "ef7b9e8c38638b9cbb639507a83305e9",
-        "x-ms-correlation-request-id": "996e992f-1152-442f-86ad-3540d3b2ea8f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11978",
-        "x-ms-request-id": "f92ec16e-5630-46a1-a312-497e7b096b09_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064225Z:996e992f-1152-442f-86ad-3540d3b2ea8f"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ebc2129c9b1db8f2f00c329eeef29dd9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:26 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "ebc2129c9b1db8f2f00c329eeef29dd9",
-        "x-ms-correlation-request-id": "e62ff978-747a-4bfb-bb78-1c235912d30f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11977",
-        "x-ms-request-id": "235735c1-0d4d-4a47-9df7-1923c9917429_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064226Z:e62ff978-747a-4bfb-bb78-1c235912d30f"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3d866d8dc528d782e316aea11dfbd71b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:27 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "3d866d8dc528d782e316aea11dfbd71b",
-        "x-ms-correlation-request-id": "a85ef4e0-e995-4805-afe7-cd8aec1d1b78",
-        "x-ms-ratelimit-remaining-subscription-reads": "11976",
-        "x-ms-request-id": "13b52ef0-47dc-4fdd-996d-4e11fa82f52e_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064228Z:a85ef4e0-e995-4805-afe7-cd8aec1d1b78"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d96f2f6ed366f088acc2fe5705fd9dc9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:30 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d96f2f6ed366f088acc2fe5705fd9dc9",
-        "x-ms-correlation-request-id": "c1d6071b-515d-43ff-9963-ec31dbda3282",
-        "x-ms-ratelimit-remaining-subscription-reads": "11975",
-        "x-ms-request-id": "3f020b12-5d5a-4473-9458-305bd5797d80_M7CH3_M7CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064230Z:c1d6071b-515d-43ff-9963-ec31dbda3282"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3b79bbc6c8add7c090eb0706ec509bf4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:32 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "3b79bbc6c8add7c090eb0706ec509bf4",
-        "x-ms-correlation-request-id": "2ca32255-1b0b-4bf3-b614-fd4b262e60bf",
-        "x-ms-ratelimit-remaining-subscription-reads": "11974",
-        "x-ms-request-id": "ffe5f17a-3933-428a-88b4-a8057279f1a1_M3CH3_M3CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064233Z:2ca32255-1b0b-4bf3-b614-fd4b262e60bf"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "be301735c382ba73e4969066c62bd1e5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:35 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "be301735c382ba73e4969066c62bd1e5",
-        "x-ms-correlation-request-id": "98e50326-64dc-48cc-a211-5c81e018d203",
-        "x-ms-ratelimit-remaining-subscription-reads": "11973",
-        "x-ms-request-id": "c54bc0bd-4c30-427f-87e5-1196059a7f22_M0CH3_M0CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064235Z:98e50326-64dc-48cc-a211-5c81e018d203"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "61dbe5799c82a56e6f98497bcb82035c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:36 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "61dbe5799c82a56e6f98497bcb82035c",
-        "x-ms-correlation-request-id": "64297042-ed24-4258-abf3-ce0ca26900b6",
-        "x-ms-ratelimit-remaining-subscription-reads": "11972",
-        "x-ms-request-id": "556a81ec-8e54-4594-a5ca-89a2c57e82d5_M10CH3_M10CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064236Z:64297042-ed24-4258-abf3-ce0ca26900b6"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ee210927decd024748bf5617375a1064",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:39 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "ee210927decd024748bf5617375a1064",
-        "x-ms-correlation-request-id": "b88da095-cdd7-47f1-9c84-5d46973951cd",
-        "x-ms-ratelimit-remaining-subscription-reads": "11971",
-        "x-ms-request-id": "d5df67a5-ce3d-44e7-b0a2-a4d279fea74a_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064239Z:b88da095-cdd7-47f1-9c84-5d46973951cd"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:41:52.357Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "078c221939749972a98a4fe979f7ee62",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:41 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "078c221939749972a98a4fe979f7ee62",
-        "x-ms-correlation-request-id": "ce29d95c-e45a-4e36-bfab-c8f05987a34e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11970",
-        "x-ms-request-id": "3c4f6d2a-009a-4a87-84bf-6097f400dd02_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064241Z:ce29d95c-e45a-4e36-bfab-c8f05987a34e"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307",
+        "name": "testnamespacemgmt5307",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -1729,24 +898,25 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:42:39.953Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5307",
+          "createdAt": "2022-06-29T14:40:21.28Z",
+          "updatedAt": "2022-06-29T14:43:09.717Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5307.servicebus.windows.net:443/",
           "status": "Active"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/virtualNetworks/vnet-9517?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.Network/virtualNetworks/vnet-6378?api-version=2021-02-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "261",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.Network/1.0.0-beta.3 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "09bc3e3418e29d9ad918c246566e1588",
+        "traceparent": "00-807c7b0921488242920ea8c0f34189bc-f87cca225a896642-00",
+        "User-Agent": "azsdk-net-ResourceManager.Network/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a0457ca08db73dcd0cba24f7dbf2fec5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -1777,11 +947,11 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Azure-AsyncNotification": "Enabled",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/780e81f5-3a74-45d2-ba3c-e0e766aec38d?api-version=2021-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/5eb3bc7b-56f0-473c-b400-26c745a7b89c?api-version=2021-02-01",
         "Cache-Control": "no-cache",
-        "Content-Length": "1339",
+        "Content-Length": "1337",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:45 GMT",
+        "Date": "Wed, 29 Jun 2022 14:43:28 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "3",
@@ -1791,100 +961,61 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "de313744-2474-412d-b16b-e7a4e6e3405a",
-        "x-ms-client-request-id": "09bc3e3418e29d9ad918c246566e1588",
-        "x-ms-correlation-request-id": "d587e5e3-ed2a-4437-9e13-d771497da916",
+        "x-ms-arm-service-request-id": "fc10b598-cbdd-4980-9575-d5372ee4ba0f",
+        "x-ms-client-request-id": "a0457ca08db73dcd0cba24f7dbf2fec5",
+        "x-ms-correlation-request-id": "ed5feb35-dbb1-4b6d-8809-244db8852b7b",
         "x-ms-ratelimit-remaining-subscription-writes": "1198",
-        "x-ms-request-id": "780e81f5-3a74-45d2-ba3c-e0e766aec38d",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064245Z:d587e5e3-ed2a-4437-9e13-d771497da916"
+        "x-ms-request-id": "5eb3bc7b-56f0-473c-b400-26c745a7b89c",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144329Z:ed5feb35-dbb1-4b6d-8809-244db8852b7b"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022name\u0022: \u0022vnet-9517\u0022,\r\n",
-        "  \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/virtualNetworks/vnet-9517\u0022,\r\n",
-        "  \u0022etag\u0022: \u0022W/\\\u00222b68f359-0aed-4d15-ace3-ed4a21d80781\\\u0022\u0022,\r\n",
-        "  \u0022type\u0022: \u0022Microsoft.Network/virtualNetworks\u0022,\r\n",
-        "  \u0022location\u0022: \u0022westus2\u0022,\r\n",
-        "  \u0022properties\u0022: {\r\n",
-        "    \u0022provisioningState\u0022: \u0022Updating\u0022,\r\n",
-        "    \u0022resourceGuid\u0022: \u0022426925e7-663e-485c-8c2b-a7bb39f58dd2\u0022,\r\n",
-        "    \u0022addressSpace\u0022: {\r\n",
-        "      \u0022addressPrefixes\u0022: [\r\n",
-        "        \u002210.0.0.0/16\u0022\r\n",
-        "      ]\r\n",
-        "    },\r\n",
-        "    \u0022dhcpOptions\u0022: {\r\n",
-        "      \u0022dnsServers\u0022: [\r\n",
-        "        \u002210.1.1.1\u0022,\r\n",
-        "        \u002210.1.2.4\u0022\r\n",
-        "      ]\r\n",
-        "    },\r\n",
-        "    \u0022subnets\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022name\u0022: \u0022default\u0022,\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/virtualNetworks/vnet-9517/subnets/default\u0022,\r\n",
-        "        \u0022etag\u0022: \u0022W/\\\u00222b68f359-0aed-4d15-ace3-ed4a21d80781\\\u0022\u0022,\r\n",
-        "        \u0022properties\u0022: {\r\n",
-        "          \u0022provisioningState\u0022: \u0022Updating\u0022,\r\n",
-        "          \u0022addressPrefix\u0022: \u002210.0.1.0/24\u0022,\r\n",
-        "          \u0022delegations\u0022: [],\r\n",
-        "          \u0022privateEndpointNetworkPolicies\u0022: \u0022Disabled\u0022,\r\n",
-        "          \u0022privateLinkServiceNetworkPolicies\u0022: \u0022Enabled\u0022\r\n",
-        "        },\r\n",
-        "        \u0022type\u0022: \u0022Microsoft.Network/virtualNetworks/subnets\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022virtualNetworkPeerings\u0022: [],\r\n",
-        "    \u0022enableDdosProtection\u0022: false\r\n",
-        "  }\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "name": "vnet-6378",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.Network/virtualNetworks/vnet-6378",
+        "etag": "W/\u002225c9bcde-ed9d-487e-8aae-6c5e8b59e4d2\u0022",
+        "type": "Microsoft.Network/virtualNetworks",
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Updating",
+          "resourceGuid": "6a895370-9c8f-45a4-984a-19d953dcd46c",
+          "addressSpace": {
+            "addressPrefixes": [
+              "10.0.0.0/16"
+            ]
+          },
+          "dhcpOptions": {
+            "dnsServers": [
+              "10.1.1.1",
+              "10.1.2.4"
+            ]
+          },
+          "subnets": [
+            {
+              "name": "default",
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.Network/virtualNetworks/vnet-6378/subnets/default",
+              "etag": "W/\u002225c9bcde-ed9d-487e-8aae-6c5e8b59e4d2\u0022",
+              "properties": {
+                "provisioningState": "Updating",
+                "addressPrefix": "10.0.1.0/24",
+                "delegations": [],
+                "privateEndpointNetworkPolicies": "Disabled",
+                "privateLinkServiceNetworkPolicies": "Enabled"
+              },
+              "type": "Microsoft.Network/virtualNetworks/subnets"
+            }
+          ],
+          "virtualNetworkPeerings": [],
+          "enableDdosProtection": false
+        }
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/780e81f5-3a74-45d2-ba3c-e0e766aec38d?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/5eb3bc7b-56f0-473c-b400-26c745a7b89c?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1b0384f35a530936f1699b20af53521c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:45 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "fd69b9af-99b4-4a32-9c26-b9e57ec3b24a",
-        "x-ms-client-request-id": "1b0384f35a530936f1699b20af53521c",
-        "x-ms-correlation-request-id": "aaf4c16a-0ef8-4be1-8bb2-6904c9bf8ca7",
-        "x-ms-ratelimit-remaining-subscription-reads": "11969",
-        "x-ms-request-id": "19d63870-526c-4c04-a3bf-e5dfa80cc6c8",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064246Z:aaf4c16a-0ef8-4be1-8bb2-6904c9bf8ca7"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/780e81f5-3a74-45d2-ba3c-e0e766aec38d?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "959460396c454d975025819dd50b3f50",
+        "traceparent": "00-807c7b0921488242920ea8c0f34189bc-70bf07978d482349-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f978d3842b33b2df1ad801d9b3764c1a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -1893,7 +1024,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "29",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:46 GMT",
+        "Date": "Wed, 29 Jun 2022 14:43:28 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1902,36 +1033,35 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "253b1baf-f423-46fd-905f-5a3342b54d45",
-        "x-ms-client-request-id": "959460396c454d975025819dd50b3f50",
-        "x-ms-correlation-request-id": "6447c4b9-c1b1-4364-abfc-b164fe198ff2",
-        "x-ms-ratelimit-remaining-subscription-reads": "11968",
-        "x-ms-request-id": "be7ceb6a-ea53-4597-9c5a-fb4e2bbb19a2",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064247Z:6447c4b9-c1b1-4364-abfc-b164fe198ff2"
+        "x-ms-arm-service-request-id": "6feecbe1-680e-4597-bd1e-06dff1711048",
+        "x-ms-client-request-id": "f978d3842b33b2df1ad801d9b3764c1a",
+        "x-ms-correlation-request-id": "56968a16-6934-4ffc-bf9e-f64f3ddc9562",
+        "x-ms-ratelimit-remaining-subscription-reads": "11981",
+        "x-ms-request-id": "39635eb3-1646-4a4a-91b8-6f2fabff2bb5",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144329Z:56968a16-6934-4ffc-bf9e-f64f3ddc9562"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022Succeeded\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "Succeeded"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/virtualNetworks/vnet-9517?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.Network/virtualNetworks/vnet-6378?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d252f2c7f96a8a342b9f03914bcde735",
+        "traceparent": "00-807c7b0921488242920ea8c0f34189bc-c41334d480ab4149-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "0b9a39172596abd9425302d6047bd6d1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1341",
+        "Content-Length": "1339",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:47 GMT",
-        "ETag": "W/\u0022f7e134ca-8111-4c96-ae19-2ffc3562aa39\u0022",
+        "Date": "Wed, 29 Jun 2022 14:43:29 GMT",
+        "ETag": "W/\u0022a6f8c4b7-0b8d-4802-a657-aaf89f891dde\u0022",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1940,74 +1070,73 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "7abc3f2a-0524-4f14-a905-3c893e75d83d",
-        "x-ms-client-request-id": "d252f2c7f96a8a342b9f03914bcde735",
-        "x-ms-correlation-request-id": "5f4540fa-3372-408f-853d-9913cd599564",
-        "x-ms-ratelimit-remaining-subscription-reads": "11967",
-        "x-ms-request-id": "77f50e8f-abeb-4f8e-9ce9-6f30f19ba286",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064247Z:5f4540fa-3372-408f-853d-9913cd599564"
+        "x-ms-arm-service-request-id": "613a7a83-6f64-486a-8502-89db7ae1f09b",
+        "x-ms-client-request-id": "0b9a39172596abd9425302d6047bd6d1",
+        "x-ms-correlation-request-id": "e28a8981-f4fd-46cf-8d62-0e9022dcc340",
+        "x-ms-ratelimit-remaining-subscription-reads": "11980",
+        "x-ms-request-id": "a80e9ab4-461c-4fd1-b324-c98046e0b816",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144329Z:e28a8981-f4fd-46cf-8d62-0e9022dcc340"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022name\u0022: \u0022vnet-9517\u0022,\r\n",
-        "  \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/virtualNetworks/vnet-9517\u0022,\r\n",
-        "  \u0022etag\u0022: \u0022W/\\\u0022f7e134ca-8111-4c96-ae19-2ffc3562aa39\\\u0022\u0022,\r\n",
-        "  \u0022type\u0022: \u0022Microsoft.Network/virtualNetworks\u0022,\r\n",
-        "  \u0022location\u0022: \u0022westus2\u0022,\r\n",
-        "  \u0022properties\u0022: {\r\n",
-        "    \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "    \u0022resourceGuid\u0022: \u0022426925e7-663e-485c-8c2b-a7bb39f58dd2\u0022,\r\n",
-        "    \u0022addressSpace\u0022: {\r\n",
-        "      \u0022addressPrefixes\u0022: [\r\n",
-        "        \u002210.0.0.0/16\u0022\r\n",
-        "      ]\r\n",
-        "    },\r\n",
-        "    \u0022dhcpOptions\u0022: {\r\n",
-        "      \u0022dnsServers\u0022: [\r\n",
-        "        \u002210.1.1.1\u0022,\r\n",
-        "        \u002210.1.2.4\u0022\r\n",
-        "      ]\r\n",
-        "    },\r\n",
-        "    \u0022subnets\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022name\u0022: \u0022default\u0022,\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/virtualNetworks/vnet-9517/subnets/default\u0022,\r\n",
-        "        \u0022etag\u0022: \u0022W/\\\u0022f7e134ca-8111-4c96-ae19-2ffc3562aa39\\\u0022\u0022,\r\n",
-        "        \u0022properties\u0022: {\r\n",
-        "          \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "          \u0022addressPrefix\u0022: \u002210.0.1.0/24\u0022,\r\n",
-        "          \u0022delegations\u0022: [],\r\n",
-        "          \u0022privateEndpointNetworkPolicies\u0022: \u0022Disabled\u0022,\r\n",
-        "          \u0022privateLinkServiceNetworkPolicies\u0022: \u0022Enabled\u0022\r\n",
-        "        },\r\n",
-        "        \u0022type\u0022: \u0022Microsoft.Network/virtualNetworks/subnets\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022virtualNetworkPeerings\u0022: [],\r\n",
-        "    \u0022enableDdosProtection\u0022: false\r\n",
-        "  }\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "name": "vnet-6378",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.Network/virtualNetworks/vnet-6378",
+        "etag": "W/\u0022a6f8c4b7-0b8d-4802-a657-aaf89f891dde\u0022",
+        "type": "Microsoft.Network/virtualNetworks",
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "resourceGuid": "6a895370-9c8f-45a4-984a-19d953dcd46c",
+          "addressSpace": {
+            "addressPrefixes": [
+              "10.0.0.0/16"
+            ]
+          },
+          "dhcpOptions": {
+            "dnsServers": [
+              "10.1.1.1",
+              "10.1.2.4"
+            ]
+          },
+          "subnets": [
+            {
+              "name": "default",
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.Network/virtualNetworks/vnet-6378/subnets/default",
+              "etag": "W/\u0022a6f8c4b7-0b8d-4802-a657-aaf89f891dde\u0022",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "addressPrefix": "10.0.1.0/24",
+                "delegations": [],
+                "privateEndpointNetworkPolicies": "Disabled",
+                "privateLinkServiceNetworkPolicies": "Enabled"
+              },
+              "type": "Microsoft.Network/virtualNetworks/subnets"
+            }
+          ],
+          "virtualNetworkPeerings": [],
+          "enableDdosProtection": false
+        }
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.Network/privateEndpoints/pe-2005?api-version=2021-02-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "733",
+        "Content-Length": "731",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.Network/1.0.0-beta.3 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bbf3fd55878ab6ecca2dd99933e6294b",
+        "traceparent": "00-ded43fa83884564bb2afbda20cf8b91f-2c137ee9a6a8bc4a-00",
+        "User-Agent": "azsdk-net-ResourceManager.Network/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "0479087221924a76976ef3613e27946e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "location": "westus2",
         "properties": {
           "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.Network/virtualNetworks/vnet-6378/subnets/default",
             "name": "default",
             "type": "Microsoft.Network/virtualNetworks/subnets",
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/virtualNetworks/vnet-9517/subnets/default",
             "properties": {
               "addressPrefix": "10.0.1.0/24",
               "delegations": [],
@@ -2017,9 +1146,9 @@
           },
           "manualPrivateLinkServiceConnections": [
             {
-              "name": "pec9749",
+              "name": "pec9039",
               "properties": {
-                "privateLinkServiceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
+                "privateLinkServiceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307",
                 "groupIds": [
                   "namespace"
                 ],
@@ -2032,11 +1161,11 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Azure-AsyncNotification": "Enabled",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d9cd2a7b-82e7-4cb3-8ecd-3274ac83bd70?api-version=2021-02-01",
         "Cache-Control": "no-cache",
-        "Content-Length": "1958",
+        "Content-Length": "1953",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:53 GMT",
+        "Date": "Wed, 29 Jun 2022 14:43:33 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
@@ -2046,65 +1175,64 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "0fbb2ad3-077e-4a1b-b8ca-309b71c33f49",
-        "x-ms-client-request-id": "bbf3fd55878ab6ecca2dd99933e6294b",
-        "x-ms-correlation-request-id": "b37e4c65-4d43-43c4-bb20-978a2462bf0b",
+        "x-ms-arm-service-request-id": "85ae7f9e-a249-4a35-a7aa-eb090082c1e5",
+        "x-ms-client-request-id": "0479087221924a76976ef3613e27946e",
+        "x-ms-correlation-request-id": "fade98f3-0a79-482e-88bb-ae501a2c1309",
         "x-ms-ratelimit-remaining-subscription-writes": "1197",
-        "x-ms-request-id": "c859e380-a5df-470c-a07a-dbfb94612bf5",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064254Z:b37e4c65-4d43-43c4-bb20-978a2462bf0b"
+        "x-ms-request-id": "d9cd2a7b-82e7-4cb3-8ecd-3274ac83bd70",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144334Z:fade98f3-0a79-482e-88bb-ae501a2c1309"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022name\u0022: \u0022pe-6421\u0022,\r\n",
-        "  \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421\u0022,\r\n",
-        "  \u0022etag\u0022: \u0022W/\\\u00221ec688d4-c75d-4b8b-8715-d4c39187e88b\\\u0022\u0022,\r\n",
-        "  \u0022type\u0022: \u0022Microsoft.Network/privateEndpoints\u0022,\r\n",
-        "  \u0022location\u0022: \u0022westus2\u0022,\r\n",
-        "  \u0022properties\u0022: {\r\n",
-        "    \u0022provisioningState\u0022: \u0022Updating\u0022,\r\n",
-        "    \u0022resourceGuid\u0022: \u00227b277058-57e3-4a46-b58c-aa90f2933694\u0022,\r\n",
-        "    \u0022privateLinkServiceConnections\u0022: [],\r\n",
-        "    \u0022manualPrivateLinkServiceConnections\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022name\u0022: \u0022pec9749\u0022,\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421/manualPrivateLinkServiceConnections/pec9749\u0022,\r\n",
-        "        \u0022etag\u0022: \u0022W/\\\u00221ec688d4-c75d-4b8b-8715-d4c39187e88b\\\u0022\u0022,\r\n",
-        "        \u0022properties\u0022: {\r\n",
-        "          \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "          \u0022privateLinkServiceId\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792\u0022,\r\n",
-        "          \u0022groupIds\u0022: [\r\n",
-        "            \u0022namespace\u0022\r\n",
-        "          ],\r\n",
-        "          \u0022requestMessage\u0022: \u0022SDK test\u0022,\r\n",
-        "          \u0022privateLinkServiceConnectionState\u0022: {\r\n",
-        "            \u0022status\u0022: \u0022Pending\u0022,\r\n",
-        "            \u0022description\u0022: \u0022SDK test\u0022,\r\n",
-        "            \u0022actionsRequired\u0022: \u0022None\u0022\r\n",
-        "          }\r\n",
-        "        },\r\n",
-        "        \u0022type\u0022: \u0022Microsoft.Network/privateEndpoints/manualPrivateLinkServiceConnections\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022subnet\u0022: {\r\n",
-        "      \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/virtualNetworks/vnet-9517/subnets/default\u0022\r\n",
-        "    },\r\n",
-        "    \u0022networkInterfaces\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/networkInterfaces/pe-6421.nic.ba240df0-a415-4c27-9543-c936e8122f9a\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022customDnsConfigs\u0022: []\r\n",
-        "  }\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "name": "pe-2005",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.Network/privateEndpoints/pe-2005",
+        "etag": "W/\u0022d46b40d7-cdab-47ae-a8d6-28afb4febe52\u0022",
+        "type": "Microsoft.Network/privateEndpoints",
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Updating",
+          "resourceGuid": "40d59801-4425-4341-9000-3539f1d76025",
+          "privateLinkServiceConnections": [],
+          "manualPrivateLinkServiceConnections": [
+            {
+              "name": "pec9039",
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.Network/privateEndpoints/pe-2005/manualPrivateLinkServiceConnections/pec9039",
+              "etag": "W/\u0022d46b40d7-cdab-47ae-a8d6-28afb4febe52\u0022",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateLinkServiceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307",
+                "groupIds": [
+                  "namespace"
+                ],
+                "requestMessage": "SDK test",
+                "privateLinkServiceConnectionState": {
+                  "status": "Pending",
+                  "description": "SDK test",
+                  "actionsRequired": "None"
+                }
+              },
+              "type": "Microsoft.Network/privateEndpoints/manualPrivateLinkServiceConnections"
+            }
+          ],
+          "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.Network/virtualNetworks/vnet-6378/subnets/default"
+          },
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.Network/networkInterfaces/pe-2005.nic.64c5d913-4cb3-4953-b4aa-a72948190d17"
+            }
+          ],
+          "customDnsConfigs": []
+        }
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d9cd2a7b-82e7-4cb3-8ecd-3274ac83bd70?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "42b5afab0c5ccb68e5b42f06b0916c1d",
+        "traceparent": "00-ded43fa83884564bb2afbda20cf8b91f-0294aa102c9e6748-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "4303f78f13a179a7944c8d6bb7e014db",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -2113,7 +1241,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "30",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:54 GMT",
+        "Date": "Wed, 29 Jun 2022 14:43:34 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
@@ -2123,26 +1251,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "09b636da-d9c9-4a49-9991-28bdb6f1b9e7",
-        "x-ms-client-request-id": "42b5afab0c5ccb68e5b42f06b0916c1d",
-        "x-ms-correlation-request-id": "fcca370e-3f12-4089-b283-11120d2dc201",
-        "x-ms-ratelimit-remaining-subscription-reads": "11966",
-        "x-ms-request-id": "e6ab4de6-a88b-4e52-8cab-d9dc9df6e9dc",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064254Z:fcca370e-3f12-4089-b283-11120d2dc201"
+        "x-ms-arm-service-request-id": "280ea729-7674-4f1c-8202-d1320d1fba24",
+        "x-ms-client-request-id": "4303f78f13a179a7944c8d6bb7e014db",
+        "x-ms-correlation-request-id": "2698d846-04cf-4821-b4ac-90e172ef313e",
+        "x-ms-ratelimit-remaining-subscription-reads": "11979",
+        "x-ms-request-id": "9b9c5f0d-e7e0-4882-a6ab-33719215f605",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144335Z:2698d846-04cf-4821-b4ac-90e172ef313e"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "InProgress"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d9cd2a7b-82e7-4cb3-8ecd-3274ac83bd70?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2a74006772341674d0e950e41de7b447",
+        "traceparent": "00-ded43fa83884564bb2afbda20cf8b91f-39bb10c1cff4c547-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a9409541e53113e90eac4cb2f86d9cf8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -2151,7 +1278,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "30",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:55 GMT",
+        "Date": "Wed, 29 Jun 2022 14:43:44 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "20",
@@ -2161,26 +1288,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "c566ed98-7af0-4224-8f6a-72f6868c24df",
-        "x-ms-client-request-id": "2a74006772341674d0e950e41de7b447",
-        "x-ms-correlation-request-id": "20a3cf35-9c0d-4753-82b6-b3dfd1f91d84",
-        "x-ms-ratelimit-remaining-subscription-reads": "11965",
-        "x-ms-request-id": "e28c9c65-df72-4a51-b14b-0368ef9aedc4",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064256Z:20a3cf35-9c0d-4753-82b6-b3dfd1f91d84"
+        "x-ms-arm-service-request-id": "a007337c-c0fb-4759-95f9-bf9443b8772e",
+        "x-ms-client-request-id": "a9409541e53113e90eac4cb2f86d9cf8",
+        "x-ms-correlation-request-id": "20d1ea51-c46e-4d5d-92ff-f19ede4494bc",
+        "x-ms-ratelimit-remaining-subscription-reads": "11978",
+        "x-ms-request-id": "5c59f892-6732-4eb0-b7f5-cf878552e22f",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144345Z:20d1ea51-c46e-4d5d-92ff-f19ede4494bc"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "InProgress"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d9cd2a7b-82e7-4cb3-8ecd-3274ac83bd70?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "83ee8defe7314cee54359afc102559d8",
+        "traceparent": "00-ded43fa83884564bb2afbda20cf8b91f-541ad98884b7fd4d-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "46d1c26c502327cd8526d085d18d15d6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -2189,7 +1315,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "30",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:56 GMT",
+        "Date": "Wed, 29 Jun 2022 14:44:05 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "20",
@@ -2199,1280 +1325,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "7eee3c37-42bd-4af5-898a-dea324ee022a",
-        "x-ms-client-request-id": "83ee8defe7314cee54359afc102559d8",
-        "x-ms-correlation-request-id": "5e6e1772-be86-4fe8-9341-ed773564ae2a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11964",
-        "x-ms-request-id": "b6a209a1-81df-425d-8a31-ab58f7d4e79b",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064257Z:5e6e1772-be86-4fe8-9341-ed773564ae2a"
+        "x-ms-arm-service-request-id": "be1f7928-f9c5-4ec4-af2f-d0b962ed3fc0",
+        "x-ms-client-request-id": "46d1c26c502327cd8526d085d18d15d6",
+        "x-ms-correlation-request-id": "6f66089f-95cb-4012-8987-6dd2576d6fc2",
+        "x-ms-ratelimit-remaining-subscription-reads": "11977",
+        "x-ms-request-id": "ebac21fc-e3c8-4da9-a69c-5115677f2eda",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144405Z:6f66089f-95cb-4012-8987-6dd2576d6fc2"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "InProgress"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/d9cd2a7b-82e7-4cb3-8ecd-3274ac83bd70?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "009d4b39140f38173b9f7173bc83adfe",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:58 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "40",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "823c30c1-d0a2-4018-a657-45f8eb1be442",
-        "x-ms-client-request-id": "009d4b39140f38173b9f7173bc83adfe",
-        "x-ms-correlation-request-id": "61a693bc-3428-40d6-8cbc-c928395c06df",
-        "x-ms-ratelimit-remaining-subscription-reads": "11963",
-        "x-ms-request-id": "0b43a7d3-e8d6-46cd-9ef5-4ced5bd51bab",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064258Z:61a693bc-3428-40d6-8cbc-c928395c06df"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2217e8ffe8a380eb1228d5fed87705ab",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:42:59 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "40",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "7261940f-4102-491f-b2db-d4b29f2dad41",
-        "x-ms-client-request-id": "2217e8ffe8a380eb1228d5fed87705ab",
-        "x-ms-correlation-request-id": "710134e8-dd50-473b-8824-9ce8e2d479eb",
-        "x-ms-ratelimit-remaining-subscription-reads": "11962",
-        "x-ms-request-id": "9d3795e9-cdc9-4210-84a5-432c8f5d600d",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064259Z:710134e8-dd50-473b-8824-9ce8e2d479eb"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d1aa778fb44ada3776b54892757b8fd1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:00 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "80",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "85962d45-ea9d-47fe-a77a-030ab6e3ac66",
-        "x-ms-client-request-id": "d1aa778fb44ada3776b54892757b8fd1",
-        "x-ms-correlation-request-id": "ad75393c-48ca-4a6c-b09d-c65deb7c1c44",
-        "x-ms-ratelimit-remaining-subscription-reads": "11961",
-        "x-ms-request-id": "6eeb2419-85f2-48a3-86ee-22241452ffbc",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064301Z:ad75393c-48ca-4a6c-b09d-c65deb7c1c44"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "28fd9c88360d5135601ceee63f1860c4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:01 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "80",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "1855bc11-98f4-4168-b70c-b8d64e0363a1",
-        "x-ms-client-request-id": "28fd9c88360d5135601ceee63f1860c4",
-        "x-ms-correlation-request-id": "ddb44986-b9c2-4735-bac8-004571d1b4aa",
-        "x-ms-ratelimit-remaining-subscription-reads": "11960",
-        "x-ms-request-id": "8a14abc7-6617-4b34-816e-8cae48d9cc1d",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064302Z:ddb44986-b9c2-4735-bac8-004571d1b4aa"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "45e3c699dbd84bb3b03dacee9f590b96",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:03 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "160",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "3f6feae6-d010-447a-8067-f04585997c9b",
-        "x-ms-client-request-id": "45e3c699dbd84bb3b03dacee9f590b96",
-        "x-ms-correlation-request-id": "da016bef-2ee6-4aba-a6fc-58b1e74ffeee",
-        "x-ms-ratelimit-remaining-subscription-reads": "11959",
-        "x-ms-request-id": "7eb3632b-c1f1-45b5-89fb-e875e646a848",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064303Z:da016bef-2ee6-4aba-a6fc-58b1e74ffeee"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3b760498dd7a589d4259712dc6509b5e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:04 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "160",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "6de64abe-c5cf-4874-9404-07c9f0c2068b",
-        "x-ms-client-request-id": "3b760498dd7a589d4259712dc6509b5e",
-        "x-ms-correlation-request-id": "2c02d069-d1fd-4d26-af31-62b6af58ccce",
-        "x-ms-ratelimit-remaining-subscription-reads": "11958",
-        "x-ms-request-id": "cfac7598-1a6a-4af9-927c-2fe9fd170df1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064305Z:2c02d069-d1fd-4d26-af31-62b6af58ccce"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "aff883554a97adf8e8b177d08a46b106",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:05 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "0d782a30-cbac-4825-a404-097b4edd9153",
-        "x-ms-client-request-id": "aff883554a97adf8e8b177d08a46b106",
-        "x-ms-correlation-request-id": "be6530ec-3e8f-4886-819d-20f3432e36d1",
-        "x-ms-ratelimit-remaining-subscription-reads": "11957",
-        "x-ms-request-id": "24ef6677-65a5-44df-ac33-b38d8515edca",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064306Z:be6530ec-3e8f-4886-819d-20f3432e36d1"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3b4e571124a1bb4a288b027f6986855f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:07 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "aead1718-2100-4187-be70-21ff7c809353",
-        "x-ms-client-request-id": "3b4e571124a1bb4a288b027f6986855f",
-        "x-ms-correlation-request-id": "4cec61a9-0cdc-47d4-9a13-9f7ee01f994f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11956",
-        "x-ms-request-id": "e2280cab-bfed-4235-a024-a1d5631bf01c",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064307Z:4cec61a9-0cdc-47d4-9a13-9f7ee01f994f"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1c984da15c614eff0cc953c865cdcdfb",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:08 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "1157bcea-f0a5-40d8-84fc-4311adb3ae95",
-        "x-ms-client-request-id": "1c984da15c614eff0cc953c865cdcdfb",
-        "x-ms-correlation-request-id": "be9b24c2-2c2b-4479-9936-b732891eea24",
-        "x-ms-ratelimit-remaining-subscription-reads": "11955",
-        "x-ms-request-id": "25b1e86a-b356-41b7-a79f-2962e133e189",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064309Z:be9b24c2-2c2b-4479-9936-b732891eea24"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6e1b6ba7600231bc393c860c47784361",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:09 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "119d3139-8991-476d-b3c3-ebe9e2bffc8d",
-        "x-ms-client-request-id": "6e1b6ba7600231bc393c860c47784361",
-        "x-ms-correlation-request-id": "9113f28d-defb-4c7d-bb7d-a84402975702",
-        "x-ms-ratelimit-remaining-subscription-reads": "11954",
-        "x-ms-request-id": "aa29ed76-cd0b-472d-87b7-dc2b1a6a65ad",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064310Z:9113f28d-defb-4c7d-bb7d-a84402975702"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3d2e182c95adb5a557002ed8d081565b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:10 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "920ae9a8-80f7-4f22-9f5c-24e25d8cde64",
-        "x-ms-client-request-id": "3d2e182c95adb5a557002ed8d081565b",
-        "x-ms-correlation-request-id": "7742a07f-3ab1-43c2-a407-34db54b9882e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11953",
-        "x-ms-request-id": "92407e83-4e2d-47f6-868f-3fe1a4107849",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064311Z:7742a07f-3ab1-43c2-a407-34db54b9882e"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fdd807bd166a415c9067e224d5f30694",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:12 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "8bce63a7-1126-4b7d-bbd1-5c154e7d16be",
-        "x-ms-client-request-id": "fdd807bd166a415c9067e224d5f30694",
-        "x-ms-correlation-request-id": "48539321-c070-4540-94f0-fc03d520f12a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11952",
-        "x-ms-request-id": "bcea0d7e-92e3-4660-8583-e8b17c9780ab",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064312Z:48539321-c070-4540-94f0-fc03d520f12a"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4d9bf185909e114dc666170231e460b7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:13 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "3f691d40-715d-4a7e-9d67-2826d4c22419",
-        "x-ms-client-request-id": "4d9bf185909e114dc666170231e460b7",
-        "x-ms-correlation-request-id": "2b6a8564-a7c5-4487-9ff1-573bbe46393b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11951",
-        "x-ms-request-id": "3ce8e6c4-51b5-4f79-9d8b-6059df792e35",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064314Z:2b6a8564-a7c5-4487-9ff1-573bbe46393b"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "404e2be6459f16f7bbedac46b381e064",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:14 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "1f041856-a4f0-42a2-9edb-faa93c54fcf0",
-        "x-ms-client-request-id": "404e2be6459f16f7bbedac46b381e064",
-        "x-ms-correlation-request-id": "91464c04-35d4-44f8-ad05-2e3ff6ab26fd",
-        "x-ms-ratelimit-remaining-subscription-reads": "11950",
-        "x-ms-request-id": "031636f0-a226-436f-b9b0-b474540a63bc",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064315Z:91464c04-35d4-44f8-ad05-2e3ff6ab26fd"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "df539af908e62cbdb9c63704ff5a10ac",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:16 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "88fb8bcb-879f-4465-8f5a-790ac6484d55",
-        "x-ms-client-request-id": "df539af908e62cbdb9c63704ff5a10ac",
-        "x-ms-correlation-request-id": "2f5f445c-eaf7-4a26-b505-6a72a33c6ca8",
-        "x-ms-ratelimit-remaining-subscription-reads": "11949",
-        "x-ms-request-id": "d38e371a-69d1-46b6-be4e-e27cf7ddaeee",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064316Z:2f5f445c-eaf7-4a26-b505-6a72a33c6ca8"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a93d2a07c5a53ff4fa8591b0e4075e45",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:17 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "8166667c-d9c9-4eeb-8ae6-2cc05243028f",
-        "x-ms-client-request-id": "a93d2a07c5a53ff4fa8591b0e4075e45",
-        "x-ms-correlation-request-id": "f0b02b7a-1088-4ae5-99e7-871b021677de",
-        "x-ms-ratelimit-remaining-subscription-reads": "11948",
-        "x-ms-request-id": "a3b527ee-9314-4016-971b-090422ebf66c",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064318Z:f0b02b7a-1088-4ae5-99e7-871b021677de"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9608b2868091ded16e2187d90ef31761",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:18 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "5f7df219-c1f8-484c-a698-825a7bc4401e",
-        "x-ms-client-request-id": "9608b2868091ded16e2187d90ef31761",
-        "x-ms-correlation-request-id": "b489b610-d365-462d-9f23-60a3ba3a9eb9",
-        "x-ms-ratelimit-remaining-subscription-reads": "11947",
-        "x-ms-request-id": "0d0c0dc8-1c39-4c52-a015-ecbf01dd3acb",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064319Z:b489b610-d365-462d-9f23-60a3ba3a9eb9"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "883effdc374434bea613e560760c48b1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:19 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "7f7cffa4-ff0b-4b82-8b31-f21f25d17692",
-        "x-ms-client-request-id": "883effdc374434bea613e560760c48b1",
-        "x-ms-correlation-request-id": "8a5eb3b4-2b91-4e0a-baed-7fa63f08a055",
-        "x-ms-ratelimit-remaining-subscription-reads": "11946",
-        "x-ms-request-id": "f79960fb-9d12-4ad6-8dea-99ab167e1c6a",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064320Z:8a5eb3b4-2b91-4e0a-baed-7fa63f08a055"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4c7df2677a51871b585e3a833d1b3107",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:21 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "d30723f9-0444-44b0-b78c-7f61e57e12c8",
-        "x-ms-client-request-id": "4c7df2677a51871b585e3a833d1b3107",
-        "x-ms-correlation-request-id": "262a06bc-e2f7-40be-a3ec-9e2a726ef433",
-        "x-ms-ratelimit-remaining-subscription-reads": "11945",
-        "x-ms-request-id": "4dd55d9d-6551-4673-91e0-ae59448966e9",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064321Z:262a06bc-e2f7-40be-a3ec-9e2a726ef433"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e5d4306ed5c94f01f3d4ef7d9b706762",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:22 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "39492cdc-b80d-470b-9831-13169432328e",
-        "x-ms-client-request-id": "e5d4306ed5c94f01f3d4ef7d9b706762",
-        "x-ms-correlation-request-id": "163db177-3609-4321-bb42-38deb0aab2d0",
-        "x-ms-ratelimit-remaining-subscription-reads": "11944",
-        "x-ms-request-id": "80dfac27-35d5-4349-ad51-3f40c8eeea94",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064323Z:163db177-3609-4321-bb42-38deb0aab2d0"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1c71d5d9ca75620fe4b730e5fc3bf68b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:24 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "c27609be-7e10-4e47-bdc0-7fd10f760758",
-        "x-ms-client-request-id": "1c71d5d9ca75620fe4b730e5fc3bf68b",
-        "x-ms-correlation-request-id": "c5c79597-004b-4f61-a5dd-39e64c6ab85a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11943",
-        "x-ms-request-id": "b39dfcf8-cc7b-416d-8911-cce5087b8b84",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064324Z:c5c79597-004b-4f61-a5dd-39e64c6ab85a"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "45f2dee2633892e8f02e587d8a9debe7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:25 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "9590cc3a-b9e8-4dca-88ff-02d068deadfa",
-        "x-ms-client-request-id": "45f2dee2633892e8f02e587d8a9debe7",
-        "x-ms-correlation-request-id": "1c6032ee-ca77-4f7f-8da1-0bd085e0f816",
-        "x-ms-ratelimit-remaining-subscription-reads": "11942",
-        "x-ms-request-id": "4bfa7e74-dd50-4afb-993f-421d3bcba905",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064326Z:1c6032ee-ca77-4f7f-8da1-0bd085e0f816"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "67aad8f714aaa39121710112a51c52b8",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:27 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "4dd64658-a97d-421a-9618-e563b6d470a8",
-        "x-ms-client-request-id": "67aad8f714aaa39121710112a51c52b8",
-        "x-ms-correlation-request-id": "de72a170-a3c5-43b3-9ec6-a855c62582ad",
-        "x-ms-ratelimit-remaining-subscription-reads": "11941",
-        "x-ms-request-id": "c9821a1e-e716-44f0-adfc-e236cf26d578",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064328Z:de72a170-a3c5-43b3-9ec6-a855c62582ad"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bd9b64dd217e762aeddf2b467292d846",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:28 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "e086099a-c305-4243-a0cb-6fd8f4000ce6",
-        "x-ms-client-request-id": "bd9b64dd217e762aeddf2b467292d846",
-        "x-ms-correlation-request-id": "e93f257b-77e6-4584-ba9e-7b07b4be32cd",
-        "x-ms-ratelimit-remaining-subscription-reads": "11940",
-        "x-ms-request-id": "85c59d1d-0337-4125-b632-8d42a4a2678b",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064329Z:e93f257b-77e6-4584-ba9e-7b07b4be32cd"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "24ed48cb8e91cde14c4f24c662d6ecd4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:30 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "df4ec1f7-2d4a-44fc-9dac-3dbaca5a8c13",
-        "x-ms-client-request-id": "24ed48cb8e91cde14c4f24c662d6ecd4",
-        "x-ms-correlation-request-id": "ad42ff88-dd70-42e0-8e83-1ee80c040d4a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11939",
-        "x-ms-request-id": "b34e7823-afe0-49ac-954e-8b279d023ea9",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064331Z:ad42ff88-dd70-42e0-8e83-1ee80c040d4a"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "269f9fdb2e02d669ad347acae94b318f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:31 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "6d28d052-0b40-498c-b486-e2885b0d4b4d",
-        "x-ms-client-request-id": "269f9fdb2e02d669ad347acae94b318f",
-        "x-ms-correlation-request-id": "a50fee96-7cf0-43e3-8599-d1d0b9149763",
-        "x-ms-ratelimit-remaining-subscription-reads": "11938",
-        "x-ms-request-id": "71541bcc-3383-420e-aa13-bf0e4e7fa0d9",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064332Z:a50fee96-7cf0-43e3-8599-d1d0b9149763"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5d46ba992e2e4e2782ce712ffc631417",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:33 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "af3106d1-4cd3-4c48-a152-7d10c609ae73",
-        "x-ms-client-request-id": "5d46ba992e2e4e2782ce712ffc631417",
-        "x-ms-correlation-request-id": "a6bf374a-f79a-40a5-ad31-b53b9b918004",
-        "x-ms-ratelimit-remaining-subscription-reads": "11937",
-        "x-ms-request-id": "dbebf775-15df-4014-aed3-7550109b7a37",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064333Z:a6bf374a-f79a-40a5-ad31-b53b9b918004"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d26a56f2b1f29d44de17765c1416e301",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:34 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "d642118e-1d50-4f5b-8618-c6d8d655ffec",
-        "x-ms-client-request-id": "d26a56f2b1f29d44de17765c1416e301",
-        "x-ms-correlation-request-id": "9a066e90-e65c-41c3-9255-3873fcf95cc4",
-        "x-ms-ratelimit-remaining-subscription-reads": "11936",
-        "x-ms-request-id": "10ad40e5-cf8e-4dad-b509-68442b6798ab",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064335Z:9a066e90-e65c-41c3-9255-3873fcf95cc4"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a72c951d8f8faca67850a333bc3ad949",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:35 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "c9ae5c17-7a1c-4ece-bd2b-bb5ca7b7b011",
-        "x-ms-client-request-id": "a72c951d8f8faca67850a333bc3ad949",
-        "x-ms-correlation-request-id": "babfc1d6-a19a-4726-8a20-483db02b96e3",
-        "x-ms-ratelimit-remaining-subscription-reads": "11935",
-        "x-ms-request-id": "da82ecab-b14a-4215-bbb9-635a7f595594",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064336Z:babfc1d6-a19a-4726-8a20-483db02b96e3"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "93d862205ee0e79c76a87e17b8ca3a6c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:37 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "7d42b6af-517f-4cc7-9e6b-a9a11b768377",
-        "x-ms-client-request-id": "93d862205ee0e79c76a87e17b8ca3a6c",
-        "x-ms-correlation-request-id": "fdcc73c6-ceb4-4823-8839-fcc003656d77",
-        "x-ms-ratelimit-remaining-subscription-reads": "11934",
-        "x-ms-request-id": "95981765-7b7f-481d-a54f-25ef9d46f2a6",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064338Z:fdcc73c6-ceb4-4823-8839-fcc003656d77"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "67116fea6c376387b0bd59a20e10e0a4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:38 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "98525b46-8516-4280-a751-4ef7faf9f4c9",
-        "x-ms-client-request-id": "67116fea6c376387b0bd59a20e10e0a4",
-        "x-ms-correlation-request-id": "4cd7d48c-48ae-46af-890d-bf6ddeb6f39c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11933",
-        "x-ms-request-id": "856af05f-2265-4038-ab90-e4a9b7d2ce59",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064339Z:4cd7d48c-48ae-46af-890d-bf6ddeb6f39c"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b23c2c3e503ebf20f94531e7108ef4ad",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:39 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "712bc885-0d78-4994-89e5-ba9a52f8217b",
-        "x-ms-client-request-id": "b23c2c3e503ebf20f94531e7108ef4ad",
-        "x-ms-correlation-request-id": "9ab74254-9648-46cb-a912-21df1da1d668",
-        "x-ms-ratelimit-remaining-subscription-reads": "11932",
-        "x-ms-request-id": "cc4446d0-e0af-484e-8a55-8b4189865929",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064340Z:9ab74254-9648-46cb-a912-21df1da1d668"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4d4936167129b312da74e22204f9d965",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:41 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "ab8be9d4-d5d2-43c2-97bf-7d50bbfd29a9",
-        "x-ms-client-request-id": "4d4936167129b312da74e22204f9d965",
-        "x-ms-correlation-request-id": "b648a90b-ab25-4c61-944d-481745f81218",
-        "x-ms-ratelimit-remaining-subscription-reads": "11931",
-        "x-ms-request-id": "882e5e13-7a24-4a38-846f-8d86dbdbe4d8",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064342Z:b648a90b-ab25-4c61-944d-481745f81218"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/c859e380-a5df-470c-a07a-dbfb94612bf5?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8cd9d9c7878d992e4f516ef13ba05221",
+        "traceparent": "00-ded43fa83884564bb2afbda20cf8b91f-ecddc617cdd22247-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "17c74ecb585eaaff0df034f4c6f58126",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -3481,7 +1352,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "29",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:42 GMT",
+        "Date": "Wed, 29 Jun 2022 14:44:26 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -3490,36 +1361,35 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "d3ee99ca-4a8e-40a5-bbff-2865d0ac9b6c",
-        "x-ms-client-request-id": "8cd9d9c7878d992e4f516ef13ba05221",
-        "x-ms-correlation-request-id": "08d75204-dc3d-426c-9687-0e9a50168806",
-        "x-ms-ratelimit-remaining-subscription-reads": "11930",
-        "x-ms-request-id": "0624b698-d006-42ab-b7d9-67839cd8382d",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064343Z:08d75204-dc3d-426c-9687-0e9a50168806"
+        "x-ms-arm-service-request-id": "a0480eff-94d8-471c-96aa-0cb48ca0c231",
+        "x-ms-client-request-id": "17c74ecb585eaaff0df034f4c6f58126",
+        "x-ms-correlation-request-id": "969e5fa5-0070-4c7b-9599-26ea6374cd21",
+        "x-ms-ratelimit-remaining-subscription-reads": "11976",
+        "x-ms-request-id": "131a56ae-c6de-4a31-a660-c83c6011f0ab",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144426Z:969e5fa5-0070-4c7b-9599-26ea6374cd21"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022Succeeded\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "Succeeded"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.Network/privateEndpoints/pe-2005?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d78bacc993c6cc7a1989d7c96dfebaff",
+        "traceparent": "00-ded43fa83884564bb2afbda20cf8b91f-bfee95c91cdae747-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f5ff95afcd0ff1b7c818240a14634181",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1959",
+        "Content-Length": "1954",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:43 GMT",
-        "ETag": "W/\u00224c8d8de8-b0c5-4197-bc2f-fb14e39ebc86\u0022",
+        "Date": "Wed, 29 Jun 2022 14:44:26 GMT",
+        "ETag": "W/\u0022a5305d4b-caf1-47f9-a203-09e5e113d377\u0022",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -3528,101 +1398,100 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "33cb4528-c204-4b8f-9a36-9e285d130477",
-        "x-ms-client-request-id": "d78bacc993c6cc7a1989d7c96dfebaff",
-        "x-ms-correlation-request-id": "34da26c3-38a4-4e4c-a68c-17cff4f2c37c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11929",
-        "x-ms-request-id": "04f2329d-2b4b-4fad-beb3-b1f49c84dbd9",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064344Z:34da26c3-38a4-4e4c-a68c-17cff4f2c37c"
+        "x-ms-arm-service-request-id": "19cc71d4-6977-4f77-ae6c-8cc4fd1d13e8",
+        "x-ms-client-request-id": "f5ff95afcd0ff1b7c818240a14634181",
+        "x-ms-correlation-request-id": "bc22507f-602d-4382-bc25-eed9100b022a",
+        "x-ms-ratelimit-remaining-subscription-reads": "11975",
+        "x-ms-request-id": "cc9541f0-64a5-44b9-aa52-b259af3bdafc",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144426Z:bc22507f-602d-4382-bc25-eed9100b022a"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022name\u0022: \u0022pe-6421\u0022,\r\n",
-        "  \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421\u0022,\r\n",
-        "  \u0022etag\u0022: \u0022W/\\\u00224c8d8de8-b0c5-4197-bc2f-fb14e39ebc86\\\u0022\u0022,\r\n",
-        "  \u0022type\u0022: \u0022Microsoft.Network/privateEndpoints\u0022,\r\n",
-        "  \u0022location\u0022: \u0022westus2\u0022,\r\n",
-        "  \u0022properties\u0022: {\r\n",
-        "    \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "    \u0022resourceGuid\u0022: \u00227b277058-57e3-4a46-b58c-aa90f2933694\u0022,\r\n",
-        "    \u0022privateLinkServiceConnections\u0022: [],\r\n",
-        "    \u0022manualPrivateLinkServiceConnections\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022name\u0022: \u0022pec9749\u0022,\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421/manualPrivateLinkServiceConnections/pec9749\u0022,\r\n",
-        "        \u0022etag\u0022: \u0022W/\\\u00224c8d8de8-b0c5-4197-bc2f-fb14e39ebc86\\\u0022\u0022,\r\n",
-        "        \u0022properties\u0022: {\r\n",
-        "          \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "          \u0022privateLinkServiceId\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792\u0022,\r\n",
-        "          \u0022groupIds\u0022: [\r\n",
-        "            \u0022namespace\u0022\r\n",
-        "          ],\r\n",
-        "          \u0022requestMessage\u0022: \u0022SDK test\u0022,\r\n",
-        "          \u0022privateLinkServiceConnectionState\u0022: {\r\n",
-        "            \u0022status\u0022: \u0022Pending\u0022,\r\n",
-        "            \u0022description\u0022: \u0022SDK test\u0022,\r\n",
-        "            \u0022actionsRequired\u0022: \u0022None\u0022\r\n",
-        "          }\r\n",
-        "        },\r\n",
-        "        \u0022type\u0022: \u0022Microsoft.Network/privateEndpoints/manualPrivateLinkServiceConnections\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022subnet\u0022: {\r\n",
-        "      \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/virtualNetworks/vnet-9517/subnets/default\u0022\r\n",
-        "    },\r\n",
-        "    \u0022networkInterfaces\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/networkInterfaces/pe-6421.nic.ba240df0-a415-4c27-9543-c936e8122f9a\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022customDnsConfigs\u0022: []\r\n",
-        "  }\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "name": "pe-2005",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.Network/privateEndpoints/pe-2005",
+        "etag": "W/\u0022a5305d4b-caf1-47f9-a203-09e5e113d377\u0022",
+        "type": "Microsoft.Network/privateEndpoints",
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "resourceGuid": "40d59801-4425-4341-9000-3539f1d76025",
+          "privateLinkServiceConnections": [],
+          "manualPrivateLinkServiceConnections": [
+            {
+              "name": "pec9039",
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.Network/privateEndpoints/pe-2005/manualPrivateLinkServiceConnections/pec9039",
+              "etag": "W/\u0022a5305d4b-caf1-47f9-a203-09e5e113d377\u0022",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateLinkServiceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307",
+                "groupIds": [
+                  "namespace"
+                ],
+                "requestMessage": "SDK test",
+                "privateLinkServiceConnectionState": {
+                  "status": "Pending",
+                  "description": "SDK test",
+                  "actionsRequired": "None"
+                }
+              },
+              "type": "Microsoft.Network/privateEndpoints/manualPrivateLinkServiceConnections"
+            }
+          ],
+          "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.Network/virtualNetworks/vnet-6378/subnets/default"
+          },
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.Network/networkInterfaces/pe-2005.nic.64c5d913-4cb3-4953-b4aa-a72948190d17"
+            }
+          ],
+          "customDnsConfigs": []
+        }
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "361fcb6b67b58e2008affdd703207839",
+        "traceparent": "00-ee7de93ab90e3c4b9a305f30329df600-a0f8261cd71f9547-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "aae6759684a61499c32739331cd8608f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "689",
+        "Content-Length": "687",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:44 GMT",
+        "Date": "Wed, 29 Jun 2022 14:44:28 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "361fcb6b67b58e2008affdd703207839",
-        "x-ms-correlation-request-id": "2f2357d5-854c-46e6-9107-9bcff7fd6b0f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11928",
-        "x-ms-request-id": "0fd2c389-3c2b-41c3-8997-6b7544453930_M3CH3_M3CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064345Z:2f2357d5-854c-46e6-9107-9bcff7fd6b0f"
+        "x-ms-client-request-id": "aae6759684a61499c32739331cd8608f",
+        "x-ms-correlation-request-id": "8156464b-1a1c-4a6e-80e6-a0d6890a05ea",
+        "x-ms-ratelimit-remaining-subscription-reads": "11974",
+        "x-ms-request-id": "8b3ead10-463a-4374-8afd-f87a34e8627c_M4SN1_M4SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144428Z:8156464b-1a1c-4a6e-80e6-a0d6890a05ea"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010",
-            "name": "93458198-b81a-404d-bce4-abe5da174010",
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f",
+            "name": "01d7e6a8-e533-45dc-a977-83c8c80e6c1f",
             "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
             "location": "East US 2",
             "properties": {
               "provisioningState": "Succeeded",
               "privateEndpoint": {
-                "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421"
+                "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.Network/privateEndpoints/pe-2005"
               },
               "privateLinkServiceConnectionState": {
                 "status": "Pending",
@@ -3637,46 +1506,47 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5859c122016e339f5f0c7304af652c50",
+        "traceparent": "00-6a187bb1b0b9b6439ff484fe8fdaf101-27642209eb72d74e-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "3cd6aaa5208efdc797d54f4533f495a9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "677",
+        "Content-Length": "675",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:46 GMT",
+        "Date": "Wed, 29 Jun 2022 14:44:29 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5859c122016e339f5f0c7304af652c50",
-        "x-ms-correlation-request-id": "9b3edf16-929e-40d1-9b83-f4ec3833f8c7",
-        "x-ms-ratelimit-remaining-subscription-reads": "11927",
-        "x-ms-request-id": "c2e308ec-8bea-41b1-a119-97793247a55e_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064347Z:9b3edf16-929e-40d1-9b83-f4ec3833f8c7"
+        "x-ms-client-request-id": "3cd6aaa5208efdc797d54f4533f495a9",
+        "x-ms-correlation-request-id": "c41a5551-00b0-4d3b-ae46-68af1ed91236",
+        "x-ms-ratelimit-remaining-subscription-reads": "11973",
+        "x-ms-request-id": "5e3cc771-c3c2-4378-94d5-7e4fec3a13fb_M0SN1_M0SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144429Z:c41a5551-00b0-4d3b-ae46-68af1ed91236"
       },
       "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010",
-        "name": "93458198-b81a-404d-bce4-abe5da174010",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f",
+        "name": "01d7e6a8-e533-45dc-a977-83c8c80e6c1f",
         "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
         "location": "East US 2",
         "properties": {
           "provisioningState": "Succeeded",
           "privateEndpoint": {
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421"
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.Network/privateEndpoints/pe-2005"
           },
           "privateLinkServiceConnectionState": {
             "status": "Pending",
@@ -3689,1639 +1559,23 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f?api-version=2021-11-01",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6f866e971b80616b8cfdcf1795a3c9f8",
+        "traceparent": "00-d57d16083ecbbb4b8045785dba5097ab-d70e08758e8f2e41-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "515eb3aed60e2b7ffbeb31e79483d5f0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com:443/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010?api-version=2021-11-01\u0026operationType=Delete",
+        "Azure-AsyncOperation": "https://management.azure.com:443/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f?api-version=2021-11-01\u0026operationType=Delete",
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Fri, 19 Nov 2021 06:43:46 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "6f866e971b80616b8cfdcf1795a3c9f8",
-        "x-ms-correlation-request-id": "c983c55f-9eb0-40f0-ad98-896141a3a7c0",
-        "x-ms-ratelimit-remaining-subscription-deletes": "14998",
-        "x-ms-request-id": "348b9e46-9ab2-44d0-8ff4-4e9321fb75cd_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064347Z:c983c55f-9eb0-40f0-ad98-896141a3a7c0"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "943fac83089a06b855f7cc7032889dbb",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "464",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:46 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "943fac83089a06b855f7cc7032889dbb",
-        "x-ms-correlation-request-id": "06e43384-6d70-4d8f-af16-560571bf1748",
-        "x-ms-ratelimit-remaining-subscription-reads": "11926",
-        "x-ms-request-id": "a5b249d5-229f-4a3d-80da-24daa1e9397d_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064347Z:06e43384-6d70-4d8f-af16-560571bf1748"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010",
-        "name": "93458198-b81a-404d-bce4-abe5da174010",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:43:47.403Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "11f47a437fbe36acdd1b439544c26d70",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "464",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:49 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "11f47a437fbe36acdd1b439544c26d70",
-        "x-ms-correlation-request-id": "53beb1b9-faea-424a-b209-4ee05bf9ca54",
-        "x-ms-ratelimit-remaining-subscription-reads": "11925",
-        "x-ms-request-id": "b6603dce-f570-4757-9f23-0f5ec2c6284c_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064349Z:53beb1b9-faea-424a-b209-4ee05bf9ca54"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010",
-        "name": "93458198-b81a-404d-bce4-abe5da174010",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:43:47.403Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e8932b1e3463085de5a057ad942037a4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "464",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:51 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "e8932b1e3463085de5a057ad942037a4",
-        "x-ms-correlation-request-id": "3a047c73-4370-40b3-a39f-f3ca52beb0e3",
-        "x-ms-ratelimit-remaining-subscription-reads": "11924",
-        "x-ms-request-id": "e30ab7df-20b9-4aee-9100-0a4252ba69ee_M0CH3_M0CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064351Z:3a047c73-4370-40b3-a39f-f3ca52beb0e3"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010",
-        "name": "93458198-b81a-404d-bce4-abe5da174010",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:43:47.403Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "79661c4dcd2704e40009b77fc423c292",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "464",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:54 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "79661c4dcd2704e40009b77fc423c292",
-        "x-ms-correlation-request-id": "7476c08e-0953-4d05-b6aa-0a9bbd0cb504",
-        "x-ms-ratelimit-remaining-subscription-reads": "11923",
-        "x-ms-request-id": "42974e8d-67f3-4670-8673-cd5d82230766_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064354Z:7476c08e-0953-4d05-b6aa-0a9bbd0cb504"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010",
-        "name": "93458198-b81a-404d-bce4-abe5da174010",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:43:47.403Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "06525b8ab5f40e581deb2c1d28fea1bc",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "464",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:55 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "06525b8ab5f40e581deb2c1d28fea1bc",
-        "x-ms-correlation-request-id": "5933ee10-d256-4740-a5ed-23bd07b98384",
-        "x-ms-ratelimit-remaining-subscription-reads": "11922",
-        "x-ms-request-id": "c59c459e-2f67-4b9d-989e-f69387cf2f5e_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064355Z:5933ee10-d256-4740-a5ed-23bd07b98384"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010",
-        "name": "93458198-b81a-404d-bce4-abe5da174010",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:43:47.403Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "28479fe3f35c5149478fe8597dde43c1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "464",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:56 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "28479fe3f35c5149478fe8597dde43c1",
-        "x-ms-correlation-request-id": "14a52095-eeca-454d-9797-26245f7a6179",
-        "x-ms-ratelimit-remaining-subscription-reads": "11921",
-        "x-ms-request-id": "ea7098c2-f9f1-4c9d-9f96-3f1ae803774a_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064356Z:14a52095-eeca-454d-9797-26245f7a6179"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010",
-        "name": "93458198-b81a-404d-bce4-abe5da174010",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:43:47.403Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3922c4de31ce98afc3575c3ba0c6db01",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "464",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:43:58 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "3922c4de31ce98afc3575c3ba0c6db01",
-        "x-ms-correlation-request-id": "768bed2b-2d23-4236-850b-86df9b137966",
-        "x-ms-ratelimit-remaining-subscription-reads": "11920",
-        "x-ms-request-id": "9ac79811-d5b1-4ca8-be08-9ec4b9e87908_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064358Z:768bed2b-2d23-4236-850b-86df9b137966"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010",
-        "name": "93458198-b81a-404d-bce4-abe5da174010",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:43:57.903Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "259bfa689adc97361200bf65cdfe913e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "460",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:44:00 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "259bfa689adc97361200bf65cdfe913e",
-        "x-ms-correlation-request-id": "a723dfe1-960c-4097-97ea-1066a17257bd",
-        "x-ms-ratelimit-remaining-subscription-reads": "11919",
-        "x-ms-request-id": "167a3922-7806-4f23-8c38-a5af353b638a_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064400Z:a723dfe1-960c-4097-97ea-1066a17257bd"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010/operationStatus/93458198-b81a-404d-bce4-abe5da174010",
-        "name": "93458198-b81a-404d-bce4-abe5da174010",
-        "status": "Succeeded",
-        "startTime": "0001-01-01T00:00:00",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "633f6aa868dbb2eeefae6405960eb080",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "169",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:44:00 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "633f6aa868dbb2eeefae6405960eb080",
-        "x-ms-correlation-request-id": "3063fc62-6b5e-41f9-8f51-30132df67d7e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11918",
-        "x-ms-request-id": "628afeab-b4ec-4114-b52f-be58b88d40e2_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064400Z:3063fc62-6b5e-41f9-8f51-30132df67d7e"
-      },
-      "ResponseBody": {
-        "error": {
-          "message": "The requested resource 93458198-b81a-404d-bce4-abe5da174010 does not exist. CorrelationId: 3063fc62-6b5e-41f9-8f51-30132df67d7e",
-          "code": "NotFound"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "82f1e6b31d4344e58e8b26cd724acbc5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "12",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:44:01 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "82f1e6b31d4344e58e8b26cd724acbc5",
-        "x-ms-correlation-request-id": "8ab65bfc-8608-4e90-9901-abbe89d0f449",
-        "x-ms-ratelimit-remaining-subscription-reads": "11917",
-        "x-ms-request-id": "ae680c9e-1097-4259-881d-36298861fef1_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064401Z:8ab65bfc-8608-4e90-9901-abbe89d0f449"
-      },
-      "ResponseBody": {
-        "value": []
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/privateEndpointConnections?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "36931ec5788700260be8352e35300104",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "12",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:44:01 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "36931ec5788700260be8352e35300104",
-        "x-ms-correlation-request-id": "e99e4f3d-298b-4696-8033-53f633cf9c98",
-        "x-ms-ratelimit-remaining-subscription-reads": "11916",
-        "x-ms-request-id": "a5b57686-0867-4cba-adc8-10b677b5e507_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064401Z:e99e4f3d-298b-4696-8033-53f633cf9c98"
-      },
-      "ResponseBody": {
-        "value": []
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e6b13e500e0d8afb85fbd450412040a5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Date": "Fri, 19 Nov 2021 06:44:03 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "e6b13e500e0d8afb85fbd450412040a5",
-        "x-ms-correlation-request-id": "807e41b4-01ab-4b09-8cf5-9890a3bd3a2c",
-        "x-ms-ratelimit-remaining-subscription-deletes": "14997",
-        "x-ms-request-id": "45088724-34c7-4c2e-b13d-86a5f60f14b6_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064403Z:807e41b4-01ab-4b09-8cf5-9890a3bd3a2c"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "337d228ae498b6b82208b18ba3d5bfea",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:44:03 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "50",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "337d228ae498b6b82208b18ba3d5bfea",
-        "x-ms-correlation-request-id": "55c7abcd-f0fd-4d90-91fa-5e4f341c2ae7",
-        "x-ms-ratelimit-remaining-subscription-reads": "11915",
-        "x-ms-request-id": "0540453b-354a-4007-b91e-2bca80bfe0c5_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064403Z:55c7abcd-f0fd-4d90-91fa-5e4f341c2ae7"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010",
-              "name": "93458198-b81a-404d-bce4-abe5da174010",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:44:03.06Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "974b8fa889f0d6894576261c97a1a2ce",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:44:06 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "38",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "974b8fa889f0d6894576261c97a1a2ce",
-        "x-ms-correlation-request-id": "30728358-ad01-4f49-b6ce-fce9e2a72242",
-        "x-ms-ratelimit-remaining-subscription-reads": "11914",
-        "x-ms-request-id": "5bf8580a-2888-40c4-82f4-34cc49992b95_M10CH3_M10CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064406Z:30728358-ad01-4f49-b6ce-fce9e2a72242"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010",
-              "name": "93458198-b81a-404d-bce4-abe5da174010",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:44:03.06Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1ec676ec0da3fd0de6885572c86d97ea",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:44:07 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "49",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "1ec676ec0da3fd0de6885572c86d97ea",
-        "x-ms-correlation-request-id": "40aaf6fb-fed2-4b91-9d36-3688223ae53a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11913",
-        "x-ms-request-id": "00b978cb-d07a-4e09-9eec-315b3f9705aa_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064407Z:40aaf6fb-fed2-4b91-9d36-3688223ae53a"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010",
-              "name": "93458198-b81a-404d-bce4-abe5da174010",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:44:03.06Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "58b28c31776b006d99a6ed21bd9b1f81",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:44:09 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "32",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "58b28c31776b006d99a6ed21bd9b1f81",
-        "x-ms-correlation-request-id": "a4a25c2a-b64e-4339-9fa4-1f966d5d6f78",
-        "x-ms-ratelimit-remaining-subscription-reads": "11912",
-        "x-ms-request-id": "1b984888-1c39-4005-8362-3154f24fe6fc_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064409Z:a4a25c2a-b64e-4339-9fa4-1f966d5d6f78"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010",
-              "name": "93458198-b81a-404d-bce4-abe5da174010",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:44:03.06Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2d9fe266a00f9a46824db06734170dd7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:44:10 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "44",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2d9fe266a00f9a46824db06734170dd7",
-        "x-ms-correlation-request-id": "ea7580c3-a2d5-4de5-828c-711867e4bb97",
-        "x-ms-ratelimit-remaining-subscription-reads": "11911",
-        "x-ms-request-id": "12e0c0e8-1a71-4e18-898f-21e16c15abe1_M11CH3_M11CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064411Z:ea7580c3-a2d5-4de5-828c-711867e4bb97"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010",
-              "name": "93458198-b81a-404d-bce4-abe5da174010",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:44:03.06Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0beb3cdf49ef756209c585fd1fec3f4b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:44:12 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "43",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "0beb3cdf49ef756209c585fd1fec3f4b",
-        "x-ms-correlation-request-id": "dff2726b-8b53-4666-b2ec-7d7e3a46a0e9",
-        "x-ms-ratelimit-remaining-subscription-reads": "11910",
-        "x-ms-request-id": "87c8b8f0-f807-47fb-8861-14cdc0e6cddf_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064412Z:dff2726b-8b53-4666-b2ec-7d7e3a46a0e9"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010",
-              "name": "93458198-b81a-404d-bce4-abe5da174010",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:44:03.06Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e60bd3696ace91db4517d61ec605cc82",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:44:13 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "53",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "e60bd3696ace91db4517d61ec605cc82",
-        "x-ms-correlation-request-id": "714fa920-ca11-48e2-9e24-4c968fe77cd6",
-        "x-ms-ratelimit-remaining-subscription-reads": "11909",
-        "x-ms-request-id": "2356dff4-b13c-4617-87c3-172607f1c723_M3CH3_M3CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064413Z:714fa920-ca11-48e2-9e24-4c968fe77cd6"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010",
-              "name": "93458198-b81a-404d-bce4-abe5da174010",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:44:03.06Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8141159913b01d92802923491a497b96",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:44:14 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "48",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8141159913b01d92802923491a497b96",
-        "x-ms-correlation-request-id": "e91f9c1a-21d6-429c-92ed-62f1bd536cbe",
-        "x-ms-ratelimit-remaining-subscription-reads": "11908",
-        "x-ms-request-id": "2512f0f2-df07-4019-9722-39ba5456ea4f_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064415Z:e91f9c1a-21d6-429c-92ed-62f1bd536cbe"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010",
-              "name": "93458198-b81a-404d-bce4-abe5da174010",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:44:03.06Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "60fe650d270b75096059c6d77344af04",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:44:17 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "41",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "60fe650d270b75096059c6d77344af04",
-        "x-ms-correlation-request-id": "a3b0ebc5-ba5d-4e67-90b5-3f5a809a3362",
-        "x-ms-ratelimit-remaining-subscription-reads": "11907",
-        "x-ms-request-id": "a0a3e6e2-21b8-4239-aba4-a82dfa42071f_M5CH3_M5CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064417Z:a3b0ebc5-ba5d-4e67-90b5-3f5a809a3362"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010",
-              "name": "93458198-b81a-404d-bce4-abe5da174010",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:44:03.06Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "096403f9beaa569a41ee65a4469276fb",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:44:18 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "57",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "096403f9beaa569a41ee65a4469276fb",
-        "x-ms-correlation-request-id": "c7169c11-aa29-4a86-b2e4-eb92037d31ae",
-        "x-ms-ratelimit-remaining-subscription-reads": "11906",
-        "x-ms-request-id": "841072fa-6334-4403-9787-ba91d8607dd2_M5CH3_M5CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064418Z:c7169c11-aa29-4a86-b2e4-eb92037d31ae"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010",
-              "name": "93458198-b81a-404d-bce4-abe5da174010",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:44:03.06Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "60103f9b6c0771760ccc20564dbaa93c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:44:20 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "48",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "60103f9b6c0771760ccc20564dbaa93c",
-        "x-ms-correlation-request-id": "8575fef7-e033-41b7-8d1d-1692516639a0",
-        "x-ms-ratelimit-remaining-subscription-reads": "11905",
-        "x-ms-request-id": "a80761a7-e031-42fb-ac3f-2b33e6e72f89_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064421Z:8575fef7-e033-41b7-8d1d-1692516639a0"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010",
-              "name": "93458198-b81a-404d-bce4-abe5da174010",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:44:03.06Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "16501f7972e54febcba71e1dc1652ece",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:44:22 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "39",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "16501f7972e54febcba71e1dc1652ece",
-        "x-ms-correlation-request-id": "5c92f132-0c04-4e93-beec-22db4156125a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11904",
-        "x-ms-request-id": "1214a50e-5041-4585-8920-21867ce283d8_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064422Z:5c92f132-0c04-4e93-beec-22db4156125a"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010",
-              "name": "93458198-b81a-404d-bce4-abe5da174010",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:44:03.06Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "333ccae24f348cfd8df2fdde9d440987",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:44:23 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "56",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "333ccae24f348cfd8df2fdde9d440987",
-        "x-ms-correlation-request-id": "bcfa5963-ce6f-4b37-8215-637d1572052d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11903",
-        "x-ms-request-id": "d2329478-09e0-4d06-8687-c7ddafcba9f7_M7CH3_M7CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064423Z:bcfa5963-ce6f-4b37-8215-637d1572052d"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010",
-              "name": "93458198-b81a-404d-bce4-abe5da174010",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:44:03.06Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "272a29445f41291654c0955f4d59afa7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Connection": "close",
-        "Content-Length": "1489",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:44:24 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "34",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "272a29445f41291654c0955f4d59afa7",
-        "x-ms-correlation-request-id": "5c7ec527-288f-454f-96e5-a7e8f6fe72d3",
-        "x-ms-ratelimit-remaining-subscription-reads": "11902",
-        "x-ms-request-id": "180a3ab3-68fe-466e-bc7c-ff839435f96d_M7CH3_M7CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064425Z:5c7ec527-288f-454f-96e5-a7e8f6fe72d3"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792",
-        "name": "testnamespacemgmt2792",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792/privateEndpointConnections/93458198-b81a-404d-bce4-abe5da174010",
-              "name": "93458198-b81a-404d-bce4-abe5da174010",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.Network/privateEndpoints/pe-6421"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt2792",
-          "createdAt": "2021-11-19T06:41:52.357Z",
-          "updatedAt": "2021-11-19T06:44:03.06Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2792.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-3912/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2792/operationresults/testnamespacemgmt2792?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8273529d767e2a0821c389f2740db286",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Date": "Fri, 19 Nov 2021 06:44:25 GMT",
+        "Date": "Wed, 29 Jun 2022 14:44:31 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -5331,17 +1585,340 @@
         "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8273529d767e2a0821c389f2740db286",
-        "x-ms-correlation-request-id": "bf343069-2785-463f-9627-cde3ce46220b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11994",
-        "x-ms-request-id": "c80473b0-3c04-4a9b-aa3f-aef2424d2d8d_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064426Z:bf343069-2785-463f-9627-cde3ce46220b"
+        "x-ms-client-request-id": "515eb3aed60e2b7ffbeb31e79483d5f0",
+        "x-ms-correlation-request-id": "6c772aa3-f74e-44ee-9608-3a8574aaa850",
+        "x-ms-ratelimit-remaining-subscription-deletes": "14999",
+        "x-ms-request-id": "0b052352-a336-4bb1-b4f1-0d769eafee5a_M4SN1_M4SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144431Z:6c772aa3-f74e-44ee-9608-3a8574aaa850"
       },
-      "ResponseBody": []
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f?api-version=2021-11-01\u0026operationType=Delete",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d57d16083ecbbb4b8045785dba5097ab-7e6d1c6b01adc64e-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "68858f920f79ce802bab40a3eee06813",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f?api-version=2021-11-01\u0026operationType=Delete",
+        "Cache-Control": "no-cache",
+        "Content-Length": "463",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 29 Jun 2022 14:44:33 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/SN1",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "68858f920f79ce802bab40a3eee06813",
+        "x-ms-correlation-request-id": "c6414a71-844f-4827-9ff4-9c76fbc4597e",
+        "x-ms-ratelimit-remaining-subscription-reads": "11972",
+        "x-ms-request-id": "787e3527-a534-4a01-bb8b-4651893f6bfd_M8SN1_M8SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144433Z:c6414a71-844f-4827-9ff4-9c76fbc4597e"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f",
+        "name": "01d7e6a8-e533-45dc-a977-83c8c80e6c1f",
+        "status": "Deleting",
+        "startTime": "2022-06-29T14:44:31.69Z",
+        "endTime": "0001-01-01T00:00:00Z"
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f?api-version=2021-11-01\u0026operationType=Delete",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d57d16083ecbbb4b8045785dba5097ab-8821120250a64949-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "9e8e5e002b8fa81cc0e8a425c4aef5a7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f?api-version=2021-11-01\u0026operationType=Delete",
+        "Cache-Control": "no-cache",
+        "Content-Length": "463",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 29 Jun 2022 14:44:36 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/SN1",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "9e8e5e002b8fa81cc0e8a425c4aef5a7",
+        "x-ms-correlation-request-id": "31e0bafd-2ba5-45fb-b8a0-df11503acf8f",
+        "x-ms-ratelimit-remaining-subscription-reads": "11971",
+        "x-ms-request-id": "0bfeb632-1df2-4547-bd78-881a2659e4c2_M4SN1_M4SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144436Z:31e0bafd-2ba5-45fb-b8a0-df11503acf8f"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f",
+        "name": "01d7e6a8-e533-45dc-a977-83c8c80e6c1f",
+        "status": "Deleting",
+        "startTime": "2022-06-29T14:44:31.69Z",
+        "endTime": "0001-01-01T00:00:00Z"
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f?api-version=2021-11-01\u0026operationType=Delete",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d57d16083ecbbb4b8045785dba5097ab-d450c8d1fd649345-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "0555620a6cfea87614963ee2c44f87cd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f?api-version=2021-11-01\u0026operationType=Delete",
+        "Cache-Control": "no-cache",
+        "Content-Length": "463",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 29 Jun 2022 14:44:38 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/SN1",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "0555620a6cfea87614963ee2c44f87cd",
+        "x-ms-correlation-request-id": "b04d8aca-913f-4bcc-b8a9-0276b117cb65",
+        "x-ms-ratelimit-remaining-subscription-reads": "11970",
+        "x-ms-request-id": "86980623-97ec-4205-b718-fa84c9b80bcf_M11SN1_M11SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144438Z:b04d8aca-913f-4bcc-b8a9-0276b117cb65"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f",
+        "name": "01d7e6a8-e533-45dc-a977-83c8c80e6c1f",
+        "status": "Deleting",
+        "startTime": "2022-06-29T14:44:31.69Z",
+        "endTime": "0001-01-01T00:00:00Z"
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f?api-version=2021-11-01\u0026operationType=Delete",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d57d16083ecbbb4b8045785dba5097ab-5c89dd92f4f4ed44-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "d6d0ff8141c5663f72dca7916b5b0a7d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f?api-version=2021-11-01\u0026operationType=Delete",
+        "Cache-Control": "no-cache",
+        "Content-Length": "463",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 29 Jun 2022 14:44:40 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/SN1",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "d6d0ff8141c5663f72dca7916b5b0a7d",
+        "x-ms-correlation-request-id": "a7f49b9c-0650-4250-8abc-75316d6ff809",
+        "x-ms-ratelimit-remaining-subscription-reads": "11969",
+        "x-ms-request-id": "5a587756-45fb-418e-9bf7-135c2de136e5_M7SN1_M7SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144440Z:a7f49b9c-0650-4250-8abc-75316d6ff809"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f",
+        "name": "01d7e6a8-e533-45dc-a977-83c8c80e6c1f",
+        "status": "Deleting",
+        "startTime": "2022-06-29T14:44:31.69Z",
+        "endTime": "0001-01-01T00:00:00Z"
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f?api-version=2021-11-01\u0026operationType=Delete",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d57d16083ecbbb4b8045785dba5097ab-dcb2bfb825d1ca4f-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "8b9899b5628b9415e7e58af9ec39e371",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f?api-version=2021-11-01\u0026operationType=Delete",
+        "Cache-Control": "no-cache",
+        "Content-Length": "464",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 29 Jun 2022 14:44:43 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/SN1",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "8b9899b5628b9415e7e58af9ec39e371",
+        "x-ms-correlation-request-id": "a3292d5c-b83c-4efb-8cf2-161820137682",
+        "x-ms-ratelimit-remaining-subscription-reads": "11968",
+        "x-ms-request-id": "7131a8a8-ec46-47bb-9129-1f2ae838c573_M0SN1_M0SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144443Z:a3292d5c-b83c-4efb-8cf2-161820137682"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f",
+        "name": "01d7e6a8-e533-45dc-a977-83c8c80e6c1f",
+        "status": "Deleting",
+        "startTime": "2022-06-29T14:44:42.687Z",
+        "endTime": "0001-01-01T00:00:00Z"
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f?api-version=2021-11-01\u0026operationType=Delete",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d57d16083ecbbb4b8045785dba5097ab-8c7d972d0fa64241-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c4a4d7611eddc9e123ee9221c5e53db8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 29 Jun 2022 14:44:48 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/SN1",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "c4a4d7611eddc9e123ee9221c5e53db8",
+        "x-ms-correlation-request-id": "f98bddbf-6470-4127-a79a-6dc15c2e84d2",
+        "x-ms-ratelimit-remaining-subscription-reads": "11967",
+        "x-ms-request-id": "fa2afda8-dbab-4d72-855f-900795b2df3c_M0SN1_M0SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144448Z:f98bddbf-6470-4127-a79a-6dc15c2e84d2"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f/operationStatus/01d7e6a8-e533-45dc-a977-83c8c80e6c1f",
+        "name": "01d7e6a8-e533-45dc-a977-83c8c80e6c1f",
+        "status": "Succeeded",
+        "startTime": "0001-01-01T00:00:00Z",
+        "endTime": "0001-01-01T00:00:00Z"
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections/01d7e6a8-e533-45dc-a977-83c8c80e6c1f?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b5927297a71b2444b0b34998e5184b68-f75cf9919036ea4e-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "2b2dc18bfbb71e41e93befe0b6467939",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "169",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 29 Jun 2022 14:44:49 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/SN1",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2b2dc18bfbb71e41e93befe0b6467939",
+        "x-ms-correlation-request-id": "3c5ca667-f264-4775-a929-e2fb285215a0",
+        "x-ms-ratelimit-remaining-subscription-reads": "11966",
+        "x-ms-request-id": "902ad9e7-6632-4fef-ad96-d4b081f511df_M11SN1_M11SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144450Z:3c5ca667-f264-4775-a929-e2fb285215a0"
+      },
+      "ResponseBody": {
+        "error": {
+          "message": "The requested resource 01d7e6a8-e533-45dc-a977-83c8c80e6c1f does not exist. CorrelationId: 3c5ca667-f264-4775-a929-e2fb285215a0",
+          "code": "NotFound"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-791/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5307/privateEndpointConnections?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d599ca4911973748aa5168ea25e1f44d-70545e8cdfed5f46-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "942f35f845b7969fb7cf689ccff4ce02",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "12",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 29 Jun 2022 14:44:51 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/SN1",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "942f35f845b7969fb7cf689ccff4ce02",
+        "x-ms-correlation-request-id": "c35ef735-7bf6-4cb7-93d6-959688967806",
+        "x-ms-ratelimit-remaining-subscription-reads": "11965",
+        "x-ms-request-id": "917bf199-58dd-4a30-8fb5-fadbe945c567_M8SN1_M8SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144451Z:c35ef735-7bf6-4cb7-93d6-959688967806"
+      },
+      "ResponseBody": {
+        "value": []
+      }
     }
   ],
   "Variables": {
-    "RandomSeed": "1722587804",
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
+    "RandomSeed": "1272392110",
     "RESOURCE_MANAGER_URL": null,
     "SUBSCRIPTION_ID": "db1ab6f0-4769-4b27-930e-01e2ef9c123c"
   }

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionDeleteAsync.json
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/PrivateEndpointConnectionTests/PrivateEndpointConnectionDeleteAsync.json
@@ -6,34 +6,43 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f8a20ac97f995a4aabe4c33ef530f6d9-263d2b939308994b-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8bd445ff5cef9f9458ba3f2f91ba34f5",
+        "traceparent": "00-56ed76e09131b24781c58b5f32d6a248-a283465ff4107e45-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6c9b6550c42a542e97ee8804e9811c1e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "468",
+        "Content-Length": "747",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:52 GMT",
+        "Date": "Wed, 29 Jun 2022 14:44:59 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "3c1b27f9-c7cc-4ab2-9e04-c51e1d017c62",
-        "x-ms-ratelimit-remaining-subscription-reads": "11822",
-        "x-ms-request-id": "3c1b27f9-c7cc-4ab2-9e04-c51e1d017c62",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064853Z:3c1b27f9-c7cc-4ab2-9e04-c51e1d017c62"
+        "x-ms-correlation-request-id": "ef9e409d-11b9-457b-bc5b-1c23b1aa02b0",
+        "x-ms-ratelimit-remaining-subscription-reads": "11964",
+        "x-ms-request-id": "ef9e409d-11b9-457b-bc5b-1c23b1aa02b0",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144459Z:ef9e409d-11b9-457b-bc5b-1c23b1aa02b0"
       },
       "ResponseBody": {
         "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "authorizationSource": "RoleBased",
         "managedByTenants": [],
         "tags": {
-          "tagKey1": "tagValue1",
-          "tagKey2": "tagValue2"
+          "TagKey-9823": "TagValue-566",
+          "TagKey-3481": "TagValue-320",
+          "TagKey-4926": "TagValue-1187",
+          "TagKey-751": "TagValue-3921",
+          "TagKey-1866": "TagValue-8559",
+          "TagKey-3094": "TagValue-9190",
+          "TagKey-2449": "TagValue-9",
+          "TagKey-8379": "TagValue-164",
+          "TagKey-7470": "TagValue-2205",
+          "TagKey-4236": "TagValue-3698",
+          "TagKey-5316": "TagValue-2725"
         },
         "subscriptionId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
@@ -47,15 +56,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourcegroups/testeventhubRG-6109?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourcegroups/testeventhubRG-5841?api-version=2021-04-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "44",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bf1698cb2a7934eece51058111f6ddee",
+        "traceparent": "00-a3368ffc879ce3408521078c5ae34a4a-6cadeeb7f9358b45-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "1c16a8be6eeff89c5ed02ef24d12c4c5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -69,19 +79,19 @@
         "Cache-Control": "no-cache",
         "Content-Length": "258",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:53 GMT",
+        "Date": "Wed, 29 Jun 2022 14:45:02 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "8b94bde5-5e21-48f0-9f75-f2c465abf249",
-        "x-ms-ratelimit-remaining-subscription-writes": "1191",
-        "x-ms-request-id": "8b94bde5-5e21-48f0-9f75-f2c465abf249",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064853Z:8b94bde5-5e21-48f0-9f75-f2c465abf249"
+        "x-ms-correlation-request-id": "6242b4e4-7770-4506-b629-f0598411a7ba",
+        "x-ms-ratelimit-remaining-subscription-writes": "1196",
+        "x-ms-request-id": "6242b4e4-7770-4506-b629-f0598411a7ba",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144503Z:6242b4e4-7770-4506-b629-f0598411a7ba"
       },
       "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109",
-        "name": "testeventhubRG-6109",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841",
+        "name": "testeventhubRG-5841",
         "type": "Microsoft.Resources/resourceGroups",
         "location": "eastus2",
         "tags": {
@@ -100,19 +110,20 @@
         "Authorization": "Sanitized",
         "Content-Length": "32",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6661f872615925e055e29c7c25b0fe4c",
+        "traceparent": "00-2ed620461f530a40ab4b3c6f7af4ae9d-215e79b86b6ac648-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "30f2663448d26f9d14c32c0330698d20",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "testnamespacemgmt3393"
+        "name": "testnamespacemgmt9473"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "53",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:54 GMT",
+        "Date": "Wed, 29 Jun 2022 14:45:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -122,11 +133,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "6661f872615925e055e29c7c25b0fe4c",
-        "x-ms-correlation-request-id": "14689a25-cd00-4eb2-a933-9b37df7c35a3",
-        "x-ms-ratelimit-remaining-subscription-writes": "1196",
-        "x-ms-request-id": "45a2c700-3d5d-410f-a39e-9ec5566cdf81_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064854Z:14689a25-cd00-4eb2-a933-9b37df7c35a3"
+        "x-ms-client-request-id": "30f2663448d26f9d14c32c0330698d20",
+        "x-ms-correlation-request-id": "6d9cc350-dc48-4a21-b745-8fcfe87006f4",
+        "x-ms-ratelimit-remaining-subscription-writes": "1198",
+        "x-ms-request-id": "85cbea51-acdd-4e1e-8f1f-01ad054eaa44_M10SN1_M10SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144504Z:6d9cc350-dc48-4a21-b745-8fcfe87006f4"
       },
       "ResponseBody": {
         "nameAvailable": true,
@@ -135,15 +146,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473?api-version=2021-11-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "48",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3c216f558676e61a57210a8f1e47c362",
+        "traceparent": "00-258f6c5fb3ddd94da7120b69a6a4400b-3acb9fc4614cdb4a-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "41d4e6df60c7fef673cbf3ff624adbc4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -156,64 +168,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:58 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "3c216f558676e61a57210a8f1e47c362",
-        "x-ms-correlation-request-id": "59d913d6-1a92-4beb-afed-7796257a94d5",
-        "x-ms-ratelimit-remaining-subscription-resource-requests": "46",
-        "x-ms-request-id": "a9e60419-9e0b-42c9-a559-05c35d380cd0_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064858Z:59d913d6-1a92-4beb-afed-7796257a94d5"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "87bb3506b1bceb4dde7a0f385751070d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:48:59 GMT",
+        "Date": "Wed, 29 Jun 2022 14:45:10 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -223,11 +178,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "87bb3506b1bceb4dde7a0f385751070d",
-        "x-ms-correlation-request-id": "0541f07f-8f53-4f90-8673-3b5399239e62",
-        "x-ms-ratelimit-remaining-subscription-reads": "11821",
-        "x-ms-request-id": "ac2acb89-315a-4fee-bf38-9650cb404dd6_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064900Z:0541f07f-8f53-4f90-8673-3b5399239e62"
+        "x-ms-client-request-id": "41d4e6df60c7fef673cbf3ff624adbc4",
+        "x-ms-correlation-request-id": "9e32970c-e9b6-4227-ad3e-ed0dee74791a",
+        "x-ms-ratelimit-remaining-subscription-resource-requests": "48",
+        "x-ms-request-id": "c36d93cd-365d-47db-b8ce-4ed54be1b5b6_M2SN1_M2SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144511Z:9e32970c-e9b6-4227-ad3e-ed0dee74791a"
       },
       "ResponseBody": {
         "sku": {
@@ -235,8 +190,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473",
+        "name": "testnamespacemgmt9473",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -247,21 +202,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9473",
+          "createdAt": "2022-06-29T14:45:09.18Z",
+          "updatedAt": "2022-06-29T14:45:09.18Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt9473.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "573c3a1ec36749b8feea07dd62d1959f",
+        "traceparent": "00-258f6c5fb3ddd94da7120b69a6a4400b-b7b83d9e3e880449-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "2b6dd1a083efd4916ff4bc07549d0cc9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -270,7 +226,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:01 GMT",
+        "Date": "Wed, 29 Jun 2022 14:45:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -280,11 +236,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "573c3a1ec36749b8feea07dd62d1959f",
-        "x-ms-correlation-request-id": "ee26f5bf-b0c8-44e8-83a7-85839d04e054",
-        "x-ms-ratelimit-remaining-subscription-reads": "11820",
-        "x-ms-request-id": "1bdbce4d-20b6-446a-afa2-72d46c85756f_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064901Z:ee26f5bf-b0c8-44e8-83a7-85839d04e054"
+        "x-ms-client-request-id": "2b6dd1a083efd4916ff4bc07549d0cc9",
+        "x-ms-correlation-request-id": "b9673d81-2030-4a71-9c9b-3c88b9d4e03b",
+        "x-ms-ratelimit-remaining-subscription-reads": "11963",
+        "x-ms-request-id": "17408f9b-7976-434e-97e7-aff69c531002_M8SN1_M8SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144516Z:b9673d81-2030-4a71-9c9b-3c88b9d4e03b"
       },
       "ResponseBody": {
         "sku": {
@@ -292,8 +248,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473",
+        "name": "testnamespacemgmt9473",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -304,21 +260,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9473",
+          "createdAt": "2022-06-29T14:45:09.18Z",
+          "updatedAt": "2022-06-29T14:45:09.18Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt9473.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e88868783c8b8fa67f5c5d19fc39dfe4",
+        "traceparent": "00-258f6c5fb3ddd94da7120b69a6a4400b-978f9aa6f3b5fa4d-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "9fc468e8d81c93f4fa74c819844c8e7e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -327,7 +284,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:02 GMT",
+        "Date": "Wed, 29 Jun 2022 14:45:19 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -337,11 +294,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "e88868783c8b8fa67f5c5d19fc39dfe4",
-        "x-ms-correlation-request-id": "5d82d378-8cc6-49a4-87ff-826639dcf042",
-        "x-ms-ratelimit-remaining-subscription-reads": "11819",
-        "x-ms-request-id": "c9180494-5445-47bf-a5f9-bc304dd004ff_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064902Z:5d82d378-8cc6-49a4-87ff-826639dcf042"
+        "x-ms-client-request-id": "9fc468e8d81c93f4fa74c819844c8e7e",
+        "x-ms-correlation-request-id": "efdf99ab-b90d-4cc2-bd26-ceff8605392d",
+        "x-ms-ratelimit-remaining-subscription-reads": "11962",
+        "x-ms-request-id": "654f5268-693d-4f65-89f4-1b71204d2fa9_M2SN1_M2SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144519Z:efdf99ab-b90d-4cc2-bd26-ceff8605392d"
       },
       "ResponseBody": {
         "sku": {
@@ -349,8 +306,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473",
+        "name": "testnamespacemgmt9473",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -361,21 +318,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9473",
+          "createdAt": "2022-06-29T14:45:09.18Z",
+          "updatedAt": "2022-06-29T14:45:09.18Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt9473.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "17291692517b43397d7289d1aa70880c",
+        "traceparent": "00-258f6c5fb3ddd94da7120b69a6a4400b-206866eed0c81042-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "905e8c9dafddbbd4ff7745378fe40bdb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -384,7 +342,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:03 GMT",
+        "Date": "Wed, 29 Jun 2022 14:45:21 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -394,11 +352,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "17291692517b43397d7289d1aa70880c",
-        "x-ms-correlation-request-id": "60daac1a-6d80-42d8-8e3b-50473fab17cd",
-        "x-ms-ratelimit-remaining-subscription-reads": "11818",
-        "x-ms-request-id": "06bc5790-ed79-4e88-b038-72606ae745b4_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064904Z:60daac1a-6d80-42d8-8e3b-50473fab17cd"
+        "x-ms-client-request-id": "905e8c9dafddbbd4ff7745378fe40bdb",
+        "x-ms-correlation-request-id": "09a3ca5f-d992-4f97-b109-85538ee2bda3",
+        "x-ms-ratelimit-remaining-subscription-reads": "11961",
+        "x-ms-request-id": "3f4f1ac8-56cf-4d5d-9cc8-81426cef0ff1_M2SN1_M2SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144522Z:09a3ca5f-d992-4f97-b109-85538ee2bda3"
       },
       "ResponseBody": {
         "sku": {
@@ -406,8 +364,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473",
+        "name": "testnamespacemgmt9473",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -418,21 +376,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9473",
+          "createdAt": "2022-06-29T14:45:09.18Z",
+          "updatedAt": "2022-06-29T14:45:09.18Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt9473.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "eebf70e51ec8e28194acd70b659e4cc4",
+        "traceparent": "00-258f6c5fb3ddd94da7120b69a6a4400b-7c381c631e6d0446-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "08c112a08e30c84adcd9307bbb774f23",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -441,7 +400,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:05 GMT",
+        "Date": "Wed, 29 Jun 2022 14:45:24 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -451,11 +410,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "eebf70e51ec8e28194acd70b659e4cc4",
-        "x-ms-correlation-request-id": "48657445-cdbc-43df-bd2c-2c4495eb57cb",
-        "x-ms-ratelimit-remaining-subscription-reads": "11817",
-        "x-ms-request-id": "58a57c03-a2bc-4cd6-8a6f-0afa34ed728e_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064905Z:48657445-cdbc-43df-bd2c-2c4495eb57cb"
+        "x-ms-client-request-id": "08c112a08e30c84adcd9307bbb774f23",
+        "x-ms-correlation-request-id": "0ac07b4b-5de2-4333-9c56-231f8afc5136",
+        "x-ms-ratelimit-remaining-subscription-reads": "11960",
+        "x-ms-request-id": "663bc333-fc88-4f03-88c5-91e6a9c44825_M4SN1_M4SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144525Z:0ac07b4b-5de2-4333-9c56-231f8afc5136"
       },
       "ResponseBody": {
         "sku": {
@@ -463,8 +422,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473",
+        "name": "testnamespacemgmt9473",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -475,21 +434,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9473",
+          "createdAt": "2022-06-29T14:45:09.18Z",
+          "updatedAt": "2022-06-29T14:45:09.18Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt9473.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4c4a220b7da727232f456b18b3d5e50f",
+        "traceparent": "00-258f6c5fb3ddd94da7120b69a6a4400b-9001a833476e4a4f-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c8693d657c3f38ec9409a0a592bd0316",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -498,7 +458,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:06 GMT",
+        "Date": "Wed, 29 Jun 2022 14:45:28 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -508,11 +468,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "4c4a220b7da727232f456b18b3d5e50f",
-        "x-ms-correlation-request-id": "85c23e49-775b-4be6-beb9-6e1fdcd46b40",
-        "x-ms-ratelimit-remaining-subscription-reads": "11816",
-        "x-ms-request-id": "95a3bfd6-1975-4e09-a390-cfb5dab5f88e_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064906Z:85c23e49-775b-4be6-beb9-6e1fdcd46b40"
+        "x-ms-client-request-id": "c8693d657c3f38ec9409a0a592bd0316",
+        "x-ms-correlation-request-id": "dc0e0b90-a9d2-452e-b6bc-0ae65ef8d04f",
+        "x-ms-ratelimit-remaining-subscription-reads": "11959",
+        "x-ms-request-id": "17576cff-62c4-411b-ad48-60de9c676674_M11SN1_M11SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144528Z:dc0e0b90-a9d2-452e-b6bc-0ae65ef8d04f"
       },
       "ResponseBody": {
         "sku": {
@@ -520,8 +480,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473",
+        "name": "testnamespacemgmt9473",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -532,21 +492,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9473",
+          "createdAt": "2022-06-29T14:45:09.18Z",
+          "updatedAt": "2022-06-29T14:45:09.18Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt9473.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8c3350d4f07a731c944783cf792eddde",
+        "traceparent": "00-258f6c5fb3ddd94da7120b69a6a4400b-34af2b8a86e99348-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "7279ed68858a0f4e4196b4037e58ff87",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -555,7 +516,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:07 GMT",
+        "Date": "Wed, 29 Jun 2022 14:45:33 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -565,11 +526,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8c3350d4f07a731c944783cf792eddde",
-        "x-ms-correlation-request-id": "34ed954f-7298-4f20-916c-71c5a05ab1ee",
-        "x-ms-ratelimit-remaining-subscription-reads": "11815",
-        "x-ms-request-id": "975af85e-9fd1-4f36-be1e-aeb7347d982d_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064908Z:34ed954f-7298-4f20-916c-71c5a05ab1ee"
+        "x-ms-client-request-id": "7279ed68858a0f4e4196b4037e58ff87",
+        "x-ms-correlation-request-id": "d12c2797-154f-4fcf-8fbb-5d81f8021fb6",
+        "x-ms-ratelimit-remaining-subscription-reads": "11958",
+        "x-ms-request-id": "3a6bc6d1-9246-4ccf-a684-f991896d48cb_M9SN1_M9SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144534Z:d12c2797-154f-4fcf-8fbb-5d81f8021fb6"
       },
       "ResponseBody": {
         "sku": {
@@ -577,8 +538,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473",
+        "name": "testnamespacemgmt9473",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -589,21 +550,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9473",
+          "createdAt": "2022-06-29T14:45:09.18Z",
+          "updatedAt": "2022-06-29T14:45:09.18Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt9473.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "87c5c4263b2567644c98bf83b3692fbe",
+        "traceparent": "00-258f6c5fb3ddd94da7120b69a6a4400b-21cd0bee1274cd4f-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "51d12228437a249c26897427eda5351f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -612,7 +574,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:09 GMT",
+        "Date": "Wed, 29 Jun 2022 14:45:45 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -622,11 +584,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "87c5c4263b2567644c98bf83b3692fbe",
-        "x-ms-correlation-request-id": "4a47455c-e393-47f6-a8dd-aac055035bca",
-        "x-ms-ratelimit-remaining-subscription-reads": "11814",
-        "x-ms-request-id": "ea132886-dec3-4b86-a57c-68dc3b9302bb_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064909Z:4a47455c-e393-47f6-a8dd-aac055035bca"
+        "x-ms-client-request-id": "51d12228437a249c26897427eda5351f",
+        "x-ms-correlation-request-id": "0ab1ff35-b92f-4a46-ad7b-3a21d4d272cd",
+        "x-ms-ratelimit-remaining-subscription-reads": "11957",
+        "x-ms-request-id": "c70ea08e-34d8-4e26-bb89-17ab0cfae065_M3SN1_M3SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144546Z:0ab1ff35-b92f-4a46-ad7b-3a21d4d272cd"
       },
       "ResponseBody": {
         "sku": {
@@ -634,8 +596,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473",
+        "name": "testnamespacemgmt9473",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -646,87 +608,31 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9473",
+          "createdAt": "2022-06-29T14:45:09.18Z",
+          "updatedAt": "2022-06-29T14:45:09.18Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt9473.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1536c8c7c06a1a4a06d7b860fa54ad00",
+        "traceparent": "00-258f6c5fb3ddd94da7120b69a6a4400b-fdfd7a1b0f2fb84c-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ce131ad5ddfedf99ef5a86a8c8e8ba3b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "736",
+        "Content-Length": "735",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:10 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "1536c8c7c06a1a4a06d7b860fa54ad00",
-        "x-ms-correlation-request-id": "cea1fc74-37d1-4aaf-816d-1ff4c85ff33b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11813",
-        "x-ms-request-id": "83aa0cdc-8960-4931-a98c-bebd5d9c1bda_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064910Z:cea1fc74-37d1-4aaf-816d-1ff4c85ff33b"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "eef28c685d0f98eaeccc40e23198bf2b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:12 GMT",
+        "Date": "Wed, 29 Jun 2022 14:46:02 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -736,11 +642,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "eef28c685d0f98eaeccc40e23198bf2b",
-        "x-ms-correlation-request-id": "d5fdc205-1567-4553-9abd-6992c1de8b3f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11812",
-        "x-ms-request-id": "8be2d36c-3baf-4b22-8238-440dad382442_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064912Z:d5fdc205-1567-4553-9abd-6992c1de8b3f"
+        "x-ms-client-request-id": "ce131ad5ddfedf99ef5a86a8c8e8ba3b",
+        "x-ms-correlation-request-id": "a718700e-dd70-4798-b296-822025e85866",
+        "x-ms-ratelimit-remaining-subscription-reads": "11956",
+        "x-ms-request-id": "6ae1ac42-33f1-41ff-b3f7-5e50ae807411_M1SN1_M1SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144602Z:a718700e-dd70-4798-b296-822025e85866"
       },
       "ResponseBody": {
         "sku": {
@@ -748,1206 +654,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b107c418c7f866737aaa814d83046cf7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:13 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "b107c418c7f866737aaa814d83046cf7",
-        "x-ms-correlation-request-id": "9f89a0ca-a42c-44e5-b457-95aab9537045",
-        "x-ms-ratelimit-remaining-subscription-reads": "11811",
-        "x-ms-request-id": "4845b4c7-a88a-4d99-ad98-f5bb9b02bacc_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064913Z:9f89a0ca-a42c-44e5-b457-95aab9537045"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "271bbeea407669afde9d299e7f68e96d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:14 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "271bbeea407669afde9d299e7f68e96d",
-        "x-ms-correlation-request-id": "a7cc69d2-ab4c-49ff-be0d-72aa3d4bab07",
-        "x-ms-ratelimit-remaining-subscription-reads": "11810",
-        "x-ms-request-id": "aa05e9d4-3701-41ad-b531-1060d87348b7_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064915Z:a7cc69d2-ab4c-49ff-be0d-72aa3d4bab07"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "36488d18fc4ca008188c7464db9c15e7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:16 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "36488d18fc4ca008188c7464db9c15e7",
-        "x-ms-correlation-request-id": "35c5e3cf-1f25-4984-bcb4-3d7f965e08b1",
-        "x-ms-ratelimit-remaining-subscription-reads": "11809",
-        "x-ms-request-id": "3ff37a09-f8d5-43f8-a276-86035ed99e30_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064916Z:35c5e3cf-1f25-4984-bcb4-3d7f965e08b1"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "72f7495f977dd7b4159dd25a9ed5e612",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:17 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "72f7495f977dd7b4159dd25a9ed5e612",
-        "x-ms-correlation-request-id": "3f376856-1ff5-49fd-aa24-8e3b6971b0e1",
-        "x-ms-ratelimit-remaining-subscription-reads": "11808",
-        "x-ms-request-id": "ce9eca29-b807-4c5b-911e-f8d3db286ca1_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064917Z:3f376856-1ff5-49fd-aa24-8e3b6971b0e1"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f53514c136bbedaab67a0eeacc4a8e41",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:18 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f53514c136bbedaab67a0eeacc4a8e41",
-        "x-ms-correlation-request-id": "5a2a335b-cfcb-4d3f-866e-ec1ff1ad5b3f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11807",
-        "x-ms-request-id": "92762658-6d59-490a-a5a1-292b670a58ac_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064919Z:5a2a335b-cfcb-4d3f-866e-ec1ff1ad5b3f"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "363e4187767080efd87021ae29ad0143",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:20 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "363e4187767080efd87021ae29ad0143",
-        "x-ms-correlation-request-id": "b761c40b-cf27-41ef-9032-6331cb84b257",
-        "x-ms-ratelimit-remaining-subscription-reads": "11806",
-        "x-ms-request-id": "86a88dbf-ed75-4434-9671-0c326828df41_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064920Z:b761c40b-cf27-41ef-9032-6331cb84b257"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c7a361a51f67292c9e0abc0388ca0bca",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:21 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c7a361a51f67292c9e0abc0388ca0bca",
-        "x-ms-correlation-request-id": "14c13907-c033-460f-9566-124952601288",
-        "x-ms-ratelimit-remaining-subscription-reads": "11805",
-        "x-ms-request-id": "402df7fd-7f15-4f55-bae7-66c5e8991412_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064921Z:14c13907-c033-460f-9566-124952601288"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5dd2910fb0964ba224b41d4b15fbc308",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:22 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5dd2910fb0964ba224b41d4b15fbc308",
-        "x-ms-correlation-request-id": "57038394-a926-498f-922b-4ec8b1887a0c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11804",
-        "x-ms-request-id": "b1901611-b397-4d95-b6ae-bb4eba3f0d6f_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064923Z:57038394-a926-498f-922b-4ec8b1887a0c"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6a44cb79c6a767da15159765baecf70e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:24 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "6a44cb79c6a767da15159765baecf70e",
-        "x-ms-correlation-request-id": "2f11c78f-5f1b-48e5-842c-dacbdadb0d0f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11803",
-        "x-ms-request-id": "fd1a2054-acb0-4080-953f-56572fee80f9_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064924Z:2f11c78f-5f1b-48e5-842c-dacbdadb0d0f"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "989f5665a4dbf5adbe58a2b302e113a3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:25 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "989f5665a4dbf5adbe58a2b302e113a3",
-        "x-ms-correlation-request-id": "13027f52-e7a8-4c2e-ba7b-83dbe0abb8de",
-        "x-ms-ratelimit-remaining-subscription-reads": "11802",
-        "x-ms-request-id": "a86b1607-9162-4507-81d7-00ed1919f9e3_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064925Z:13027f52-e7a8-4c2e-ba7b-83dbe0abb8de"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bd89b347a0854823b66a4780183d9038",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Connection": "close",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:26 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "bd89b347a0854823b66a4780183d9038",
-        "x-ms-correlation-request-id": "73c0e419-967a-4e80-bac4-790f31771a41",
-        "x-ms-ratelimit-remaining-subscription-reads": "11801",
-        "x-ms-request-id": "4930d7e5-7ab2-4cda-9216-758135af25c3_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064927Z:73c0e419-967a-4e80-bac4-790f31771a41"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bee50fbc2a5cd52d1d4eab4e24276534",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:28 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "bee50fbc2a5cd52d1d4eab4e24276534",
-        "x-ms-correlation-request-id": "a0990ede-6c94-41b6-b444-ee481203e099",
-        "x-ms-ratelimit-remaining-subscription-reads": "11997",
-        "x-ms-request-id": "64387b77-cb59-45c9-b2cb-25772d4edb59_M1SN1_M1SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064929Z:a0990ede-6c94-41b6-b444-ee481203e099"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "071ef4023a62c5883256e1705c2cdd81",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:30 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "071ef4023a62c5883256e1705c2cdd81",
-        "x-ms-correlation-request-id": "b3a11cca-c346-4d82-a60e-db949e768853",
-        "x-ms-ratelimit-remaining-subscription-reads": "11996",
-        "x-ms-request-id": "34d79ae0-82d3-48b8-bbf7-eb04a8f0a9a1_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064931Z:b3a11cca-c346-4d82-a60e-db949e768853"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f3f769c754fb1c4785b49f37f4d4248f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:33 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f3f769c754fb1c4785b49f37f4d4248f",
-        "x-ms-correlation-request-id": "017dfe46-d237-4e93-bf34-ab4d1be51e63",
-        "x-ms-ratelimit-remaining-subscription-reads": "11995",
-        "x-ms-request-id": "c876e86a-7729-4e3c-8f4a-1317d4d1df77_M11SN1_M11SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064934Z:017dfe46-d237-4e93-bf34-ab4d1be51e63"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "247e1305891e81d5871f8c0549bd78f1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:34 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "247e1305891e81d5871f8c0549bd78f1",
-        "x-ms-correlation-request-id": "9cc420e3-e822-4583-97f2-4dc98107d844",
-        "x-ms-ratelimit-remaining-subscription-reads": "11994",
-        "x-ms-request-id": "baeab596-3c7c-4063-bf13-1af3c6279916_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064935Z:9cc420e3-e822-4583-97f2-4dc98107d844"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ba872a71712fad38ac0181ae9a51d15d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:36 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "ba872a71712fad38ac0181ae9a51d15d",
-        "x-ms-correlation-request-id": "e2093310-b9f0-43d2-b9b4-b39675763d36",
-        "x-ms-ratelimit-remaining-subscription-reads": "11993",
-        "x-ms-request-id": "5c42782f-0a2c-47ff-80d4-eafd65c98db2_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064937Z:e2093310-b9f0-43d2-b9b4-b39675763d36"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "496a5132b9ae3d6294756cdcc841d2c8",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:39 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "496a5132b9ae3d6294756cdcc841d2c8",
-        "x-ms-correlation-request-id": "c188a4db-c03e-4dba-bf46-92962e6518ce",
-        "x-ms-ratelimit-remaining-subscription-reads": "11992",
-        "x-ms-request-id": "2a59354f-dcbc-4cd6-ab2a-82260cf58847_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064939Z:c188a4db-c03e-4dba-bf46-92962e6518ce"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c9c5ae3b694d945fdad1771c0827e735",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:41 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c9c5ae3b694d945fdad1771c0827e735",
-        "x-ms-correlation-request-id": "04934fe8-d2e8-4732-8867-fd1633b1bb17",
-        "x-ms-ratelimit-remaining-subscription-reads": "11991",
-        "x-ms-request-id": "d8640e70-c9a3-461f-bd38-95a8d5304d50_M0SN1_M0SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064941Z:04934fe8-d2e8-4732-8867-fd1633b1bb17"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f7d32e4e2f53b843c74926ba045ce56b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:43 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f7d32e4e2f53b843c74926ba045ce56b",
-        "x-ms-correlation-request-id": "30e7c22f-1394-4e9a-a084-e0210ea134b2",
-        "x-ms-ratelimit-remaining-subscription-reads": "11990",
-        "x-ms-request-id": "76f40b12-bc7f-4147-a269-b492f5108c94_M1SN1_M1SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064943Z:30e7c22f-1394-4e9a-a084-e0210ea134b2"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "eb72b92f078bc810f1d66edd4145356c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:45 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "eb72b92f078bc810f1d66edd4145356c",
-        "x-ms-correlation-request-id": "9ae715db-2387-4f6c-ae03-dc3002d0dc7e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11989",
-        "x-ms-request-id": "ea8ffdcd-bb53-464c-859d-d6d1885b4951_M1SN1_M1SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064945Z:9ae715db-2387-4f6c-ae03-dc3002d0dc7e"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:48:57.15Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "998d368ddb6e0c746b0c020343a58f7e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "734",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:47 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "998d368ddb6e0c746b0c020343a58f7e",
-        "x-ms-correlation-request-id": "4f1cf787-2f2e-427d-a7dc-9e1a8331ee79",
-        "x-ms-ratelimit-remaining-subscription-reads": "11988",
-        "x-ms-request-id": "25d7984f-7ca9-4879-a97f-72355510d0d0_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064947Z:4f1cf787-2f2e-427d-a7dc-9e1a8331ee79"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473",
+        "name": "testnamespacemgmt9473",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -1958,24 +666,25 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:49:45.64Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt9473",
+          "createdAt": "2022-06-29T14:45:09.18Z",
+          "updatedAt": "2022-06-29T14:45:56.737Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt9473.servicebus.windows.net:443/",
           "status": "Active"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/virtualNetworks/vnet-8533?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.Network/virtualNetworks/vnet-4925?api-version=2021-02-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "261",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.Network/1.0.0-beta.3 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b44eed0caafb1e460b057cc166768113",
+        "traceparent": "00-01c6b8a765a73f4b989968bfc4cf7808-5bc6814e340a734b-00",
+        "User-Agent": "azsdk-net-ResourceManager.Network/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "eb707c189bb25124544c011126219c60",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -2006,11 +715,11 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Azure-AsyncNotification": "Enabled",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/43082609-1ae5-4581-8c11-ac90315b2bae?api-version=2021-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/316a9723-183c-49da-ac15-cc72401c6725?api-version=2021-02-01",
         "Cache-Control": "no-cache",
         "Content-Length": "1339",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:54 GMT",
+        "Date": "Wed, 29 Jun 2022 14:46:07 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "3",
@@ -2020,100 +729,61 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "30e4f16d-8628-4710-92eb-adaac09a58d7",
-        "x-ms-client-request-id": "b44eed0caafb1e460b057cc166768113",
-        "x-ms-correlation-request-id": "a1d873d1-bac1-469b-90ac-d49755527329",
-        "x-ms-ratelimit-remaining-subscription-writes": "1199",
-        "x-ms-request-id": "43082609-1ae5-4581-8c11-ac90315b2bae",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064954Z:a1d873d1-bac1-469b-90ac-d49755527329"
+        "x-ms-arm-service-request-id": "9524257c-4c68-4dc1-b952-fd70b821fc65",
+        "x-ms-client-request-id": "eb707c189bb25124544c011126219c60",
+        "x-ms-correlation-request-id": "6653a2f5-33e4-4e81-832d-211e306ee441",
+        "x-ms-ratelimit-remaining-subscription-writes": "1195",
+        "x-ms-request-id": "316a9723-183c-49da-ac15-cc72401c6725",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144607Z:6653a2f5-33e4-4e81-832d-211e306ee441"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022name\u0022: \u0022vnet-8533\u0022,\r\n",
-        "  \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/virtualNetworks/vnet-8533\u0022,\r\n",
-        "  \u0022etag\u0022: \u0022W/\\\u002208a08f41-8f34-4227-8e63-13912349b2e9\\\u0022\u0022,\r\n",
-        "  \u0022type\u0022: \u0022Microsoft.Network/virtualNetworks\u0022,\r\n",
-        "  \u0022location\u0022: \u0022westus2\u0022,\r\n",
-        "  \u0022properties\u0022: {\r\n",
-        "    \u0022provisioningState\u0022: \u0022Updating\u0022,\r\n",
-        "    \u0022resourceGuid\u0022: \u0022bb9467f6-6b61-49a3-9d62-d1c5d07b420e\u0022,\r\n",
-        "    \u0022addressSpace\u0022: {\r\n",
-        "      \u0022addressPrefixes\u0022: [\r\n",
-        "        \u002210.0.0.0/16\u0022\r\n",
-        "      ]\r\n",
-        "    },\r\n",
-        "    \u0022dhcpOptions\u0022: {\r\n",
-        "      \u0022dnsServers\u0022: [\r\n",
-        "        \u002210.1.1.1\u0022,\r\n",
-        "        \u002210.1.2.4\u0022\r\n",
-        "      ]\r\n",
-        "    },\r\n",
-        "    \u0022subnets\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022name\u0022: \u0022default\u0022,\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/virtualNetworks/vnet-8533/subnets/default\u0022,\r\n",
-        "        \u0022etag\u0022: \u0022W/\\\u002208a08f41-8f34-4227-8e63-13912349b2e9\\\u0022\u0022,\r\n",
-        "        \u0022properties\u0022: {\r\n",
-        "          \u0022provisioningState\u0022: \u0022Updating\u0022,\r\n",
-        "          \u0022addressPrefix\u0022: \u002210.0.1.0/24\u0022,\r\n",
-        "          \u0022delegations\u0022: [],\r\n",
-        "          \u0022privateEndpointNetworkPolicies\u0022: \u0022Disabled\u0022,\r\n",
-        "          \u0022privateLinkServiceNetworkPolicies\u0022: \u0022Enabled\u0022\r\n",
-        "        },\r\n",
-        "        \u0022type\u0022: \u0022Microsoft.Network/virtualNetworks/subnets\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022virtualNetworkPeerings\u0022: [],\r\n",
-        "    \u0022enableDdosProtection\u0022: false\r\n",
-        "  }\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "name": "vnet-4925",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.Network/virtualNetworks/vnet-4925",
+        "etag": "W/\u0022e6768a84-198d-4b96-9300-3d7ed3f3773e\u0022",
+        "type": "Microsoft.Network/virtualNetworks",
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Updating",
+          "resourceGuid": "ed9b309d-c868-4222-b7d8-decce5424240",
+          "addressSpace": {
+            "addressPrefixes": [
+              "10.0.0.0/16"
+            ]
+          },
+          "dhcpOptions": {
+            "dnsServers": [
+              "10.1.1.1",
+              "10.1.2.4"
+            ]
+          },
+          "subnets": [
+            {
+              "name": "default",
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.Network/virtualNetworks/vnet-4925/subnets/default",
+              "etag": "W/\u0022e6768a84-198d-4b96-9300-3d7ed3f3773e\u0022",
+              "properties": {
+                "provisioningState": "Updating",
+                "addressPrefix": "10.0.1.0/24",
+                "delegations": [],
+                "privateEndpointNetworkPolicies": "Disabled",
+                "privateLinkServiceNetworkPolicies": "Enabled"
+              },
+              "type": "Microsoft.Network/virtualNetworks/subnets"
+            }
+          ],
+          "virtualNetworkPeerings": [],
+          "enableDdosProtection": false
+        }
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/43082609-1ae5-4581-8c11-ac90315b2bae?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/316a9723-183c-49da-ac15-cc72401c6725?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5835f1f0b8e78c91477b63d5f84b0595",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:54 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "10",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "bba99987-cb0a-4abc-bda3-f9bd7044d019",
-        "x-ms-client-request-id": "5835f1f0b8e78c91477b63d5f84b0595",
-        "x-ms-correlation-request-id": "9d286fdf-f64f-478b-8695-994d37de6ab3",
-        "x-ms-ratelimit-remaining-subscription-reads": "11987",
-        "x-ms-request-id": "a372c0a5-04d8-453f-af6a-0418d4f73fc2",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064955Z:9d286fdf-f64f-478b-8695-994d37de6ab3"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/43082609-1ae5-4581-8c11-ac90315b2bae?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "778af081afc00fa09a0a4e7a2a411286",
+        "traceparent": "00-01c6b8a765a73f4b989968bfc4cf7808-9ab64ee9cde6bb45-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "28d51d3834c57f23ee7ca99098cec938",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -2122,7 +792,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "29",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:56 GMT",
+        "Date": "Wed, 29 Jun 2022 14:46:07 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -2131,26 +801,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "260e559b-1072-40c7-b784-1a43b7ee456b",
-        "x-ms-client-request-id": "778af081afc00fa09a0a4e7a2a411286",
-        "x-ms-correlation-request-id": "f69a84d6-18b7-4f09-85a0-d5074e53895b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11986",
-        "x-ms-request-id": "9dc21149-5a7c-4bff-b477-d9f862753560",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064956Z:f69a84d6-18b7-4f09-85a0-d5074e53895b"
+        "x-ms-arm-service-request-id": "1682efea-cf99-40b8-bf89-2c65dac945d6",
+        "x-ms-client-request-id": "28d51d3834c57f23ee7ca99098cec938",
+        "x-ms-correlation-request-id": "4d9dc8fa-4cfb-471e-8ecb-6e3b88162742",
+        "x-ms-ratelimit-remaining-subscription-reads": "11955",
+        "x-ms-request-id": "6f60a6e3-2927-4534-91a3-09cd5f2177cf",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144607Z:4d9dc8fa-4cfb-471e-8ecb-6e3b88162742"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022Succeeded\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "Succeeded"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/virtualNetworks/vnet-8533?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.Network/virtualNetworks/vnet-4925?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "74d036b82941012c9b4287d0997e4c1a",
+        "traceparent": "00-01c6b8a765a73f4b989968bfc4cf7808-5a959ca838f4524d-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ba3348e9f6568fd731e8f9507b675ef8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -2159,8 +828,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1341",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:49:56 GMT",
-        "ETag": "W/\u00227755ef30-b353-4914-b484-0363008d0160\u0022",
+        "Date": "Wed, 29 Jun 2022 14:46:08 GMT",
+        "ETag": "W/\u0022273edb37-685b-4b4c-97b4-88ab573ffdb8\u0022",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -2169,74 +838,73 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "234ca405-d592-496e-a828-0630fd89003a",
-        "x-ms-client-request-id": "74d036b82941012c9b4287d0997e4c1a",
-        "x-ms-correlation-request-id": "f39a078f-64d0-452a-b0be-cb33b5f189b9",
-        "x-ms-ratelimit-remaining-subscription-reads": "11985",
-        "x-ms-request-id": "59c1b613-d31c-40e0-9cf8-1d8d711e5eae",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T064956Z:f39a078f-64d0-452a-b0be-cb33b5f189b9"
+        "x-ms-arm-service-request-id": "01e27dc8-9115-4ec4-b868-bff197533baa",
+        "x-ms-client-request-id": "ba3348e9f6568fd731e8f9507b675ef8",
+        "x-ms-correlation-request-id": "6fa047aa-b261-4879-b517-543cbad6e8a5",
+        "x-ms-ratelimit-remaining-subscription-reads": "11954",
+        "x-ms-request-id": "bda63031-9348-41e6-a9fe-95caf27ffdab",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144608Z:6fa047aa-b261-4879-b517-543cbad6e8a5"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022name\u0022: \u0022vnet-8533\u0022,\r\n",
-        "  \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/virtualNetworks/vnet-8533\u0022,\r\n",
-        "  \u0022etag\u0022: \u0022W/\\\u00227755ef30-b353-4914-b484-0363008d0160\\\u0022\u0022,\r\n",
-        "  \u0022type\u0022: \u0022Microsoft.Network/virtualNetworks\u0022,\r\n",
-        "  \u0022location\u0022: \u0022westus2\u0022,\r\n",
-        "  \u0022properties\u0022: {\r\n",
-        "    \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "    \u0022resourceGuid\u0022: \u0022bb9467f6-6b61-49a3-9d62-d1c5d07b420e\u0022,\r\n",
-        "    \u0022addressSpace\u0022: {\r\n",
-        "      \u0022addressPrefixes\u0022: [\r\n",
-        "        \u002210.0.0.0/16\u0022\r\n",
-        "      ]\r\n",
-        "    },\r\n",
-        "    \u0022dhcpOptions\u0022: {\r\n",
-        "      \u0022dnsServers\u0022: [\r\n",
-        "        \u002210.1.1.1\u0022,\r\n",
-        "        \u002210.1.2.4\u0022\r\n",
-        "      ]\r\n",
-        "    },\r\n",
-        "    \u0022subnets\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022name\u0022: \u0022default\u0022,\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/virtualNetworks/vnet-8533/subnets/default\u0022,\r\n",
-        "        \u0022etag\u0022: \u0022W/\\\u00227755ef30-b353-4914-b484-0363008d0160\\\u0022\u0022,\r\n",
-        "        \u0022properties\u0022: {\r\n",
-        "          \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "          \u0022addressPrefix\u0022: \u002210.0.1.0/24\u0022,\r\n",
-        "          \u0022delegations\u0022: [],\r\n",
-        "          \u0022privateEndpointNetworkPolicies\u0022: \u0022Disabled\u0022,\r\n",
-        "          \u0022privateLinkServiceNetworkPolicies\u0022: \u0022Enabled\u0022\r\n",
-        "        },\r\n",
-        "        \u0022type\u0022: \u0022Microsoft.Network/virtualNetworks/subnets\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022virtualNetworkPeerings\u0022: [],\r\n",
-        "    \u0022enableDdosProtection\u0022: false\r\n",
-        "  }\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "name": "vnet-4925",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.Network/virtualNetworks/vnet-4925",
+        "etag": "W/\u0022273edb37-685b-4b4c-97b4-88ab573ffdb8\u0022",
+        "type": "Microsoft.Network/virtualNetworks",
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "resourceGuid": "ed9b309d-c868-4222-b7d8-decce5424240",
+          "addressSpace": {
+            "addressPrefixes": [
+              "10.0.0.0/16"
+            ]
+          },
+          "dhcpOptions": {
+            "dnsServers": [
+              "10.1.1.1",
+              "10.1.2.4"
+            ]
+          },
+          "subnets": [
+            {
+              "name": "default",
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.Network/virtualNetworks/vnet-4925/subnets/default",
+              "etag": "W/\u0022273edb37-685b-4b4c-97b4-88ab573ffdb8\u0022",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "addressPrefix": "10.0.1.0/24",
+                "delegations": [],
+                "privateEndpointNetworkPolicies": "Disabled",
+                "privateLinkServiceNetworkPolicies": "Enabled"
+              },
+              "type": "Microsoft.Network/virtualNetworks/subnets"
+            }
+          ],
+          "virtualNetworkPeerings": [],
+          "enableDdosProtection": false
+        }
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/privateEndpoints/pe-6925?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.Network/privateEndpoints/pe-223?api-version=2021-02-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "733",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-ResourceManager.Network/1.0.0-beta.3 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d5fa1c8340852650bddd6917610568dc",
+        "traceparent": "00-ae28c2aa7f7b04489127c44fffaeed2e-cc8b8723affa6f44-00",
+        "User-Agent": "azsdk-net-ResourceManager.Network/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "734c08d9609be40956b4dfbaef2398e7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "location": "westus2",
         "properties": {
           "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.Network/virtualNetworks/vnet-4925/subnets/default",
             "name": "default",
             "type": "Microsoft.Network/virtualNetworks/subnets",
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/virtualNetworks/vnet-8533/subnets/default",
             "properties": {
               "addressPrefix": "10.0.1.0/24",
               "delegations": [],
@@ -2246,9 +914,9 @@
           },
           "manualPrivateLinkServiceConnections": [
             {
-              "name": "pec3957",
+              "name": "pec4236",
               "properties": {
-                "privateLinkServiceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
+                "privateLinkServiceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473",
                 "groupIds": [
                   "namespace"
                 ],
@@ -2261,11 +929,11 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Azure-AsyncNotification": "Enabled",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/9a3abe73-bf11-4467-9744-a7ff90fa6e94?api-version=2021-02-01",
         "Cache-Control": "no-cache",
-        "Content-Length": "1958",
+        "Content-Length": "1954",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:01 GMT",
+        "Date": "Wed, 29 Jun 2022 14:46:11 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
@@ -2275,65 +943,64 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "a4998e86-0d69-4914-a437-f17cee695e6c",
-        "x-ms-client-request-id": "d5fa1c8340852650bddd6917610568dc",
-        "x-ms-correlation-request-id": "e16d07d4-5acf-4a5d-9634-2689c15ee1a5",
-        "x-ms-ratelimit-remaining-subscription-writes": "1198",
-        "x-ms-request-id": "0413e045-d9a8-4900-93a5-a8a480df5088",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065001Z:e16d07d4-5acf-4a5d-9634-2689c15ee1a5"
+        "x-ms-arm-service-request-id": "7c227cbe-dbbd-40e1-b863-601e310c2d40",
+        "x-ms-client-request-id": "734c08d9609be40956b4dfbaef2398e7",
+        "x-ms-correlation-request-id": "0f0a264f-27d7-4b54-90b1-8862baf5bcd9",
+        "x-ms-ratelimit-remaining-subscription-writes": "1194",
+        "x-ms-request-id": "9a3abe73-bf11-4467-9744-a7ff90fa6e94",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144612Z:0f0a264f-27d7-4b54-90b1-8862baf5bcd9"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022name\u0022: \u0022pe-6925\u0022,\r\n",
-        "  \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/privateEndpoints/pe-6925\u0022,\r\n",
-        "  \u0022etag\u0022: \u0022W/\\\u002262066f74-b4f1-4cb6-a0da-7ea269c5f67f\\\u0022\u0022,\r\n",
-        "  \u0022type\u0022: \u0022Microsoft.Network/privateEndpoints\u0022,\r\n",
-        "  \u0022location\u0022: \u0022westus2\u0022,\r\n",
-        "  \u0022properties\u0022: {\r\n",
-        "    \u0022provisioningState\u0022: \u0022Updating\u0022,\r\n",
-        "    \u0022resourceGuid\u0022: \u00220a6359ae-b1fd-4111-b04c-c209dedfff20\u0022,\r\n",
-        "    \u0022privateLinkServiceConnections\u0022: [],\r\n",
-        "    \u0022manualPrivateLinkServiceConnections\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022name\u0022: \u0022pec3957\u0022,\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/privateEndpoints/pe-6925/manualPrivateLinkServiceConnections/pec3957\u0022,\r\n",
-        "        \u0022etag\u0022: \u0022W/\\\u002262066f74-b4f1-4cb6-a0da-7ea269c5f67f\\\u0022\u0022,\r\n",
-        "        \u0022properties\u0022: {\r\n",
-        "          \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "          \u0022privateLinkServiceId\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393\u0022,\r\n",
-        "          \u0022groupIds\u0022: [\r\n",
-        "            \u0022namespace\u0022\r\n",
-        "          ],\r\n",
-        "          \u0022requestMessage\u0022: \u0022SDK test\u0022,\r\n",
-        "          \u0022privateLinkServiceConnectionState\u0022: {\r\n",
-        "            \u0022status\u0022: \u0022Pending\u0022,\r\n",
-        "            \u0022description\u0022: \u0022SDK test\u0022,\r\n",
-        "            \u0022actionsRequired\u0022: \u0022None\u0022\r\n",
-        "          }\r\n",
-        "        },\r\n",
-        "        \u0022type\u0022: \u0022Microsoft.Network/privateEndpoints/manualPrivateLinkServiceConnections\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022subnet\u0022: {\r\n",
-        "      \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/virtualNetworks/vnet-8533/subnets/default\u0022\r\n",
-        "    },\r\n",
-        "    \u0022networkInterfaces\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/networkInterfaces/pe-6925.nic.e1084ec0-726d-4f92-bca7-31d43bc07907\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022customDnsConfigs\u0022: []\r\n",
-        "  }\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "name": "pe-223",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.Network/privateEndpoints/pe-223",
+        "etag": "W/\u002205937a8e-bf8d-492c-878f-f1dcbe3c7829\u0022",
+        "type": "Microsoft.Network/privateEndpoints",
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Updating",
+          "resourceGuid": "18ba3065-3c42-4b93-83c1-9d899f602140",
+          "privateLinkServiceConnections": [],
+          "manualPrivateLinkServiceConnections": [
+            {
+              "name": "pec4236",
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.Network/privateEndpoints/pe-223/manualPrivateLinkServiceConnections/pec4236",
+              "etag": "W/\u002205937a8e-bf8d-492c-878f-f1dcbe3c7829\u0022",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateLinkServiceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473",
+                "groupIds": [
+                  "namespace"
+                ],
+                "requestMessage": "SDK test",
+                "privateLinkServiceConnectionState": {
+                  "status": "Pending",
+                  "description": "SDK test",
+                  "actionsRequired": "None"
+                }
+              },
+              "type": "Microsoft.Network/privateEndpoints/manualPrivateLinkServiceConnections"
+            }
+          ],
+          "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.Network/virtualNetworks/vnet-4925/subnets/default"
+          },
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.Network/networkInterfaces/pe-223.nic.d36f9ebb-666e-48a1-825f-5611281250aa"
+            }
+          ],
+          "customDnsConfigs": []
+        }
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/9a3abe73-bf11-4467-9744-a7ff90fa6e94?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f6be41ffe38c90b0241a6b4f9784e082",
+        "traceparent": "00-ae28c2aa7f7b04489127c44fffaeed2e-57c0135284f1ba49-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c0f4668176ecd3adb0719f22af77f8d5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -2342,7 +1009,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "30",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:01 GMT",
+        "Date": "Wed, 29 Jun 2022 14:46:12 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Retry-After": "10",
@@ -2352,1204 +1019,25 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "39509c47-7c2d-41e1-8f19-0e6995101b78",
-        "x-ms-client-request-id": "f6be41ffe38c90b0241a6b4f9784e082",
-        "x-ms-correlation-request-id": "2efdc962-1b82-4c80-8f37-ddea5f96a626",
-        "x-ms-ratelimit-remaining-subscription-reads": "11984",
-        "x-ms-request-id": "0cd55f21-f620-4279-86f6-5021fd980eb2",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065001Z:2efdc962-1b82-4c80-8f37-ddea5f96a626"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8a61bd68eba02b945870f8071981b1a2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:03 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "20",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "e43cc1be-22ef-4966-beaf-2f9951347f02",
-        "x-ms-client-request-id": "8a61bd68eba02b945870f8071981b1a2",
-        "x-ms-correlation-request-id": "c33ea2cb-51e3-43ca-a14f-a8bdd02126b9",
-        "x-ms-ratelimit-remaining-subscription-reads": "11983",
-        "x-ms-request-id": "2522b47c-0357-4229-9537-869275a137bd",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065003Z:c33ea2cb-51e3-43ca-a14f-a8bdd02126b9"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1f17351f7246385011ea6c3aec73f158",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:04 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "20",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "07bb514a-0e66-4b0c-8068-f59fd0bc41e8",
-        "x-ms-client-request-id": "1f17351f7246385011ea6c3aec73f158",
-        "x-ms-correlation-request-id": "6b476537-c2f5-4f5d-8b38-8916a51a167f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11982",
-        "x-ms-request-id": "49b6f3ed-4daa-4919-a547-42e6bd559a1a",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065004Z:6b476537-c2f5-4f5d-8b38-8916a51a167f"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b767a59e32ba1393ac939d1beba976a2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:05 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "40",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "62bff423-5fed-428e-905d-1c6aaff5d879",
-        "x-ms-client-request-id": "b767a59e32ba1393ac939d1beba976a2",
-        "x-ms-correlation-request-id": "abd4b461-7e1f-4fcd-8c52-daae7a97a5d5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11981",
-        "x-ms-request-id": "e3a2e99b-95e9-4f4c-99e7-9d7c5deb994b",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065005Z:abd4b461-7e1f-4fcd-8c52-daae7a97a5d5"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6230c969c06cf53b6c2978b67f5a3ee5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:06 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "40",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "fceac78c-4892-4281-81d4-98a294df6ac9",
-        "x-ms-client-request-id": "6230c969c06cf53b6c2978b67f5a3ee5",
-        "x-ms-correlation-request-id": "b659b8ae-413b-4308-a7bb-570112da7d92",
-        "x-ms-ratelimit-remaining-subscription-reads": "11980",
-        "x-ms-request-id": "30bb028e-a2c8-4e26-8ff8-d67df7591e73",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065007Z:b659b8ae-413b-4308-a7bb-570112da7d92"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7368a07ff919ece8a10473b3d4354d68",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:08 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "80",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "aac08829-573a-4712-aa6f-fdd76ba7c383",
-        "x-ms-client-request-id": "7368a07ff919ece8a10473b3d4354d68",
-        "x-ms-correlation-request-id": "599af8eb-6d61-49b0-9522-afd3e8dd901e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11979",
-        "x-ms-request-id": "1d2b6726-df20-4098-9c7e-a56198e41e35",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065008Z:599af8eb-6d61-49b0-9522-afd3e8dd901e"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "23d0c9738e43ddeb6a714b90b9dd9452",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:09 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "80",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "af7619a3-e338-4ed4-b0bd-9839f7d05c82",
-        "x-ms-client-request-id": "23d0c9738e43ddeb6a714b90b9dd9452",
-        "x-ms-correlation-request-id": "85debb11-0184-4dff-89f3-e8ab9d9ac3c5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11978",
-        "x-ms-request-id": "c28be928-f4a1-46e5-899e-f59b33faf080",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065009Z:85debb11-0184-4dff-89f3-e8ab9d9ac3c5"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4a9bb85402406f89e143c1684d872137",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:10 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "160",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "6274bfaf-ffb8-481b-8514-f79e0145c393",
-        "x-ms-client-request-id": "4a9bb85402406f89e143c1684d872137",
-        "x-ms-correlation-request-id": "e086742e-bb5d-4504-b7bd-87f84ed6d935",
-        "x-ms-ratelimit-remaining-subscription-reads": "11977",
-        "x-ms-request-id": "d0ab7440-5a9f-4591-95a4-d99966d9baf2",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065010Z:e086742e-bb5d-4504-b7bd-87f84ed6d935"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b64210db1a89f0a2b58b09a7ae5732c4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:11 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "160",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "ea0cd277-516c-485e-8171-1778d191d589",
-        "x-ms-client-request-id": "b64210db1a89f0a2b58b09a7ae5732c4",
-        "x-ms-correlation-request-id": "a292a9ba-5f6e-4f57-b775-68c86bfa858a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11976",
-        "x-ms-request-id": "7f34d1ef-ca0c-4acb-aa60-17f6f864eaf9",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065012Z:a292a9ba-5f6e-4f57-b775-68c86bfa858a"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1c5f2070029970283f6142ffcd8390e2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:13 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "73c6fdf1-b496-4097-a73d-d08964ad65b0",
-        "x-ms-client-request-id": "1c5f2070029970283f6142ffcd8390e2",
-        "x-ms-correlation-request-id": "f490ac1e-6f44-40b8-b516-4cc39fd87944",
-        "x-ms-ratelimit-remaining-subscription-reads": "11975",
-        "x-ms-request-id": "54b329b0-ef36-485b-be34-fb4eb8e65a70",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065013Z:f490ac1e-6f44-40b8-b516-4cc39fd87944"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a9b51350dd9a3ac816aa95b5f9e1c189",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:14 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "9a572321-6f9e-485c-9c0e-14a9c0de8ee4",
-        "x-ms-client-request-id": "a9b51350dd9a3ac816aa95b5f9e1c189",
-        "x-ms-correlation-request-id": "8b08b221-5e7d-44d1-b53d-1bf2605ec3ea",
-        "x-ms-ratelimit-remaining-subscription-reads": "11974",
-        "x-ms-request-id": "0e275107-15b0-4974-8a0d-0dd51ae28a66",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065014Z:8b08b221-5e7d-44d1-b53d-1bf2605ec3ea"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2cf8fc100528d89de7d27628d8a22331",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:15 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "cfd5a119-ca97-4b17-9931-ec1eebac728a",
-        "x-ms-client-request-id": "2cf8fc100528d89de7d27628d8a22331",
-        "x-ms-correlation-request-id": "699dedac-72fe-4a55-a8e0-dd15350a3b14",
-        "x-ms-ratelimit-remaining-subscription-reads": "11973",
-        "x-ms-request-id": "b0933fdb-6f7c-4427-8ba9-d9c77f79279c",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065016Z:699dedac-72fe-4a55-a8e0-dd15350a3b14"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9a5726fb89a2922a582505ee6d73775e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:17 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "ebdcc948-d1d0-4912-8add-c76060d8daf4",
-        "x-ms-client-request-id": "9a5726fb89a2922a582505ee6d73775e",
-        "x-ms-correlation-request-id": "43a498a4-56d6-4708-860b-9655889229a5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11972",
-        "x-ms-request-id": "b73ea049-60f3-41a8-a6f9-33cc2383f60b",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065017Z:43a498a4-56d6-4708-860b-9655889229a5"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d0eeb89f638b4aba76dcc1c867a06173",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:18 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "ebe4171b-50e6-4749-92ef-6c3f73a12513",
-        "x-ms-client-request-id": "d0eeb89f638b4aba76dcc1c867a06173",
-        "x-ms-correlation-request-id": "801e4686-e611-445e-9f3c-ba45d0372fca",
-        "x-ms-ratelimit-remaining-subscription-reads": "11971",
-        "x-ms-request-id": "dd948de0-201a-49f2-b315-cf519d7346b3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065018Z:801e4686-e611-445e-9f3c-ba45d0372fca"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d2b96387278a87e7d265d403ffae6b74",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:19 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "984e9819-e8a9-4ebe-bc85-469be019e6b1",
-        "x-ms-client-request-id": "d2b96387278a87e7d265d403ffae6b74",
-        "x-ms-correlation-request-id": "e38cc121-1351-4445-8be8-c623dc89aeeb",
-        "x-ms-ratelimit-remaining-subscription-reads": "11970",
-        "x-ms-request-id": "be7ab266-c012-42b6-b1db-861758301c50",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065020Z:e38cc121-1351-4445-8be8-c623dc89aeeb"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1f88185b52b497a66c0c24c6c7622bb7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:20 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "704b6075-fce2-4d52-a742-04d687837a5d",
-        "x-ms-client-request-id": "1f88185b52b497a66c0c24c6c7622bb7",
-        "x-ms-correlation-request-id": "cdc0169d-171e-47b7-8273-4dbaa011435f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11969",
-        "x-ms-request-id": "ec647c13-eb53-4ec1-916e-386b74f252ea",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065021Z:cdc0169d-171e-47b7-8273-4dbaa011435f"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0a6792c3a4b978d3d166fe258eb74bc7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:22 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "258cd8a0-c775-4d85-878c-f68bfc675128",
-        "x-ms-client-request-id": "0a6792c3a4b978d3d166fe258eb74bc7",
-        "x-ms-correlation-request-id": "700e792b-ccbc-4c4c-bae4-f6826e410d7d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11968",
-        "x-ms-request-id": "5cb2fa8c-3f92-4920-adad-caceef56f864",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065022Z:700e792b-ccbc-4c4c-bae4-f6826e410d7d"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4e6c4d71421734bfbc22667d0221c070",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:23 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "9d9bdbdc-c7f1-4774-9a2c-f979dd83307f",
-        "x-ms-client-request-id": "4e6c4d71421734bfbc22667d0221c070",
-        "x-ms-correlation-request-id": "e0529db7-0668-4f4e-b58b-feb69c061eb0",
-        "x-ms-ratelimit-remaining-subscription-reads": "11967",
-        "x-ms-request-id": "8858726c-06f5-4c22-a42e-962f4e24ce18",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065023Z:e0529db7-0668-4f4e-b58b-feb69c061eb0"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6c401d3a6046b6bb44104d4d548109b4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:24 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "f43fa083-e3db-46a8-a66f-774822b1b06c",
-        "x-ms-client-request-id": "6c401d3a6046b6bb44104d4d548109b4",
-        "x-ms-correlation-request-id": "bdbbd9ae-f82d-498d-962e-43e76a1688aa",
-        "x-ms-ratelimit-remaining-subscription-reads": "11966",
-        "x-ms-request-id": "36cf8976-7fc2-48ac-9f89-1b5feb21f411",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065025Z:bdbbd9ae-f82d-498d-962e-43e76a1688aa"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7a545cc1dcf5809fd3334d973d5675b0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:26 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "2c79e56b-39d4-47de-8728-448afaeb549d",
-        "x-ms-client-request-id": "7a545cc1dcf5809fd3334d973d5675b0",
-        "x-ms-correlation-request-id": "87232179-55b1-4144-898d-b2e91ef34c3a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11965",
-        "x-ms-request-id": "3342bfed-ef13-4592-9f65-4e39eda4caea",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065026Z:87232179-55b1-4144-898d-b2e91ef34c3a"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "71eb8da6de77108091b60a07f572df3b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:27 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "129bfca9-11c1-4660-a667-9ed842932d00",
-        "x-ms-client-request-id": "71eb8da6de77108091b60a07f572df3b",
-        "x-ms-correlation-request-id": "3e49fa60-397d-4660-8eb3-b34dc27d4362",
-        "x-ms-ratelimit-remaining-subscription-reads": "11964",
-        "x-ms-request-id": "024a8d3a-b3d3-40cc-81e4-fcc216e082ff",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065027Z:3e49fa60-397d-4660-8eb3-b34dc27d4362"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a5bbb11846cc5e7b7dbf9913132478ed",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:28 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "de46f5d0-15d0-46aa-ad9e-221bbb464fe7",
-        "x-ms-client-request-id": "a5bbb11846cc5e7b7dbf9913132478ed",
-        "x-ms-correlation-request-id": "d887b5c0-1a93-4103-81eb-cb28786cce7e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11963",
-        "x-ms-request-id": "0cf7bc9c-5928-4840-8b31-755b23cd1134",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065029Z:d887b5c0-1a93-4103-81eb-cb28786cce7e"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c7a69d9a9796e33ddc44e83ed1988a61",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:30 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "08fab563-2e00-4434-90f1-db39e0ce87a3",
-        "x-ms-client-request-id": "c7a69d9a9796e33ddc44e83ed1988a61",
-        "x-ms-correlation-request-id": "d0a8bf64-3f25-4a4a-85c3-54de6e9a6f68",
-        "x-ms-ratelimit-remaining-subscription-reads": "11962",
-        "x-ms-request-id": "71887866-f4cc-4211-a483-5412aa5283dc",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065030Z:d0a8bf64-3f25-4a4a-85c3-54de6e9a6f68"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8b7e1153cf9b60e3128df4b7446cfc6d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:31 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "395cff65-8af1-4617-ada9-bf7d0b902944",
-        "x-ms-client-request-id": "8b7e1153cf9b60e3128df4b7446cfc6d",
-        "x-ms-correlation-request-id": "d540139b-d776-4f96-8efe-4eb6c051df15",
-        "x-ms-ratelimit-remaining-subscription-reads": "11961",
-        "x-ms-request-id": "7b11ac5e-2276-493d-9ffe-8554bab64643",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065031Z:d540139b-d776-4f96-8efe-4eb6c051df15"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "586d1c3d18cb80a574d7c9875d3c8ce4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:32 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "fd02e11d-c5c5-4354-9340-f00e7c86d228",
-        "x-ms-client-request-id": "586d1c3d18cb80a574d7c9875d3c8ce4",
-        "x-ms-correlation-request-id": "7c8a4324-f923-4472-9df3-e77b4677aad2",
-        "x-ms-ratelimit-remaining-subscription-reads": "11960",
-        "x-ms-request-id": "6717593c-90af-450e-83b1-8b2d97b800e1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065033Z:7c8a4324-f923-4472-9df3-e77b4677aad2"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "01c03835eca6ca52b946b509a3869f6f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:33 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "6cec1771-e515-4794-a22b-c3fae9ce8bf6",
-        "x-ms-client-request-id": "01c03835eca6ca52b946b509a3869f6f",
-        "x-ms-correlation-request-id": "5f34042e-c914-4103-a0f5-c12c4a1e2f04",
-        "x-ms-ratelimit-remaining-subscription-reads": "11959",
-        "x-ms-request-id": "c430d784-ae28-4293-8d15-1489ff535c27",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065034Z:5f34042e-c914-4103-a0f5-c12c4a1e2f04"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b5017b48322b3b956cfd17c3065c03d5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:35 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "93d5922e-875c-4399-bc49-b2d6c09afe9d",
-        "x-ms-client-request-id": "b5017b48322b3b956cfd17c3065c03d5",
-        "x-ms-correlation-request-id": "802e1328-8549-425a-9569-dbfb41ecf234",
-        "x-ms-ratelimit-remaining-subscription-reads": "11958",
-        "x-ms-request-id": "aaf3dd11-ff22-4d21-a3ba-eb8b653b6719",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065035Z:802e1328-8549-425a-9569-dbfb41ecf234"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0c820f00fbac50c7caa29e85639cddee",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:36 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "2b776f72-684a-49a8-b1a0-b2ba3d086d9d",
-        "x-ms-client-request-id": "0c820f00fbac50c7caa29e85639cddee",
-        "x-ms-correlation-request-id": "cc85d712-8b59-485b-a8c9-d3387547edb2",
-        "x-ms-ratelimit-remaining-subscription-reads": "11957",
-        "x-ms-request-id": "5faded98-e42b-4585-aa1d-ba0a90960d1a",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065036Z:cc85d712-8b59-485b-a8c9-d3387547edb2"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e23f5938d73b02b9a28495a8d58ec35d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:37 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "8607883a-0aba-403a-99f7-282f4733467c",
-        "x-ms-client-request-id": "e23f5938d73b02b9a28495a8d58ec35d",
-        "x-ms-correlation-request-id": "a62d3ef2-31b7-473f-9e5e-5fae88a7bfba",
-        "x-ms-ratelimit-remaining-subscription-reads": "11956",
-        "x-ms-request-id": "508acb95-df4b-4c72-b5b8-5f7189b62ab1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065038Z:a62d3ef2-31b7-473f-9e5e-5fae88a7bfba"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9308df4393034dc3b3b0ea899410d8d0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:39 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "9902a1b7-0850-4378-9e18-156c1d71a930",
-        "x-ms-client-request-id": "9308df4393034dc3b3b0ea899410d8d0",
-        "x-ms-correlation-request-id": "ead3da78-0fc4-47be-9ea9-8df14ff73210",
-        "x-ms-ratelimit-remaining-subscription-reads": "11955",
-        "x-ms-request-id": "cb350749-983b-4de1-a137-07d6952f1ffb",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065039Z:ead3da78-0fc4-47be-9ea9-8df14ff73210"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ad8b291f201c299a567f6927661e7b3b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:40 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "d8b10933-0d22-41cc-accb-c7a33aaf1054",
-        "x-ms-client-request-id": "ad8b291f201c299a567f6927661e7b3b",
-        "x-ms-correlation-request-id": "bf8ef562-edfc-4bb2-9de7-a536b00fe212",
-        "x-ms-ratelimit-remaining-subscription-reads": "11954",
-        "x-ms-request-id": "4f302383-7f1f-42b6-a06e-a54920f395de",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065041Z:bf8ef562-edfc-4bb2-9de7-a536b00fe212"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "834141de4994a4ea96f22e8aec306e91",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:42 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "7dd0b0a2-3e29-49c1-bf22-079a654e27c4",
-        "x-ms-client-request-id": "834141de4994a4ea96f22e8aec306e91",
-        "x-ms-correlation-request-id": "672320d6-ce3e-4196-b01a-6a3b1e700c8b",
+        "x-ms-arm-service-request-id": "aa4192f6-39bd-4054-9ada-08b82af92cce",
+        "x-ms-client-request-id": "c0f4668176ecd3adb0719f22af77f8d5",
+        "x-ms-correlation-request-id": "45b98981-9e58-4e7d-a90b-4197fa514f78",
         "x-ms-ratelimit-remaining-subscription-reads": "11953",
-        "x-ms-request-id": "81586109-2a92-4a21-a376-e07f6b53e12e",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065042Z:672320d6-ce3e-4196-b01a-6a3b1e700c8b"
+        "x-ms-request-id": "bd324af0-79b7-4a15-8b7f-660441b84ae6",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144612Z:45b98981-9e58-4e7d-a90b-4197fa514f78"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "InProgress"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/9a3abe73-bf11-4467-9744-a7ff90fa6e94?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ac88c4ac1602224045de3d83299be695",
+        "traceparent": "00-ae28c2aa7f7b04489127c44fffaeed2e-c0c3cfb42a86cd49-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b39393b78ccf96bac2067dbd2536e1cf",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -3558,36 +1046,35 @@
         "Cache-Control": "no-cache",
         "Content-Length": "30",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:43 GMT",
+        "Date": "Wed, 29 Jun 2022 14:46:22 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "100",
+        "Retry-After": "20",
         "Server": [
           "Microsoft-HTTPAPI/2.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "a492ac46-323c-45ee-96ef-35c2b69ef1ee",
-        "x-ms-client-request-id": "ac88c4ac1602224045de3d83299be695",
-        "x-ms-correlation-request-id": "2de4ff44-998c-4a3a-b64e-b508a5b8f6f8",
+        "x-ms-arm-service-request-id": "7f0f992c-5b3f-468c-951f-47a02afe81f1",
+        "x-ms-client-request-id": "b39393b78ccf96bac2067dbd2536e1cf",
+        "x-ms-correlation-request-id": "9d3705e8-8fad-49d0-b487-acdc1fa50a4d",
         "x-ms-ratelimit-remaining-subscription-reads": "11952",
-        "x-ms-request-id": "bf8b7fac-4747-4c09-bbb3-f53877c13e7f",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065043Z:2de4ff44-998c-4a3a-b64e-b508a5b8f6f8"
+        "x-ms-request-id": "df3aa09c-9046-4373-abd3-2472a55bea28",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144622Z:9d3705e8-8fad-49d0-b487-acdc1fa50a4d"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "InProgress"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/9a3abe73-bf11-4467-9744-a7ff90fa6e94?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "52aaae3555cfd63b3ee6172af20f3d26",
+        "traceparent": "00-ae28c2aa7f7b04489127c44fffaeed2e-0a1e61fe5c9abb4d-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "89392d96d82e5dfafc55d206a323967f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -3596,36 +1083,35 @@
         "Cache-Control": "no-cache",
         "Content-Length": "30",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:44 GMT",
+        "Date": "Wed, 29 Jun 2022 14:46:42 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "100",
+        "Retry-After": "20",
         "Server": [
           "Microsoft-HTTPAPI/2.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "fccc3be1-c87f-407b-8218-56c17532b399",
-        "x-ms-client-request-id": "52aaae3555cfd63b3ee6172af20f3d26",
-        "x-ms-correlation-request-id": "12852e9b-6ff5-4d14-bb8a-335d4e3ae2be",
+        "x-ms-arm-service-request-id": "c6f8462f-0ca8-4f51-b70d-9c8324c3bfa9",
+        "x-ms-client-request-id": "89392d96d82e5dfafc55d206a323967f",
+        "x-ms-correlation-request-id": "ba88fd61-fb4c-44a1-82c7-d9b431c76786",
         "x-ms-ratelimit-remaining-subscription-reads": "11951",
-        "x-ms-request-id": "3039234c-687e-4f52-9caa-cccbfab4b548",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065045Z:12852e9b-6ff5-4d14-bb8a-335d4e3ae2be"
+        "x-ms-request-id": "b80b863f-6ef0-48e3-b37c-45a54cf0f9fd",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144643Z:ba88fd61-fb4c-44a1-82c7-d9b431c76786"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "InProgress"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/9a3abe73-bf11-4467-9744-a7ff90fa6e94?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a17bd811ce96c739001f3db50c667bfa",
+        "traceparent": "00-ae28c2aa7f7b04489127c44fffaeed2e-40631955e8d58744-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6f1c65e46bf3f5e2ab5efee6f8efad7a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -3634,302 +1120,35 @@
         "Cache-Control": "no-cache",
         "Content-Length": "30",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:46 GMT",
+        "Date": "Wed, 29 Jun 2022 14:47:02 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "Retry-After": "100",
+        "Retry-After": "40",
         "Server": [
           "Microsoft-HTTPAPI/2.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "27ee5f1c-7a4a-4882-b1e4-1e9f32b45291",
-        "x-ms-client-request-id": "a17bd811ce96c739001f3db50c667bfa",
-        "x-ms-correlation-request-id": "b56377d1-34fb-4d8a-b552-df0314be7ec4",
+        "x-ms-arm-service-request-id": "bb7c0ac1-0555-46c3-b0ca-8a85e38fbd82",
+        "x-ms-client-request-id": "6f1c65e46bf3f5e2ab5efee6f8efad7a",
+        "x-ms-correlation-request-id": "71c55043-37b1-480b-8db5-3964c1c26497",
         "x-ms-ratelimit-remaining-subscription-reads": "11950",
-        "x-ms-request-id": "243f1abf-e883-4f35-b0b3-dd8b8ddd71b2",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065046Z:b56377d1-34fb-4d8a-b552-df0314be7ec4"
+        "x-ms-request-id": "f510a603-2ba1-4229-bd11-50383989e62c",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144703Z:71c55043-37b1-480b-8db5-3964c1c26497"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "InProgress"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/9a3abe73-bf11-4467-9744-a7ff90fa6e94?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3d54990b1b8557c289b26d1bff162f35",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:47 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "39aba0bc-2e43-4867-ab35-7bab322f7d76",
-        "x-ms-client-request-id": "3d54990b1b8557c289b26d1bff162f35",
-        "x-ms-correlation-request-id": "b46af401-b6b7-47ea-b72b-b2d970e5b620",
-        "x-ms-ratelimit-remaining-subscription-reads": "11949",
-        "x-ms-request-id": "f0f3e816-7bca-43c8-8d7a-49791e23964d",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065048Z:b46af401-b6b7-47ea-b72b-b2d970e5b620"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "507216a1451f66ff75e251af1786c9d8",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:48 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "1760dbc1-edac-459a-b134-5f867d3cdfc3",
-        "x-ms-client-request-id": "507216a1451f66ff75e251af1786c9d8",
-        "x-ms-correlation-request-id": "24245bb2-5118-4d02-9122-07e7a8ed3062",
-        "x-ms-ratelimit-remaining-subscription-reads": "11948",
-        "x-ms-request-id": "8e11ef1d-4028-4b71-bae0-24a9e6dcb0e7",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065049Z:24245bb2-5118-4d02-9122-07e7a8ed3062"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "591e1c6bffbbf5a1162418e3611dc8ea",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:49 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "3160af91-cb22-4e8f-ac1d-fd92fd8b20c5",
-        "x-ms-client-request-id": "591e1c6bffbbf5a1162418e3611dc8ea",
-        "x-ms-correlation-request-id": "61d6c721-adba-4f11-9b2b-eff3f02b64f9",
-        "x-ms-ratelimit-remaining-subscription-reads": "11947",
-        "x-ms-request-id": "5b624292-5252-45a4-96b8-41ed970618f9",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065050Z:61d6c721-adba-4f11-9b2b-eff3f02b64f9"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f61407ef2af4c5db9aedc8a3c9123f02",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:51 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "b5fb2786-ee0a-43d0-91a5-af3c909ab2c9",
-        "x-ms-client-request-id": "f61407ef2af4c5db9aedc8a3c9123f02",
-        "x-ms-correlation-request-id": "db8f1588-cea5-4483-a2b6-3734f6955aae",
-        "x-ms-ratelimit-remaining-subscription-reads": "11946",
-        "x-ms-request-id": "98083968-58ff-488c-9a11-89029e101ffb",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065051Z:db8f1588-cea5-4483-a2b6-3734f6955aae"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e2b095e8d6f7a17a757c3afb2d1b0557",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:52 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "262c5fc4-2cee-4033-b458-9b0cfb941be8",
-        "x-ms-client-request-id": "e2b095e8d6f7a17a757c3afb2d1b0557",
-        "x-ms-correlation-request-id": "d56043ba-4363-499e-9e69-ce7aa91ff30e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11945",
-        "x-ms-request-id": "c99664cc-233f-4daf-93eb-515c4a763238",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065053Z:d56043ba-4363-499e-9e69-ce7aa91ff30e"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0fc06719d37140e44158bfcd37fd2b04",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:53 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "ab300cb0-cc2f-41a1-91b9-a2ba02ed5f04",
-        "x-ms-client-request-id": "0fc06719d37140e44158bfcd37fd2b04",
-        "x-ms-correlation-request-id": "2c7cda1e-267a-4eb4-a739-2185b1f87550",
-        "x-ms-ratelimit-remaining-subscription-reads": "11944",
-        "x-ms-request-id": "72b47fe2-2cbb-4acb-bc97-8b24b6017e14",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065054Z:2c7cda1e-267a-4eb4-a739-2185b1f87550"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ccfb15e4e56c18f38d728077f0df987e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "30",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:55 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "100",
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "bd6c1370-88b1-4235-a854-905f697cd0ec",
-        "x-ms-client-request-id": "ccfb15e4e56c18f38d728077f0df987e",
-        "x-ms-correlation-request-id": "9ddddd84-39f7-413c-9d22-4430e05e3dc3",
-        "x-ms-ratelimit-remaining-subscription-reads": "11943",
-        "x-ms-request-id": "ca081daa-f30a-4d3f-88b7-df17d10297c9",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065055Z:9ddddd84-39f7-413c-9d22-4430e05e3dc3"
-      },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022InProgress\u0022\r\n",
-        "}"
-      ]
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network/locations/westus2/operations/0413e045-d9a8-4900-93a5-a8a480df5088?api-version=2021-02-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "628970e82f511490b070a19e17ac6a77",
+        "traceparent": "00-ae28c2aa7f7b04489127c44fffaeed2e-919d50cfa0845843-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "828ccf906e3edfa69835b679bab3f39f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -3938,7 +1157,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "29",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:56 GMT",
+        "Date": "Wed, 29 Jun 2022 14:47:43 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -3947,36 +1166,35 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "45122719-79f6-44b7-8e43-378c228d0f9b",
-        "x-ms-client-request-id": "628970e82f511490b070a19e17ac6a77",
-        "x-ms-correlation-request-id": "2f8c4777-71f5-42f3-81dc-a575d34d027c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11942",
-        "x-ms-request-id": "c981fe05-921e-4881-a716-ee798ab0c628",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065056Z:2f8c4777-71f5-42f3-81dc-a575d34d027c"
+        "x-ms-arm-service-request-id": "e8d807c8-4306-4188-b0f8-5b1c988cb75b",
+        "x-ms-client-request-id": "828ccf906e3edfa69835b679bab3f39f",
+        "x-ms-correlation-request-id": "407f0d66-af26-4f14-aaa6-b9653a85e46a",
+        "x-ms-ratelimit-remaining-subscription-reads": "11949",
+        "x-ms-request-id": "8b7dd901-ab64-45a3-9b81-18ac6617f710",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144743Z:407f0d66-af26-4f14-aaa6-b9653a85e46a"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022status\u0022: \u0022Succeeded\u0022\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "status": "Succeeded"
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/privateEndpoints/pe-6925?api-version=2021-02-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.Network/privateEndpoints/pe-223?api-version=2021-02-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "18173650392034eb73a782ff536c4f61",
+        "traceparent": "00-ae28c2aa7f7b04489127c44fffaeed2e-77825713b23f4d45-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c0d9fe7071192adb4a43ddd0da14640d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1959",
+        "Content-Length": "1955",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:56 GMT",
-        "ETag": "W/\u0022a4570967-4465-40fd-9f6a-e9d250b88088\u0022",
+        "Date": "Wed, 29 Jun 2022 14:47:44 GMT",
+        "ETag": "W/\u002273fab458-eee5-4689-b75e-45d6f1bd548f\u0022",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -3985,101 +1203,100 @@
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-arm-service-request-id": "5add1b8a-9194-4eef-95dd-8d5e3ea4332d",
-        "x-ms-client-request-id": "18173650392034eb73a782ff536c4f61",
-        "x-ms-correlation-request-id": "86604849-b6f3-40a5-bc02-4afce6dc5b94",
-        "x-ms-ratelimit-remaining-subscription-reads": "11941",
-        "x-ms-request-id": "21ce2802-a3a7-4f48-8213-e8c871b0130b",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065057Z:86604849-b6f3-40a5-bc02-4afce6dc5b94"
+        "x-ms-arm-service-request-id": "cd650c7b-6b28-44ab-a1f8-81d021638471",
+        "x-ms-client-request-id": "c0d9fe7071192adb4a43ddd0da14640d",
+        "x-ms-correlation-request-id": "849442e2-2545-4041-81e7-5c723e1c873a",
+        "x-ms-ratelimit-remaining-subscription-reads": "11948",
+        "x-ms-request-id": "b125ec45-f45f-406a-8370-1f9cb5761f22",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144744Z:849442e2-2545-4041-81e7-5c723e1c873a"
       },
-      "ResponseBody": [
-        "{\r\n",
-        "  \u0022name\u0022: \u0022pe-6925\u0022,\r\n",
-        "  \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/privateEndpoints/pe-6925\u0022,\r\n",
-        "  \u0022etag\u0022: \u0022W/\\\u0022a4570967-4465-40fd-9f6a-e9d250b88088\\\u0022\u0022,\r\n",
-        "  \u0022type\u0022: \u0022Microsoft.Network/privateEndpoints\u0022,\r\n",
-        "  \u0022location\u0022: \u0022westus2\u0022,\r\n",
-        "  \u0022properties\u0022: {\r\n",
-        "    \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "    \u0022resourceGuid\u0022: \u00220a6359ae-b1fd-4111-b04c-c209dedfff20\u0022,\r\n",
-        "    \u0022privateLinkServiceConnections\u0022: [],\r\n",
-        "    \u0022manualPrivateLinkServiceConnections\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022name\u0022: \u0022pec3957\u0022,\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/privateEndpoints/pe-6925/manualPrivateLinkServiceConnections/pec3957\u0022,\r\n",
-        "        \u0022etag\u0022: \u0022W/\\\u0022a4570967-4465-40fd-9f6a-e9d250b88088\\\u0022\u0022,\r\n",
-        "        \u0022properties\u0022: {\r\n",
-        "          \u0022provisioningState\u0022: \u0022Succeeded\u0022,\r\n",
-        "          \u0022privateLinkServiceId\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393\u0022,\r\n",
-        "          \u0022groupIds\u0022: [\r\n",
-        "            \u0022namespace\u0022\r\n",
-        "          ],\r\n",
-        "          \u0022requestMessage\u0022: \u0022SDK test\u0022,\r\n",
-        "          \u0022privateLinkServiceConnectionState\u0022: {\r\n",
-        "            \u0022status\u0022: \u0022Pending\u0022,\r\n",
-        "            \u0022description\u0022: \u0022SDK test\u0022,\r\n",
-        "            \u0022actionsRequired\u0022: \u0022None\u0022\r\n",
-        "          }\r\n",
-        "        },\r\n",
-        "        \u0022type\u0022: \u0022Microsoft.Network/privateEndpoints/manualPrivateLinkServiceConnections\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022subnet\u0022: {\r\n",
-        "      \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/virtualNetworks/vnet-8533/subnets/default\u0022\r\n",
-        "    },\r\n",
-        "    \u0022networkInterfaces\u0022: [\r\n",
-        "      {\r\n",
-        "        \u0022id\u0022: \u0022/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/networkInterfaces/pe-6925.nic.e1084ec0-726d-4f92-bca7-31d43bc07907\u0022\r\n",
-        "      }\r\n",
-        "    ],\r\n",
-        "    \u0022customDnsConfigs\u0022: []\r\n",
-        "  }\r\n",
-        "}"
-      ]
+      "ResponseBody": {
+        "name": "pe-223",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.Network/privateEndpoints/pe-223",
+        "etag": "W/\u002273fab458-eee5-4689-b75e-45d6f1bd548f\u0022",
+        "type": "Microsoft.Network/privateEndpoints",
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "resourceGuid": "18ba3065-3c42-4b93-83c1-9d899f602140",
+          "privateLinkServiceConnections": [],
+          "manualPrivateLinkServiceConnections": [
+            {
+              "name": "pec4236",
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.Network/privateEndpoints/pe-223/manualPrivateLinkServiceConnections/pec4236",
+              "etag": "W/\u002273fab458-eee5-4689-b75e-45d6f1bd548f\u0022",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateLinkServiceId": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473",
+                "groupIds": [
+                  "namespace"
+                ],
+                "requestMessage": "SDK test",
+                "privateLinkServiceConnectionState": {
+                  "status": "Pending",
+                  "description": "SDK test",
+                  "actionsRequired": "None"
+                }
+              },
+              "type": "Microsoft.Network/privateEndpoints/manualPrivateLinkServiceConnections"
+            }
+          ],
+          "subnet": {
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.Network/virtualNetworks/vnet-4925/subnets/default"
+          },
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.Network/networkInterfaces/pe-223.nic.d36f9ebb-666e-48a1-825f-5611281250aa"
+            }
+          ],
+          "customDnsConfigs": []
+        }
+      }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c6e540c0c874b4b284e61bfc445401e0",
+        "traceparent": "00-6dc854c181a2a84a9b347f0412c7d3ce-c5e66784a1d0ac46-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "d37657a814967640be3cd7beb4693bf8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "689",
+        "Content-Length": "688",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:58 GMT",
+        "Date": "Wed, 29 Jun 2022 14:47:44 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c6e540c0c874b4b284e61bfc445401e0",
-        "x-ms-correlation-request-id": "9b5a3b08-90b8-4d1a-b1a7-278f4bc3f369",
-        "x-ms-ratelimit-remaining-subscription-reads": "11940",
-        "x-ms-request-id": "12181ec5-4e11-40ed-8fad-36a7fd24cb4c_M8SN1_M8SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065058Z:9b5a3b08-90b8-4d1a-b1a7-278f4bc3f369"
+        "x-ms-client-request-id": "d37657a814967640be3cd7beb4693bf8",
+        "x-ms-correlation-request-id": "d904791e-15fb-4d37-908e-4f80bc82e4db",
+        "x-ms-ratelimit-remaining-subscription-reads": "11947",
+        "x-ms-request-id": "fa5b1596-3234-4e71-bbdb-dedb91a8f2f0_M10CH3_M10CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144745Z:d904791e-15fb-4d37-908e-4f80bc82e4db"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455",
-            "name": "840842ac-a3a2-483a-a40f-12422390e455",
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1",
+            "name": "36cd5727-b73a-4a3c-ae41-0d4980a5d3b1",
             "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
             "location": "East US 2",
             "properties": {
               "provisioningState": "Succeeded",
               "privateEndpoint": {
-                "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/privateEndpoints/pe-6925"
+                "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.Network/privateEndpoints/pe-223"
               },
               "privateLinkServiceConnectionState": {
                 "status": "Pending",
@@ -4094,46 +1311,47 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ba26090880c8af5e8555efaaad91c144",
+        "traceparent": "00-9d10efd7cbb2534c8a616c9ee93a1e4a-dcac13b6c8d1db4d-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "fa755e6bed161e60f46237fa90d60583",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "677",
+        "Content-Length": "676",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:50:58 GMT",
+        "Date": "Wed, 29 Jun 2022 14:47:45 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "ba26090880c8af5e8555efaaad91c144",
-        "x-ms-correlation-request-id": "c050f5f5-91c1-40e2-a813-fb0507613d4d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11939",
-        "x-ms-request-id": "c9322911-1040-481a-bb7c-feb22d4138eb_M1SN1_M1SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065059Z:c050f5f5-91c1-40e2-a813-fb0507613d4d"
+        "x-ms-client-request-id": "fa755e6bed161e60f46237fa90d60583",
+        "x-ms-correlation-request-id": "765b1e08-b0f0-4c8f-a56b-03e714870024",
+        "x-ms-ratelimit-remaining-subscription-reads": "11946",
+        "x-ms-request-id": "4b305e4c-ed3d-4c17-9693-cc92a78dc651_M10CH3_M10CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144745Z:765b1e08-b0f0-4c8f-a56b-03e714870024"
       },
       "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455",
-        "name": "840842ac-a3a2-483a-a40f-12422390e455",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1",
+        "name": "36cd5727-b73a-4a3c-ae41-0d4980a5d3b1",
         "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
         "location": "East US 2",
         "properties": {
           "provisioningState": "Succeeded",
           "privateEndpoint": {
-            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/privateEndpoints/pe-6925"
+            "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.Network/privateEndpoints/pe-223"
           },
           "privateLinkServiceConnectionState": {
             "status": "Pending",
@@ -4146,326 +1364,294 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1?api-version=2021-11-01",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d6de3f20a4c687028462933a1deeef1f",
+        "traceparent": "00-5704e04acec56d41a8a533d26b3601e3-4c09a67e113e2b40-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "62d0a9d11f3c5b09bd6201dd9a1d76e1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com:443/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455?api-version=2021-11-01\u0026operationType=Delete",
+        "Azure-AsyncOperation": "https://management.azure.com:443/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1?api-version=2021-11-01\u0026operationType=Delete",
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Fri, 19 Nov 2021 06:50:59 GMT",
+        "Date": "Wed, 29 Jun 2022 14:47:46 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d6de3f20a4c687028462933a1deeef1f",
-        "x-ms-correlation-request-id": "ed707cdb-4e4c-4e3f-a6b9-7dbd8c01c5fb",
+        "x-ms-client-request-id": "62d0a9d11f3c5b09bd6201dd9a1d76e1",
+        "x-ms-correlation-request-id": "984c7e69-c6d7-44a8-8ad7-36de9dce8ea7",
         "x-ms-ratelimit-remaining-subscription-deletes": "14998",
-        "x-ms-request-id": "2bb8208f-cba7-471b-b527-0d56cdd59db0_M5SN1_M5SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065100Z:ed707cdb-4e4c-4e3f-a6b9-7dbd8c01c5fb"
+        "x-ms-request-id": "e17410d4-ed18-4d24-95f7-fc3bb4c6a567_M9CH3_M9CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144746Z:984c7e69-c6d7-44a8-8ad7-36de9dce8ea7"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455?api-version=2021-11-01\u0026operationType=Delete",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1?api-version=2021-11-01\u0026operationType=Delete",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "04dbd7242b766419069f3666ec239196",
+        "traceparent": "00-5704e04acec56d41a8a533d26b3601e3-21bbca11b7443747-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "0aec5337d8984bbc55193db4eb8384d6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455?api-version=2021-11-01\u0026operationType=Delete",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1?api-version=2021-11-01\u0026operationType=Delete",
         "Cache-Control": "no-cache",
-        "Content-Length": "463",
+        "Content-Length": "465",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:00 GMT",
+        "Date": "Wed, 29 Jun 2022 14:47:46 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "04dbd7242b766419069f3666ec239196",
-        "x-ms-correlation-request-id": "02957d76-98ed-40c2-9992-18d78998b3a8",
-        "x-ms-ratelimit-remaining-subscription-reads": "11938",
-        "x-ms-request-id": "d43d5ab5-d588-4e72-ba81-70903a9d23dc_M5SN1_M5SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065100Z:02957d76-98ed-40c2-9992-18d78998b3a8"
+        "x-ms-client-request-id": "0aec5337d8984bbc55193db4eb8384d6",
+        "x-ms-correlation-request-id": "4d124df9-ed7b-4486-b9f0-de17e395fdb8",
+        "x-ms-ratelimit-remaining-subscription-reads": "11945",
+        "x-ms-request-id": "bafa1185-6146-451a-943b-0ccd93a6ae4d_M10CH3_M10CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144746Z:4d124df9-ed7b-4486-b9f0-de17e395fdb8"
       },
       "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455",
-        "name": "840842ac-a3a2-483a-a40f-12422390e455",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1",
+        "name": "36cd5727-b73a-4a3c-ae41-0d4980a5d3b1",
         "status": "Deleting",
-        "startTime": "2021-11-19T06:51:00.45Z",
-        "endTime": "0001-01-01T00:00:00"
+        "startTime": "2022-06-29T14:47:45.997Z",
+        "endTime": "0001-01-01T00:00:00Z"
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455?api-version=2021-11-01\u0026operationType=Delete",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1?api-version=2021-11-01\u0026operationType=Delete",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0b04cf65779a8bfea69ef39063e3ad7c",
+        "traceparent": "00-5704e04acec56d41a8a533d26b3601e3-b26a4c1387b09d42-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "abf155eb897067e4b3156be440d47e76",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455?api-version=2021-11-01\u0026operationType=Delete",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1?api-version=2021-11-01\u0026operationType=Delete",
         "Cache-Control": "no-cache",
-        "Content-Length": "463",
+        "Content-Length": "465",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:02 GMT",
+        "Date": "Wed, 29 Jun 2022 14:47:48 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "0b04cf65779a8bfea69ef39063e3ad7c",
-        "x-ms-correlation-request-id": "fe91fe8c-fbe6-4ec0-b613-48574df2d7b5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11937",
-        "x-ms-request-id": "e6a2af39-43f5-4e28-b1f3-49887cac2bf4_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065103Z:fe91fe8c-fbe6-4ec0-b613-48574df2d7b5"
+        "x-ms-client-request-id": "abf155eb897067e4b3156be440d47e76",
+        "x-ms-correlation-request-id": "85f55223-cdaa-4176-9cd8-6bdcdd7ac3f2",
+        "x-ms-ratelimit-remaining-subscription-reads": "11944",
+        "x-ms-request-id": "dda45ab1-76cf-4238-a039-3391fab90bfe_M10CH3_M10CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144748Z:85f55223-cdaa-4176-9cd8-6bdcdd7ac3f2"
       },
       "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455",
-        "name": "840842ac-a3a2-483a-a40f-12422390e455",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1",
+        "name": "36cd5727-b73a-4a3c-ae41-0d4980a5d3b1",
         "status": "Deleting",
-        "startTime": "2021-11-19T06:51:00.45Z",
-        "endTime": "0001-01-01T00:00:00"
+        "startTime": "2022-06-29T14:47:45.997Z",
+        "endTime": "0001-01-01T00:00:00Z"
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455?api-version=2021-11-01\u0026operationType=Delete",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1?api-version=2021-11-01\u0026operationType=Delete",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4516a15aeb1379a9889343a65f3353be",
+        "traceparent": "00-5704e04acec56d41a8a533d26b3601e3-a4f1821344ae7c4a-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "46a5197c6c302f48281a25852c42ce73",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455?api-version=2021-11-01\u0026operationType=Delete",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1?api-version=2021-11-01\u0026operationType=Delete",
         "Cache-Control": "no-cache",
-        "Content-Length": "463",
+        "Content-Length": "465",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:03 GMT",
+        "Date": "Wed, 29 Jun 2022 14:47:49 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "4516a15aeb1379a9889343a65f3353be",
-        "x-ms-correlation-request-id": "14497aa9-6308-45d5-9832-b6bf8921a64a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11936",
-        "x-ms-request-id": "0132d178-2ed1-4056-b41c-e7a5fbb03813_M1SN1_M1SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065104Z:14497aa9-6308-45d5-9832-b6bf8921a64a"
+        "x-ms-client-request-id": "46a5197c6c302f48281a25852c42ce73",
+        "x-ms-correlation-request-id": "06bae6dc-4ffe-4f97-b0a7-c9a347d580c0",
+        "x-ms-ratelimit-remaining-subscription-reads": "11943",
+        "x-ms-request-id": "2a2c86b5-bac2-4ee2-b5d5-61628acb945b_M10CH3_M10CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144750Z:06bae6dc-4ffe-4f97-b0a7-c9a347d580c0"
       },
       "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455",
-        "name": "840842ac-a3a2-483a-a40f-12422390e455",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1",
+        "name": "36cd5727-b73a-4a3c-ae41-0d4980a5d3b1",
         "status": "Deleting",
-        "startTime": "2021-11-19T06:51:00.45Z",
-        "endTime": "0001-01-01T00:00:00"
+        "startTime": "2022-06-29T14:47:45.997Z",
+        "endTime": "0001-01-01T00:00:00Z"
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455?api-version=2021-11-01\u0026operationType=Delete",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1?api-version=2021-11-01\u0026operationType=Delete",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0abaaaa5fc03ac58d9505ed838890123",
+        "traceparent": "00-5704e04acec56d41a8a533d26b3601e3-f8155f411abeab4d-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "874808d33a54ad776e8557826cd70b81",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455?api-version=2021-11-01\u0026operationType=Delete",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1?api-version=2021-11-01\u0026operationType=Delete",
         "Cache-Control": "no-cache",
-        "Content-Length": "463",
+        "Content-Length": "465",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:06 GMT",
+        "Date": "Wed, 29 Jun 2022 14:47:51 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "0abaaaa5fc03ac58d9505ed838890123",
-        "x-ms-correlation-request-id": "314fae6d-4e79-4590-a4f7-5fb91866cb8e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11935",
-        "x-ms-request-id": "230bb601-41f5-4a41-962e-fc6a03023d62_M9SN1_M9SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065107Z:314fae6d-4e79-4590-a4f7-5fb91866cb8e"
+        "x-ms-client-request-id": "874808d33a54ad776e8557826cd70b81",
+        "x-ms-correlation-request-id": "e1716e4c-4c44-41f4-bc8e-ab63fe530b26",
+        "x-ms-ratelimit-remaining-subscription-reads": "11942",
+        "x-ms-request-id": "994869c2-e465-43bf-bc08-bb620220bf40_M9CH3_M9CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144751Z:e1716e4c-4c44-41f4-bc8e-ab63fe530b26"
       },
       "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455",
-        "name": "840842ac-a3a2-483a-a40f-12422390e455",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1",
+        "name": "36cd5727-b73a-4a3c-ae41-0d4980a5d3b1",
         "status": "Deleting",
-        "startTime": "2021-11-19T06:51:00.45Z",
-        "endTime": "0001-01-01T00:00:00"
+        "startTime": "2022-06-29T14:47:45.997Z",
+        "endTime": "0001-01-01T00:00:00Z"
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455?api-version=2021-11-01\u0026operationType=Delete",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1?api-version=2021-11-01\u0026operationType=Delete",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4b0bb9f14b0d7a83268a820734572c73",
+        "traceparent": "00-5704e04acec56d41a8a533d26b3601e3-27f41f88ce94a040-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "d237c69a3dde7fa50dc28256645f3a71",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455?api-version=2021-11-01\u0026operationType=Delete",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1?api-version=2021-11-01\u0026operationType=Delete",
         "Cache-Control": "no-cache",
-        "Content-Length": "463",
+        "Content-Length": "465",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:08 GMT",
+        "Date": "Wed, 29 Jun 2022 14:47:54 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "4b0bb9f14b0d7a83268a820734572c73",
-        "x-ms-correlation-request-id": "7f680c2e-443c-4385-832c-0113fe10d4a1",
-        "x-ms-ratelimit-remaining-subscription-reads": "11934",
-        "x-ms-request-id": "675874cd-c386-439c-8e47-17816c178e48_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065109Z:7f680c2e-443c-4385-832c-0113fe10d4a1"
+        "x-ms-client-request-id": "d237c69a3dde7fa50dc28256645f3a71",
+        "x-ms-correlation-request-id": "c183d445-5444-421b-a353-42c68a7e4889",
+        "x-ms-ratelimit-remaining-subscription-reads": "11941",
+        "x-ms-request-id": "6a1c4cf0-da79-46f1-8000-8edaaa817a84_M10CH3_M10CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144754Z:c183d445-5444-421b-a353-42c68a7e4889"
       },
       "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455",
-        "name": "840842ac-a3a2-483a-a40f-12422390e455",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1",
+        "name": "36cd5727-b73a-4a3c-ae41-0d4980a5d3b1",
         "status": "Deleting",
-        "startTime": "2021-11-19T06:51:00.45Z",
-        "endTime": "0001-01-01T00:00:00"
+        "startTime": "2022-06-29T14:47:45.997Z",
+        "endTime": "0001-01-01T00:00:00Z"
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455?api-version=2021-11-01\u0026operationType=Delete",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1?api-version=2021-11-01\u0026operationType=Delete",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b8eb344aa3285e7948696cc38cd041fe",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455?api-version=2021-11-01\u0026operationType=Delete",
-        "Cache-Control": "no-cache",
-        "Content-Length": "464",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:10 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "b8eb344aa3285e7948696cc38cd041fe",
-        "x-ms-correlation-request-id": "00572987-bee8-4c64-a65f-1297031a0969",
-        "x-ms-ratelimit-remaining-subscription-reads": "11933",
-        "x-ms-request-id": "9955fab4-b4e2-4638-9b7b-2a4997eda802_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065111Z:00572987-bee8-4c64-a65f-1297031a0969"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455",
-        "name": "840842ac-a3a2-483a-a40f-12422390e455",
-        "status": "Deleting",
-        "startTime": "2021-11-19T06:51:10.713Z",
-        "endTime": "0001-01-01T00:00:00"
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455?api-version=2021-11-01\u0026operationType=Delete",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a5b42092082759b02640e37879507881",
+        "traceparent": "00-5704e04acec56d41a8a533d26b3601e3-832c43c401758940-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.1.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "3711f847f78b4222a1f7d8aa14c5c350",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "460",
+        "Content-Length": "462",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:12 GMT",
+        "Date": "Wed, 29 Jun 2022 14:47:59 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a5b42092082759b02640e37879507881",
-        "x-ms-correlation-request-id": "417328f5-8458-47c7-a6d2-fd19a22120ec",
-        "x-ms-ratelimit-remaining-subscription-reads": "11932",
-        "x-ms-request-id": "75db1db4-d78a-4954-8281-68443b69d1de_M8SN1_M8SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065113Z:417328f5-8458-47c7-a6d2-fd19a22120ec"
+        "x-ms-client-request-id": "3711f847f78b4222a1f7d8aa14c5c350",
+        "x-ms-correlation-request-id": "7170fc65-b286-4b5e-8713-f73e3ca81bd4",
+        "x-ms-ratelimit-remaining-subscription-reads": "11940",
+        "x-ms-request-id": "03b39602-4aff-4b84-a245-c4d97034a21c_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144800Z:7170fc65-b286-4b5e-8713-f73e3ca81bd4"
       },
       "ResponseBody": {
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455/operationStatus/840842ac-a3a2-483a-a40f-12422390e455",
-        "name": "840842ac-a3a2-483a-a40f-12422390e455",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1/operationStatus/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1",
+        "name": "36cd5727-b73a-4a3c-ae41-0d4980a5d3b1",
         "status": "Succeeded",
-        "startTime": "0001-01-01T00:00:00",
-        "endTime": "0001-01-01T00:00:00"
+        "startTime": "0001-01-01T00:00:00Z",
+        "endTime": "0001-01-01T00:00:00Z"
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections/36cd5727-b73a-4a3c-ae41-0d4980a5d3b1?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "038eeb23489e4dfa40ad02a4dec0ed55",
+        "traceparent": "00-f9dbbab35250a8418012939c61650f25-39b6d1844637a447-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "65eaa40ffb0a959463c97992b721490f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -4474,37 +1660,38 @@
         "Cache-Control": "no-cache",
         "Content-Length": "169",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:12 GMT",
+        "Date": "Wed, 29 Jun 2022 14:48:00 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "038eeb23489e4dfa40ad02a4dec0ed55",
-        "x-ms-correlation-request-id": "2ccda0ce-34c6-4249-8a49-32f7f771ccd7",
-        "x-ms-ratelimit-remaining-subscription-reads": "11931",
-        "x-ms-request-id": "f31b75e5-273a-43ce-8edb-f91f9c59070e_M7SN1_M7SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065113Z:2ccda0ce-34c6-4249-8a49-32f7f771ccd7"
+        "x-ms-client-request-id": "65eaa40ffb0a959463c97992b721490f",
+        "x-ms-correlation-request-id": "51e2f255-fc82-49dd-b888-7699c90209a8",
+        "x-ms-ratelimit-remaining-subscription-reads": "11939",
+        "x-ms-request-id": "c7ad00f8-8458-4eb0-9f29-8eb046abff19_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144800Z:51e2f255-fc82-49dd-b888-7699c90209a8"
       },
       "ResponseBody": {
         "error": {
-          "message": "The requested resource 840842ac-a3a2-483a-a40f-12422390e455 does not exist. CorrelationId: 2ccda0ce-34c6-4249-8a49-32f7f771ccd7",
+          "message": "The requested resource 36cd5727-b73a-4a3c-ae41-0d4980a5d3b1 does not exist. CorrelationId: 51e2f255-fc82-49dd-b888-7699c90209a8",
           "code": "NotFound"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-5841/providers/Microsoft.EventHub/namespaces/testnamespacemgmt9473/privateEndpointConnections?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1375844886a2414b839192e8c000e4f8",
+        "traceparent": "00-06bf3c0f50be9e4298f9c46914c6c4f0-11a57ec497d16d46-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "733be64bd3c6a2f5a4f531e665fb6a48",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -4513,927 +1700,30 @@
         "Cache-Control": "no-cache",
         "Content-Length": "12",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:13 GMT",
+        "Date": "Wed, 29 Jun 2022 14:48:01 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "1375844886a2414b839192e8c000e4f8",
-        "x-ms-correlation-request-id": "4c6303c3-b810-46d9-9eab-715cc768dc5b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11930",
-        "x-ms-request-id": "bd5d4520-e4d6-4bcc-ad48-9aca82f0ebf8_M0SN1_M0SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065114Z:4c6303c3-b810-46d9-9eab-715cc768dc5b"
+        "x-ms-client-request-id": "733be64bd3c6a2f5a4f531e665fb6a48",
+        "x-ms-correlation-request-id": "fed01c26-d331-46f7-a1ef-c0385176e3b5",
+        "x-ms-ratelimit-remaining-subscription-reads": "11938",
+        "x-ms-request-id": "5337d34f-74c5-4b9a-96f3-949abf3d5b28_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20220629T144801Z:fed01c26-d331-46f7-a1ef-c0385176e3b5"
       },
       "ResponseBody": {
         "value": []
       }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/privateEndpointConnections?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a19febf13e42495f2667647a050c7a66",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "12",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:15 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a19febf13e42495f2667647a050c7a66",
-        "x-ms-correlation-request-id": "16ccd34a-e7b8-48da-838d-a3c24f9e9998",
-        "x-ms-ratelimit-remaining-subscription-reads": "11929",
-        "x-ms-request-id": "6643bd88-0367-40b2-8d29-20d7125ef3e8_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065115Z:16ccd34a-e7b8-48da-838d-a3c24f9e9998"
-      },
-      "ResponseBody": {
-        "value": []
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.0.0-alpha.20211119.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f52f8d5365db9dde9f4c7f0cb6118d3f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Date": "Fri, 19 Nov 2021 06:51:19 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f52f8d5365db9dde9f4c7f0cb6118d3f",
-        "x-ms-correlation-request-id": "bbf7b390-61ef-40b9-bdd9-708b03f011d7",
-        "x-ms-ratelimit-remaining-subscription-deletes": "14997",
-        "x-ms-request-id": "9bc829cd-9403-449f-a09b-7021044dbeba_M4SN1_M4SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065120Z:bbf7b390-61ef-40b9-bdd9-708b03f011d7"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "32952b16efd18c1d0d0202f6bf529314",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1488",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:20 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "42",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "32952b16efd18c1d0d0202f6bf529314",
-        "x-ms-correlation-request-id": "45998b56-df41-4456-87cb-88093f222126",
-        "x-ms-ratelimit-remaining-subscription-reads": "11928",
-        "x-ms-request-id": "ac4d63f3-1798-448f-9150-b94a6cd75f85_M10SN1_M10SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065121Z:45998b56-df41-4456-87cb-88093f222126"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455",
-              "name": "840842ac-a3a2-483a-a40f-12422390e455",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/privateEndpoints/pe-6925"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:51:20.42Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fbb124d9875908457a25d0af78a27ace",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1488",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:22 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "44",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "fbb124d9875908457a25d0af78a27ace",
-        "x-ms-correlation-request-id": "58dba7da-637b-444d-aa3c-8e1bc8b5bd0b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11927",
-        "x-ms-request-id": "9eeb54c9-7d10-4407-aa21-d40ecb5e76e6_M6SN1_M6SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065123Z:58dba7da-637b-444d-aa3c-8e1bc8b5bd0b"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455",
-              "name": "840842ac-a3a2-483a-a40f-12422390e455",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/privateEndpoints/pe-6925"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:51:20.42Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8af607105b7cd96eec26e51e491c4ad1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1488",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:24 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "45",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8af607105b7cd96eec26e51e491c4ad1",
-        "x-ms-correlation-request-id": "be190d61-adb4-4ca4-913c-4804ce1a2f3c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11926",
-        "x-ms-request-id": "6e6ea1e8-40ef-428d-b688-0a86781cb30b_M8SN1_M8SN1",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065125Z:be190d61-adb4-4ca4-913c-4804ce1a2f3c"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455",
-              "name": "840842ac-a3a2-483a-a40f-12422390e455",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/privateEndpoints/pe-6925"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:51:20.42Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fd62d897401f8f1de68db7ac1f6d146a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1488",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:27 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "56",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "fd62d897401f8f1de68db7ac1f6d146a",
-        "x-ms-correlation-request-id": "a9b60e1a-5b49-46b0-8019-ad61a874d95c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11925",
-        "x-ms-request-id": "d6fb8dbf-6f3e-4298-929e-af53697faf01_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065128Z:a9b60e1a-5b49-46b0-8019-ad61a874d95c"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455",
-              "name": "840842ac-a3a2-483a-a40f-12422390e455",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/privateEndpoints/pe-6925"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:51:20.42Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b7e63387095c7d97b6d80e32a126be5e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1488",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:29 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "42",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "b7e63387095c7d97b6d80e32a126be5e",
-        "x-ms-correlation-request-id": "56bbd770-2c0e-4fa1-ad33-a523e8dd6923",
-        "x-ms-ratelimit-remaining-subscription-reads": "11924",
-        "x-ms-request-id": "627c121c-1c0e-431b-a43d-7edde90f9ef6_M5CH3_M5CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065130Z:56bbd770-2c0e-4fa1-ad33-a523e8dd6923"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455",
-              "name": "840842ac-a3a2-483a-a40f-12422390e455",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/privateEndpoints/pe-6925"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:51:20.42Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9f17feda7d40cfafea66a3efa3c2ba7f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1488",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:31 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "50",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "9f17feda7d40cfafea66a3efa3c2ba7f",
-        "x-ms-correlation-request-id": "23ac9fdd-7fcc-4416-940d-34e4b1fa1382",
-        "x-ms-ratelimit-remaining-subscription-reads": "11923",
-        "x-ms-request-id": "ee658f0a-e65a-4d58-91fd-a35e0d6cad59_M3CH3_M3CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065132Z:23ac9fdd-7fcc-4416-940d-34e4b1fa1382"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455",
-              "name": "840842ac-a3a2-483a-a40f-12422390e455",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/privateEndpoints/pe-6925"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:51:20.42Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "15977b1293358e7440e4474631eaedc0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "1488",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:33 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "42",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "15977b1293358e7440e4474631eaedc0",
-        "x-ms-correlation-request-id": "4adbdf6b-c0c4-41c9-ad83-9b9f3adbf100",
-        "x-ms-ratelimit-remaining-subscription-reads": "11922",
-        "x-ms-request-id": "de1b3c67-754f-4200-bdf3-662013731a81_M9CH3_M9CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065134Z:4adbdf6b-c0c4-41c9-ad83-9b9f3adbf100"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "privateEndpointConnections": [
-            {
-              "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393/privateEndpointConnections/840842ac-a3a2-483a-a40f-12422390e455",
-              "name": "840842ac-a3a2-483a-a40f-12422390e455",
-              "type": "Microsoft.EventHub/Namespaces/PrivateEndpointConnections",
-              "location": "East US 2",
-              "properties": {
-                "provisioningState": "Deleting",
-                "privateEndpoint": {
-                  "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.Network/privateEndpoints/pe-6925"
-                },
-                "privateLinkServiceConnectionState": {
-                  "status": "Disconnected",
-                  "description": "SDK test"
-                },
-                "groupIds": [
-                  "namespace"
-                ]
-              }
-            }
-          ],
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:51:20.42Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "20d259ce7455092a8316cdf666a7d9f3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:35 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "39",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "20d259ce7455092a8316cdf666a7d9f3",
-        "x-ms-correlation-request-id": "55a85007-053e-402a-bc08-b42e633d7c47",
-        "x-ms-ratelimit-remaining-subscription-reads": "11921",
-        "x-ms-request-id": "223634ec-ab03-4745-8319-bec6333dadfd_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065136Z:55a85007-053e-402a-bc08-b42e633d7c47"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:51:20.42Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "26208f1ea88f462889895e5b35689eff",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:39 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "51",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "26208f1ea88f462889895e5b35689eff",
-        "x-ms-correlation-request-id": "2544c420-88af-40fa-8ab3-c94427fdf16d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11920",
-        "x-ms-request-id": "7f448a0a-4588-4cad-9395-ed90dba1bd15_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065139Z:2544c420-88af-40fa-8ab3-c94427fdf16d"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:51:20.42Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4a21e37999f09e29508d921fc67e2799",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:40 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "47",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "4a21e37999f09e29508d921fc67e2799",
-        "x-ms-correlation-request-id": "e9707982-574a-430f-90ad-e34e985bb836",
-        "x-ms-ratelimit-remaining-subscription-reads": "11919",
-        "x-ms-request-id": "8c195de0-1af2-4daa-ab03-515afba772e6_M1CH3_M1CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065140Z:e9707982-574a-430f-90ad-e34e985bb836"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:51:20.42Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a128530bc7ca2531308b96cc16cfd41a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "736",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Nov 2021 06:51:42 GMT",
-        "Expires": "-1",
-        "Location": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-        "Pragma": "no-cache",
-        "Retry-After": "49",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a128530bc7ca2531308b96cc16cfd41a",
-        "x-ms-correlation-request-id": "459c6729-0f53-41e8-9484-357ab425e829",
-        "x-ms-ratelimit-remaining-subscription-reads": "11918",
-        "x-ms-request-id": "f2b91ced-7770-4c6e-ae94-a8a5d7c3201e_M11CH3_M11CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065142Z:459c6729-0f53-41e8-9484-357ab425e829"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393",
-        "name": "testnamespacemgmt3393",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt3393",
-          "createdAt": "2021-11-19T06:48:57.15Z",
-          "updatedAt": "2021-11-19T06:51:20.42Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3393.servicebus.windows.net:443/",
-          "status": "Removing"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6109/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3393/operationresults/testnamespacemgmt3393?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-ResourceManager/1.0.0-beta.5 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "827dcd788f8684036682d5011609800b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Date": "Fri, 19 Nov 2021 06:51:45 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "827dcd788f8684036682d5011609800b",
-        "x-ms-correlation-request-id": "c5a2883c-20f3-4767-a2a8-7b87ee3123e7",
-        "x-ms-ratelimit-remaining-subscription-reads": "11917",
-        "x-ms-request-id": "86e3f384-281d-4de5-87d1-363e67ff874c_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHEASTASIA:20211119T065145Z:c5a2883c-20f3-4767-a2a8-7b87ee3123e7"
-      },
-      "ResponseBody": []
     }
   ],
   "Variables": {
-    "RandomSeed": "330605234",
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
+    "RandomSeed": "2004930669",
     "RESOURCE_MANAGER_URL": null,
     "SUBSCRIPTION_ID": "db1ab6f0-4769-4b27-930e-01e2ef9c123c"
   }

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Tests/ConsumerGroupTests.cs
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Tests/ConsumerGroupTests.cs
@@ -36,22 +36,6 @@ namespace Azure.ResourceManager.EventHubs.Tests
             _consumerGroupCollection = _eventHub.GetEventHubsConsumerGroups();
         }
 
-        [TearDown]
-        public async Task ClearNamespaces()
-        {
-            //remove all namespaces under current resource group
-            if (_resourceGroup != null)
-            {
-                EventHubsNamespaceCollection namespaceCollection = _resourceGroup.GetEventHubsNamespaces();
-                List<EventHubsNamespaceResource> namespaceList = await namespaceCollection.GetAllAsync().ToEnumerableAsync();
-                foreach (EventHubsNamespaceResource eventHubNamespace in namespaceList)
-                {
-                    await eventHubNamespace.DeleteAsync(WaitUntil.Completed);
-                }
-                _resourceGroup = null;
-            }
-        }
-
         [Test]
         [RecordedTest]
         public async Task CreateDeleteConsumerGroup()

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Tests/DisasterRecoveryTests.cs
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Tests/DisasterRecoveryTests.cs
@@ -21,21 +21,6 @@ namespace Azure.ResourceManager.EventHubs.Tests
         public DisasterRecoveryTests(bool isAsync) : base(isAsync)
         {
         }
-        [TearDown]
-        public async Task ClearNamespaces()
-        {
-            //remove all namespaces under current resource group
-            if (_resourceGroup != null)
-            {
-                EventHubsNamespaceCollection namespaceCollection = _resourceGroup.GetEventHubsNamespaces();
-                List<EventHubsNamespaceResource> namespaceList = await namespaceCollection.GetAllAsync().ToEnumerableAsync();
-                foreach (EventHubsNamespaceResource eventHubNamespace in namespaceList)
-                {
-                    await eventHubNamespace.DeleteAsync(WaitUntil.Completed);
-                }
-                _resourceGroup = null;
-            }
-        }
 
         [Test]
         [RecordedTest]

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Tests/EventHubNamespaceTests.cs
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Tests/EventHubNamespaceTests.cs
@@ -24,22 +24,6 @@ namespace Azure.ResourceManager.EventHubs.Tests
         {
         }
 
-        [TearDown]
-        public async Task ClearNamespaces()
-        {
-            //remove all namespaces under current resource group
-            if (_resourceGroup != null)
-            {
-                EventHubsNamespaceCollection namespaceCollection = _resourceGroup.GetEventHubsNamespaces();
-                List<EventHubsNamespaceResource> namespaceList = await namespaceCollection.GetAllAsync().ToEnumerableAsync();
-                foreach (EventHubsNamespaceResource eventHubNamespace in namespaceList)
-                {
-                    await eventHubNamespace.DeleteAsync(WaitUntil.Completed);
-                }
-                _resourceGroup = null;
-            }
-        }
-
         [Test]
         [RecordedTest]
         public async Task CreateDeleteNamespace()

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Tests/PrivateEndpointConnectionTests.cs
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Tests/PrivateEndpointConnectionTests.cs
@@ -34,17 +34,6 @@ namespace Azure.ResourceManager.EventHubs.Tests
             _eventHubNamespace = (await namespaceCollection.CreateOrUpdateAsync(WaitUntil.Completed, namespaceName, new EventHubsNamespaceData(DefaultLocation))).Value;
         }
 
-        [TearDown]
-        public async Task TearDown()
-        {
-            List<EventHubsPrivateEndpointConnectionResource> privateEndpointConnections = await _privateEndpointConnectionCollection.GetAllAsync().ToEnumerableAsync();
-            foreach (EventHubsPrivateEndpointConnectionResource connection in privateEndpointConnections)
-            {
-                await connection.DeleteAsync(WaitUntil.Completed);
-            }
-            await _eventHubNamespace.DeleteAsync(WaitUntil.Completed);
-        }
-
         [Test]
         [RecordedTest]
         [Ignore("RequestFailedException")]
@@ -72,7 +61,6 @@ namespace Azure.ResourceManager.EventHubs.Tests
 
         [Test]
         [RecordedTest]
-        [Ignore("can pass locally, cost too much time on pipeline")]
         public async Task GetAllPrivateEndpointConnection()
         {
             PrivateEndpointResource privateEndpoint = await CreatePrivateEndpoint();
@@ -84,7 +72,6 @@ namespace Azure.ResourceManager.EventHubs.Tests
         }
         [Test]
         [RecordedTest]
-        [Ignore("can pass locally, cost too much time on pipeline")]
         public async Task PrivateEndpointConnectionDelete()
         {
             await CreatePrivateEndpoint();
@@ -119,7 +106,7 @@ namespace Azure.ResourceManager.EventHubs.Tests
             vnet.AddressPrefixes.Add("10.0.0.0/16");
             vnet.DhcpOptionsDnsServers.Add("10.1.1.1");
             vnet.DhcpOptionsDnsServers.Add("10.1.2.4");
-            VirtualNetworkResource virtualNetwork = await _resourceGroup.GetVirtualNetworks().CreateOrUpdate(WaitUntil.Started, vnetName, vnet).WaitForCompletionAsync();
+            VirtualNetworkResource virtualNetwork = (await _resourceGroup.GetVirtualNetworks().CreateOrUpdateAsync(WaitUntil.Completed, vnetName, vnet)).Value;
 
             var name = Recording.GenerateAssetName("pe-");
             var privateEndpointData = new PrivateEndpointData
@@ -140,7 +127,7 @@ namespace Azure.ResourceManager.EventHubs.Tests
                 },
             };
 
-            return await _resourceGroup.GetPrivateEndpoints().CreateOrUpdate(WaitUntil.Started, name, privateEndpointData).WaitForCompletionAsync();
+            return (await _resourceGroup.GetPrivateEndpoints().CreateOrUpdateAsync(WaitUntil.Completed, name, privateEndpointData)).Value;
         }
 
         private void VerifyPrivateEndpointConnections(PrivateLinkServiceConnection expectedValue, EventHubsPrivateEndpointConnectionResource actualValue)

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Tests/SchemaGroupTests.cs
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Tests/SchemaGroupTests.cs
@@ -28,21 +28,6 @@ namespace Azure.ResourceManager.EventHubs.Tests
             EventHubsNamespaceResource eHNamespace = (await namespaceCollection.CreateOrUpdateAsync(WaitUntil.Completed, namespaceName, new EventHubsNamespaceData(DefaultLocation))).Value;
             _schemaGroupCollection = eHNamespace.GetEventHubsSchemaGroups();
         }
-        [TearDown]
-        public async Task ClearNamespaces()
-        {
-            //remove all namespaces under current resource group
-            if (_resourceGroup != null)
-            {
-                EventHubsNamespaceCollection namespaceCollection = _resourceGroup.GetEventHubsNamespaces();
-                List<EventHubsNamespaceResource> namespaceList = await namespaceCollection.GetAllAsync().ToEnumerableAsync();
-                foreach (EventHubsNamespaceResource eventHubNamespace in namespaceList)
-                {
-                    await eventHubNamespace.DeleteAsync(WaitUntil.Completed);
-                }
-                _resourceGroup = null;
-            }
-        }
 
         [Test]
         [RecordedTest]

--- a/sdk/eventhub/ci.mgmt.yml
+++ b/sdk/eventhub/ci.mgmt.yml
@@ -24,10 +24,8 @@ pr:
     - sdk/eventhub/ci.mgmt.yml
     - sdk/eventhub/service.projects
     - sdk/eventhub/Azure.ResourceManager.EventHubs
-    - sdk/resources/
     - sdk/resourcemanager/
     - sdk/network/
-    - sdk/storage/
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml


### PR DESCRIPTION
This PR removed the project reference of Azure.ResourceManage.Resources and Azure.ResourceManage.Storage, which means that we don't need to include the `sdk/resources` and `sdk/storage` in the pr path of ci.mgmt.yml.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
