### PR TITLE
Remove data factory test values

### DIFF
--- a/sdk/datafactory/Azure.ResourceManager.DataFactory/tests/Scenario/DataFactoryDatasetResourceTests.cs
+++ b/sdk/datafactory/Azure.ResourceManager.DataFactory/tests/Scenario/DataFactoryDatasetResourceTests.cs
@@ -14,7 +14,7 @@ namespace Azure.ResourceManager.IotHub.Tests.Scenario
 {
     internal class DataFactoryDatasetResourceTests : DataFactoryManagementTestBase
     {
-        private const string _accessKey = "DefaultEndpointsProtocol=https;AccountName=220722datafactory;EndpointSuffix=core.windows.net;AccountKey=th4S/DG4Cz8uq1vbv8a8ooRZqKk+TLmsgSKb004bgen/4epF+E8wYhzFp0pv3PbRF5dy8SDgwHdI+AStU7Ejbw==;";
+        private const string _accessKey = "REDACTED";
         private DataFactoryResource _dataFactory;
         private string _linkedServiceName;
         public DataFactoryDatasetResourceTests(bool isAsync) : base(isAsync)

--- a/sdk/datafactory/Azure.ResourceManager.DataFactory/tests/Scenario/LinkedServiceResourceTests.cs
+++ b/sdk/datafactory/Azure.ResourceManager.DataFactory/tests/Scenario/LinkedServiceResourceTests.cs
@@ -16,7 +16,7 @@ namespace Azure.ResourceManager.IotHub.Tests.Scenario
 {
     internal class LinkedServiceResourceTests : DataFactoryManagementTestBase
     {
-        private const string _accessKey = "DefaultEndpointsProtocol=https;AccountName=220722datafactory;EndpointSuffix=core.windows.net;AccountKey=th4S/DG4Cz8uq1vbv8a8ooRZqKk+TLmsgSKb004bgen/4epF+E8wYhzFp0pv3PbRF5dy8SDgwHdI+AStU7Ejbw==;";
+        private const string _accessKey = "REDACTED";
         private DataFactoryResource _dataFactory;
         public LinkedServiceResourceTests(bool isAsync) : base(isAsync)
         {


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
