### PR TITLE
Blob partitioned transfer tests support transfer validation client options

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Options/PartitionedTransferOptions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Options/PartitionedTransferOptions.cs
@@ -50,6 +50,9 @@ namespace Azure.Storage.Blobs.Perf.Options
         [Option("client-encryption")]
         public string EncryptionVersionString { get; set; }
 
+        [Option("transfer-validation")]
+        public ValidationAlgorithm? TransferValidationAlgorithm { get; set; }
+
         public StorageTransferOptions StorageTransferOptions { get; private set; }
 
         BlobClientOptions IBlobClientOptionsProvider.ClientOptions
@@ -77,6 +80,18 @@ namespace Azure.Storage.Blobs.Perf.Options
                 }
                 return new SpecializedBlobClientOptions
                 {
+                    UploadTransferValidationOptions = TransferValidationAlgorithm.HasValue
+                        ? new UploadTransferValidationOptions
+                        {
+                            Algorithm = TransferValidationAlgorithm.Value
+                        }
+                        : default,
+                    DownloadTransferValidationOptions = TransferValidationAlgorithm.HasValue
+                        ? new DownloadTransferValidationOptions
+                        {
+                            Algorithm = TransferValidationAlgorithm.Value
+                        }
+                        : default,
                     ClientSideEncryption = TryParseEncryptionVersion(EncryptionVersionString, out ClientSideEncryptionVersion version)
                         ? new ClientSideEncryptionOptions(version)
                         {


### PR DESCRIPTION
UploadBlob and DownloadBlob tests now support `--transfer-validation` argument, accepting string of `ValidationAlgorithm` to set relevant client-options.