### PR TITLE
Fix typos in AzureEventSourceListener class description

### DIFF
--- a/sdk/core/Azure.Core/src/Diagnostics/AzureEventSourceListener.cs
+++ b/sdk/core/Azure.Core/src/Diagnostics/AzureEventSourceListener.cs
@@ -11,7 +11,7 @@ using Azure.Core.Shared;
 namespace Azure.Core.Diagnostics
 {
     /// <summary>
-    /// Implementation of <see cref="EventListener"/> that listens to events produces by Azure SDK Client libraries.
+    /// Implementation of <see cref="EventListener"/> that listens to events produced by Azure SDK client libraries.
     /// </summary>
     public class AzureEventSourceListener: EventListener
     {


### PR DESCRIPTION
Fixes a couple typos I noticed in the API reference page on docs.microsoft.com:

![image](https://user-images.githubusercontent.com/10702007/180273611-b3e8343d-cb42-4635-a633-713f2d031427.png)
