### PR TITLE
point to perf pr

### DIFF
--- a/eng/pipelines/templates/jobs/perf.yml
+++ b/eng/pipelines/templates/jobs/perf.yml
@@ -37,7 +37,7 @@ resources:
     type: github
     endpoint: Azure
     name: Azure/azure-sdk-tools
-    ref: main
+    ref: refs/pull/3525/merge
 
 jobs:
 - job: Perf


### PR DESCRIPTION
Temporarily pointing the perf pipeline at the tools PR to be able to test client-side encryption for Storage-blob. This will not be merged!