### PR TITLE
fix(sdk): `ServiceVersion` should be pascal case in generated codes

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -155,7 +155,7 @@
     All should have PrivateAssets="All" set so they don't become package dependencies
   -->
   <ItemGroup>
-    <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20220714.1" PrivateAssets="All" />
+    <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20220714.2" PrivateAssets="All" />
     <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20220111.2" PrivateAssets="All" />
     <PackageReference Update="coverlet.collector" Version="1.3.0" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" PrivateAssets="All" />

--- a/sdk/agrifood/Azure.Verticals.AgriFood.Farming/api/Azure.Verticals.AgriFood.Farming.netstandard2.0.cs
+++ b/sdk/agrifood/Azure.Verticals.AgriFood.Farming/api/Azure.Verticals.AgriFood.Farming.netstandard2.0.cs
@@ -95,10 +95,10 @@ namespace Azure.Verticals.AgriFood.Farming
     }
     public partial class FarmBeatsClientOptions : Azure.Core.ClientOptions
     {
-        public FarmBeatsClientOptions(Azure.Verticals.AgriFood.Farming.FarmBeatsClientOptions.ServiceVersion version = Azure.Verticals.AgriFood.Farming.FarmBeatsClientOptions.ServiceVersion.V2021_03_31_preview) { }
+        public FarmBeatsClientOptions(Azure.Verticals.AgriFood.Farming.FarmBeatsClientOptions.ServiceVersion version = Azure.Verticals.AgriFood.Farming.FarmBeatsClientOptions.ServiceVersion.V2021_03_31_Preview) { }
         public enum ServiceVersion
         {
-            V2021_03_31_preview = 1,
+            V2021_03_31_Preview = 1,
         }
     }
     public partial class FarmClient

--- a/sdk/agrifood/Azure.Verticals.AgriFood.Farming/src/Generated/FarmBeatsClientOptions.cs
+++ b/sdk/agrifood/Azure.Verticals.AgriFood.Farming/src/Generated/FarmBeatsClientOptions.cs
@@ -13,13 +13,13 @@ namespace Azure.Verticals.AgriFood.Farming
     /// <summary> Client options for FarmBeats library clients. </summary>
     public partial class FarmBeatsClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2021_03_31_preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2021_03_31_Preview;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "2021-03-31-preview". </summary>
-            V2021_03_31_preview = 1,
+            V2021_03_31_Preview = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace Azure.Verticals.AgriFood.Farming
         {
             Version = version switch
             {
-                ServiceVersion.V2021_03_31_preview => "2021-03-31-preview",
+                ServiceVersion.V2021_03_31_Preview => "2021-03-31-preview",
                 _ => throw new NotSupportedException()
             };
         }

--- a/sdk/agrifood/Azure.Verticals.AgriFood.Farming/src/GlobalSuppressions.cs
+++ b/sdk/agrifood/Azure.Verticals.AgriFood.Farming/src/GlobalSuppressions.cs
@@ -1,6 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: SuppressMessage("Usage", "AZC0016:Invalid ServiceVersion member name.", Justification = "Generated code: https://github.com/Azure/autorest.csharp/issues/1524", Scope = "type", Target = "~T:Azure.Verticals.AgriFood.Farming.FarmBeatsClientOptions.ServiceVersion")]

--- a/sdk/anomalydetector/Azure.AI.AnomalyDetector/api/Azure.AI.AnomalyDetector.netstandard2.0.cs
+++ b/sdk/anomalydetector/Azure.AI.AnomalyDetector/api/Azure.AI.AnomalyDetector.netstandard2.0.cs
@@ -30,10 +30,10 @@ namespace Azure.AI.AnomalyDetector
     }
     public partial class AnomalyDetectorClientOptions : Azure.Core.ClientOptions
     {
-        public AnomalyDetectorClientOptions(Azure.AI.AnomalyDetector.AnomalyDetectorClientOptions.ServiceVersion version = Azure.AI.AnomalyDetector.AnomalyDetectorClientOptions.ServiceVersion.V1_1_preview_1) { }
+        public AnomalyDetectorClientOptions(Azure.AI.AnomalyDetector.AnomalyDetectorClientOptions.ServiceVersion version = Azure.AI.AnomalyDetector.AnomalyDetectorClientOptions.ServiceVersion.V1_1_Preview_1) { }
         public enum ServiceVersion
         {
-            V1_1_preview_1 = 1,
+            V1_1_Preview_1 = 1,
         }
     }
 }

--- a/sdk/anomalydetector/Azure.AI.AnomalyDetector/src/Generated/AnomalyDetectorClientOptions.cs
+++ b/sdk/anomalydetector/Azure.AI.AnomalyDetector/src/Generated/AnomalyDetectorClientOptions.cs
@@ -13,13 +13,13 @@ namespace Azure.AI.AnomalyDetector
     /// <summary> Client options for AnomalyDetectorClient. </summary>
     public partial class AnomalyDetectorClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V1_1_preview_1;
+        private const ServiceVersion LatestVersion = ServiceVersion.V1_1_Preview_1;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "1.1-preview.1". </summary>
-            V1_1_preview_1 = 1,
+            V1_1_Preview_1 = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace Azure.AI.AnomalyDetector
         {
             Version = version switch
             {
-                ServiceVersion.V1_1_preview_1 => "1.1-preview.1",
+                ServiceVersion.V1_1_Preview_1 => "1.1-preview.1",
                 _ => throw new NotSupportedException()
             };
         }

--- a/sdk/anomalydetector/Azure.AI.AnomalyDetector/src/GlobalSuppressions.cs
+++ b/sdk/anomalydetector/Azure.AI.AnomalyDetector/src/GlobalSuppressions.cs
@@ -1,6 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: SuppressMessage("Usage", "AZC0016:Invalid ServiceVersion member name.", Justification = "Generated code: https://github.com/Azure/autorest.csharp/issues/1524", Scope = "type", Target = "~T:Azure.AI.AnomalyDetector.AnomalyDetectorClientOptions.ServiceVersion")]

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/GlobalSuppressions.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/GlobalSuppressions.cs
@@ -1,6 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: SuppressMessage("Usage", "AZC0016:Invalid ServiceVersion member name.", Justification = "Generated code: https://github.com/Azure/autorest.csharp/issues/1524", Scope = "type", Target = "~T:Azure.Security.ConfidentialLedger.ConfidentialLedgerClientOptions.ServiceVersion")]

--- a/sdk/deviceupdate/Azure.IoT.DeviceUpdate/api/Azure.IoT.DeviceUpdate.netstandard2.0.cs
+++ b/sdk/deviceupdate/Azure.IoT.DeviceUpdate/api/Azure.IoT.DeviceUpdate.netstandard2.0.cs
@@ -116,10 +116,10 @@ namespace Azure.IoT.DeviceUpdate
     }
     public partial class DeviceUpdateClientOptions : Azure.Core.ClientOptions
     {
-        public DeviceUpdateClientOptions(Azure.IoT.DeviceUpdate.DeviceUpdateClientOptions.ServiceVersion version = Azure.IoT.DeviceUpdate.DeviceUpdateClientOptions.ServiceVersion.V2022_07_01_preview) { }
+        public DeviceUpdateClientOptions(Azure.IoT.DeviceUpdate.DeviceUpdateClientOptions.ServiceVersion version = Azure.IoT.DeviceUpdate.DeviceUpdateClientOptions.ServiceVersion.V2022_07_01_Preview) { }
         public enum ServiceVersion
         {
-            V2022_07_01_preview = 1,
+            V2022_07_01_Preview = 1,
         }
     }
 }

--- a/sdk/deviceupdate/Azure.IoT.DeviceUpdate/src/Azure.IoT.DeviceUpdate.csproj
+++ b/sdk/deviceupdate/Azure.IoT.DeviceUpdate/src/Azure.IoT.DeviceUpdate.csproj
@@ -8,7 +8,7 @@
     <PackageTags>Azure Device Update</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <!-- These supressions should be removed in a production library -->
-    <NoWarn>$(NoWarn);CS0169;AZC0016;AZC0012</NoWarn>
+    <NoWarn>$(NoWarn);CS0169;AZC0012</NoWarn>
     <DefineConstants>$(DefineConstants);EXPERIMENTAL</DefineConstants>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>

--- a/sdk/deviceupdate/Azure.IoT.DeviceUpdate/src/Generated/DeviceUpdateClientOptions.cs
+++ b/sdk/deviceupdate/Azure.IoT.DeviceUpdate/src/Generated/DeviceUpdateClientOptions.cs
@@ -13,13 +13,13 @@ namespace Azure.IoT.DeviceUpdate
     /// <summary> Client options for DeviceUpdate library clients. </summary>
     public partial class DeviceUpdateClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2022_07_01_preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2022_07_01_Preview;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "2022-07-01-preview". </summary>
-            V2022_07_01_preview = 1,
+            V2022_07_01_Preview = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace Azure.IoT.DeviceUpdate
         {
             Version = version switch
             {
-                ServiceVersion.V2022_07_01_preview => "2022-07-01-preview",
+                ServiceVersion.V2022_07_01_Preview => "2022-07-01-preview",
                 _ => throw new NotSupportedException()
             };
         }

--- a/sdk/deviceupdate/Azure.IoT.DeviceUpdate/src/GlobalSuppressions.cs
+++ b/sdk/deviceupdate/Azure.IoT.DeviceUpdate/src/GlobalSuppressions.cs
@@ -1,6 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: SuppressMessage("Usage", "AZC0016:Invalid ServiceVersion member name.", Justification = "Generated code: https://github.com/Azure/autorest.csharp/issues/1524", Scope = "type", Target = "~T:Azure.IoT.DeviceUpdate.DeviceUpdateClientOptions.ServiceVersion")]

--- a/sdk/monitor/Azure.Monitor.Ingestion/api/Azure.Monitor.Ingestion.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.Ingestion/api/Azure.Monitor.Ingestion.netstandard2.0.cs
@@ -11,10 +11,10 @@ namespace Azure.Monitor.Ingestion
     }
     public partial class LogsIngestionClientOptions : Azure.Core.ClientOptions
     {
-        public LogsIngestionClientOptions(Azure.Monitor.Ingestion.LogsIngestionClientOptions.ServiceVersion version = Azure.Monitor.Ingestion.LogsIngestionClientOptions.ServiceVersion.V2021_11_01_preview) { }
+        public LogsIngestionClientOptions(Azure.Monitor.Ingestion.LogsIngestionClientOptions.ServiceVersion version = Azure.Monitor.Ingestion.LogsIngestionClientOptions.ServiceVersion.V2021_11_01_Preview) { }
         public enum ServiceVersion
         {
-            V2021_11_01_preview = 1,
+            V2021_11_01_Preview = 1,
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.Ingestion/src/Generated/LogsIngestionClientOptions.cs
+++ b/sdk/monitor/Azure.Monitor.Ingestion/src/Generated/LogsIngestionClientOptions.cs
@@ -13,13 +13,13 @@ namespace Azure.Monitor.Ingestion
     /// <summary> Client options for LogsIngestionClient. </summary>
     public partial class LogsIngestionClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2021_11_01_preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2021_11_01_Preview;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "2021-11-01-preview". </summary>
-            V2021_11_01_preview = 1,
+            V2021_11_01_Preview = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace Azure.Monitor.Ingestion
         {
             Version = version switch
             {
-                ServiceVersion.V2021_11_01_preview => "2021-11-01-preview",
+                ServiceVersion.V2021_11_01_Preview => "2021-11-01-preview",
                 _ => throw new NotSupportedException()
             };
         }

--- a/sdk/monitor/Azure.Monitor.Ingestion/src/GlobalSuppressions.cs
+++ b/sdk/monitor/Azure.Monitor.Ingestion/src/GlobalSuppressions.cs
@@ -3,5 +3,4 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Usage", "AZC0016:Invalid ServiceVersion member name.", Justification = "Generated code: https://github.com/Azure/autorest.csharp/issues/1524")]
 [assembly: SuppressMessage("Usage", "AZC0001:Use one of the following pre-approved namespace groups (https://azure.github.io/azure-sdk/registered_namespaces.html): Azure.AI, Azure.Analytics, Azure.Communication, Azure.Data, Azure.DigitalTwins, Azure.IoT, Azure.Learn, Azure.Media, Azure.Management, Azure.Messaging, Azure.ResourceManager, Azure.Search, Azure.Security, Azure.Storage, Azure.Template, Azure.Identity, Microsoft.Extensions.Azure", Justification = "https://github.com/Azure/azure-sdk-tools/issues/3483", Scope = "namespace", Target = "~N:Azure.Monitor.Ingestion")]

--- a/sdk/network/Azure.ResourceManager.Network/tests/Tests/PrivateEndpointTests.cs
+++ b/sdk/network/Azure.ResourceManager.Network/tests/Tests/PrivateEndpointTests.cs
@@ -64,7 +64,7 @@ namespace Azure.ResourceManager.Network.Tests
         private async Task<StorageAccountResource> createStorageAccount()
         {
             var name = Recording.GenerateAssetName("testsa");
-            var parameters = new StorageAccountCreateOrUpdateContent(new StorageSku(StorageSkuName.StandardLRS), StorageKind.Storage,TestEnvironment.Location);
+            var parameters = new StorageAccountCreateOrUpdateContent(new StorageSku(StorageSkuName.StandardLrs), StorageKind.Storage,TestEnvironment.Location);
             return (await resourceGroup.GetStorageAccounts().CreateOrUpdateAsync(WaitUntil.Completed, name,parameters)).Value;
             //var storageAccountId = $"/subscriptions/{TestEnvironment.SubscriptionId}/resourceGroups/{resourceGroup.Data.Name}/providers/Microsoft.Storage/storageAccounts/{name}";
 

--- a/sdk/purview/Azure.Analytics.Purview.Account/api/Azure.Analytics.Purview.Account.netstandard2.0.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Account/api/Azure.Analytics.Purview.Account.netstandard2.0.cs
@@ -23,10 +23,10 @@ namespace Azure.Analytics.Purview.Account
     }
     public partial class PurviewAccountClientOptions : Azure.Core.ClientOptions
     {
-        public PurviewAccountClientOptions(Azure.Analytics.Purview.Account.PurviewAccountClientOptions.ServiceVersion version = Azure.Analytics.Purview.Account.PurviewAccountClientOptions.ServiceVersion.V2019_11_01_preview) { }
+        public PurviewAccountClientOptions(Azure.Analytics.Purview.Account.PurviewAccountClientOptions.ServiceVersion version = Azure.Analytics.Purview.Account.PurviewAccountClientOptions.ServiceVersion.V2019_11_01_Preview) { }
         public enum ServiceVersion
         {
-            V2019_11_01_preview = 1,
+            V2019_11_01_Preview = 1,
         }
     }
     public partial class PurviewCollection

--- a/sdk/purview/Azure.Analytics.Purview.Account/src/Generated/PurviewAccountClientOptions.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Account/src/Generated/PurviewAccountClientOptions.cs
@@ -13,13 +13,13 @@ namespace Azure.Analytics.Purview.Account
     /// <summary> Client options for PurviewAccountClient. </summary>
     public partial class PurviewAccountClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2019_11_01_preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2019_11_01_Preview;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "2019-11-01-preview". </summary>
-            V2019_11_01_preview = 1,
+            V2019_11_01_Preview = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace Azure.Analytics.Purview.Account
         {
             Version = version switch
             {
-                ServiceVersion.V2019_11_01_preview => "2019-11-01-preview",
+                ServiceVersion.V2019_11_01_Preview => "2019-11-01-preview",
                 _ => throw new NotSupportedException()
             };
         }

--- a/sdk/purview/Azure.Analytics.Purview.Account/src/GlobalSuppressions.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Account/src/GlobalSuppressions.cs
@@ -1,6 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: SuppressMessage("Usage", "AZC0016:Invalid ServiceVersion member name.", Justification = "Generated code: https://github.com/Azure/autorest.csharp/issues/1524", Scope = "type", Target = "~T:Azure.Analytics.Purview.Account.PurviewAccountClientOptions.ServiceVersion")]

--- a/sdk/purview/Azure.Analytics.Purview.Catalog/api/Azure.Analytics.Purview.Catalog.netstandard2.0.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Catalog/api/Azure.Analytics.Purview.Catalog.netstandard2.0.cs
@@ -29,10 +29,10 @@ namespace Azure.Analytics.Purview.Catalog
     }
     public partial class PurviewCatalogClientOptions : Azure.Core.ClientOptions
     {
-        public PurviewCatalogClientOptions(Azure.Analytics.Purview.Catalog.PurviewCatalogClientOptions.ServiceVersion version = Azure.Analytics.Purview.Catalog.PurviewCatalogClientOptions.ServiceVersion.V2022_03_01_preview) { }
+        public PurviewCatalogClientOptions(Azure.Analytics.Purview.Catalog.PurviewCatalogClientOptions.ServiceVersion version = Azure.Analytics.Purview.Catalog.PurviewCatalogClientOptions.ServiceVersion.V2022_03_01_Preview) { }
         public enum ServiceVersion
         {
-            V2022_03_01_preview = 1,
+            V2022_03_01_Preview = 1,
         }
     }
     public partial class PurviewCollections

--- a/sdk/purview/Azure.Analytics.Purview.Catalog/src/Generated/PurviewCatalogClientOptions.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Catalog/src/Generated/PurviewCatalogClientOptions.cs
@@ -13,13 +13,13 @@ namespace Azure.Analytics.Purview.Catalog
     /// <summary> Client options for PurviewCatalogClient. </summary>
     public partial class PurviewCatalogClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2022_03_01_preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2022_03_01_Preview;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "2022-03-01-preview". </summary>
-            V2022_03_01_preview = 1,
+            V2022_03_01_Preview = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace Azure.Analytics.Purview.Catalog
         {
             Version = version switch
             {
-                ServiceVersion.V2022_03_01_preview => "2022-03-01-preview",
+                ServiceVersion.V2022_03_01_Preview => "2022-03-01-preview",
                 _ => throw new NotSupportedException()
             };
         }

--- a/sdk/purview/Azure.Analytics.Purview.Catalog/src/GlobalSuppressions.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Catalog/src/GlobalSuppressions.cs
@@ -1,6 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: SuppressMessage("Usage", "AZC0016:Invalid ServiceVersion member name.", Justification = "Generated code: https://github.com/Azure/autorest.csharp/issues/1524", Scope = "type", Target = "~T:Azure.Analytics.Purview.Catalog.PurviewCatalogClientOptions.ServiceVersion")]

--- a/sdk/purview/Azure.Analytics.Purview.Scanning/api/Azure.Analytics.Purview.Scanning.netstandard2.0.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Scanning/api/Azure.Analytics.Purview.Scanning.netstandard2.0.cs
@@ -103,10 +103,10 @@ namespace Azure.Analytics.Purview.Scanning
     }
     public partial class PurviewScanningServiceClientOptions : Azure.Core.ClientOptions
     {
-        public PurviewScanningServiceClientOptions(Azure.Analytics.Purview.Scanning.PurviewScanningServiceClientOptions.ServiceVersion version = Azure.Analytics.Purview.Scanning.PurviewScanningServiceClientOptions.ServiceVersion.V2018_12_01_preview) { }
+        public PurviewScanningServiceClientOptions(Azure.Analytics.Purview.Scanning.PurviewScanningServiceClientOptions.ServiceVersion version = Azure.Analytics.Purview.Scanning.PurviewScanningServiceClientOptions.ServiceVersion.V2018_12_01_Preview) { }
         public enum ServiceVersion
         {
-            V2018_12_01_preview = 1,
+            V2018_12_01_Preview = 1,
         }
     }
 }

--- a/sdk/purview/Azure.Analytics.Purview.Scanning/src/Generated/PurviewScanningServiceClientOptions.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Scanning/src/Generated/PurviewScanningServiceClientOptions.cs
@@ -13,13 +13,13 @@ namespace Azure.Analytics.Purview.Scanning
     /// <summary> Client options for PurviewScanningServiceClient. </summary>
     public partial class PurviewScanningServiceClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2018_12_01_preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2018_12_01_Preview;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "2018-12-01-preview". </summary>
-            V2018_12_01_preview = 1,
+            V2018_12_01_Preview = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace Azure.Analytics.Purview.Scanning
         {
             Version = version switch
             {
-                ServiceVersion.V2018_12_01_preview => "2018-12-01-preview",
+                ServiceVersion.V2018_12_01_Preview => "2018-12-01-preview",
                 _ => throw new NotSupportedException()
             };
         }

--- a/sdk/purview/Azure.Analytics.Purview.Scanning/src/GlobalSuppressions.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Scanning/src/GlobalSuppressions.cs
@@ -1,6 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: SuppressMessage("Usage", "AZC0016:Invalid ServiceVersion member name.", Justification = "Generated code: https://github.com/Azure/autorest.csharp/issues/1524", Scope = "type", Target = "~T:Azure.Analytics.Purview.Scanning.PurviewScanningServiceClientOptions.ServiceVersion")]

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/api/Azure.Analytics.Synapse.Artifacts.netstandard2.0.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/api/Azure.Analytics.Synapse.Artifacts.netstandard2.0.cs
@@ -2,14 +2,14 @@ namespace Azure.Analytics.Synapse.Artifacts
 {
     public partial class ArtifactsClientOptions : Azure.Core.ClientOptions
     {
-        public ArtifactsClientOptions(Azure.Analytics.Synapse.Artifacts.ArtifactsClientOptions.ServiceVersion version = Azure.Analytics.Synapse.Artifacts.ArtifactsClientOptions.ServiceVersion.V2021_12_01_preview) { }
+        public ArtifactsClientOptions(Azure.Analytics.Synapse.Artifacts.ArtifactsClientOptions.ServiceVersion version = Azure.Analytics.Synapse.Artifacts.ArtifactsClientOptions.ServiceVersion.V2021_12_01_Preview) { }
         public enum ServiceVersion
         {
             V2020_12_01 = 1,
-            V2021_06_01_preview = 2,
-            V2021_07_01_preview = 3,
-            V2021_11_01_preview = 4,
-            V2021_12_01_preview = 5,
+            V2021_06_01_Preview = 2,
+            V2021_07_01_Preview = 3,
+            V2021_11_01_Preview = 4,
+            V2021_12_01_Preview = 5,
         }
     }
     public partial class BigDataPoolsClient

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/src/Generated/ArtifactsClientOptions.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/src/Generated/ArtifactsClientOptions.cs
@@ -13,7 +13,7 @@ namespace Azure.Analytics.Synapse.Artifacts
     /// <summary> Client options for ArtifactsClient. </summary>
     public partial class ArtifactsClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2021_12_01_preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2021_12_01_Preview;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
@@ -21,13 +21,13 @@ namespace Azure.Analytics.Synapse.Artifacts
             /// <summary> Service version "2020-12-01". </summary>
             V2020_12_01 = 1,
             /// <summary> Service version "2021-06-01-preview". </summary>
-            V2021_06_01_preview = 2,
+            V2021_06_01_Preview = 2,
             /// <summary> Service version "2021-07-01-preview". </summary>
-            V2021_07_01_preview = 3,
+            V2021_07_01_Preview = 3,
             /// <summary> Service version "2021-11-01-preview". </summary>
-            V2021_11_01_preview = 4,
+            V2021_11_01_Preview = 4,
             /// <summary> Service version "2021-12-01-preview". </summary>
-            V2021_12_01_preview = 5,
+            V2021_12_01_Preview = 5,
         }
 
         internal string Version { get; }
@@ -38,10 +38,10 @@ namespace Azure.Analytics.Synapse.Artifacts
             Version = version switch
             {
                 ServiceVersion.V2020_12_01 => "2020-12-01",
-                ServiceVersion.V2021_06_01_preview => "2021-06-01-preview",
-                ServiceVersion.V2021_07_01_preview => "2021-07-01-preview",
-                ServiceVersion.V2021_11_01_preview => "2021-11-01-preview",
-                ServiceVersion.V2021_12_01_preview => "2021-12-01-preview",
+                ServiceVersion.V2021_06_01_Preview => "2021-06-01-preview",
+                ServiceVersion.V2021_07_01_Preview => "2021-07-01-preview",
+                ServiceVersion.V2021_11_01_Preview => "2021-11-01-preview",
+                ServiceVersion.V2021_12_01_Preview => "2021-12-01-preview",
                 _ => throw new NotSupportedException()
             };
         }

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/src/GlobalSuppressions.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/src/GlobalSuppressions.cs
@@ -1,6 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: SuppressMessage("Usage", "AZC0016:Invalid ServiceVersion member name.", Justification = "Generated code: https://github.com/Azure/autorest.csharp/issues/1524", Scope = "type", Target = "~T:Azure.Analytics.Synapse.Artifacts.ArtifactsClientOptions.ServiceVersion")]

--- a/sdk/synapse/Azure.Analytics.Synapse.Monitoring/api/Azure.Analytics.Synapse.Monitoring.netstandard2.0.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Monitoring/api/Azure.Analytics.Synapse.Monitoring.netstandard2.0.cs
@@ -11,10 +11,10 @@ namespace Azure.Analytics.Synapse.Monitoring
     }
     public partial class MonitoringClientOptions : Azure.Core.ClientOptions
     {
-        public MonitoringClientOptions(Azure.Analytics.Synapse.Monitoring.MonitoringClientOptions.ServiceVersion version = Azure.Analytics.Synapse.Monitoring.MonitoringClientOptions.ServiceVersion.V2019_11_01_preview) { }
+        public MonitoringClientOptions(Azure.Analytics.Synapse.Monitoring.MonitoringClientOptions.ServiceVersion version = Azure.Analytics.Synapse.Monitoring.MonitoringClientOptions.ServiceVersion.V2019_11_01_Preview) { }
         public enum ServiceVersion
         {
-            V2019_11_01_preview = 1,
+            V2019_11_01_Preview = 1,
         }
     }
 }

--- a/sdk/synapse/Azure.Analytics.Synapse.Monitoring/src/Generated/MonitoringClientOptions.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Monitoring/src/Generated/MonitoringClientOptions.cs
@@ -13,13 +13,13 @@ namespace Azure.Analytics.Synapse.Monitoring
     /// <summary> Client options for MonitoringClient. </summary>
     public partial class MonitoringClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2019_11_01_preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2019_11_01_Preview;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "2019-11-01-preview". </summary>
-            V2019_11_01_preview = 1,
+            V2019_11_01_Preview = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace Azure.Analytics.Synapse.Monitoring
         {
             Version = version switch
             {
-                ServiceVersion.V2019_11_01_preview => "2019-11-01-preview",
+                ServiceVersion.V2019_11_01_Preview => "2019-11-01-preview",
                 _ => throw new NotSupportedException()
             };
         }

--- a/sdk/synapse/Azure.Analytics.Synapse.Monitoring/src/GlobalSuppressions.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Monitoring/src/GlobalSuppressions.cs
@@ -1,6 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: SuppressMessage("Usage", "AZC0016:Invalid ServiceVersion member name.", Justification = "Generated code: https://github.com/Azure/autorest.csharp/issues/1524", Scope = "type", Target = "~T:Azure.Analytics.Synapse.Monitoring.MonitoringClientOptions.ServiceVersion")]

--- a/sdk/template/.content/src/GlobalSuppressions.cs
+++ b/sdk/template/.content/src/GlobalSuppressions.cs
@@ -4,4 +4,3 @@
 using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage("Usage", "AZC0002:DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.", Justification = "CancellationToken can be passed through RequestOptions")]
-[assembly: SuppressMessage("Usage", "AZC0016:Invalid ServiceVersion member name.", Justification = "Generated code: https://github.com/Azure/autorest.csharp/issues/1524")]


### PR DESCRIPTION
- update generated `XXXOptions` classes to have pascal case `ServiceVersion` definition
- remove corresponding `AZC0016` error suppression
- remove `AZC0016` error suppression from template

resolve https://github.com/Azure/autorest.csharp/issues/1524

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
