### PR TITLE
Service Bus Custom Endpoint Support

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
@@ -412,6 +412,7 @@ The [Azure Identity library](https://github.com/Azure/azure-sdk-for-net/tree/mai
 // Create a ServiceBusClient that will authenticate through Active Directory
 string fullyQualifiedNamespace = "yournamespace.servicebus.windows.net";
 ServiceBusClient client = new ServiceBusClient(fullyQualifiedNamespace, new DefaultAzureCredential());
+```
 
 ### Initiating the connection with a custom endpoint
 
@@ -420,12 +421,14 @@ If an alternative host name is needed to establish the connection to the service
 ```C#:Snippet:ServiceBusCustomEndpoint
 // Connect to the service using a custom endpoint
 string connectionString = "<connection_string>";
-string customEndpoint = "<custom_endpoint>";
+string customEndpoint = "<custom_endpoint";
 
 var options = new ServiceBusClientOptions
 {
     CustomEndpointAddress = new Uri(customEndpoint)
 };
+
+ServiceBusClient client = new ServiceBusClient(connectionString, options);
 ```
 
 ### Working with Sessions

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
@@ -418,7 +418,7 @@ ServiceBusClient client = new ServiceBusClient(fullyQualifiedNamespace, new Defa
 
 If an alternative host name is needed to establish the connection to the service, a custom endpoint address can be provided through the `ServiceBusClientOptions`. The client will use this endpoint to open the initial connection, and then will use the default endpoint provided by the Service Bus service for all following operations and validation.
 
-```C#:Snippet:ServiceBusCustomEndpoint
+```C# Snippet:ServiceBusCustomEndpoint
 // Connect to the service using a custom endpoint
 string connectionString = "<connection_string>";
 string customEndpoint = "<custom_endpoint";

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
@@ -56,6 +56,8 @@ ServiceBusClient client = new ServiceBusClient(connectionString);
 
 To see how to authenticate using Azure.Identity, view this [example](#authenticating-with-azureidentity).
 
+To see how to initiate the connection with a custom endpoint, view this [example](#initiating-the-connection-with-a-custom-endpoint).
+
 ### ASP.NET Core
 
 To inject `ServiceBusClient` as a dependency in an ASP.NET Core app, install the Azure client library integration for ASP.NET Core package.
@@ -150,6 +152,7 @@ We guarantee that all client instance methods are thread-safe and independent of
 * [Dead letter a message](#dead-letter-a-message)
 * [Using the processor](#using-the-processor)
 * [Authenticating with Azure.Identity](#authenticating-with-azureidentity)
+* [Initiating the connection with a custom endpoint](#initiating-the-connection-with-a-custom-endpoint)
 * [Working with sessions](#working-with-sessions)
 * [More samples](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/README.md)
 
@@ -409,6 +412,20 @@ The [Azure Identity library](https://github.com/Azure/azure-sdk-for-net/tree/mai
 // Create a ServiceBusClient that will authenticate through Active Directory
 string fullyQualifiedNamespace = "yournamespace.servicebus.windows.net";
 ServiceBusClient client = new ServiceBusClient(fullyQualifiedNamespace, new DefaultAzureCredential());
+
+### Initiating the connection with a custom endpoint
+
+If an alternative host name is needed to establish the connection to the service, a custom endpoint address can be provided through the `ServiceBusClientOptions`. The client will use this endpoint to open the initial connection, and then will use the default endpoint provided by the Service Bus service for all following operations and validation.
+
+```C#:Snippet:ServiceBusCustomEndpoint
+// Connect to the service using a custom endpoint
+string connectionString = "<connection_string>";
+string customEndpoint = "<custom_endpoint>";
+
+var options = new ServiceBusClientOptions
+{
+    CustomEndpointAddress = new Uri(customEndpoint)
+};
 ```
 
 ### Working with Sessions

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
@@ -421,7 +421,7 @@ If an alternative host name is needed to establish the connection to the service
 ```C# Snippet:ServiceBusCustomEndpoint
 // Connect to the service using a custom endpoint
 string connectionString = "<connection_string>";
-string customEndpoint = "<custom_endpoint";
+string customEndpoint = "<custom_endpoint>";
 
 var options = new ServiceBusClientOptions
 {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -105,6 +105,7 @@ namespace Azure.Messaging.ServiceBus
     public partial class ServiceBusClientOptions
     {
         public ServiceBusClientOptions() { }
+        public System.Uri CustomEndpointAddress { get { throw null; } set { } }
         public bool EnableCrossEntityTransactions { get { throw null; } set { } }
         public Azure.Messaging.ServiceBus.ServiceBusRetryOptions RetryOptions { get { throw null; } set { } }
         public Azure.Messaging.ServiceBus.ServiceBusTransportType TransportType { get { throw null; } set { } }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
@@ -50,7 +50,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         public override Uri ServiceEndpoint { get; }
 
         /// <summary>
-        ///   The endpoint for the Service Bus service to be used when establising the connection.
+        ///   The endpoint for the Service Bus service to be used when establishing the connection.
         /// </summary>
         ///
         public Uri ConnectionEndpoint { get; }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
@@ -50,6 +50,12 @@ namespace Azure.Messaging.ServiceBus.Amqp
         public override Uri ServiceEndpoint { get; }
 
         /// <summary>
+        ///   The endpoint for the Service Bus service to be used when establising the connection.
+        /// </summary>
+        ///
+        public Uri ConnectionEndpoint { get; }
+
+        /// <summary>
         ///   Gets the credential to use for authorization with the Service Bus service.
         /// </summary>
         ///
@@ -95,6 +101,12 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 Host = host
             }.Uri;
 
+            ConnectionEndpoint = (options.CustomEndpointAddress == null) ? ServiceEndpoint : new UriBuilder
+            {
+                Scheme = ServiceEndpoint.Scheme,
+                Host = options.CustomEndpointAddress.Host
+            }.Uri;
+
             Credential = credential;
             if (options.EnableTransportMetrics)
             {
@@ -102,6 +114,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             }
             ConnectionScope = new AmqpConnectionScope(
                 ServiceEndpoint,
+                ConnectionEndpoint,
                 credential,
                 options.TransportType,
                 options.WebProxy,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -173,6 +173,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///   Initializes a new instance of the <see cref="AmqpConnectionScope"/> class.
         /// </summary>
         /// <param name="serviceEndpoint">Endpoint for the Service Bus service to which the scope is associated.</param>
+        /// <param name="connectionEndpoint">The endpoint to use for the initial connection to the Service Bus service.</param>
         /// <param name="credential">The credential to use for authorization with the Service Bus service.</param>
         /// <param name="transport">The transport to use for communication.</param>
         /// <param name="proxy">The proxy, if any, to use for communication.</param>
@@ -181,6 +182,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="metrics">The metrics instance to populate transport metrics. May be null.</param>
         public AmqpConnectionScope(
             Uri serviceEndpoint,
+            Uri connectionEndpoint,
             ServiceBusTokenCredential credential,
             ServiceBusTransportType transport,
             IWebProxy proxy,
@@ -196,11 +198,11 @@ namespace Azure.Messaging.ServiceBus.Amqp
             ServiceEndpoint = serviceEndpoint;
             Transport = transport;
             Proxy = proxy;
-            Id = $"{ ServiceEndpoint }-{ Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture).Substring(0, 8) }";
+            Id = $"{ServiceEndpoint}-{Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture).Substring(0, 8)}";
             TokenProvider = new CbsTokenProvider(new ServiceBusTokenCredential(credential), AuthorizationTokenExpirationBuffer, OperationCancellationSource.Token);
             _useSingleSession = useSingleSession;
 #pragma warning disable CA2214 // Do not call overridable methods in constructors. This internal method is virtual for testing purposes.
-            Task<AmqpConnection> connectionFactory(TimeSpan timeout) => CreateAndOpenConnectionAsync(AmqpVersion, ServiceEndpoint, Transport, Proxy, Id, timeout, metrics);
+            Task<AmqpConnection> connectionFactory(TimeSpan timeout) => CreateAndOpenConnectionAsync(AmqpVersion, ServiceEndpoint, connectionEndpoint, Transport, Proxy, Id, timeout, metrics);
 #pragma warning restore CA2214 // Do not call overridable methods in constructors
 
             ActiveConnection = new FaultTolerantAmqpObject<AmqpConnection>(
@@ -434,6 +436,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///
         /// <param name="amqpVersion">The version of AMQP to use for the connection.</param>
         /// <param name="serviceEndpoint">The endpoint for the Service Bus service to which the scope is associated.</param>
+        /// <param name="connectionEndpoint">The endpoint to use for the initial connection to the Service Bus service.</param>
         /// <param name="transportType">The type of transport to use for communication.</param>
         /// <param name="proxy">The proxy, if any, to use for communication.</param>
         /// <param name="scopeIdentifier">The unique identifier for the associated scope.</param>
@@ -443,19 +446,21 @@ namespace Azure.Messaging.ServiceBus.Amqp
         protected virtual async Task<AmqpConnection> CreateAndOpenConnectionAsync(
             Version amqpVersion,
             Uri serviceEndpoint,
+            Uri connectionEndpoint,
             ServiceBusTransportType transportType,
             IWebProxy proxy,
             string scopeIdentifier,
             TimeSpan timeout,
             ServiceBusTransportMetrics metrics)
         {
-            var hostName = serviceEndpoint.Host;
+            var serviceHostName = serviceEndpoint.Host;
+            var connectionHostName = connectionEndpoint.Host;
             AmqpSettings amqpSettings = CreateAmpqSettings(AmqpVersion);
-            AmqpConnectionSettings connectionSetings = CreateAmqpConnectionSettings(hostName, scopeIdentifier);
+            AmqpConnectionSettings connectionSetings = CreateAmqpConnectionSettings(serviceHostName, scopeIdentifier);
 
             TransportSettings transportSettings = transportType.IsWebSocketTransport()
-                ? CreateTransportSettingsForWebSockets(hostName, proxy)
-                : CreateTransportSettingsforTcp(hostName, serviceEndpoint.Port);
+                ? CreateTransportSettingsForWebSockets(connectionHostName, proxy)
+                : CreateTransportSettingsforTcp(connectionHostName, connectionEndpoint.Port);
 
             // Create and open the connection, respecting the timeout constraint
             // that was received.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
@@ -122,7 +122,8 @@ namespace Azure.Messaging.ServiceBus
                 WebProxy = WebProxy,
                 RetryOptions = RetryOptions.Clone(),
                 EnableCrossEntityTransactions = EnableCrossEntityTransactions,
-                EnableTransportMetrics = EnableTransportMetrics
+                EnableTransportMetrics = EnableTransportMetrics,
+                CustomEndpointAddress = CustomEndpointAddress
             };
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
+using System;
 using System.ComponentModel;
 using System.Net;
 using Azure.Core;
@@ -35,6 +35,19 @@ namespace Azure.Messaging.ServiceBus
         /// </remarks>
         ///
         public IWebProxy WebProxy { get; set; }
+
+        /// <summary>
+        ///   A custom endpoint address that can be used when establishing the connection to the Service Bus
+        ///   service.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   The custom endpoint address will be used in place of the default endpoint provided by the Service
+        ///   Bus namespace when establishing the connection. The connection string or fully qualified namespace
+        ///   will still be needed in order to validate the connection with the service.
+        /// </remarks>
+        ///
+        public Uri CustomEndpointAddress { get; set; }
 
         /// <summary>
         /// The set of options to use for determining whether a failed operation should be retried and,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpClientTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpClientTests.cs
@@ -23,7 +23,7 @@ namespace Azure.Messaging.ServiceBus.Tests
         [Test]
         public void ConstructorInitializesTheEndpointsWithDefaults()
         {
-            var options = new ServiceBusClientOptions() { CustomEndpointAddress = new Uri("http://fake.custom.com") };
+            var options = new ServiceBusClientOptions();
             var endpoint = new Uri("http://fake.endpoint.com");
             var token = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
             var client = new AmqpClient(endpoint.Host, token.Object, options);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpClientTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpClientTests.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+using Azure.Messaging.ServiceBus.Amqp;
+using Azure.Messaging.ServiceBus.Authorization;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Messaging.ServiceBus.Tests
+{
+    /// <summary>
+    /// The suite of tests for the <see cref="AmqpClient"/> class.
+    /// </summary>
+    [TestFixture]
+    public class AmqpClientTests
+    {
+        /// <summary>
+        /// Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorInitializesTheEndpointsWithDefaults()
+        {
+            var options = new ServiceBusClientOptions() { CustomEndpointAddress = new Uri("http://fake.custom.com") };
+            var endpoint = new Uri("http://fake.endpoint.com");
+            var token = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
+            var client = new AmqpClient(endpoint.Host, token.Object, options);
+
+            Assert.That(client.ConnectionEndpoint.Host, Is.EqualTo(endpoint.Host), "The connection endpoint should have used the namespace URI.");
+            Assert.That(client.ServiceEndpoint.Host, Is.EqualTo(endpoint.Host), "The service endpoint should have used the namespace URI.");
+        }
+
+        /// <summary>
+        /// Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorInitializesTheEndpointsWithOptions()
+        {
+            var options = new ServiceBusClientOptions() { CustomEndpointAddress = new Uri("http://fake.custom.com") };
+            var endpoint = new Uri("http://fake.endpoint.com");
+            var token = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
+            var client = new AmqpClient(endpoint.Host, token.Object, options);
+
+            Assert.That(client.ConnectionEndpoint.Host, Is.EqualTo(options.CustomEndpointAddress.Host), "The connection endpoint should have used the custom endpoint URI from the options.");
+            Assert.That(client.ServiceEndpoint.Host, Is.EqualTo(endpoint.Host), "The service endpoint should have used the namespace URI.");
+        }
+    }
+}

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
@@ -34,7 +34,8 @@ namespace Azure.Messaging.ServiceBus.Tests
         public void CalculateLinkAuthorizationRefreshIntervalRespectsTheRefreshBuffer()
         {
             var credential = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
-            var mockScope = new MockConnectionScope(new Uri("sb://mine.hubs.com"), credential.Object, ServiceBusTransportType.AmqpTcp, null);
+            var endpoint = new Uri("sb://mine.hubs.com");
+            var mockScope = new MockConnectionScope(endpoint, endpoint, credential.Object, ServiceBusTransportType.AmqpTcp, null);
             var currentTime = new DateTime(2015, 10, 27, 00, 00, 00);
             var expireTime = currentTime.AddHours(1);
             var buffer = GetAuthorizationRefreshBuffer();
@@ -55,7 +56,8 @@ namespace Azure.Messaging.ServiceBus.Tests
         public void CalculateLinkAuthorizationRefreshIntervalRespectsTheMinimumDuration()
         {
             var credential = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
-            var mockScope = new MockConnectionScope(new Uri("sb://mine.hubs.com"), credential.Object, ServiceBusTransportType.AmqpTcp, null);
+            var endpoint = new Uri("sb://mine.hubs.com");
+            var mockScope = new MockConnectionScope(endpoint, endpoint, credential.Object, ServiceBusTransportType.AmqpTcp, null);
             var currentTime = new DateTime(2015, 10, 27, 00, 00, 00);
             var jitterBuffer = TimeSpan.FromSeconds(GetAuthorizationBaseJitterSeconds()).Add(TimeSpan.FromSeconds(5));
             var minimumRefresh = GetMinimumAuthorizationRefresh();
@@ -75,7 +77,8 @@ namespace Azure.Messaging.ServiceBus.Tests
         public void CalculateLinkAuthorizationRefreshIntervalRespectsTheMaximumDuration()
         {
             var credential = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
-            var mockScope = new MockConnectionScope(new Uri("sb://mine.hubs.com"), credential.Object, ServiceBusTransportType.AmqpTcp, null);
+            var endpoint = new Uri("sb://mine.hubs.com");
+            var mockScope = new MockConnectionScope(endpoint, endpoint, credential.Object, ServiceBusTransportType.AmqpTcp, null);
             var currentTime = new DateTime(2015, 10, 27, 00, 00, 00);
             var refreshBuffer = GetAuthorizationRefreshBuffer();
             var jitterBuffer = TimeSpan.FromSeconds(GetAuthorizationBaseJitterSeconds()).Add(TimeSpan.FromSeconds(5));
@@ -103,7 +106,7 @@ namespace Azure.Messaging.ServiceBus.Tests
             var transport = ServiceBusTransportType.AmqpTcp;
             var mockCredential = new Mock<TokenCredential>();
             var mockServiceBusCredential = new Mock<ServiceBusTokenCredential>(mockCredential.Object);
-            var mockScope = new MockConnectionScope(endpoint, mockServiceBusCredential.Object, transport, null);
+            var mockScope = new MockConnectionScope(endpoint, endpoint, mockServiceBusCredential.Object, transport, null);
 
             mockScope.MockConnection
                 .Protected()
@@ -212,9 +215,10 @@ namespace Azure.Messaging.ServiceBus.Tests
 
             public MockConnectionScope(
                 Uri serviceEndpoint,
+                Uri customConnectionEndpoint,
                 ServiceBusTokenCredential credential,
                 ServiceBusTransportType transport,
-                IWebProxy proxy) : base(serviceEndpoint, credential, transport, proxy, false, default, default)
+                IWebProxy proxy) : base(serviceEndpoint, customConnectionEndpoint, credential, transport, proxy, false, default, default)
             {
                 MockConnection = new Mock<AmqpConnection>(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientTests.cs
@@ -226,6 +226,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
             Assert.That(options, Is.Not.SameAs(defaultOptions), $"The { constructorDescription } constructor should not have the same options instance.");
             Assert.That(options.TransportType, Is.EqualTo(defaultOptions.TransportType), $"The { constructorDescription } constructor should have the correct connection type.");
             Assert.That(options.WebProxy, Is.EqualTo(defaultOptions.WebProxy), $"The { constructorDescription } constructor should have the correct proxy.");
+            Assert.That(options.CustomEndpointAddress, Is.EqualTo(defaultOptions.CustomEndpointAddress), $"The {constructorDescription} constructor should have the correct custom endpoint.");
         }
 
         /// <summary>
@@ -245,6 +246,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
             Assert.That(options, Is.Not.SameAs(constructorOptions), $"The { constructorDescription } constructor should have cloned the options.");
             Assert.That(options.TransportType, Is.EqualTo(constructorOptions.TransportType), $"The { constructorDescription } constructor should have the correct connection type.");
             Assert.That(options.WebProxy, Is.EqualTo(constructorOptions.WebProxy), $"The { constructorDescription } constructor should have the correct proxy.");
+            Assert.That(options.CustomEndpointAddress, Is.EqualTo(constructorOptions.CustomEndpointAddress), $"The {constructorDescription} constructor should have the correct custom endpoint.");
         }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientTests.cs
@@ -79,11 +79,13 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
         {
             var credential = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
             var fakeConnection = "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake";
+            var fakeEndpoint = new Uri("sb://fake.com");
 
             var options = new ServiceBusClientOptions
             {
                 TransportType = ServiceBusTransportType.AmqpWebSockets,
-                WebProxy = Mock.Of<IWebProxy>()
+                WebProxy = Mock.Of<IWebProxy>(),
+                CustomEndpointAddress = fakeEndpoint
             };
 
             yield return new object[] { new ReadableOptionsMock(fakeConnection, options), options, "connection string" };

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample01_HelloWorld.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample01_HelloWorld.cs
@@ -279,7 +279,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 CustomEndpointAddress = new Uri(customEndpoint)
             };
 
-            // since ServiceBusClient implements IAsyncDisposable we create it with "await using"
             ServiceBusClient client = new ServiceBusClient(connectionString, options);
             #endregion
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample01_HelloWorld.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample01_HelloWorld.cs
@@ -265,6 +265,26 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
         }
 
         /// <summary>
+        /// Connect to the service using a custom endpoint address/>.
+        /// </summary>
+        public void ConnectUsingCustomEndpoint()
+        {
+            #region Snippet:ServiceBusCustomEndpoint
+            // Connect to the service using a custom endpoint
+            string connectionString = "<connection_string>";
+            string customEndpoint = "<custom_endpoint";
+
+            var options = new ServiceBusClientOptions
+            {
+                CustomEndpointAddress = new Uri(customEndpoint)
+            };
+
+            // since ServiceBusClient implements IAsyncDisposable we create it with "await using"
+            ServiceBusClient client = new ServiceBusClient(connectionString, options);
+            #endregion
+        }
+
+        /// <summary>
         /// Shows how to use <see cref="ServiceBusFailureReason"/> in <see cref="ServiceBusException"/>.
         /// </summary>
         public void ServiceBusExceptionFailureReasonUsage()

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample01_HelloWorld.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample01_HelloWorld.cs
@@ -272,7 +272,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
             #region Snippet:ServiceBusCustomEndpoint
             // Connect to the service using a custom endpoint
             string connectionString = "<connection_string>";
-            string customEndpoint = "<custom_endpoint";
+            string customEndpoint = "<custom_endpoint>";
 
             var options = new ServiceBusClientOptions
             {


### PR DESCRIPTION
The intention of these changes is to provide support for Custom Endpoint use when establishing a connection with the Service Bus service. The fully qualified namespace is still required after the initial connection, but this allows for easier connection in circumstances such as when routing through an application gateway or using a proxy.

See https://github.com/Azure/azure-sdk-for-net/issues/27143

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
