### PR TITLE
[Event Hub] No longer create a copy of the array in the message converter for the default and stream case

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 5.8.0-beta.1 (Unreleased)
 
+### Acknowledgments
+
+Thank you to our developer community members who helped to make the Event Hubs client libraries better with their contributions to this release:
+
+- Daniel Marbach _([GitHub](https://github.com/danielmarbach))_
+
 ### Features Added
 
 ### Breaking Changes

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Reduced memory allocations when converting messages into the underlying AMQP primitives. _(A community contribution, courtesy of [danielmarbach](https://github.com/danielmarbach))_
+
 ## 5.7.1 (2022-07-07)
 
 ### Acknowledgments
@@ -24,7 +26,7 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 ### Bugs Fixed
 
-- Fixed an issue with the `EventHubBufferedProducerClient` where it was not properly identifying when buffers were empty and should enter an idle state; this caused the background task that manages publishing to spin and consume an unreasonable amount of resources. 
+- Fixed an issue with the `EventHubBufferedProducerClient` where it was not properly identifying when buffers were empty and should enter an idle state; this caused the background task that manages publishing to spin and consume an unreasonable amount of resources.
 
 - Fixed an issue with event processor startup validation where an invalid consumer group was not properly detected.
 
@@ -44,12 +46,12 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 ### Features Added
 
-- The `EventHubBufferedProducerClient` is being introduced, intended to allow for efficient publishing of events without having to explicitly manage batches in the application.  More information can be found in its [design document](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventhub/Azure.Messaging.EventHubs/design/proposal-event-hub-buffered-producer.md).  
+- The `EventHubBufferedProducerClient` is being introduced, intended to allow for efficient publishing of events without having to explicitly manage batches in the application.  More information can be found in its [design document](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventhub/Azure.Messaging.EventHubs/design/proposal-event-hub-buffered-producer.md).
   _(Thanks to [danielmarbach](https://github.com/danielmarbach) for his contributions to the implementation)_
 
 - An additional base class for event processors, `PluggableCheckpointStoreEventProcessor<T>`, has been added to simplify creating customized event processors and integrate with concrete `CheckpointStore` implementations.
 
-- An abstract `CheckpointStore` is now available for use with the `PluggableCheckpointStoreEventProcessor<T>` to simplify creating customized event processors and allow reusing existing checkpoint store implementations. 
+- An abstract `CheckpointStore` is now available for use with the `PluggableCheckpointStoreEventProcessor<T>` to simplify creating customized event processors and allow reusing existing checkpoint store implementations.
 
 - Support for cancellation tokens has been improved for AMQP operations, enabling earlier detection of cancellation requests without needing to wait for the configured timeout to elapse.
 
@@ -91,7 +93,7 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 - An additional base class for event processors, `PluggableCheckpointStoreEventProcessor<T>`, has been added to simplify creating customized event processors and integrate with concrete `CheckpointStore` implementations.
 
-- An abstract `CheckpointStore` is now available for use with the `PluggableCheckpointStoreEventProcessor<T>` to simplify creating customized event processors and allow reusing existing checkpoint store implementations. 
+- An abstract `CheckpointStore` is now available for use with the `PluggableCheckpointStoreEventProcessor<T>` to simplify creating customized event processors and allow reusing existing checkpoint store implementations.
 
 ### Other Changes
 
@@ -139,7 +141,7 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 ### Bugs Fixed
 
-- Fixed an issue for publishing with idempotent retries enabled where the client and service state could become out-of-sync for error scenarios with ambiguous outcomes. When this occurred, callers had no way to detect or correct the condition and it was possible that new events would fail to publish or be incorrectly identified as duplicates by the service. 
+- Fixed an issue for publishing with idempotent retries enabled where the client and service state could become out-of-sync for error scenarios with ambiguous outcomes. When this occurred, callers had no way to detect or correct the condition and it was possible that new events would fail to publish or be incorrectly identified as duplicates by the service.
 
 ### Other Changes
 
@@ -408,7 +410,7 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 - `EventData` has been integrated with the new Schema Registry service, via use of the `ObjectSerializer` with `BinaryData`.
 
-- When publishing events to Event Hubs, timeouts or other transient failures may introduce ambiguity into the understanding of whether a batch of events was received by the service.  To assist in this scenario, the option to publish events idempotently across all retries of a publish operation has been added to the `EventHubProducerClient`. 
+- When publishing events to Event Hubs, timeouts or other transient failures may introduce ambiguity into the understanding of whether a batch of events was received by the service.  To assist in this scenario, the option to publish events idempotently across all retries of a publish operation has been added to the `EventHubProducerClient`.
 
 **Note:** The idempotent publishing feature is new to the Event Hubs service, and Azure Schema Registry is a new hosted schema repository service provided by Azure Event Hubs.  Both offerings may not yet be available in all regions or Azure clouds.
 
@@ -507,7 +509,7 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 - A cleanup sweep was performed to tune small areas to be more efficient and perform fewer allocations.
 
-## 5.1.0 
+## 5.1.0
 
 ### Acknowledgments
 
@@ -520,7 +522,7 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 #### General availability of preview features
 
-- The set of features from v5.1.0-preview.1 are now generally available.  This includes the `EventProcessor<TPartition>` and `PartitionReceiver` types which focus on advanced application scenarios which require greater low-level control. 
+- The set of features from v5.1.0-preview.1 are now generally available.  This includes the `EventProcessor<TPartition>` and `PartitionReceiver` types which focus on advanced application scenarios which require greater low-level control.
 
 #### Publishing events
 
@@ -529,14 +531,14 @@ Thank you to our developer community members who helped to make the Event Hubs c
 #### Bug fixes and foundation
 
 - The transport producers used for sending events to a specific partition are now managed by a pool with sliding expiration to enable more efficient resource use and cleanup.  _(A community contribution, courtesy of [albertodenatale](https://github.com/albertodenatale))_
-	
+
 - Timing operations have been refactored to make use of a more efficient approach with fewer allocations.  (A community contribution, courtesy of _[danielmarbach](https://github.com/albertodenatale))_
 
 - Fixed a bug with EventDataBatch; it is now thread-safe.
 
 - Minor enhancements to reduce allocations and improve efficiency
 
-## 5.1.0-preview.1 
+## 5.1.0-preview.1
 
 ### Acknowledgments
 
@@ -575,7 +577,7 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 - For special cases, the live tests may be instructed to use existing Azure resources instead of dynamically creating dedicated resources for the run.  (A community contribution, courtesy of [albertodenatale](https://github.com/albertodenatale))
 
-## 5.0.1 
+## 5.0.1
 
 ### Acknowledgements
 
@@ -597,9 +599,9 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 - Namespaces have been reorganized to align types to their functional area, reducing the number of types in the root namespace and offering better context for where a type is used.  Cross-functional types have been left in the root while specialized types were moved to the `Producer`, `Consumer`, or `Processor` namespaces.
 
-- The hierarchy of custom exceptions has been flattened, with only the `EventHubsException` remaining.  The well-known failure scenarios that had previously been represented as stand-alone types are now exposed by a new `Reason` property to allow for applying exception filtering and other logic where inspecting the text of an exception message wouldn't be ideal. 
+- The hierarchy of custom exceptions has been flattened, with only the `EventHubsException` remaining.  The well-known failure scenarios that had previously been represented as stand-alone types are now exposed by a new `Reason` property to allow for applying exception filtering and other logic where inspecting the text of an exception message wouldn't be ideal.
 
-## 5.0.0-preview.6 
+## 5.0.0-preview.6
 
 ### Acknowledgements
 
@@ -611,7 +613,7 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 #### Bug fixes and foundation
 
-- A bug with the use of Azure.Identity credential scopes has been fixed; Azure identities should now allow for proper authorization with Event Hubs resources.   
+- A bug with the use of Azure.Identity credential scopes has been fixed; Azure identities should now allow for proper authorization with Event Hubs resources.
 _(A community contribution, courtesy of [albertodenatale](https://github.com/albertodenatale))_
 
 - A bug with the renewal of connection string-based credentials has been fixed; clients using a connection string will now properly refresh when necessary instead of experiencing an error.
@@ -632,10 +634,10 @@ _(A community contribution, courtesy of [albertodenatale](https://github.com/alb
 
 #### Authorization
 
-- Test and sample infrastructure has been updated to work with Azure.Identity credentials in addition to connection strings.  
+- Test and sample infrastructure has been updated to work with Azure.Identity credentials in addition to connection strings.
 _(A community contribution, courtesy of [albertodenatale](https://github.com/albertodenatale))_
-  
-- A sample demonstrating the use of an Azure Active Identity principal with Event Hubs is now available.  
+
+- A sample demonstrating the use of an Azure Active Identity principal with Event Hubs is now available.
 _(A community contribution, courtesy of [albertodenatale](https://github.com/albertodenatale))_
 
 - The `EventHubsSharedKeyCredential` has been removed from this release for further design and improvements; it is intended to be reintroduced in the future.
@@ -648,9 +650,9 @@ _(A community contribution, courtesy of [albertodenatale](https://github.com/alb
 
 - A collection of internal supporting types were moved into a new [shared library](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventhub/Azure.Messaging.EventHubs.Shared) to allow them to be shared as source between the Event Hubs client libraries.  The tests assoociated with these types were also moved to the shared library for locality with the source being tested.
 
-## 5.0.0-preview.5 
+## 5.0.0-preview.5
 
-### Acknowledgments 
+### Acknowledgments
 
 Thank you to our developer community members who helped to make the Azure SDKs better with their contributions to this release:
 
@@ -660,15 +662,15 @@ Thank you to our developer community members who helped to make the Azure SDKs b
 
 #### Organization and naming
 
-- The early stages of a large refactoring of the Event Hub client type hierarchy is complete;  Event Hub producers and consumers are now stand-alone clients that can be created independently, and which may or may not share a connection to the Event Hubs service at the discretion of the developer.    
+- The early stages of a large refactoring of the Event Hub client type hierarchy is complete;  Event Hub producers and consumers are now stand-alone clients that can be created independently, and which may or may not share a connection to the Event Hubs service at the discretion of the developer.
 
   **_Please Note:_** These changes are part of a larger effort that is currently in process.  The client types have not yet been refactored to remove affinity to a specific partition which leaves some operations feeling somewhat awkward with the new structure.
-  
+
 #### Bug fixes and foundation improvements
 
-- Client types using Azure identity for authorization should now be working properly; a bug was fixed to allow the proper authorization scopes to be requested.  
+- Client types using Azure identity for authorization should now be working properly; a bug was fixed to allow the proper authorization scopes to be requested.
   _(A community contribution, courtesy of [albertodenatale](https://github.com/albertodenatale))_
-  
+
 - Service communication is now being performed by an internal communication stack; previously, it had been delegated to an internal copy of the legacy client library.
 
 - Cancellation tokens are now supported throughout the client hierarchy and across operations.
@@ -683,7 +685,7 @@ Thank you to our developer community members who helped to make the Azure SDKs b
 
 - The information about the last event enqueued to an Event Hub partition is now presented on-demand as an immutable object, if the tracking option was enabled.  This ensures that the properties are stable and consistent when being read, rather than being subject to in-place updates each time a new event is received.
 
-## 5.0.0-preview.4 
+## 5.0.0-preview.4
 
 ### Changes
 
@@ -701,7 +703,7 @@ Thank you to our developer community members who helped to make the Azure SDKs b
 
 - Improved stability and performance with refactorings around hot paths and areas of technical debt.
 
-## 5.0.0-preview.3 
+## 5.0.0-preview.3
 
 ### Changes
 
@@ -711,7 +713,7 @@ Thank you to our developer community members who helped to make the Azure SDKs b
 
 - The `EventHubConsumer` can be configured to track information about the last event to be enqueued into its associated partition in order to allow for monitoring the backlog of events to be processed without the need to make explicit calls to request partition properties from the `EventHubClient`.
 
-- Consuming events using `SubscribeToEvents` has been refactored for better performance and lower resource use. 
+- Consuming events using `SubscribeToEvents` has been refactored for better performance and lower resource use.
 
 #### Event Processor
 
@@ -727,7 +729,7 @@ Thank you to our developer community members who helped to make the Azure SDKs b
 
 - Some public types were scoped in a way that made them difficult to mock for library consumers.  These have been re-scoped to `protected internal` for better testability.  `EventData` and metadata types were the significant instances.
 
-## 5.0.0-preview.2 
+## 5.0.0-preview.2
 
 ### Changes
 
@@ -770,7 +772,7 @@ Thank you to our developer community members who helped to make the Azure SDKs b
 - An option for fixed retry has been added to accompany the exponential retry that was in place previously.
 Operation timeouts have been moved from the associated client options and incorporated into the retry options and retry policies.
 
-## 5.0.0-preview.1 
+## 5.0.0-preview.1
 
 Version 5.0.0-preview.1 is a preview of our efforts in creating a client library that is developer-friendly, idiomatic to the .NET ecosystem, and as consistent across different languages and platforms as possible.  The principles that guide our efforts can be found in the [Azure SDK Design Guidelines for .NET](https://azure.github.io/azure-sdk/dotnet_introduction.html).
 


### PR DESCRIPTION
Similar to https://github.com/Azure/azure-sdk-for-net/pull/29946 to make @jsquire happy

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
