### PR TITLE
fix(dataplane): `ServiceVersion` should be pascal case in manual codes

### DIFF
--- a/sdk/communication/Azure.Communication.Identity/src/CommunicationIdentityClientOptions.cs
+++ b/sdk/communication/Azure.Communication.Identity/src/CommunicationIdentityClientOptions.cs
@@ -41,7 +41,6 @@ namespace Azure.Communication.Identity
             /// </summary>
 #pragma warning disable CA1707 // Identifiers should not contain underscores
             V2021_03_07 = 1,
-#pragma warning restore AZC0016 // Invalid ServiceVersion member name.
 #pragma warning restore CA1707 // Identifiers should not contain underscores
             /// <summary>
             /// The V2022_06_01 of the identity service.

--- a/sdk/communication/Azure.Communication.NetworkTraversal/api/Azure.Communication.NetworkTraversal.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.NetworkTraversal/api/Azure.Communication.NetworkTraversal.netstandard2.0.cs
@@ -20,10 +20,10 @@ namespace Azure.Communication.NetworkTraversal
     }
     public partial class CommunicationRelayClientOptions : Azure.Core.ClientOptions
     {
-        public CommunicationRelayClientOptions(Azure.Communication.NetworkTraversal.CommunicationRelayClientOptions.ServiceVersion version = Azure.Communication.NetworkTraversal.CommunicationRelayClientOptions.ServiceVersion.V2022_03_01_preview) { }
+        public CommunicationRelayClientOptions(Azure.Communication.NetworkTraversal.CommunicationRelayClientOptions.ServiceVersion version = Azure.Communication.NetworkTraversal.CommunicationRelayClientOptions.ServiceVersion.V2022_03_01_Preview) { }
         public enum ServiceVersion
         {
-            V2022_03_01_preview = 1,
+            V2022_03_01_Preview = 1,
         }
     }
     public partial class CommunicationRelayConfiguration

--- a/sdk/communication/Azure.Communication.NetworkTraversal/src/CommunicationRelayClientOptions.cs
+++ b/sdk/communication/Azure.Communication.NetworkTraversal/src/CommunicationRelayClientOptions.cs
@@ -14,7 +14,7 @@ namespace Azure.Communication.NetworkTraversal
         /// <summary>
         /// The latest version of the networking service.
         /// </summary>
-        internal const ServiceVersion LatestVersion = ServiceVersion.V2022_03_01_preview;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V2022_03_01_Preview;
 
         internal string ApiVersion { get; }
 
@@ -25,7 +25,7 @@ namespace Azure.Communication.NetworkTraversal
         {
             ApiVersion = version switch
             {
-                ServiceVersion.V2022_03_01_preview => "2022-03-01-preview",
+                ServiceVersion.V2022_03_01_Preview => "2022-03-01-preview",
                 _ => throw new ArgumentOutOfRangeException(nameof(version)),
             };
         }
@@ -36,12 +36,10 @@ namespace Azure.Communication.NetworkTraversal
         public enum ServiceVersion
         {
 #pragma warning disable CA1707 // Identifiers should not contain underscores
-#pragma warning disable AZC0016 // Invalid ServiceVersion member name.
             /// <summary>
             /// The V2022_02_01 GA version of the networking service.
             /// </summary>
-            V2022_03_01_preview = 1,
-#pragma warning restore AZC0016 // Invalid ServiceVersion member name.
+            V2022_03_01_Preview = 1,
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
     }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/api/Azure.Communication.PhoneNumbers.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/api/Azure.Communication.PhoneNumbers.netstandard2.0.cs
@@ -231,10 +231,10 @@ namespace Azure.Communication.PhoneNumbers.SipRouting
     }
     public partial class SipRoutingClientOptions : Azure.Core.ClientOptions
     {
-        public SipRoutingClientOptions(Azure.Communication.PhoneNumbers.SipRouting.SipRoutingClientOptions.ServiceVersion version = Azure.Communication.PhoneNumbers.SipRouting.SipRoutingClientOptions.ServiceVersion.V2021_05_01_preview1) { }
+        public SipRoutingClientOptions(Azure.Communication.PhoneNumbers.SipRouting.SipRoutingClientOptions.ServiceVersion version = Azure.Communication.PhoneNumbers.SipRouting.SipRoutingClientOptions.ServiceVersion.V2021_05_01_Preview1) { }
         public enum ServiceVersion
         {
-            V2021_05_01_preview1 = 1,
+            V2021_05_01_Preview1 = 1,
         }
     }
     public partial class SipTrunk

--- a/sdk/communication/Azure.Communication.PhoneNumbers/src/SipRouting/SipRoutingClientOptions.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/src/SipRouting/SipRoutingClientOptions.cs
@@ -14,7 +14,7 @@ namespace Azure.Communication.PhoneNumbers.SipRouting
         /// <summary>
         /// The latest version of the calling configuration service.
         /// </summary>
-        internal const ServiceVersion LatestVersion = ServiceVersion.V2021_05_01_preview1;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V2021_05_01_Preview1;
 
         internal string ApiVersion { get; }
 
@@ -25,7 +25,7 @@ namespace Azure.Communication.PhoneNumbers.SipRouting
         {
             ApiVersion = version switch
             {
-                ServiceVersion.V2021_05_01_preview1 => "2021-05-01-preview1",
+                ServiceVersion.V2021_05_01_Preview1 => "2021-05-01-preview1",
                 _ => throw new ArgumentOutOfRangeException(nameof(version)),
             };
         }
@@ -39,9 +39,7 @@ namespace Azure.Communication.PhoneNumbers.SipRouting
             /// The V1 of the calling configuration service.
             /// </summary>
 #pragma warning disable CA1707 // Identifiers should not contain underscores
-#pragma warning disable AZC0016 // All parts of ServiceVersion members' names must begin with a number or uppercase letter and cannot have consecutive underscores
-            V2021_05_01_preview1 = 1
-#pragma warning restore AZC0016 // All parts of ServiceVersion members' names must begin with a number or uppercase letter and cannot have consecutive underscores
+            V2021_05_01_Preview1 = 1
 #pragma warning restore CA1707 // Identifiers should not contain underscores
 
         }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/api/Azure.AI.FormRecognizer.netstandard2.0.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/api/Azure.AI.FormRecognizer.netstandard2.0.cs
@@ -414,12 +414,12 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     }
     public partial class DocumentAnalysisClientOptions : Azure.Core.ClientOptions
     {
-        public DocumentAnalysisClientOptions(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentAnalysisClientOptions.ServiceVersion version = Azure.AI.FormRecognizer.DocumentAnalysis.DocumentAnalysisClientOptions.ServiceVersion.V2022_06_30_preview) { }
+        public DocumentAnalysisClientOptions(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentAnalysisClientOptions.ServiceVersion version = Azure.AI.FormRecognizer.DocumentAnalysis.DocumentAnalysisClientOptions.ServiceVersion.V2022_06_30_Preview) { }
         public Azure.AI.FormRecognizer.DocumentAnalysis.DocumentAnalysisAudience? Audience { get { throw null; } set { } }
         public Azure.AI.FormRecognizer.DocumentAnalysis.DocumentAnalysisClientOptions.ServiceVersion Version { get { throw null; } }
         public enum ServiceVersion
         {
-            V2022_06_30_preview = 1,
+            V2022_06_30_Preview = 1,
         }
     }
     public static partial class DocumentAnalysisModelFactory

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentAnalysisClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentAnalysisClient.cs
@@ -17,7 +17,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     /// documents with models built on custom document types.
     /// </summary>
     /// <remarks>
-    /// Client is only available for <see cref="DocumentAnalysisClientOptions.ServiceVersion.V2022_06_30_preview"/> and higher.
+    /// Client is only available for <see cref="DocumentAnalysisClientOptions.ServiceVersion.V2022_06_30_Preview"/> and higher.
     /// If you want to use a lower version, please use the <see cref="FormRecognizer.FormRecognizerClient"/>.
     /// </remarks>
     public class DocumentAnalysisClient

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentAnalysisClientOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentAnalysisClientOptions.cs
@@ -12,7 +12,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     /// </summary>
     public class DocumentAnalysisClientOptions : ClientOptions
     {
-        internal const ServiceVersion LatestVersion = ServiceVersion.V2022_06_30_preview;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V2022_06_30_Preview;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DocumentAnalysisClientOptions"/> class which allows
@@ -23,7 +23,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         {
             Version = version switch
             {
-                ServiceVersion.V2022_06_30_preview => version,
+                ServiceVersion.V2022_06_30_Preview => version,
                 _ => throw new NotSupportedException($"The service version {version} is not supported.")
             };
 
@@ -42,9 +42,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             /// The version 2022-06-30-preview of the service.
             /// </summary>
 #pragma warning disable CA1707 // Identifiers should not contain underscores
-#pragma warning disable AZC0016 // All parts of ServiceVersion members' names must begin with a number or uppercase letter and cannot have consecutive underscores
-            V2022_06_30_preview = 1,
-#pragma warning restore AZC0016 // All parts of ServiceVersion members' names must begin with a number or uppercase letter and cannot have consecutive underscores
+            V2022_06_30_Preview = 1,
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -63,7 +61,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         {
             return version switch
             {
-                ServiceVersion.V2022_06_30_preview => "2022_06_30_preview",
+                ServiceVersion.V2022_06_30_Preview => "2022_06_30_preview",
                 _ => throw new NotSupportedException($"The service version {version} is not supported."),
             };
         }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelAdministrationClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelAdministrationClient.cs
@@ -17,7 +17,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     /// properties.
     /// </summary>
     /// <remarks>
-    /// This client only works with <see cref="DocumentAnalysisClientOptions.ServiceVersion.V2022_06_30_preview"/> and up.
+    /// This client only works with <see cref="DocumentAnalysisClientOptions.ServiceVersion.V2022_06_30_Preview"/> and up.
     /// If you want to use a lower version, please use the <see cref="Training.FormTrainingClient"/>.
     /// </remarks>
     public class DocumentModelAdministrationClient

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentAnalysisClient/DocumentAnalysisClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentAnalysisClient/DocumentAnalysisClientLiveTests.cs
@@ -22,7 +22,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
     /// </remarks>
     [IgnoreServiceError(400, "InvalidRequest", Message = "Content is not accessible: Invalid data URL", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28923")]
     [ClientTestFixture(
-     DocumentAnalysisClientOptions.ServiceVersion.V2022_06_30_preview)]
+     DocumentAnalysisClientOptions.ServiceVersion.V2022_06_30_Preview)]
     public class DocumentAnalysisClientLiveTests : DocumentAnalysisLiveTestBase
     {
         /// <summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/DocumentAnalysisLiveTestBase.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/DocumentAnalysisLiveTestBase.cs
@@ -9,7 +9,7 @@ using Azure.Core.TestFramework;
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
 {
     [ClientTestFixture(
-    DocumentAnalysisClientOptions.ServiceVersion.V2022_06_30_preview)]
+    DocumentAnalysisClientOptions.ServiceVersion.V2022_06_30_Preview)]
     public class DocumentAnalysisLiveTestBase : RecordedTestBase<DocumentAnalysisTestEnvironment>
     {
         /// <summary>

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/api/Azure.MixedReality.ObjectAnchors.Conversion.netstandard2.0.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/api/Azure.MixedReality.ObjectAnchors.Conversion.netstandard2.0.cs
@@ -155,14 +155,14 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
     }
     public partial class ObjectAnchorsConversionClientOptions : Azure.Core.ClientOptions
     {
-        public ObjectAnchorsConversionClientOptions(Azure.MixedReality.ObjectAnchors.Conversion.ObjectAnchorsConversionClientOptions.ServiceVersion version = Azure.MixedReality.ObjectAnchors.Conversion.ObjectAnchorsConversionClientOptions.ServiceVersion.V0_3_preview_0) { }
+        public ObjectAnchorsConversionClientOptions(Azure.MixedReality.ObjectAnchors.Conversion.ObjectAnchorsConversionClientOptions.ServiceVersion version = Azure.MixedReality.ObjectAnchors.Conversion.ObjectAnchorsConversionClientOptions.ServiceVersion.V0_3_Preview_0) { }
         public System.Uri MixedRealityAuthenticationEndpoint { get { throw null; } set { } }
         public Azure.MixedReality.Authentication.MixedRealityStsClientOptions MixedRealityAuthenticationOptions { get { throw null; } set { } }
         public System.Uri ServiceEndpoint { get { throw null; } set { } }
         public enum ServiceVersion
         {
-            V0_2_preview_0 = 1,
-            V0_3_preview_0 = 2,
+            V0_2_Preview_0 = 1,
+            V0_3_Preview_0 = 2,
         }
     }
     public static partial class ObjectAnchorsConversionModelFactory

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/ObjectAnchorsConversionClientOptions.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/ObjectAnchorsConversionClientOptions.cs
@@ -42,18 +42,18 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// Initializes a new instance of the <see cref="ObjectAnchorsConversionClientOptions"/> class.
         /// </summary>
         /// <param name="version">The version.</param>
-        public ObjectAnchorsConversionClientOptions(ServiceVersion version = ServiceVersion.V0_3_preview_0)
+        public ObjectAnchorsConversionClientOptions(ServiceVersion version = ServiceVersion.V0_3_Preview_0)
         {
             Version = version switch
             {
-                ServiceVersion.V0_2_preview_0 => "0.2.preview.0",
-                ServiceVersion.V0_3_preview_0 => "0.3-preview.0",
+                ServiceVersion.V0_2_Preview_0 => "0.2.preview.0",
+                ServiceVersion.V0_3_Preview_0 => "0.3-preview.0",
                 _ => throw new ArgumentException($"The service version {version} is not supported by this library.", nameof(version))
             };
 
             SupportedAssetFileTypes = version switch
             {
-                ServiceVersion.V0_2_preview_0 or ServiceVersion.V0_3_preview_0 => new HashSet<AssetFileType>
+                ServiceVersion.V0_2_Preview_0 or ServiceVersion.V0_3_Preview_0 => new HashSet<AssetFileType>
                 {
                     AssetFileType.Fbx,
                     AssetFileType.Glb,
@@ -73,14 +73,12 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
             /// Version 0.2-preview.0 of the Azure Object Anchors service.
             /// </summary>
 #pragma warning disable CA1707 // Identifiers should not contain underscores
-#pragma warning disable AZC0016 // Invalid ServiceVersion member name.
-            V0_2_preview_0 = 1,
+            V0_2_Preview_0 = 1,
 
             /// <summary>
             /// Version 0.3-preview.0 of the Azure Object Anchors service.
             /// </summary>
-            V0_3_preview_0 = 2,
-#pragma warning restore AZC0016 // Invalid ServiceVersion member name.
+            V0_3_Preview_0 = 2,
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
     }

--- a/sdk/personalizer/Azure.AI.Personalizer/api/Azure.AI.Personalizer.netstandard2.0.cs
+++ b/sdk/personalizer/Azure.AI.Personalizer/api/Azure.AI.Personalizer.netstandard2.0.cs
@@ -66,10 +66,10 @@ namespace Azure.AI.Personalizer
     }
     public partial class PersonalizerClientOptions : Azure.Core.ClientOptions
     {
-        public PersonalizerClientOptions(Azure.AI.Personalizer.PersonalizerClientOptions.ServiceVersion version = Azure.AI.Personalizer.PersonalizerClientOptions.ServiceVersion.V1_1_preview_3, bool useLocalInference = false, float subsampleRate = 1f) { }
+        public PersonalizerClientOptions(Azure.AI.Personalizer.PersonalizerClientOptions.ServiceVersion version = Azure.AI.Personalizer.PersonalizerClientOptions.ServiceVersion.V1_1_Preview_3, bool useLocalInference = false, float subsampleRate = 1f) { }
         public enum ServiceVersion
         {
-            V1_1_preview_3 = 1,
+            V1_1_Preview_3 = 1,
         }
     }
     public partial class PersonalizerCreateEvaluationOperation : Azure.Operation<Azure.AI.Personalizer.PersonalizerEvaluation>

--- a/sdk/personalizer/Azure.AI.Personalizer/src/GlobalSuppressions.cs
+++ b/sdk/personalizer/Azure.AI.Personalizer/src/GlobalSuppressions.cs
@@ -1,6 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: SuppressMessage("Usage", "AZC0016:Invalid ServiceVersion member name.", Justification = "Generated code: https://github.com/Azure/autorest.csharp/issues/1524", Scope = "type", Target = "~T:Azure.AI.Personalizer.PersonalizerClientOptions.ServiceVersion")]

--- a/sdk/personalizer/Azure.AI.Personalizer/src/Models/PersonalizerClientOptions.cs
+++ b/sdk/personalizer/Azure.AI.Personalizer/src/Models/PersonalizerClientOptions.cs
@@ -15,13 +15,13 @@ namespace Azure.AI.Personalizer
     {
         private bool useLocalInference;
         private float subsampleRate;
-        private const ServiceVersion LatestVersion = ServiceVersion.V1_1_preview_3;
+        private const ServiceVersion LatestVersion = ServiceVersion.V1_1_Preview_3;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "v1.1-preview.3". </summary>
-            V1_1_preview_3 = 1,
+            V1_1_Preview_3 = 1,
         }
 
         internal string Version { get; }
@@ -34,7 +34,7 @@ namespace Azure.AI.Personalizer
 
             Version = version switch
             {
-                ServiceVersion.V1_1_preview_3 => "v1.1-preview.3",
+                ServiceVersion.V1_1_Preview_3 => "v1.1-preview.3",
                 _ => throw new NotSupportedException()
             };
 

--- a/sdk/purview/Azure.Analytics.Purview.Administration/api/Azure.Analytics.Purview.Administration.netstandard2.0.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Administration/api/Azure.Analytics.Purview.Administration.netstandard2.0.cs
@@ -25,10 +25,10 @@ namespace Azure.Analytics.Purview.Administration
     }
     public partial class PurviewAccountClientOptions : Azure.Core.ClientOptions
     {
-        public PurviewAccountClientOptions(Azure.Analytics.Purview.Administration.PurviewAccountClientOptions.ServiceVersion version = Azure.Analytics.Purview.Administration.PurviewAccountClientOptions.ServiceVersion.V2019_11_01_preview) { }
+        public PurviewAccountClientOptions(Azure.Analytics.Purview.Administration.PurviewAccountClientOptions.ServiceVersion version = Azure.Analytics.Purview.Administration.PurviewAccountClientOptions.ServiceVersion.V2019_11_01_Preview) { }
         public enum ServiceVersion
         {
-            V2019_11_01_preview = 1,
+            V2019_11_01_Preview = 1,
         }
     }
     public partial class PurviewCollection

--- a/sdk/purview/Azure.Analytics.Purview.Administration/src/Customizations/PurviewAccountClientOptions.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Administration/src/Customizations/PurviewAccountClientOptions.cs
@@ -16,13 +16,13 @@ namespace Azure.Analytics.Purview.Administration
     [CodeGenClient("PurviewAdministrationClientOptions")]
     public partial class PurviewAccountClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2019_11_01_preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2019_11_01_Preview;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "2019-11-01-preview". </summary>
-            V2019_11_01_preview = 1,
+            V2019_11_01_Preview = 1,
         }
 
         internal string Version { get; }
@@ -32,7 +32,7 @@ namespace Azure.Analytics.Purview.Administration
         {
             Version = version switch
             {
-                ServiceVersion.V2019_11_01_preview => "2019-11-01-preview",
+                ServiceVersion.V2019_11_01_Preview => "2019-11-01-preview",
                 _ => throw new NotSupportedException()
             };
         }

--- a/sdk/purview/Azure.Analytics.Purview.Administration/src/GlobalSuppressions.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Administration/src/GlobalSuppressions.cs
@@ -1,7 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: SuppressMessage("Usage", "AZC0016:Invalid ServiceVersion member name.", Justification = "Generated code: https://github.com/Azure/autorest.csharp/issues/1524", Scope = "type", Target = "~T:Azure.Analytics.Purview.Administration.PurviewAccountClientOptions.ServiceVersion")]
-[assembly: SuppressMessage("Usage", "AZC0016:Invalid ServiceVersion member name.", Justification = "Generated code: https://github.com/Azure/autorest.csharp/issues/1524", Scope = "type", Target = "~T:Azure.Analytics.Purview.Administration.PurviewAdministrationClientOptions.ServiceVersion")]


### PR DESCRIPTION
- fix case problem in `ServiceVersion` in manual codes
- remove suppression of `AZC0016`

part of https://github.com/Azure/autorest.csharp/issues/1524

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
