### PR TITLE
[Event Hubs] Update Scale Monitor

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsScaleMonitor.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsScaleMonitor.cs
@@ -89,8 +89,9 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
 
             try
             {
-                checkpoints = await Task.WhenAll(checkpointTasks)
-                    .ConfigureAwait(false);
+                checkpoints = (await Task.WhenAll(checkpointTasks).ConfigureAwait(false))
+                    .Where(c => c != null)
+                    .ToArray();
             }
             catch
             {
@@ -116,16 +117,12 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                 var partitionProperties = partitionRuntimeInfo[i];
 
                 var checkpoint = (BlobCheckpointStoreInternal.BlobStorageCheckpoint)checkpoints.SingleOrDefault(c => c.PartitionId == partitionProperties.Id);
-                if (checkpoint == null)
-                {
-                    partitionErrors.Add($"Unable to find a checkpoint information for partition: {partitionProperties.Id}");
-                    continue;
-                }
 
                 // Check for the unprocessed messages when there are messages on the event hub partition
                 // In that case, LastEnqueuedSequenceNumber will be >= 0
-                if ((partitionProperties.LastEnqueuedSequenceNumber != -1 && partitionProperties.LastEnqueuedSequenceNumber != checkpoint.SequenceNumber)
-                    || (checkpoint.Offset == null && partitionProperties.LastEnqueuedSequenceNumber >= 0))
+
+                if ((partitionProperties.LastEnqueuedSequenceNumber != -1 && partitionProperties.LastEnqueuedSequenceNumber != (checkpoint?.SequenceNumber ?? -1))
+                    || (checkpoint == null && partitionProperties.LastEnqueuedSequenceNumber >= 0))
                 {
                     long partitionUnprocessedEventCount = GetUnprocessedEventCount(partitionProperties, checkpoint);
                     totalUnprocessedEventCount += partitionUnprocessedEventCount;
@@ -155,35 +152,58 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
         }
 
         // Get the number of unprocessed events by deriving the delta between the server side info and the partition lease info,
-        private static long GetUnprocessedEventCount(PartitionProperties partitionInfo, BlobCheckpointStoreInternal.BlobStorageCheckpoint partitionLeaseInfo)
+        private static long GetUnprocessedEventCount(PartitionProperties partitionInfo, BlobCheckpointStoreInternal.BlobStorageCheckpoint checkpoint)
         {
-            long partitionLeaseInfoSequenceNumber = partitionLeaseInfo.SequenceNumber ?? 0;
+            // If the partition is empty, there are no events to process.
 
-            // This handles two scenarios:
-            //   1. If the partition has received its first message, Offset will be null and LastEnqueuedSequenceNumber will be 0
-            //   2. If there are no instances set to process messages, Offset will be null and LastEnqueuedSequenceNumber will be >= 0
-            if (partitionLeaseInfo.Offset == null && partitionInfo.LastEnqueuedSequenceNumber >= 0)
+            if (partitionInfo.IsEmpty)
             {
-                return (partitionInfo.LastEnqueuedSequenceNumber + 1);
+                return 0;
             }
 
-            if (partitionInfo.LastEnqueuedSequenceNumber > partitionLeaseInfoSequenceNumber)
+            // If there is no checkpoint and the beginning and last sequence numbers for the partition are the same
+            // this partition received its first event.
+
+            if (checkpoint == null
+                && partitionInfo.LastEnqueuedSequenceNumber == partitionInfo.BeginningSequenceNumber)
             {
-                return (partitionInfo.LastEnqueuedSequenceNumber - partitionLeaseInfoSequenceNumber);
+                return 1;
+            }
+
+            var startingSequenceNumber = checkpoint?.SequenceNumber switch
+            {
+                // There was no checkpoint, use the beginning sequence number - 1, since
+                // that event hasn't been processed yet.
+
+                null => partitionInfo.BeginningSequenceNumber - 1,
+
+                // Use the checkpoint.
+
+                long seq => seq
+            };
+
+            // For normal scenarios, the last sequence number will be greater than the starting number and
+            // simple subtraction can be used.
+
+            if (partitionInfo.LastEnqueuedSequenceNumber > startingSequenceNumber)
+            {
+                return (partitionInfo.LastEnqueuedSequenceNumber - startingSequenceNumber);
             }
 
             // Partition is a circular buffer, so it is possible that
-            // LastEnqueuedSequenceNumber < SequenceNumber
+            // LastEnqueuedSequenceNumber < startingSequenceNumber
+
             long count = 0;
             unchecked
             {
-                count = (long.MaxValue - partitionInfo.LastEnqueuedSequenceNumber) + partitionLeaseInfoSequenceNumber;
+                count = (long.MaxValue - partitionInfo.LastEnqueuedSequenceNumber) + startingSequenceNumber;
             }
 
-            // It's possible for checkpointing to be ahead of the partition's LastEnqueuedSequenceNumber,
-            // especially if checkpointing is happening often and load is very low.
-            // If count is negative, we need to know that this read is invalid, so return 0.
+            // It's possible for the starting sequence number to be ahead of the last sequence number,
+            // especially if checkpointing is happening often and load is very low.  If count is negative,
+            // we need to know that this read is invalid, so return 0.
             // e.g., (9223372036854775807 - 10) + 11 = -9223372036854775808
+
             return (count < 0) ? 0 : count;
         }
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsScaleMonitor.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsScaleMonitor.cs
@@ -89,8 +89,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
 
             try
             {
-                checkpoints = (await Task.WhenAll(checkpointTasks).ConfigureAwait(false))
-                    ?? Array.Empty<EventProcessorCheckpoint>();
+                checkpoints = await Task.WhenAll(checkpointTasks).ConfigureAwait(false);
             }
             catch
             {

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsScaleMonitor.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsScaleMonitor.cs
@@ -90,8 +90,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
             try
             {
                 checkpoints = (await Task.WhenAll(checkpointTasks).ConfigureAwait(false))
-                    .Where(c => c != null)
-                    .ToArray();
+                    ?? Array.Empty<EventProcessorCheckpoint>();
             }
             catch
             {
@@ -116,7 +115,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
             {
                 var partitionProperties = partitionRuntimeInfo[i];
 
-                var checkpoint = (BlobCheckpointStoreInternal.BlobStorageCheckpoint)checkpoints.SingleOrDefault(c => c.PartitionId == partitionProperties.Id);
+                var checkpoint = (BlobCheckpointStoreInternal.BlobStorageCheckpoint)checkpoints.SingleOrDefault(c => c?.PartitionId == partitionProperties.Id);
 
                 // Check for the unprocessed messages when there are messages on the event hub partition
                 // In that case, LastEnqueuedSequenceNumber will be >= 0

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHostPartition.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHostPartition.cs
@@ -60,7 +60,11 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
         {
             private readonly EventProcessorHostPartition _hostPartition;
 
-            public EventProcessorHostPartitionContext(EventProcessorHostPartition hostPartition) : base(hostPartition.PartitionId)
+            public EventProcessorHostPartitionContext(EventProcessorHostPartition hostPartition)
+                : base(hostPartition.ProcessorHost.FullyQualifiedNamespace,
+                    hostPartition.ProcessorHost.EventHubName,
+                    hostPartition.ProcessorHost.ConsumerGroup,
+                    hostPartition.PartitionId)
             {
                 _hostPartition = hostPartition;
             }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
@@ -24,7 +24,7 @@ using NUnit.Framework;
 namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 {
     [NonParallelizable]
-    [LiveOnly]
+    [LiveOnly(true)]
     public class EventHubEndToEndTests : WebJobsEventHubTestBase
     {
         private static EventWaitHandle _eventWait;

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubTests.cs
@@ -289,6 +289,19 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 eventProcessorOptions.DefaultStartingPosition);
         }
 
+        [Test]
+        public void HostPartitionPopulatesPartitionContext()
+        {
+            var partition = GetPartitionContext();
+            var processor = partition.ProcessorHost;
+            var context = partition.PartitionContext;
+
+            Assert.AreEqual(processor.FullyQualifiedNamespace, context.FullyQualifiedNamespace);
+            Assert.AreEqual(processor.EventHubName, context.EventHubName);
+            Assert.AreEqual(processor.ConsumerGroup, context.ConsumerGroup);
+            Assert.AreEqual(partition.PartitionId, context.PartitionId);
+        }
+
         internal static EventProcessorHostPartition GetPartitionContext(string partitionId = "0", string eventHubPath = "path",
             string consumerGroupName = "group", string owner = null)
         {

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsScaleMonitorTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsScaleMonitorTests.cs
@@ -88,27 +88,22 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             Assert.AreEqual(1, metrics.PartitionCount);
             Assert.AreNotEqual(default(DateTime), metrics.Timestamp);
 
-            // Partition got its first message (Offset == null, LastEnqueued == 0)
-            this._checkpoints = new EventProcessorCheckpoint[]
-            {
-                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = null,  SequenceNumber = 0 }
-            };
-
+            // Partition got its first message (no checkpoint, LastEnqueued == 0)
+            this._checkpoints = new EventProcessorCheckpoint[0];
             metrics = await _scaleMonitor.GetMetricsAsync();
 
             Assert.AreEqual(1, metrics.EventCount);
             Assert.AreEqual(1, metrics.PartitionCount);
             Assert.AreNotEqual(default(DateTime), metrics.Timestamp);
 
-            // No instances assigned to process events on partition (Offset == null, LastEnqueued > 0)
-            this._checkpoints = new EventProcessorCheckpoint[]
-            {
-                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = null, SequenceNumber = 0 }
-            };
+            // No instances assigned to process events on partition (no checkpoint, LastEnqueued > 0)
+            this._checkpoints = new EventProcessorCheckpoint[0];
 
             _partitions = new List<PartitionProperties>
             {
-                new TestPartitionProperties(lastSequenceNumber: 5)
+                new TestPartitionProperties(
+                    beginningSequenceNumber: 5,
+                    lastSequenceNumber: 10)
             };
 
             metrics = await _scaleMonitor.GetMetricsAsync();
@@ -117,10 +112,10 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             Assert.AreEqual(1, metrics.PartitionCount);
             Assert.AreNotEqual(default(DateTime), metrics.Timestamp);
 
-            // Checkpointing is ahead of partition info (SequenceNumber > LastEnqueued)
+            // Checkpointing is ahead of partition info and invalid (SequenceNumber > LastEnqueued)
             this._checkpoints = new EventProcessorCheckpoint[]
             {
-                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = 25, SequenceNumber = 11 }
+                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = 999, SequenceNumber = 11 }
             };
 
             _partitions = new List<PartitionProperties>


### PR DESCRIPTION
# Summary

The focus of these changes is to update the scale monitor for the Event Hubs Function extension to correct some left over T1 patterns that are no longer applicable.  For example, it is valid to have null checkpoints for a partition, but not possible to have a checkpoint with null offset. Additionally, correcting the assumption that the beginning sequence number for a partition is always 0.  This may not be true if the partition has been previously used and events have aged out, such as for very low volume or DR/fail-over scenarios.

Riding along is a fix for how the `PartitionContext` passed around is populated; the extended set of properties added in v5.7.0 had been ignored by the extension.