### PR TITLE
Make `OperationStatusResult` initialization constructor from internal to public

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/CHANGELOG.md
+++ b/sdk/resourcemanager/Azure.ResourceManager/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Release History
 
-## 1.1.2 (2022-07-01)
+## 1.2.0 (Unreleased)
 
 ### Features Added
 
-- Add `ExtendedLocation` to common type.
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
+- Changed `OperationStatusResult` initialization constructor from internal to public.
 
 ## 1.1.2 (2022-07-01)
 

--- a/sdk/resourcemanager/Azure.ResourceManager/api/Azure.ResourceManager.netstandard2.0.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/api/Azure.ResourceManager.netstandard2.0.cs
@@ -422,7 +422,7 @@ namespace Azure.ResourceManager.Models
     }
     public partial class OperationStatusResult
     {
-        internal OperationStatusResult() { }
+        public OperationStatusResult(string status) { }
         public System.DateTimeOffset? EndOn { get { throw null; } }
         public Azure.ResponseError Error { get { throw null; } }
         public Azure.Core.ResourceIdentifier Id { get { throw null; } }

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Azure.ResourceManager.csproj
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Azure.ResourceManager.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.1.2</Version>
+    <Version>1.2.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.1.2</ApiCompatVersion>
     <PackageId>Azure.ResourceManager</PackageId>

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/OperationStatusResult.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/OperationStatusResult.Serialization.cs
@@ -15,8 +15,14 @@ using Azure.Core;
 namespace Azure.ResourceManager.Models
 {
     [JsonConverter(typeof(OperationStatusResultConverter))]
-    public partial class OperationStatusResult
+    public partial class OperationStatusResult : IUtf8JsonSerializable
     {
+        void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
+        {
+            writer.WriteStartObject();
+            writer.WriteEndObject();
+        }
+
         internal static OperationStatusResult DeserializeOperationStatusResult(JsonElement element)
         {
             Optional<ResourceIdentifier> id = default;
@@ -112,7 +118,7 @@ namespace Azure.ResourceManager.Models
         {
             public override void Write(Utf8JsonWriter writer, OperationStatusResult model, JsonSerializerOptions options)
             {
-                throw new NotImplementedException();
+                writer.WriteObjectValue(model);
             }
             public override OperationStatusResult Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/OperationStatusResult.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/OperationStatusResult.cs
@@ -20,7 +20,7 @@ namespace Azure.ResourceManager.Models
         /// <param name="status"> Operation status. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="status"/> is null. </exception>
         [InitializationConstructor]
-        internal OperationStatusResult(string status)
+        public OperationStatusResult(string status)
         {
             if (status == null)
             {

--- a/sdk/resourcemanager/Azure.ResourceManager/src/autorest.md
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/autorest.md
@@ -127,12 +127,16 @@ directive:
       $["x-namespace"] = "Azure.ResourceManager.Models";
       $["x-accessibility"] = "public";
   - from: types.json
-    where: $.definitions['OperationStatusResult']
+    where: $.definitions.OperationStatusResult
     transform: >
       $["x-ms-mgmt-propertyReferenceType"] = false;
       $["x-ms-mgmt-typeReferenceType"] = true;
       $["x-csharp-formats"] = "json";
-      $["x-csharp-usage"] = "model,output";
+      $["x-csharp-usage"] = "model,input,output";
+  - from: types.json
+    where: $.definitions.OperationStatusResult.properties.*
+    transform: >
+      $["readOnly"] = true;
   - from: managedidentity.json
     where: $.definitions.SystemAssignedServiceIdentity
     transform: >


### PR DESCRIPTION
Resolve #29636 

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
