### PR TITLE
MR Auth: Updated System.IdentityModel.Tokens.Jwt to 6.21.0

### DIFF
--- a/sdk/mixedreality/Azure.MixedReality.Authentication/CHANGELOG.md
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.1.0-beta.1 (Unreleased)
 
+### Key Bug Fixes
+
+- Many dependencies were updated as well as updating `System.IdentityModel.Tokens.Jwt` to `6.21.0` to remove a dependency on a vulnerable version of `Newtonsoft.Json`.
+
 ## 1.0.1 (2021-05-25)
 
 ### Key Bug Fixes

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/src/Azure.MixedReality.Authentication.csproj
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/src/Azure.MixedReality.Authentication.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" VersionOverride="6.21.0" />
     <PackageReference Include="System.Text.Encodings.Web" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>


### PR DESCRIPTION
The Azure.MixedReality.Authentication library currently depends on [System.IdentityModel.Tokens.Jwt `5.4.0`](https://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt/5.4.0). The version of that particular package is determined by `eng/Packages.Data.props`, which dictates the version of that package for all consumers in this repository. I see 6 projects that consume the package. System.IdentityModel.Tokens.Jwt `5.4.0` depends on Newtonsoft.Json 10.0.1, which has an insecure default setting causing a high severity vulnerability. This triggers vulnerability scanners for consumers of the Azure.MixedReality.Authentication library. Newer versions of System.IdentityModel.Tokens.Jwt `6.x` no longer have a dependency on Newtonsoft.Json. So, i'm overriding our version to use the latest of the `6.x` flavor to remove the dependency.

See #29617.