### PR TITLE
[FormRecognizer] Exposing AccessToken and TargetResourceId in CopyAuthorization

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 - Added `Length` property to `BoundingPolygon`.
+- Added a public constructor to `CopyAuthorization`.
+- Added properties `AccessToken` and `TargetResourceId` to `CopyAuthorization`.
 
 ### Breaking Changes
 - Updated all long-running operation client methods to a new pattern. This affects `StartAnalyzeDocument`, `StartAnalyzeDocumentFromUri`, `StartBuildModel`, `StartCopyModelTo`, and `StartCreateComposedModel` methods. Changes are:
@@ -24,6 +26,8 @@
 - Renamed parameter `buildModelOptions` to `options` in the `StartBuildModel` method.
 - `FormRecognizerClientOptions.Audience` and `DocumentAnalysisClientOptions.Audience` now default to `null`.
 - In the `DocumentAnalysis` namespace, `CopyModelOperation.PercentCompleted` and `BuildModelOperation.PercentCompleted` now throw an `InvalidOperationException` if called before a call to `UpdateStatus`.
+- Updated `CopyAuthorization.TargetModelLocation` to be a `Uri` instead of `string`.
+- Removed method `DocumentAnalysisModelFactory.CopyAuthorization`.
 
 ### Bugs Fixed
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/api/Azure.AI.FormRecognizer.netstandard2.0.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/api/Azure.AI.FormRecognizer.netstandard2.0.cs
@@ -340,12 +340,12 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     public partial class CopyAuthorization
     {
         public CopyAuthorization(string targetResourceId, string targetResourceRegion, string targetModelId, System.Uri targetModelLocation, string accessToken, System.DateTimeOffset expiresOn) { }
-        public string AccessToken { get { throw null; } set { } }
+        public string AccessToken { get { throw null; } }
         public System.DateTimeOffset ExpiresOn { get { throw null; } }
-        public string TargetModelId { get { throw null; } set { } }
+        public string TargetModelId { get { throw null; } }
         public System.Uri TargetModelLocation { get { throw null; } }
-        public string TargetResourceId { get { throw null; } set { } }
-        public string TargetResourceRegion { get { throw null; } set { } }
+        public string TargetResourceId { get { throw null; } }
+        public string TargetResourceRegion { get { throw null; } }
     }
     public partial class CopyModelOperation : Azure.Operation<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentModelDetails>
     {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/api/Azure.AI.FormRecognizer.netstandard2.0.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/api/Azure.AI.FormRecognizer.netstandard2.0.cs
@@ -339,11 +339,13 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     }
     public partial class CopyAuthorization
     {
-        internal CopyAuthorization() { }
+        public CopyAuthorization(string targetResourceId, string targetResourceRegion, string targetModelId, System.Uri targetModelLocation, string accessToken, System.DateTimeOffset expiresOn) { }
+        public string AccessToken { get { throw null; } set { } }
         public System.DateTimeOffset ExpiresOn { get { throw null; } }
-        public string TargetModelId { get { throw null; } }
-        public string TargetModelLocation { get { throw null; } }
-        public string TargetResourceRegion { get { throw null; } }
+        public string TargetModelId { get { throw null; } set { } }
+        public System.Uri TargetModelLocation { get { throw null; } }
+        public string TargetResourceId { get { throw null; } set { } }
+        public string TargetResourceRegion { get { throw null; } set { } }
     }
     public partial class CopyModelOperation : Azure.Operation<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentModelDetails>
     {
@@ -424,7 +426,6 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         public static Azure.AI.FormRecognizer.DocumentAnalysis.AnalyzeResult AnalyzeResult(string modelId = null, string content = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentPage> pages = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentTable> tables = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentKeyValuePair> keyValuePairs = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentStyle> styles = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentLanguage> languages = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.AnalyzedDocument> documents = null) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.BoundingPolygon BoundingPolygon(System.Collections.Generic.IEnumerable<System.Drawing.PointF> points = null) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.BoundingRegion BoundingRegion(int pageNumber = 0, Azure.AI.FormRecognizer.DocumentAnalysis.BoundingPolygon boundingPolygon = default(Azure.AI.FormRecognizer.DocumentAnalysis.BoundingPolygon)) { throw null; }
-        public static Azure.AI.FormRecognizer.DocumentAnalysis.CopyAuthorization CopyAuthorization(string targetResourceRegion = null, string targetModelId = null, string targetModelLocation = null, System.DateTimeOffset expiresOn = default(System.DateTimeOffset)) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.CurrencyValue CurrencyValue(double amount = 0, string symbol = null) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.DocTypeInfo DocTypeInfo(string description = null, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentBuildMode? buildMode = default(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentBuildMode?), System.Collections.Generic.IReadOnlyDictionary<string, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentFieldSchema> fieldSchema = null, System.Collections.Generic.IReadOnlyDictionary<string, float> fieldConfidence = null) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentFieldSchema DocumentFieldSchema(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentFieldType type = Azure.AI.FormRecognizer.DocumentAnalysis.DocumentFieldType.String, string description = null, string example = null, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentFieldSchema items = null, System.Collections.Generic.IReadOnlyDictionary<string, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentFieldSchema> properties = null) { throw null; }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyAuthorization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyAuthorization.cs
@@ -44,6 +44,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         public Uri TargetModelLocation { get; }
 
         /// <summary> Date/time when the access token expires. </summary>
+        [CodeGenMember("ExpirationDateTime")]
         public DateTimeOffset ExpiresOn { get; }
 
         /// <summary> Token used to authorize the request. </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyAuthorization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyAuthorization.cs
@@ -34,11 +34,22 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             ExpiresOn = expiresOn;
         }
 
+        /// <summary> Location of the target Azure resource where the model should be copied to. </summary>
+        public string TargetResourceRegion { get; }
+
+         /// <summary> Identifier of the target model. </summary>
+         public string TargetModelId { get; }
+
         /// <summary> URI of the copied model in the target account. </summary>
         public Uri TargetModelLocation { get; }
 
         /// <summary> Date/time when the access token expires. </summary>
-        [CodeGenMember("ExpirationDateTime")]
         public DateTimeOffset ExpiresOn { get; }
+
+        /// <summary> Token used to authorize the request. </summary>
+        public string AccessToken { get; }
+
+        /// <summary> ID of the target Azure resource where the model should be copied to. </summary>
+        public string TargetResourceId { get; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyAuthorization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyAuthorization.cs
@@ -9,47 +9,22 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     [CodeGenModel("CopyAuthorization")]
     public partial class CopyAuthorization
     {
-        /// <summary>
-        /// Initializes a new instance of CopyAuthorization. Used by the <see cref="DocumentAnalysisModelFactory"/>.
-        /// </summary>
-        internal CopyAuthorization(string targetResourceRegion, string targetModelId, string targetModelLocation, DateTimeOffset expiresOn)
-        {
-            TargetResourceRegion = targetResourceRegion;
-            TargetModelId = targetModelId;
-            TargetModelLocation = targetModelLocation;
-            ExpiresOn = expiresOn;
-        }
-
         /// <summary> Initializes a new instance of CopyAuthorization. </summary>
         /// <param name="targetResourceId"> ID of the target Azure resource where the model should be copied to. </param>
         /// <param name="targetResourceRegion"> Location of the target Azure resource where the model should be copied to. </param>
         /// <param name="targetModelId"> Identifier of the target model. </param>
-        /// <param name="targetModelLocation"> URL of the copied model in the target account. </param>
+        /// <param name="targetModelLocation"> URI of the copied model in the target account. </param>
         /// <param name="accessToken"> Token used to authorize the request. </param>
         /// <param name="expiresOn"> Date/time when the access token expires. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="targetResourceId"/>, <paramref name="targetResourceRegion"/>, <paramref name="targetModelId"/>, <paramref name="targetModelLocation"/>, or <paramref name="accessToken"/> is null. </exception>
-        internal CopyAuthorization(string targetResourceId, string targetResourceRegion, string targetModelId, string targetModelLocation, string accessToken, DateTimeOffset expiresOn)
+        /// <exception cref="ArgumentNullException"> <paramref name="targetResourceId"/>, <paramref name="targetResourceRegion"/>, <paramref name="targetModelId"/>, <paramref name="targetModelLocation"/> or <paramref name="accessToken"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="targetResourceId"/>, <paramref name="targetResourceRegion"/>, <paramref name="targetModelId"/> or <paramref name="accessToken"/> is empty. </exception>
+        public CopyAuthorization(string targetResourceId, string targetResourceRegion, string targetModelId, Uri targetModelLocation, string accessToken, DateTimeOffset expiresOn)
         {
-            if (targetResourceId == null)
-            {
-                throw new ArgumentNullException(nameof(targetResourceId));
-            }
-            if (targetResourceRegion == null)
-            {
-                throw new ArgumentNullException(nameof(targetResourceRegion));
-            }
-            if (targetModelId == null)
-            {
-                throw new ArgumentNullException(nameof(targetModelId));
-            }
-            if (targetModelLocation == null)
-            {
-                throw new ArgumentNullException(nameof(targetModelLocation));
-            }
-            if (accessToken == null)
-            {
-                throw new ArgumentNullException(nameof(accessToken));
-            }
+            Argument.AssertNotNullOrEmpty(targetResourceId, nameof(targetResourceId));
+            Argument.AssertNotNullOrEmpty(targetResourceRegion, nameof(targetResourceRegion));
+            Argument.AssertNotNullOrEmpty(targetModelId, nameof(targetModelId));
+            Argument.AssertNotNull(targetModelLocation, nameof(targetModelLocation));
+            Argument.AssertNotNullOrEmpty(accessToken, nameof(accessToken));
 
             TargetResourceId = targetResourceId;
             TargetResourceRegion = targetResourceRegion;
@@ -58,28 +33,12 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             AccessToken = accessToken;
             ExpiresOn = expiresOn;
         }
-        /// <summary> Location of the target Azure resource where the model should be copied to. </summary>
-        [CodeGenMember("TargetResourceRegion")]
-        public string TargetResourceRegion { get; }
 
-        /// <summary> Identifier of the target model. </summary>
-        [CodeGenMember("TargetModelId")]
-        public string TargetModelId { get; }
-
-        /// <summary> URL of the copied model in the target account. </summary>
-        [CodeGenMember("TargetModelLocation")]
-        public string TargetModelLocation { get; }
+        /// <summary> URI of the copied model in the target account. </summary>
+        public Uri TargetModelLocation { get; }
 
         /// <summary> Date/time when the access token expires. </summary>
         [CodeGenMember("ExpirationDateTime")]
         public DateTimeOffset ExpiresOn { get; }
-
-        /// <summary> Token used to authorize the request. </summary>
-        [CodeGenMember("AccessToken")]
-        internal string AccessToken { get; set; }
-
-        /// <summary> ID of the target Azure resource where the model should be copied to. </summary>
-        [CodeGenMember("TargetResourceId")]
-        internal string TargetResourceId { get; set; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentAnalysisModelFactory.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentAnalysisModelFactory.cs
@@ -94,17 +94,6 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             return new BoundingRegion(pageNumber, boundingPolygon);
         }
 
-        /// <summary> Initializes a new instance of CopyAuthorization. </summary>
-        /// <param name="targetResourceRegion"> Location of the target Azure resource where the model should be copied to. </param>
-        /// <param name="targetModelId"> Identifier of the target model. </param>
-        /// <param name="targetModelLocation"> URL of the copied model in the target account. </param>
-        /// <param name="expiresOn"> Date/time when the access token expires. </param>
-        /// <returns> A new <see cref="DocumentAnalysis.CopyAuthorization"/> instance for mocking. </returns>
-        public static CopyAuthorization CopyAuthorization(string targetResourceRegion = null, string targetModelId = null, string targetModelLocation = null, DateTimeOffset expiresOn = default)
-        {
-            return new CopyAuthorization(targetResourceRegion, targetModelId, targetModelLocation, expiresOn);
-        }
-
         /// <summary> Initializes a new instance of CurrencyValue. </summary>
         /// <param name="amount"> Currency amount. </param>
         /// <param name="symbol"> Currency symbol label, if any. </param>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CopyAuthorization.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CopyAuthorization.Serialization.cs
@@ -27,7 +27,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             writer.WritePropertyName("accessToken");
             writer.WriteStringValue(AccessToken);
             writer.WritePropertyName("expirationDateTime");
-            writer.WriteStringValue(ExpirationDateTime, "O");
+            writer.WriteStringValue(ExpiresOn, "O");
             writer.WriteEndObject();
         }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CopyAuthorization.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CopyAuthorization.Serialization.cs
@@ -23,7 +23,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             writer.WritePropertyName("targetModelId");
             writer.WriteStringValue(TargetModelId);
             writer.WritePropertyName("targetModelLocation");
-            writer.WriteStringValue(TargetModelLocation);
+            writer.WriteStringValue(TargetModelLocation.AbsoluteUri);
             writer.WritePropertyName("accessToken");
             writer.WriteStringValue(AccessToken);
             writer.WritePropertyName("expirationDateTime");
@@ -36,7 +36,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             string targetResourceId = default;
             string targetResourceRegion = default;
             string targetModelId = default;
-            string targetModelLocation = default;
+            Uri targetModelLocation = default;
             string accessToken = default;
             DateTimeOffset expirationDateTime = default;
             foreach (var property in element.EnumerateObject())
@@ -58,7 +58,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
                 }
                 if (property.NameEquals("targetModelLocation"))
                 {
-                    targetModelLocation = property.Value.GetString();
+                    targetModelLocation = new Uri(property.Value.GetString());
                     continue;
                 }
                 if (property.NameEquals("accessToken"))

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CopyAuthorization.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CopyAuthorization.Serialization.cs
@@ -27,7 +27,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             writer.WritePropertyName("accessToken");
             writer.WriteStringValue(AccessToken);
             writer.WritePropertyName("expirationDateTime");
-            writer.WriteStringValue(ExpiresOn, "O");
+            writer.WriteStringValue(ExpirationDateTime, "O");
             writer.WriteEndObject();
         }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CopyAuthorization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CopyAuthorization.cs
@@ -12,14 +12,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     /// <summary> Authorization to copy a model to the specified target resource and modelId. </summary>
     public partial class CopyAuthorization
     {
-
-        /// <summary> ID of the target Azure resource where the model should be copied to. </summary>
-        public string TargetResourceId { get; set; }
-        /// <summary> Location of the target Azure resource where the model should be copied to. </summary>
-        public string TargetResourceRegion { get; set; }
-        /// <summary> Identifier of the target model. </summary>
-        public string TargetModelId { get; set; }
-        /// <summary> Token used to authorize the request. </summary>
-        public string AccessToken { get; set; }
+        /// <summary> Date/time when the access token expires. </summary>
+        public DateTimeOffset ExpirationDateTime { get; set; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CopyAuthorization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CopyAuthorization.cs
@@ -12,5 +12,14 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     /// <summary> Authorization to copy a model to the specified target resource and modelId. </summary>
     public partial class CopyAuthorization
     {
+
+        /// <summary> ID of the target Azure resource where the model should be copied to. </summary>
+        public string TargetResourceId { get; set; }
+        /// <summary> Location of the target Azure resource where the model should be copied to. </summary>
+        public string TargetResourceRegion { get; set; }
+        /// <summary> Identifier of the target model. </summary>
+        public string TargetModelId { get; set; }
+        /// <summary> Token used to authorize the request. </summary>
+        public string AccessToken { get; set; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CopyAuthorization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CopyAuthorization.cs
@@ -12,7 +12,5 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     /// <summary> Authorization to copy a model to the specified target resource and modelId. </summary>
     public partial class CopyAuthorization
     {
-        /// <summary> Date/time when the access token expires. </summary>
-        public DateTimeOffset ExpirationDateTime { get; set; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationClientTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationClientTests.cs
@@ -129,7 +129,8 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
         [Test]
         public void StartCopyModelArgumentValidation()
         {
-            var copyAuth = new CopyAuthorization("<resourceId>", "<region>", "<modelId>", "<modelLocation>", "<accesstoken>", default);
+            var fakeUri = new Uri("https://fake.uri");
+            var copyAuth = new CopyAuthorization("<resourceId>", "<region>", "<modelId>", fakeUri, "<accesstoken>", default);
 
             var client = CreateInstrumentedClient();
 


### PR DESCRIPTION
- Added a public constructor to `CopyAuthorization`.
- Added properties `AccessToken` and `TargetResourceId` to `CopyAuthorization`.
- Updated `CopyAuthorization.TargetModelLocation` to be a `Uri` instead of `string`.
- Removed method `DocumentAnalysisModelFactory.CopyAuthorization`.