### PR TITLE
Create a StartRecordingOptions bag

### DIFF
--- a/sdk/communication/Azure.Communication.CallingServer/api/Azure.Communication.CallingServer.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/api/Azure.Communication.CallingServer.netstandard2.0.cs
@@ -142,8 +142,8 @@ namespace Azure.Communication.CallingServer
         public virtual System.Threading.Tasks.Task<Azure.Response> PauseRecordingAsync(string recordingId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response ResumeRecording(string recordingId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> ResumeRecordingAsync(string recordingId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.Communication.CallingServer.RecordingStatusResult> StartRecording(Azure.Communication.CallingServer.CallLocator callLocator, System.Uri recordingStateCallbackUri, Azure.Communication.CallingServer.RecordingContent? content = default(Azure.Communication.CallingServer.RecordingContent?), Azure.Communication.CallingServer.RecordingChannel? channel = default(Azure.Communication.CallingServer.RecordingChannel?), Azure.Communication.CallingServer.RecordingFormat? format = default(Azure.Communication.CallingServer.RecordingFormat?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Communication.CallingServer.RecordingStatusResult>> StartRecordingAsync(Azure.Communication.CallingServer.CallLocator callLocator, System.Uri recordingStateCallbackUri, Azure.Communication.CallingServer.RecordingContent? content = default(Azure.Communication.CallingServer.RecordingContent?), Azure.Communication.CallingServer.RecordingChannel? channel = default(Azure.Communication.CallingServer.RecordingChannel?), Azure.Communication.CallingServer.RecordingFormat? format = default(Azure.Communication.CallingServer.RecordingFormat?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.Communication.CallingServer.RecordingStatusResult> StartRecording(Azure.Communication.CallingServer.CallLocator callLocator, System.Uri recordingStateCallbackUri, Azure.Communication.CallingServer.StartRecordingOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Communication.CallingServer.RecordingStatusResult>> StartRecordingAsync(Azure.Communication.CallingServer.CallLocator callLocator, System.Uri recordingStateCallbackUri, Azure.Communication.CallingServer.StartRecordingOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response StopRecording(string recordingId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> StopRecordingAsync(string recordingId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
@@ -324,6 +324,13 @@ namespace Azure.Communication.CallingServer
         public override bool Equals(Azure.Communication.CallingServer.CallLocator other) { throw null; }
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
+    }
+    public partial class StartRecordingOptions
+    {
+        public StartRecordingOptions() { }
+        public Azure.Communication.CallingServer.RecordingChannel RecordingChannel { get { throw null; } set { } }
+        public Azure.Communication.CallingServer.RecordingContent RecordingContent { get { throw null; } set { } }
+        public Azure.Communication.CallingServer.RecordingFormat RecordingFormat { get { throw null; } set { } }
     }
     public partial class TransferCallToParticipantOptions
     {

--- a/sdk/communication/Azure.Communication.CallingServer/src/CallRecording.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/CallRecording.cs
@@ -49,11 +49,9 @@ namespace Azure.Communication.CallingServer
         /// </summary>
         /// <param name="callLocator"> The callLocator. </param>
         /// <param name="recordingStateCallbackUri">The uri to send state change callbacks.</param>
+        /// <param name="options">Optional parameters</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <param name="content">content for recording.</param>
-        /// <param name="channel">channel for recording.</param>
-        /// <param name="format">format for recording.</param>
-        public virtual Response<RecordingStatusResult> StartRecording(CallLocator callLocator, Uri recordingStateCallbackUri, RecordingContent? content = null, RecordingChannel? channel = null, RecordingFormat? format = null, CancellationToken cancellationToken = default)
+        public virtual Response<RecordingStatusResult> StartRecording(CallLocator callLocator, Uri recordingStateCallbackUri, StartRecordingOptions options = default, CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(CallRecording)}.{nameof(StartRecording)}");
             scope.Start();
@@ -62,9 +60,13 @@ namespace Azure.Communication.CallingServer
                 StartCallRecordingRequestInternal request = new StartCallRecordingRequestInternal(CallLocatorSerializer.Serialize(callLocator))
                 {
                     RecordingStateCallbackUri = recordingStateCallbackUri.AbsoluteUri,
-                    RecordingChannelType = channel,
-                    RecordingContentType = content,
-                    RecordingFormatType = format,
+                };
+
+                if (options != null)
+                {
+                    request.RecordingChannelType = options.RecordingChannel;
+                    request.RecordingContentType = options.RecordingContent;
+                    request.RecordingFormatType = options.RecordingFormat;
                 };
 
                 return contentRestClient.Recording(request, cancellationToken);
@@ -81,11 +83,9 @@ namespace Azure.Communication.CallingServer
         /// </summary>
         /// <param name="callLocator"> The callLocator. </param>
         /// <param name="recordingStateCallbackUri">The uri to send state change callbacks.</param>
+        /// <param name="options">Optional parameters</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <param name="content">content for recording.</param>
-        /// <param name="channel">channel for recording.</param>
-        /// <param name="format">format for recording.</param>
-        public virtual async Task<Response<RecordingStatusResult>> StartRecordingAsync(CallLocator callLocator, Uri recordingStateCallbackUri, RecordingContent? content = null, RecordingChannel? channel = null, RecordingFormat? format = null, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<RecordingStatusResult>> StartRecordingAsync(CallLocator callLocator, Uri recordingStateCallbackUri, StartRecordingOptions options = default, CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(CallRecording)}.{nameof(StartRecording)}");
             scope.Start();
@@ -94,9 +94,13 @@ namespace Azure.Communication.CallingServer
                 StartCallRecordingRequestInternal request = new StartCallRecordingRequestInternal(CallLocatorSerializer.Serialize(callLocator))
                 {
                     RecordingStateCallbackUri = recordingStateCallbackUri.AbsoluteUri,
-                    RecordingChannelType = channel,
-                    RecordingContentType = content,
-                    RecordingFormatType = format,
+                };
+
+                if (options != null)
+                {
+                    request.RecordingChannelType = options.RecordingChannel;
+                    request.RecordingContentType = options.RecordingContent;
+                    request.RecordingFormatType = options.RecordingFormat;
                 };
                 return await contentRestClient.RecordingAsync(request, cancellationToken).ConfigureAwait(false);
             }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/StartRecordingOptions.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/StartRecordingOptions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Communication.CallingServer
+{
+    /// <summary>
+    /// Optional parameters for the Start Recording operation.
+    /// </summary>
+    public class StartRecordingOptions
+    {
+        /// <summary>
+        /// The recording channel.
+        /// </summary>
+        public RecordingChannel RecordingChannel { get; set; }
+
+        /// <summary>
+        /// The recording content.
+        /// </summary>
+        public RecordingContent RecordingContent { get; set; }
+
+        /// <summary>
+        /// The recording format.
+        /// </summary>
+        public RecordingFormat RecordingFormat { get; set; }
+    }
+}

--- a/sdk/communication/Azure.Communication.CallingServer/tests/CallRecording/CallRecordingTests.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/tests/CallRecording/CallRecordingTests.cs
@@ -180,7 +180,7 @@ namespace Azure.Communication.CallingServer
                 },
                 new Func<CallRecording, TestDelegate>?[]
                 {
-                   callRecording => () => callRecording.StartRecording(_callLocator, _callBackUri, RecordingContent.AudioVideo, RecordingChannel.Mixed, RecordingFormat.Mp4)
+                   callRecording => () => callRecording.StartRecording(_callLocator, _callBackUri, new StartRecordingOptions(){RecordingContent = RecordingContent.AudioVideo, RecordingChannel = RecordingChannel.Mixed, RecordingFormat = RecordingFormat.Mp4 })
                 },
                 new Func<CallRecording, TestDelegate>?[]
                 {
@@ -211,7 +211,7 @@ namespace Azure.Communication.CallingServer
                 },
                 new Func<CallRecording, AsyncTestDelegate>?[]
                 {
-                   callRecording => async () => await callRecording.StartRecordingAsync(_callLocator, _callBackUri, RecordingContent.AudioVideo, RecordingChannel.Mixed, RecordingFormat.Mp4).ConfigureAwait(false),
+                   callRecording => async () => await callRecording.StartRecordingAsync(_callLocator, _callBackUri).ConfigureAwait(false),
                 },
                 new Func<CallRecording, AsyncTestDelegate>?[]
                 {


### PR DESCRIPTION
Putting all the optional parameters of StartRecording operations into an options bag to match Java.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
