### PR TITLE
fix(sdk): incorrect `ServiceVresion` in `Azure.MixedReality.Authentication`

### DIFF
--- a/sdk/mixedreality/Azure.MixedReality.Authentication/api/Azure.MixedReality.Authentication.netstandard2.0.cs
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/api/Azure.MixedReality.Authentication.netstandard2.0.cs
@@ -17,7 +17,9 @@ namespace Azure.MixedReality.Authentication
         public MixedRealityStsClientOptions(Azure.MixedReality.Authentication.MixedRealityStsClientOptions.ServiceVersion version = Azure.MixedReality.Authentication.MixedRealityStsClientOptions.ServiceVersion.V2019_02_28_preview) { }
         public enum ServiceVersion
         {
+            [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
             V2019_02_28_preview = 1,
+            V2019_02_28_Preview = 1,
         }
     }
 }

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/src/MixedRealityStsClientOptions.cs
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/src/MixedRealityStsClientOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ComponentModel;
 using Azure.Core;
 
 namespace Azure.MixedReality.Authentication
@@ -19,11 +20,11 @@ namespace Azure.MixedReality.Authentication
         /// Initializes a new instance of the <see cref="MixedRealityStsClientOptions"/> class.
         /// </summary>
         /// <param name="version">The version.</param>
-        public MixedRealityStsClientOptions(ServiceVersion version = ServiceVersion.V2019_02_28_preview)
+        public MixedRealityStsClientOptions(ServiceVersion version = ServiceVersion.V2019_02_28_Preview)
         {
             Version = version switch
             {
-                ServiceVersion.V2019_02_28_preview => "2019-02-28-preview",
+                ServiceVersion.V2019_02_28_Preview => "2019-02-28-preview",
                 _ => throw new ArgumentException($"The service version {version} is not supported by this library.", nameof(version))
             };
         }
@@ -38,8 +39,15 @@ namespace Azure.MixedReality.Authentication
             /// </summary>
 #pragma warning disable CA1707 // Identifiers should not contain underscores
 #pragma warning disable AZC0016 // Invalid ServiceVersion member name.
+            [EditorBrowsable(EditorBrowsableState.Never)]
             V2019_02_28_preview = 1,
 #pragma warning restore AZC0016 // Invalid ServiceVersion member name.
+            /// <summary>
+            /// Version 2019-02-28-preview of the Mixed Reality STS service.
+            /// </summary>
+#pragma warning disable CA1069 // Enums values should not be duplicated
+            V2019_02_28_Preview = 1,
+#pragma warning restore CA1069 // Enums values should not be duplicated
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
     }


### PR DESCRIPTION
Per SDK guideline, the variable name should be pascal case. So `V2019_02_28_preview` should be `V2019_02_28_Preview` (with upper case `P`). Since `Azure.MixedReality.Authentication` is already GAed, we cannot simply update the enum definition.

This commit will fix the case problem and keep backward compatibility by:

- add the correct enum definition `V2019_02_28_Preview` with the same value `1`
- hide the problematic enum definition `V2019_02_28_preview` using attribute `[EditorBrowsable(EditorBrowsableState.Never)]`
- change the default value and service version selection in `MixedRealityStsClientOptions()`

part of https://github.com/Azure/autorest.csharp/issues/1524

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
