### PR TITLE
[Search] Remove "seal-single-value-enum-by-default" autorest flag

### DIFF
--- a/sdk/search/Azure.Search.Documents/src/autorest.md
+++ b/sdk/search/Azure.Search.Documents/src/autorest.md
@@ -14,8 +14,6 @@ input-file:
  - https://github.com/Azure/azure-rest-api-specs/blob/d850f41f89530917000d8e6bb463f42bb745b930/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchindex.json
  - https://github.com/Azure/azure-rest-api-specs/blob/d850f41f89530917000d8e6bb463f42bb745b930/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchservice.json
 generation1-convenience-client: true
-modelerfour:
-    seal-single-value-enum-by-default: true
 ```
 
 ## Release hacks
@@ -300,6 +298,7 @@ directive:
           required: true,
           type: "string",
           enum: [ accept ],
+          "x-ms-enum": { "modelAsString": false },
           "x-ms-parameter-location": "method"
         });
       }
@@ -331,4 +330,18 @@ directive:
   from: swagger-document
   where: $.parameters.ClientRequestIdParameter
   transform: $["x-ms-parameter-location"] = "client";
+```
+
+## Seal single value enums
+
+Prevents the creation of single-value extensible enum in generated code. The following single-value enum will be generated as string constants.
+
+```yaml
+directive:
+  from: swagger-document
+  where: $.parameters.PreferHeaderParameter
+  transform: >
+    $["x-ms-enum"] = {
+      "modelAsString": false
+    }
 ```

--- a/sdk/search/Azure.Search.Documents/src/autorest.md
+++ b/sdk/search/Azure.Search.Documents/src/autorest.md
@@ -334,7 +334,7 @@ directive:
 
 ## Seal single value enums
 
-Prevents the creation of single-value extensible enum in generated code. The following single-value enum will be generated as string constants.
+Prevents the creation of single-value extensible enum in generated code. The following single-value enum will be generated as string constant.
 
 ```yaml
 directive:


### PR DESCRIPTION
As per https://github.com/Azure/azure-sdk-for-net/pull/24567#discussion_r724546945, removing `seal-single-value-enum-by-default` flag from autorest config. This flag will eventually be deprecated.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/24624