### PR TITLE
MR Auth: Updated dependencies

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -108,7 +108,7 @@
     <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="2.19.3" />
 
     <!-- TODO: Make sure this package is arch-board approved -->
-    <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
+    <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
 
     <!-- OpenTelemetry dependency approved for Azure.Monitor.OpenTelemetry.Exporter package only -->
     <PackageReference Update="OpenTelemetry" Version="1.2.0"  Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/CHANGELOG.md
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 1.1.0-beta.1 (Unreleased)
 
+### Key Bug Fixes
+
+- The `Azure.Core` dependency was updated to `1.25.0`.
+- The `System.IdentityModel.Tokens.Jwt` dependency was updated to `6.5.0`.
+- The `System.Text.Json` dependency was updated to `4.7.2`.
+
 ## 1.0.1 (2021-05-25)
 
 ### Key Bug Fixes


### PR DESCRIPTION
- This change updates the common dependency version for `System.IdentityModel.Tokens.Jwt` to `6.5.0`, which is the first version to remove the dependency on `Newtonsoft.Json`.
