### PR TITLE
Update ACL .NET client

### DIFF
--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -8,8 +8,6 @@
 
 ### Bugs Fixed
 
-- Custom client `options` used when instantiating a `ConfidentialLedgerClient` are no longer also passed to the `ConfidentialLedgerIdentityServiceClient` instance used during construction of the `ConfidentialLedgerClient`, as these two clients have different requirements, in particular on certificate validation. 
-
 ### Other Changes
 
 - The `CertValidationCheck` callback for `ConfidentialLedgerClient` instances now checks the final certificate in the server's certificate chain matches the trusted TLS certificate. Previously this callback checked if the thumbprint of the trusted TLS certificate was present anywhere in the server's certificate chain. 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Updated `CreateClient` code snippet so that documented code snippets for creating Ledger clients are up to date. 
+- Custom client `options` used when instantiating a `ConfidentialLedgerClient` are no longer also passed to the `ConfidentialLedgerIdentityServiceClient` instance used during construction of the `ConfidentialLedgerClient`, as these two clients have different requirements, in particular on certificate validation. 
 
 ### Other Changes
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- The `CertValidationCheck` callback for `ConfidentialLedgerClient` instances now checks the final certificate in the server's certificate chain matches the trusted TLS certificate. Previously this callback checked the thumbprint of the trusted TLS certificate was present anywhere in the server's certificate chain.
+
 ## 1.0.0-beta.3 (2022-07-07)
 
 ### Breaking Changes

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -8,9 +8,11 @@
 
 ### Bugs Fixed
 
+- Updated `CreateClient` code snippet so that documented code snippets for creating Ledger clients are up to date. 
+
 ### Other Changes
 
-- The `CertValidationCheck` callback for `ConfidentialLedgerClient` instances now checks the final certificate in the server's certificate chain matches the trusted TLS certificate. Previously this callback checked the thumbprint of the trusted TLS certificate was present anywhere in the server's certificate chain.
+- The `CertValidationCheck` callback for `ConfidentialLedgerClient` instances now checks the final certificate in the server's certificate chain matches the trusted TLS certificate. Previously this callback checked if the thumbprint of the trusted TLS certificate was present anywhere in the server's certificate chain. 
 
 ## 1.0.0-beta.3 (2022-07-07)
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/README.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/README.md
@@ -134,7 +134,7 @@ string transactionId = postOperation.Id;
 string subLedgerId = "subledger:0";
 
 // Provide both the transactionId and subLedgerId.
-Response getBySubledgerResponse = ledgerClient.GetLedgerEntry(transactionId,  subLedgerId);
+Response getBySubledgerResponse = ledgerClient.GetLedgerEntry(transactionId, subLedgerId);
 
 // Try until the entry is available.
 bool loaded = false;

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/README.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/README.md
@@ -45,8 +45,6 @@ Then, `DefaultAzureCredential` will be able to authenticate the `ConfidentialLed
 
 Constructing the client also requires your Confidential Ledger's URI, which you can obtain from the Azure Portal page for your Confidential Ledger in the `Ledger URI` field under the `Properties` section, or from Azure CLI. When you have retrieved the `Ledger URI`, please use it to replace `"https://my-ledger-url.confidential-ledger.azure.com"` in the example below.
 
-> Note: Confidential Ledger Clients accept advanced configuration via a third argument, `options`, which is not shown in this example. See the [ConfidentialLedgerClient][azure_confidential_ledger_client] documentation for details. 
-
 ```C# Snippet:CreateClient
 var ledgerClient = new ConfidentialLedgerClient(new Uri("https://my-ledger-url.confidential-ledger.azure.com"), new DefaultAzureCredential());
 ```
@@ -397,7 +395,6 @@ For more information see the [Code of Conduct FAQ][coc_faq] or contact
 [azure_cli]: https://docs.microsoft.com/cli/azure
 [azure_cloud_shell]: https://shell.azure.com/bash
 [azure_confidential_computing]: https://azure.microsoft.com/solutions/confidential-compute
-[azure_confidential_ledger_client]: https://docs.azure.cn/en-us/dotnet/api/azure.storage.confidentialledger.confidentialledgerclient.-ctor?view=azure-dotnet-preview#azure-storage-confidentialledger-confidentialledgerclient-ctor(system-uri-azure-core-tokencredential-azure-storage-confidentialledger-confidentialledgerclientoptions)
 [azure_sub]: https://azure.microsoft.com/free/dotnet/
 [ccf]: https://github.com/Microsoft/CCF
 [azure_identity]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/identity/Azure.Identity

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClient.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClient.cs
@@ -45,7 +45,7 @@ namespace Azure.Security.ConfidentialLedger
                     throw new ArgumentNullException(nameof(credential));
             }
             var actualOptions = options ?? new ConfidentialLedgerClientOptions();
-            X509Certificate2 serviceCert = identityServiceCert ?? GetIdentityServerTlsCert(ledgerUri, actualOptions);
+            X509Certificate2 serviceCert = identityServiceCert ?? GetIdentityServerTlsCert(ledgerUri);
 
             var transportOptions = GetIdentityServerTlsCertAndTrust(serviceCert);
             if (clientCertificate != null)
@@ -158,9 +158,9 @@ namespace Azure.Security.ConfidentialLedger
             }
         }
 
-        internal static X509Certificate2 GetIdentityServerTlsCert(Uri ledgerUri, ConfidentialLedgerClientOptions options, ConfidentialLedgerIdentityServiceClient client = null)
+        internal static X509Certificate2 GetIdentityServerTlsCert(Uri ledgerUri, ConfidentialLedgerIdentityServiceClient client = null)
         {
-            var identityClient = client ?? new ConfidentialLedgerIdentityServiceClient(new Uri("https://identity.confidential-ledger.core.azure.com"), options);
+            var identityClient = client ?? new ConfidentialLedgerIdentityServiceClient(new Uri("https://identity.confidential-ledger.core.azure.com"));
 
             // Get the ledger's  TLS certificate for our ledger.
             var ledgerId = ledgerUri.Host.Substring(0, ledgerUri.Host.IndexOf('.'));

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClient.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClient.cs
@@ -45,7 +45,7 @@ namespace Azure.Security.ConfidentialLedger
                     throw new ArgumentNullException(nameof(credential));
             }
             var actualOptions = options ?? new ConfidentialLedgerClientOptions();
-            X509Certificate2 serviceCert = identityServiceCert ?? GetIdentityServerTlsCert(ledgerUri);
+            X509Certificate2 serviceCert = identityServiceCert ?? GetIdentityServerTlsCert(ledgerUri, actualOptions);
 
             var transportOptions = GetIdentityServerTlsCertAndTrust(serviceCert);
             if (clientCertificate != null)
@@ -158,9 +158,9 @@ namespace Azure.Security.ConfidentialLedger
             }
         }
 
-        internal static X509Certificate2 GetIdentityServerTlsCert(Uri ledgerUri, ConfidentialLedgerIdentityServiceClient client = null)
+        internal static X509Certificate2 GetIdentityServerTlsCert(Uri ledgerUri, ConfidentialLedgerClientOptions options, ConfidentialLedgerIdentityServiceClient client = null)
         {
-            var identityClient = client ?? new ConfidentialLedgerIdentityServiceClient(new Uri("https://identity.confidential-ledger.core.azure.com"));
+            var identityClient = client ?? new ConfidentialLedgerIdentityServiceClient(new Uri("https://identity.confidential-ledger.core.azure.com"), options);
 
             // Get the ledger's  TLS certificate for our ledger.
             var ledgerId = ledgerUri.Host.Substring(0, ledgerUri.Host.IndexOf('.'));

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerClientLiveTests.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerClientLiveTests.cs
@@ -37,7 +37,7 @@ namespace Azure.Security.ConfidentialLedger.Tests
                     TestEnvironment.ConfidentialLedgerIdentityUrl,
                     _options);
 
-            var serviceCert = ConfidentialLedgerClient.GetIdentityServerTlsCert(TestEnvironment.ConfidentialLedgerUrl, _options, IdentityClient);
+            var serviceCert = ConfidentialLedgerClient.GetIdentityServerTlsCert(TestEnvironment.ConfidentialLedgerUrl, IdentityClient);
 
             Client = InstrumentClient(
                 new ConfidentialLedgerClient(
@@ -179,7 +179,7 @@ namespace Azure.Security.ConfidentialLedger.Tests
         {
             await Client.PostLedgerEntryAsync(
                waitUntil: WaitUntil.Completed,
-               RequestContent.Create( new { contents = Recording.GenerateAssetName("test") }));
+               RequestContent.Create(new { contents = Recording.GenerateAssetName("test") }));
 
             var result = await Client.GetCurrentLedgerEntryAsync();
             var stringResult = new StreamReader(result.ContentStream).ReadToEnd();

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerClientLiveTests.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerClientLiveTests.cs
@@ -37,7 +37,7 @@ namespace Azure.Security.ConfidentialLedger.Tests
                     TestEnvironment.ConfidentialLedgerIdentityUrl,
                     _options);
 
-            var serviceCert = ConfidentialLedgerClient.GetIdentityServerTlsCert(TestEnvironment.ConfidentialLedgerUrl, IdentityClient);
+            var serviceCert = ConfidentialLedgerClient.GetIdentityServerTlsCert(TestEnvironment.ConfidentialLedgerUrl, _options, IdentityClient);
 
             Client = InstrumentClient(
                 new ConfidentialLedgerClient(

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/samples/HelloWorldSamples.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/samples/HelloWorldSamples.cs
@@ -22,61 +22,12 @@ namespace Azure.Security.ConfidentialLedger.Tests.samples
         [Test]
         public void HelloWorld()
         {
-            #region Snippet:GetIdentity
-
-#if SNIPPET
-            Uri identityServiceEndpoint = new("https://identity.confidential-ledger.core.azure.com") // The hostname from the identityServiceUri
-#else
-            Uri identityServiceEndpoint = TestEnvironment.ConfidentialLedgerIdentityUrl;
-#endif
-            var identityClient = new ConfidentialLedgerIdentityServiceClient(identityServiceEndpoint);
-
-            // Get the ledger's  TLS certificate for our ledger.
-#if SNIPPET
-            string ledgerId = "<the ledger id>"; // ex. "my-ledger" from "https://my-ledger.eastus.cloudapp.azure.com"
-#else
-            var ledgerId = TestEnvironment.ConfidentialLedgerUrl.Host;
-            ledgerId = ledgerId.Substring(0, ledgerId.IndexOf('.'));
-#endif
-            Response response = identityClient.GetLedgerIdentity(ledgerId);
-            X509Certificate2 ledgerTlsCert = ConfidentialLedgerIdentityServiceClient.ParseCertificate(response);
-
-            #endregion
-
             #region Snippet:CreateClient
 
-            // Create a certificate chain rooted with our TLS cert.
-            X509Chain certificateChain = new();
-            certificateChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-            certificateChain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
-            certificateChain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
-            certificateChain.ChainPolicy.VerificationTime = DateTime.Now;
-            certificateChain.ChainPolicy.UrlRetrievalTimeout = new TimeSpan(0, 0, 0);
-            certificateChain.ChainPolicy.ExtraStore.Add(ledgerTlsCert);
-
-            var f = certificateChain.Build(ledgerTlsCert);
-
-            // Define a validation function to ensure that the ledger certificate is trusted by the ledger identity TLS certificate.
-            bool CertValidationCheck(HttpRequestMessage httpRequestMessage, X509Certificate2 cert, X509Chain x509Chain, SslPolicyErrors sslPolicyErrors)
-            {
-                bool isChainValid = certificateChain.Build(cert);
-                if (!isChainValid) return false;
-
-                var isCertSignedByTheTlsCert = certificateChain.ChainElements.Cast<X509ChainElement>()
-                    .Any(x => x.Certificate.Thumbprint == ledgerTlsCert.Thumbprint);
-                return isCertSignedByTheTlsCert;
-            }
-
-            // Create an HttpClientHandler to use our certValidationCheck function.
-            var httpHandler = new HttpClientHandler();
-            httpHandler.ServerCertificateCustomValidationCallback = CertValidationCheck;
-
-            // Create the ledger client using a transport that uses our custom ServerCertificateCustomValidationCallback.
-            var options = new ConfidentialLedgerClientOptions { Transport = new HttpClientTransport(httpHandler) };
 #if SNIPPET
-            var ledgerClient = new ConfidentialLedgerClient(TestEnvironment.ConfidentialLedgerUrl, new DefaultAzureCredential(), options);
+            var ledgerClient = new ConfidentialLedgerClient(new Uri("https://my-ledger-url.confidential-ledger.azure.com"), new DefaultAzureCredential());
 #else
-            var ledgerClient = new ConfidentialLedgerClient(TestEnvironment.ConfidentialLedgerUrl, TestEnvironment.Credential, options);
+            var ledgerClient = new ConfidentialLedgerClient(TestEnvironment.ConfidentialLedgerUrl, TestEnvironment.Credential);
 #endif
 
             #endregion
@@ -159,7 +110,7 @@ namespace Azure.Security.ConfidentialLedger.Tests.samples
             string subLedgerId = "subledger:0";
 
             // Provide both the transactionId and subLedgerId.
-            Response getBySubledgerResponse = ledgerClient.GetLedgerEntry(transactionId,  subLedgerId);
+            Response getBySubledgerResponse = ledgerClient.GetLedgerEntry(transactionId, subLedgerId);
 
             // Try until the entry is available.
             bool loaded = false;


### PR DESCRIPTION
This PR updates Azure Confidential Ledger's .NET Client code and documentation. Currently running the code snippets in the .NET "Create a Client" section [here](https://docs.microsoft.com/en-gb/dotnet/api/overview/azure/security.confidentialledger-readme-pre?WT.mc_id=Portal-fx#create-a-client) fails. This PR fixes that failure and streamlines the tutorial docs. 

- ~~Tutorial code currently creates a Ledger Client with custom `CertValidationCheck` which happens to be the same as the default it is overwriting. The issue is that the Ledger Client constructor instantiates an Identity Service Client and passes it the same custom `CertValidationCheck`, but the two clients have different needs. In the tutorial's case we end up overwriting the Identity Service's default Cert Validation with the Ledger Client's `CertValidationCheck`. As the two clients have different cert validation requirements this causes the IdentityService CLient to fail to connect to the Identity Service, blocking the creation of the Ledger Client. (_The Identity Service server returns a certificate which is signed by a standard CA, not by our Ledger's Root Cert. The `CertValidationCheck` intended for the Ledger Client rejects server certs that are not signed by the Ledger's Root Cert._)~~

~~This makes it awkward for anyone wanting to implement a custom `CertValidationCheck` for their Ledger Client, as currently this check will be picked up by both the Ledger Client and the Identity Service Client. This PR prevents the Identity Client from picking up options intended for the Ledger Client. This leaves the Identity client always using its defaults. It would be good to discuss this change.~~ After discussion we decided to live with this as it is unlikely anyone will ever edit the `CertValidationCheck` and if they do they can add complexity to deal with the initial Identity Client connections.

- Additionally, this PR streamlines the "Create a Client" documentation as it is confusing for the tutorial to reimplement the `CertValidationCheck` which is already built into the Ledger Client by its constructor by default. 
- This PR also tweaks the default Ledger Client cert validation code. The `CertValidationCheck` callback for `ConfidentialLedgerClient` instances now checks the final certificate in the server's certificate chain matches the trusted TLS certificate. Previously this callback checked if the thumbprint of the trusted TLS certificate was present anywhere in the server's certificate chain. 
