### PR TITLE
Set AZ_STORAGE_CONFIG_PATH in storage virtualized test setup

### DIFF
--- a/sdk/storage/set-test-configuration.ps1
+++ b/sdk/storage/set-test-configuration.ps1
@@ -33,3 +33,7 @@ function getTestConfigurationPath() {
 $outfile = getTestConfigurationPath
 Write-Host "Writing test configuration xml to $outfile"
 $TestConfigurationXmlContent | Out-File $outfile
+
+Write-Verbose "Setting AZ_STORAGE_CONFIG_PATH environment variable used by Storage Tests"
+# https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/authoring/commands.md#logging-commands
+Write-Host "##vso[task.setvariable variable=AZ_STORAGE_CONFIG_PATH]$outfile"


### PR DESCRIPTION
We were missing an env variable addition in https://github.com/Azure/azure-sdk-for-net/pull/29916 that is needed for most tests to run (via https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Azure.Storage.Common/tests/Shared/TestConfigurations.cs#L260).