### PR TITLE
[ServiceBus] ClientLibraryInformation serializes the current information once and then no longer uses reflection

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -1314,7 +1314,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 HostName = hostName
             };
 
-            foreach (KeyValuePair<string, string> property in ClientLibraryInformation.Current.EnumerateProperties())
+            foreach (KeyValuePair<string, string> property in ClientLibraryInformation.Current.SerializedProperties)
             {
                 connectionSettings.AddProperty(property.Key, property.Value);
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/ClientLibraryInformation.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/ClientLibraryInformation.cs
@@ -56,6 +56,11 @@ namespace Azure.Messaging.ServiceBus.Core
         public string UserAgent => $"azsdk-net-{ Product }/{ Version } ({ Framework }; { Platform })";
 
         /// <summary>
+        /// Client Information properties serialized with normalized names
+        /// </summary>
+        public KeyValuePair<string, string>[] SerializedProperties { get; }
+
+        /// <summary>
         ///   Prevents a default instance of the <see cref="ClientLibraryInformation"/> class from being created.
         /// </summary>
         ///
@@ -72,6 +77,7 @@ namespace Azure.Messaging.ServiceBus.Core
 #else
             Platform = System.Runtime.InteropServices.RuntimeInformation.OSDescription;
 #endif
+            SerializedProperties = SerializeProperties(this);
         }
 
         /// <summary>
@@ -80,10 +86,12 @@ namespace Azure.Messaging.ServiceBus.Core
         ///
         /// <returns>An enumerable set of the properties, with name and value.</returns>
         ///
-        public IEnumerable<KeyValuePair<string, string>> EnumerateProperties() =>
+        private static KeyValuePair<string, string>[] SerializeProperties(ClientLibraryInformation self) =>
             typeof(ClientLibraryInformation)
                 .GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                .Select(property => new KeyValuePair<string, string>(GetTelemetryName(property), (string)property.GetValue(this, null)));
+                .Where(static property => property.Name != nameof(SerializedProperties))
+                .Select(property => new KeyValuePair<string, string>(GetTelemetryName(property), (string)property.GetValue(self, null)))
+                .ToArray();
 
         /// <summary>
         ///   Gets the name of the property, as it should appear in telemetry
@@ -94,10 +102,10 @@ namespace Azure.Messaging.ServiceBus.Core
         ///
         /// <returns>The name of the property for use as telemetry for the client library.</returns>
         ///
-        private static string GetTelemetryName(PropertyInfo property)
+        private static string GetTelemetryName(MemberInfo property)
         {
             string name = property.GetCustomAttribute<DescriptionAttribute>(false)?.Description;
-            return ((string.IsNullOrEmpty(name)) ? property.Name : name).ToLowerInvariant();
+            return (string.IsNullOrEmpty(name) ? property.Name : name).ToLowerInvariant();
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/ClientLibraryInformation.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/ClientLibraryInformation.cs
@@ -56,8 +56,9 @@ namespace Azure.Messaging.ServiceBus.Core
         public string UserAgent => $"azsdk-net-{ Product }/{ Version } ({ Framework }; { Platform })";
 
         /// <summary>
-        /// Client Information properties serialized with normalized names
+        ///   Client Information properties serialized with normalized names
         /// </summary>
+        ///
         public KeyValuePair<string, string>[] SerializedProperties { get; }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Core/ClientLibraryInformationTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Core/ClientLibraryInformationTests.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Azure.Messaging.ServiceBus.Core;
+using NUnit.Framework;
+
+namespace Azure.Messaging.ServiceBus.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="ClientLibraryInformation" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class ClientLibraryInformationTests
+    {
+        /// <summary>
+        ///   Validates functionality of the <see cref="ClientLibraryInformation.Current" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void CurentReturnsAnInstance()
+        {
+            Assert.That(ClientLibraryInformation.Current, Is.Not.Null);
+        }
+
+        /// <summary>
+        ///   Validates functionality of the <see cref="ClientLibraryInformation.Current" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void PlatformIsPopulated()
+        {
+            Assert.That(ClientLibraryInformation.Current.Platform, Is.Not.Null.And.Not.Empty);
+        }
+
+        /// <summary>
+        ///   Validates functionality of the <see cref="ClientLibraryInformation.Current" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void ProductCanBeAccessed()
+        {
+            Assert.That(() => ClientLibraryInformation.Current.Product, Throws.Nothing);
+        }
+
+        /// <summary>
+        ///   Validates functionality of the <see cref="ClientLibraryInformation.Current" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void VersionCanBeAccessed()
+        {
+            Assert.That(() => ClientLibraryInformation.Current.Version, Throws.Nothing);
+        }
+
+        /// <summary>
+        ///   Validates functionality of the <see cref="ClientLibraryInformation.Current" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void FrameworkCanBeAccessed()
+        {
+            Assert.That(() => ClientLibraryInformation.Current.Framework, Throws.Nothing);
+        }
+
+        /// <summary>
+        ///   Validates functionality of the <see cref="ClientLibraryInformation.Current" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void UserAgentCanBeAccessed()
+        {
+            Assert.That(() => ClientLibraryInformation.Current.UserAgent, Throws.Nothing);
+        }
+
+        /// <summary>
+        ///   Validates functionality of the <see cref="ClientLibraryInformation.SerializedProperties" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void SerializedPropertiesCanBeEnumerated()
+        {
+            Dictionary<string, string> expectedNames = typeof(ClientLibraryInformation)
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .ToDictionary(property => (property.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(false)?.Description ?? property.Name).ToLowerInvariant(), property => property.Name);
+
+            foreach (KeyValuePair<string, string> property in ClientLibraryInformation.Current.SerializedProperties)
+            {
+                Assert.That(expectedNames.ContainsKey(property.Key), Is.True, $"The property, { property.Key }, was not expected.");
+
+                PropertyInfo matchingProperty = typeof(ClientLibraryInformation)
+                    .GetProperty(expectedNames[property.Key], BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+
+                Assert.That(matchingProperty, Is.Not.Null, $"The property, { property.Key }, was not found.");
+                Assert.That((string)matchingProperty.GetValue(ClientLibraryInformation.Current, null), Is.EqualTo(property.Value), $"The value for { property.Key } should match.");
+            }
+        }
+
+        /// <summary>
+        ///   Validates functionality of the <see cref="ClientLibraryInformation.SerializedProperties" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void SerializedPropertiesUseDescriptionsWhenPresent()
+        {
+            ClientLibraryInformation instance = ClientLibraryInformation.Current;
+
+            HashSet<string> expectedNames = new HashSet<string>(
+                typeof(ClientLibraryInformation)
+                    .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                    .Select(property => (property.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(false)?.Description ?? property.Name).ToLowerInvariant()));
+
+            foreach (KeyValuePair<string, string> property in ClientLibraryInformation.Current.SerializedProperties)
+            {
+                Assert.That(expectedNames.Contains(property.Key), Is.True, $"The property, { property.Key }, was not found.");
+            }
+        }
+
+        /// <summary>
+        ///   Validates functionality of the <see cref="ClientLibraryInformation.SerializedProperties" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void SerializedPropertiesArePopulated()
+        {
+            foreach (KeyValuePair<string, string> property in ClientLibraryInformation.Current.SerializedProperties)
+            {
+                Assert.That(property.Value, Is.Not.Null.And.Not.Empty, $"The property, { property.Key }, was not populated.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
