### PR TITLE
Perf investigation

### DIFF
--- a/eng/pipelines/templates/jobs/perf.yml
+++ b/eng/pipelines/templates/jobs/perf.yml
@@ -37,7 +37,7 @@ resources:
     type: github
     endpoint: Azure
     name: Azure/azure-sdk-tools
-    ref: refs/pull/3525/merge
+    ref: main
 
 jobs:
 - job: Perf

--- a/eng/pipelines/templates/jobs/perf.yml
+++ b/eng/pipelines/templates/jobs/perf.yml
@@ -37,7 +37,7 @@ resources:
     type: github
     endpoint: Azure
     name: Azure/azure-sdk-tools
-    ref: main
+    ref: refs/pull/3525/merge
 
 jobs:
 - job: Perf


### PR DESCRIPTION
Switch an allocation to array pool rental.
Change logic to not rely on array length.
Doubles small blob perf on this code path.