### PR TITLE
[ServiceBus] No longer create a copy of the array in the message converter for the default and stream case

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Reduced memory allocations when converting messages into the underlying AMQP primitives. _(A community contribution, courtesy of [danielmarbach](https://github.com/danielmarbach))_
+
 ## 7.9.0 (2022-07-11)
 
 ### Features Added

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
@@ -159,14 +159,22 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 {
                     using var memStreamCopy = new MemoryStream((int)(memStreamSource.Length - memStreamSource.Position));
                     memStreamSource.CopyTo(memStreamCopy, StreamBufferSizeInBytes);
-                    return new ArraySegment<byte>(memStreamCopy.ToArray());
+                    if (!memStreamCopy.TryGetBuffer(out ArraySegment<byte> segment))
+                    {
+                        segment = new ArraySegment<byte>(memStreamCopy.ToArray());
+                    }
+                    return segment;
                 }
 
                 default:
                 {
-                    using var memStream = new MemoryStream(StreamBufferSizeInBytes);
-                    stream.CopyTo(memStream, StreamBufferSizeInBytes);
-                    return new ArraySegment<byte>(memStream.ToArray());
+                    using var memStreamCopy = new MemoryStream(StreamBufferSizeInBytes);
+                    stream.CopyTo(memStreamCopy, StreamBufferSizeInBytes);
+                    if (!memStreamCopy.TryGetBuffer(out ArraySegment<byte> segment))
+                    {
+                        segment = new ArraySegment<byte>(memStreamCopy.ToArray());
+                    }
+                    return segment;
                 }
             }
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
@@ -850,14 +850,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
             return buffer;
         }
 
-        private static Data ToData(AmqpMessage message)
-        {
-            ArraySegment<byte>[] payload = message.GetPayload();
-            var buffer = new BufferListStream(payload);
-            ArraySegment<byte> value = buffer.ReadBytes((int)buffer.Length);
-            return new Data { Value = value };
-        }
-
         internal static AmqpMap GetSqlRuleFilterMap(SqlRuleFilter sqlRuleFilter)
         {
             var amqpFilterMap = new AmqpMap

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
@@ -839,9 +839,10 @@ namespace Azure.Messaging.ServiceBus.Amqp
             }
             else
             {
-                using (var memoryStream = new MemoryStream(512))
+                using var memoryStream = new MemoryStream(StreamBufferSizeInBytes);
+                stream.CopyTo(memoryStream, StreamBufferSizeInBytes);
+                if (!memoryStream.TryGetBuffer(out buffer))
                 {
-                    stream.CopyTo(memoryStream, 512);
                     buffer = new ArraySegment<byte>(memoryStream.ToArray());
                 }
             }


### PR DESCRIPTION
This gets rid of the extra allocations and CPU overhead when calling `ToArray`. For the default and memory stream case that is quite a bit of allocations and memory copying operations that are no longer necessary.

- [x] Update Change Log
- [x] Settle discussions about disposing and `TryGetBuffer` vs `GetBuffer`

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
