### PR TITLE
fix(ci): add `storage` as `network` mgmt sdk dependency

### DIFF
--- a/sdk/network/ci.yml
+++ b/sdk/network/ci.yml
@@ -21,6 +21,8 @@ pr:
     include:
     - sdk/network/
     - sdk/resourcemanager/
+    # remove after we change to depend on storage nuget package
+    - sdk/storage/Azure.ResourceManager.Storage
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml


### PR DESCRIPTION
`network` mgmt SDK test cases depend on `storage` mgmt SDK. So we need to add `storage` mgmt SDK as the dependency in CI, just in case the upstream changes could break `network` CI.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
