### PR TITLE
extend timeout in minutes for analyze job

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -141,6 +141,7 @@ jobs:
 
   - job: "Analyze"
     condition: and(succeededOrFailed(), ne(variables['Skip.Analyze'], true))
+    timeoutInMinutes: 100
     pool:
       name: azsdk-pool-mms-ubuntu-2004-general
       vmImage: MMSUbuntu20.04


### PR DESCRIPTION
The nightly build for core has been consistently failing due to timeout errors. Extending the timeout for analyzer job to 100 min (from 60)