### PR TITLE
Add LiveOnly back to unblock CI

### DIFF
--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerClientLiveTests.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerClientLiveTests.cs
@@ -16,6 +16,7 @@ using NUnit.Framework;
 
 namespace Azure.Security.ConfidentialLedger.Tests
 {
+    [LiveOnly]
     public class ConfidentialLedgerClientLiveTests : RecordedTestBase<ConfidentialLedgerEnvironment>
     {
         private TokenCredential Credential;


### PR DESCRIPTION
A few PRs https://github.com/Azure/azure-sdk-for-net/pull/30106, https://github.com/Azure/azure-sdk-for-net/pull/30109, are failing with Confidential Ledger tests and we believe removing [LiveOnly in this PR](https://github.com/Azure/azure-sdk-for-net/commit/f0cfc5893edc4a641164adc670f2b01c8b761173#diff-684b9cbb3d0b75cc1dd98629b07ce0821029fb19c526f68479bda99f67d8051fL18) caused it.  Adding it back until @christothes can investigate when he is back.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
