### PR TITLE
Service Bus Client Identifier

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -13,6 +13,7 @@ namespace Azure.Messaging.ServiceBus
     }
     public sealed partial class ProcessErrorEventArgs : System.EventArgs
     {
+        public ProcessErrorEventArgs(System.Exception exception, Azure.Messaging.ServiceBus.ServiceBusErrorSource errorSource, string fullyQualifiedNamespace, string entityPath, string identifier, System.Threading.CancellationToken cancellationToken) { }
         public ProcessErrorEventArgs(System.Exception exception, Azure.Messaging.ServiceBus.ServiceBusErrorSource errorSource, string fullyQualifiedNamespace, string entityPath, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.CancellationToken CancellationToken { get { throw null; } }
         public string EntityPath { get { throw null; } }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -96,7 +96,7 @@ namespace Azure.Messaging.ServiceBus
         public ServiceBusClient(string fullyQualifiedNamespace, Azure.Core.TokenCredential credential, Azure.Messaging.ServiceBus.ServiceBusClientOptions options) { }
         public ServiceBusClient(string connectionString, Azure.Messaging.ServiceBus.ServiceBusClientOptions options) { }
         public virtual string FullyQualifiedNamespace { get { throw null; } }
-        public string Identifier { get { throw null; } }
+        public virtual string Identifier { get { throw null; } }
         public virtual bool IsClosed { get { throw null; } }
         public Azure.Messaging.ServiceBus.ServiceBusTransportType TransportType { get { throw null; } }
         public virtual System.Threading.Tasks.Task<Azure.Messaging.ServiceBus.ServiceBusSessionReceiver> AcceptNextSessionAsync(string queueName, Azure.Messaging.ServiceBus.ServiceBusSessionReceiverOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -252,7 +252,7 @@ namespace Azure.Messaging.ServiceBus
         public virtual bool AutoCompleteMessages { get { throw null; } }
         public virtual string EntityPath { get { throw null; } }
         public virtual string FullyQualifiedNamespace { get { throw null; } }
-        public string Identifier { get { throw null; } }
+        public virtual string Identifier { get { throw null; } }
         public virtual bool IsClosed { get { throw null; } }
         public virtual bool IsProcessing { get { throw null; } }
         public virtual System.TimeSpan MaxAutoLockRenewalDuration { get { throw null; } }
@@ -335,7 +335,7 @@ namespace Azure.Messaging.ServiceBus
         protected ServiceBusReceiver(Azure.Messaging.ServiceBus.ServiceBusClient client, string topicName, string subscriptionName, Azure.Messaging.ServiceBus.ServiceBusReceiverOptions options) { }
         public virtual string EntityPath { get { throw null; } }
         public virtual string FullyQualifiedNamespace { get { throw null; } }
-        public string Identifier { get { throw null; } }
+        public virtual string Identifier { get { throw null; } }
         public virtual bool IsClosed { get { throw null; } }
         public virtual int PrefetchCount { get { throw null; } }
         public virtual Azure.Messaging.ServiceBus.ServiceBusReceiveMode ReceiveMode { get { throw null; } }
@@ -428,7 +428,7 @@ namespace Azure.Messaging.ServiceBus
         protected ServiceBusSender(Azure.Messaging.ServiceBus.ServiceBusClient client, string queueOrTopicName, Azure.Messaging.ServiceBus.ServiceBusSenderOptions options) { }
         public virtual string EntityPath { get { throw null; } }
         public virtual string FullyQualifiedNamespace { get { throw null; } }
-        public string Identifier { get { throw null; } }
+        public virtual string Identifier { get { throw null; } }
         public virtual bool IsClosed { get { throw null; } }
         public virtual System.Threading.Tasks.Task CancelScheduledMessageAsync(long sequenceNumber, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task CancelScheduledMessagesAsync(System.Collections.Generic.IEnumerable<long> sequenceNumbers, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -467,7 +467,7 @@ namespace Azure.Messaging.ServiceBus
         public virtual bool AutoCompleteMessages { get { throw null; } }
         public virtual string EntityPath { get { throw null; } }
         public virtual string FullyQualifiedNamespace { get { throw null; } }
-        public string Identifier { get { throw null; } }
+        public virtual string Identifier { get { throw null; } }
         protected internal virtual Azure.Messaging.ServiceBus.ServiceBusProcessor InnerProcessor { get { throw null; } }
         public virtual bool IsClosed { get { throw null; } }
         public virtual bool IsProcessing { get { throw null; } }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -84,6 +84,7 @@ namespace Azure.Messaging.ServiceBus
         public ServiceBusClient(string fullyQualifiedNamespace, Azure.Core.TokenCredential credential, Azure.Messaging.ServiceBus.ServiceBusClientOptions options) { }
         public ServiceBusClient(string connectionString, Azure.Messaging.ServiceBus.ServiceBusClientOptions options) { }
         public virtual string FullyQualifiedNamespace { get { throw null; } }
+        public string Identifier { get { throw null; } }
         public virtual bool IsClosed { get { throw null; } }
         public Azure.Messaging.ServiceBus.ServiceBusTransportType TransportType { get { throw null; } }
         public virtual System.Threading.Tasks.Task<Azure.Messaging.ServiceBus.ServiceBusSessionReceiver> AcceptNextSessionAsync(string queueName, Azure.Messaging.ServiceBus.ServiceBusSessionReceiverOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -110,6 +111,7 @@ namespace Azure.Messaging.ServiceBus
         public ServiceBusClientOptions() { }
         public System.Uri CustomEndpointAddress { get { throw null; } set { } }
         public bool EnableCrossEntityTransactions { get { throw null; } set { } }
+        public string Identifier { get { throw null; } }
         public Azure.Messaging.ServiceBus.ServiceBusRetryOptions RetryOptions { get { throw null; } set { } }
         public Azure.Messaging.ServiceBus.ServiceBusTransportType TransportType { get { throw null; } set { } }
         public System.Net.IWebProxy WebProxy { get { throw null; } set { } }
@@ -238,6 +240,7 @@ namespace Azure.Messaging.ServiceBus
         public virtual bool AutoCompleteMessages { get { throw null; } }
         public virtual string EntityPath { get { throw null; } }
         public virtual string FullyQualifiedNamespace { get { throw null; } }
+        public string Identifier { get { throw null; } }
         public virtual bool IsClosed { get { throw null; } }
         public virtual bool IsProcessing { get { throw null; } }
         public virtual System.TimeSpan MaxAutoLockRenewalDuration { get { throw null; } }
@@ -264,6 +267,7 @@ namespace Azure.Messaging.ServiceBus
     {
         public ServiceBusProcessorOptions() { }
         public bool AutoCompleteMessages { get { throw null; } set { } }
+        public string Identifier { get { throw null; } set { } }
         public System.TimeSpan MaxAutoLockRenewalDuration { get { throw null; } set { } }
         public int MaxConcurrentCalls { get { throw null; } set { } }
         public int PrefetchCount { get { throw null; } set { } }
@@ -319,6 +323,7 @@ namespace Azure.Messaging.ServiceBus
         protected ServiceBusReceiver(Azure.Messaging.ServiceBus.ServiceBusClient client, string topicName, string subscriptionName, Azure.Messaging.ServiceBus.ServiceBusReceiverOptions options) { }
         public virtual string EntityPath { get { throw null; } }
         public virtual string FullyQualifiedNamespace { get { throw null; } }
+        public string Identifier { get { throw null; } }
         public virtual bool IsClosed { get { throw null; } }
         public virtual int PrefetchCount { get { throw null; } }
         public virtual Azure.Messaging.ServiceBus.ServiceBusReceiveMode ReceiveMode { get { throw null; } }
@@ -347,6 +352,7 @@ namespace Azure.Messaging.ServiceBus
     public partial class ServiceBusReceiverOptions
     {
         public ServiceBusReceiverOptions() { }
+        public string Identifier { get { throw null; } set { } }
         public int PrefetchCount { get { throw null; } set { } }
         public Azure.Messaging.ServiceBus.ServiceBusReceiveMode ReceiveMode { get { throw null; } set { } }
         public Azure.Messaging.ServiceBus.SubQueue SubQueue { get { throw null; } set { } }
@@ -405,10 +411,11 @@ namespace Azure.Messaging.ServiceBus
     }
     public partial class ServiceBusSender : System.IAsyncDisposable
     {
-        protected ServiceBusSender() { }
+        protected ServiceBusSender(Azure.Messaging.ServiceBus.ServiceBusClient client, string queueOrTopicName) { }
         protected ServiceBusSender(Azure.Messaging.ServiceBus.ServiceBusClient client, string queueOrTopicName, Azure.Messaging.ServiceBus.ServiceBusSenderOptions options) { }
         public virtual string EntityPath { get { throw null; } }
         public virtual string FullyQualifiedNamespace { get { throw null; } }
+        public string Identifier { get { throw null; } }
         public virtual bool IsClosed { get { throw null; } }
         public virtual System.Threading.Tasks.Task CancelScheduledMessageAsync(long sequenceNumber, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task CancelScheduledMessagesAsync(System.Collections.Generic.IEnumerable<long> sequenceNumbers, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -19,6 +19,7 @@ namespace Azure.Messaging.ServiceBus
         public Azure.Messaging.ServiceBus.ServiceBusErrorSource ErrorSource { get { throw null; } }
         public System.Exception Exception { get { throw null; } }
         public string FullyQualifiedNamespace { get { throw null; } }
+        public string Identifier { get { throw null; } }
     }
     public partial class ProcessMessageEventArgs : System.EventArgs
     {
@@ -26,6 +27,7 @@ namespace Azure.Messaging.ServiceBus
         public System.Threading.CancellationToken CancellationToken { get { throw null; } }
         public string EntityPath { get { throw null; } }
         public string FullyQualifiedNamespace { get { throw null; } }
+        public string Identifier { get { throw null; } }
         public Azure.Messaging.ServiceBus.ServiceBusReceivedMessage Message { get { throw null; } }
         public virtual System.Threading.Tasks.Task AbandonMessageAsync(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task CompleteMessageAsync(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -47,6 +49,7 @@ namespace Azure.Messaging.ServiceBus
         public System.Threading.CancellationToken CancellationToken { get { throw null; } }
         public string EntityPath { get { throw null; } }
         public string FullyQualifiedNamespace { get { throw null; } }
+        public string Identifier { get { throw null; } }
         public string SessionId { get { throw null; } }
         public System.DateTimeOffset SessionLockedUntil { get { throw null; } }
         public virtual System.Threading.Tasks.Task<System.BinaryData> GetSessionStateAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -60,6 +63,7 @@ namespace Azure.Messaging.ServiceBus
         public System.Threading.CancellationToken CancellationToken { get { throw null; } }
         public string EntityPath { get { throw null; } }
         public string FullyQualifiedNamespace { get { throw null; } }
+        public string Identifier { get { throw null; } }
         public Azure.Messaging.ServiceBus.ServiceBusReceivedMessage Message { get { throw null; } }
         public string SessionId { get { throw null; } }
         public System.DateTimeOffset SessionLockedUntil { get { throw null; } }
@@ -517,6 +521,7 @@ namespace Azure.Messaging.ServiceBus
     public partial class ServiceBusSessionReceiverOptions
     {
         public ServiceBusSessionReceiverOptions() { }
+        public string Identifier { get { throw null; } set { } }
         public int PrefetchCount { get { throw null; } set { } }
         public Azure.Messaging.ServiceBus.ServiceBusReceiveMode ReceiveMode { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -455,6 +455,7 @@ namespace Azure.Messaging.ServiceBus
         public virtual bool AutoCompleteMessages { get { throw null; } }
         public virtual string EntityPath { get { throw null; } }
         public virtual string FullyQualifiedNamespace { get { throw null; } }
+        public string Identifier { get { throw null; } }
         protected internal virtual Azure.Messaging.ServiceBus.ServiceBusProcessor InnerProcessor { get { throw null; } }
         public virtual bool IsClosed { get { throw null; } }
         public virtual bool IsProcessing { get { throw null; } }
@@ -488,6 +489,7 @@ namespace Azure.Messaging.ServiceBus
     {
         public ServiceBusSessionProcessorOptions() { }
         public bool AutoCompleteMessages { get { throw null; } set { } }
+        public string Identifier { get { throw null; } set { } }
         public System.TimeSpan MaxAutoLockRenewalDuration { get { throw null; } set { } }
         public int MaxConcurrentCallsPerSession { get { throw null; } set { } }
         public int MaxConcurrentSessions { get { throw null; } set { } }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -14,6 +14,7 @@ namespace Azure.Messaging.ServiceBus
     public sealed partial class ProcessErrorEventArgs : System.EventArgs
     {
         public ProcessErrorEventArgs(System.Exception exception, Azure.Messaging.ServiceBus.ServiceBusErrorSource errorSource, string fullyQualifiedNamespace, string entityPath, string identifier, System.Threading.CancellationToken cancellationToken) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public ProcessErrorEventArgs(System.Exception exception, Azure.Messaging.ServiceBus.ServiceBusErrorSource errorSource, string fullyQualifiedNamespace, string entityPath, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.CancellationToken CancellationToken { get { throw null; } }
         public string EntityPath { get { throw null; } }
@@ -24,6 +25,8 @@ namespace Azure.Messaging.ServiceBus
     }
     public partial class ProcessMessageEventArgs : System.EventArgs
     {
+        public ProcessMessageEventArgs(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, Azure.Messaging.ServiceBus.ServiceBusReceiver receiver, string identifier, System.Threading.CancellationToken cancellationToken) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public ProcessMessageEventArgs(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, Azure.Messaging.ServiceBus.ServiceBusReceiver receiver, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.CancellationToken CancellationToken { get { throw null; } }
         public string EntityPath { get { throw null; } }
@@ -46,6 +49,8 @@ namespace Azure.Messaging.ServiceBus
     }
     public partial class ProcessSessionEventArgs : System.EventArgs
     {
+        public ProcessSessionEventArgs(Azure.Messaging.ServiceBus.ServiceBusSessionReceiver receiver, string identifier, System.Threading.CancellationToken cancellationToken) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public ProcessSessionEventArgs(Azure.Messaging.ServiceBus.ServiceBusSessionReceiver receiver, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.CancellationToken CancellationToken { get { throw null; } }
         public string EntityPath { get { throw null; } }
@@ -60,6 +65,8 @@ namespace Azure.Messaging.ServiceBus
     }
     public partial class ProcessSessionMessageEventArgs : System.EventArgs
     {
+        public ProcessSessionMessageEventArgs(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, Azure.Messaging.ServiceBus.ServiceBusSessionReceiver receiver, string identifier, System.Threading.CancellationToken cancellationToken) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public ProcessSessionMessageEventArgs(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, Azure.Messaging.ServiceBus.ServiceBusSessionReceiver receiver, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.CancellationToken CancellationToken { get { throw null; } }
         public string EntityPath { get { throw null; } }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -100,6 +100,7 @@ namespace Azure.Messaging.ServiceBus
         public virtual Azure.Messaging.ServiceBus.ServiceBusReceiver CreateReceiver(string topicName, string subscriptionName, Azure.Messaging.ServiceBus.ServiceBusReceiverOptions options) { throw null; }
         public virtual Azure.Messaging.ServiceBus.ServiceBusRuleManager CreateRuleManager(string topicName, string subscriptionName) { throw null; }
         public virtual Azure.Messaging.ServiceBus.ServiceBusSender CreateSender(string queueOrTopicName) { throw null; }
+        public virtual Azure.Messaging.ServiceBus.ServiceBusSender CreateSender(string queueOrTopicName, Azure.Messaging.ServiceBus.ServiceBusSenderOptions options) { throw null; }
         public virtual Azure.Messaging.ServiceBus.ServiceBusSessionProcessor CreateSessionProcessor(string queueName, Azure.Messaging.ServiceBus.ServiceBusSessionProcessorOptions options = null) { throw null; }
         public virtual Azure.Messaging.ServiceBus.ServiceBusSessionProcessor CreateSessionProcessor(string topicName, string subscriptionName, Azure.Messaging.ServiceBus.ServiceBusSessionProcessorOptions options = null) { throw null; }
         public virtual System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
@@ -405,7 +406,7 @@ namespace Azure.Messaging.ServiceBus
     public partial class ServiceBusSender : System.IAsyncDisposable
     {
         protected ServiceBusSender() { }
-        protected ServiceBusSender(Azure.Messaging.ServiceBus.ServiceBusClient client, string queueOrTopicName) { }
+        protected ServiceBusSender(Azure.Messaging.ServiceBus.ServiceBusClient client, string queueOrTopicName, Azure.Messaging.ServiceBus.ServiceBusSenderOptions options) { }
         public virtual string EntityPath { get { throw null; } }
         public virtual string FullyQualifiedNamespace { get { throw null; } }
         public virtual bool IsClosed { get { throw null; } }
@@ -424,6 +425,17 @@ namespace Azure.Messaging.ServiceBus
         public virtual System.Threading.Tasks.Task SendMessageAsync(Azure.Messaging.ServiceBus.ServiceBusMessage message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task SendMessagesAsync(Azure.Messaging.ServiceBus.ServiceBusMessageBatch messageBatch, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task SendMessagesAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.ServiceBus.ServiceBusMessage> messages, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override string ToString() { throw null; }
+    }
+    public partial class ServiceBusSenderOptions
+    {
+        public ServiceBusSenderOptions() { }
+        public string Identifier { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }
     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -111,7 +111,7 @@ namespace Azure.Messaging.ServiceBus
         public ServiceBusClientOptions() { }
         public System.Uri CustomEndpointAddress { get { throw null; } set { } }
         public bool EnableCrossEntityTransactions { get { throw null; } set { } }
-        public string Identifier { get { throw null; } }
+        public string Identifier { get { throw null; } set { } }
         public Azure.Messaging.ServiceBus.ServiceBusRetryOptions RetryOptions { get { throw null; } set { } }
         public Azure.Messaging.ServiceBus.ServiceBusTransportType TransportType { get { throw null; } set { } }
         public System.Net.IWebProxy WebProxy { get { throw null; } set { } }
@@ -411,6 +411,7 @@ namespace Azure.Messaging.ServiceBus
     }
     public partial class ServiceBusSender : System.IAsyncDisposable
     {
+        protected ServiceBusSender() { }
         protected ServiceBusSender(Azure.Messaging.ServiceBus.ServiceBusClient client, string queueOrTopicName) { }
         protected ServiceBusSender(Azure.Messaging.ServiceBus.ServiceBusClient client, string queueOrTopicName, Azure.Messaging.ServiceBus.ServiceBusSenderOptions options) { }
         public virtual string EntityPath { get { throw null; } }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
@@ -120,7 +120,8 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 options.WebProxy,
                 options.EnableCrossEntityTransactions,
                 options.RetryOptions.TryTimeout,
-                TransportMetrics);
+                TransportMetrics,
+                options.Identifier);
         }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
@@ -120,8 +120,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 options.WebProxy,
                 options.EnableCrossEntityTransactions,
                 options.RetryOptions.TryTimeout,
-                TransportMetrics,
-                options.Identifier);
+                TransportMetrics);
         }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -687,7 +687,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 };
 
                 link = new ReceivingAmqpLink(linkSettings);
-                linkSettings.LinkName = $"{connection.Settings.ContainerId};{connection.Identifier}:{session.Identifier}:{link.Identifier}:{linkSettings.Source.ToString()}";
+                linkSettings.LinkName = Id;
 
                 link.AttachTo(session);
 
@@ -828,7 +828,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 linkSettings.AddProperty(AmqpClientConstants.TimeoutName, (uint)timeout.CalculateRemaining(stopWatch.GetElapsedTime()).TotalMilliseconds);
 
                 link = new SendingAmqpLink(linkSettings);
-                linkSettings.LinkName = $"{ Id };{ connection.Identifier }:{ session.Identifier }:{ link.Identifier }";
+                linkSettings.LinkName = Id;
                 link.AttachTo(session);
 
                 // Configure refresh for authorization of the link.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -687,7 +687,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 };
 
                 link = new ReceivingAmqpLink(linkSettings);
-                linkSettings.LinkName = $"{Id};{connection.Identifier}:{session.Identifier}:{link.Identifier}";
+                linkSettings.LinkName = $"{connection.Settings.ContainerId};{connection.Identifier}:{session.Identifier}:{link.Identifier}:{linkSettings.Source.ToString()}";
 
                 link.AttachTo(session);
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -822,7 +822,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     InitialDeliveryCount = 0,
                     Source = new Source { Address = identifier },
                     Target = new Target { Address = destinationEndpoint.AbsolutePath },
-                    OperationTimeout = _operationTimeout
+                    OperationTimeout = _operationTimeout,
                 };
 
                 linkSettings.AddProperty(AmqpClientConstants.TimeoutName, (uint)timeout.CalculateRemaining(stopWatch.GetElapsedTime()).TotalMilliseconds);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -180,7 +180,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="useSingleSession">If true, all links will use a single session.</param>
         /// <param name="operationTimeout">The timeout for operations associated with the connection.</param>
         /// <param name="metrics">The metrics instance to populate transport metrics. May be null.</param>
-        /// <param name="identifier">The unique identifier to assign this scope, if null, one will be generated.</param>
         public AmqpConnectionScope(
             Uri serviceEndpoint,
             Uri connectionEndpoint,
@@ -189,10 +188,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             IWebProxy proxy,
             bool useSingleSession,
             TimeSpan operationTimeout,
-            ServiceBusTransportMetrics metrics,
-#pragma warning disable CA1801 // Review unused parameters. This parameter will be used for future planned features.
-            string identifier = default)
-#pragma warning restore CA1801 // Review unused parameters
+            ServiceBusTransportMetrics metrics)
         {
             Argument.AssertNotNull(serviceEndpoint, nameof(serviceEndpoint));
             Argument.AssertNotNull(credential, nameof(credential));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -180,6 +180,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="useSingleSession">If true, all links will use a single session.</param>
         /// <param name="operationTimeout">The timeout for operations associated with the connection.</param>
         /// <param name="metrics">The metrics instance to populate transport metrics. May be null.</param>
+        /// <param name="identifier">The unique identifier to assign this scope, if null, one will be generated.</param>
         public AmqpConnectionScope(
             Uri serviceEndpoint,
             Uri connectionEndpoint,
@@ -188,7 +189,8 @@ namespace Azure.Messaging.ServiceBus.Amqp
             IWebProxy proxy,
             bool useSingleSession,
             TimeSpan operationTimeout,
-            ServiceBusTransportMetrics metrics)
+            ServiceBusTransportMetrics metrics,
+            string identifier = default)
         {
             Argument.AssertNotNull(serviceEndpoint, nameof(serviceEndpoint));
             Argument.AssertNotNull(credential, nameof(credential));
@@ -198,7 +200,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             ServiceEndpoint = serviceEndpoint;
             Transport = transport;
             Proxy = proxy;
-            Id = $"{ServiceEndpoint}-{Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture).Substring(0, 8)}";
+            Id = identifier ?? $"{ServiceEndpoint}-{Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture).Substring(0, 8)}";
             TokenProvider = new CbsTokenProvider(new ServiceBusTokenCredential(credential), AuthorizationTokenExpirationBuffer, OperationCancellationSource.Token);
             _useSingleSession = useSingleSession;
 #pragma warning disable CA2214 // Do not call overridable methods in constructors. This internal method is virtual for testing purposes.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -680,7 +680,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     AutoSendFlow = prefetchCount > 0,
                     SettleType = (receiveMode == ServiceBusReceiveMode.PeekLock) ? SettleMode.SettleOnDispose : SettleMode.SettleOnSend,
                     Source = new Source { Address = endpoint.AbsolutePath, FilterSet = filters },
-                    Target = new Target { Address = Guid.NewGuid().ToString() },
+                    Target = new Target { Address = identifier },
                     OperationTimeout = _operationTimeout
                 };
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -818,7 +818,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 {
                     Role = false,
                     InitialDeliveryCount = 0,
-                    Source = new Source { Address = Guid.NewGuid().ToString() },
+                    Source = new Source { Address = identifier },
                     Target = new Target { Address = destinationEndpoint.AbsolutePath },
                     OperationTimeout = _operationTimeout
                 };

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -190,7 +190,9 @@ namespace Azure.Messaging.ServiceBus.Amqp
             bool useSingleSession,
             TimeSpan operationTimeout,
             ServiceBusTransportMetrics metrics,
+#pragma warning disable CA1801 // Review unused parameters. This parameter will be used for future planned features.
             string identifier = default)
+#pragma warning restore CA1801 // Review unused parameters
         {
             Argument.AssertNotNull(serviceEndpoint, nameof(serviceEndpoint));
             Argument.AssertNotNull(credential, nameof(credential));
@@ -200,7 +202,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             ServiceEndpoint = serviceEndpoint;
             Transport = transport;
             Proxy = proxy;
-            Id = identifier ?? $"{ServiceEndpoint}-{Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture).Substring(0, 8)}";
+            Id = $"{ServiceEndpoint}-{Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture).Substring(0, 8)}";
             TokenProvider = new CbsTokenProvider(new ServiceBusTokenCredential(credential), AuthorizationTokenExpirationBuffer, OperationCancellationSource.Token);
             _useSingleSession = useSingleSession;
 #pragma warning disable CA2214 // Do not call overridable methods in constructors. This internal method is virtual for testing purposes.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -687,7 +687,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 };
 
                 link = new ReceivingAmqpLink(linkSettings);
-                linkSettings.LinkName = Id;
+                linkSettings.LinkName = $"{Id};{connection.Identifier}:{session.Identifier}:{link.Identifier}";
 
                 link.AttachTo(session);
 
@@ -828,7 +828,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 linkSettings.AddProperty(AmqpClientConstants.TimeoutName, (uint)timeout.CalculateRemaining(stopWatch.GetElapsedTime()).TotalMilliseconds);
 
                 link = new SendingAmqpLink(linkSettings);
-                linkSettings.LinkName = Id;
+                linkSettings.LinkName = $"{Id};{connection.Identifier}:{session.Identifier}:{link.Identifier}";
                 link.AttachTo(session);
 
                 // Configure refresh for authorization of the link.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -56,6 +56,11 @@ namespace Azure.Messaging.ServiceBus.Amqp
         public override bool IsSessionLinkClosed => _isSessionReceiver && LinkException != null;
 
         /// <summary>
+        /// The identifier for the sender.
+        /// </summary>
+        public string Identifier { get; }
+
+        /// <summary>
         /// The name of the Service Bus entity to which the receiver is bound.
         /// </summary>
         ///
@@ -81,7 +86,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// The <see cref="ServiceBusReceiveMode"/> used to specify how messages are received. Defaults to PeekLock mode.
         /// </summary>
         private readonly ServiceBusReceiveMode _receiveMode;
-        private readonly string _identifier;
         private readonly FaultTolerantAmqpObject<ReceivingAmqpLink> _receiveLink;
         private readonly FaultTolerantAmqpObject<RequestResponseAmqpLink> _managementLink;
 
@@ -162,7 +166,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             _isSessionReceiver = isSessionReceiver;
             _isProcessor = isProcessor;
             _receiveMode = receiveMode;
-            _identifier = identifier;
+            Identifier = identifier;
             _requestResponseLockedMessages = new ConcurrentExpiringSet<Guid>();
             SessionId = sessionId;
 
@@ -189,7 +193,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         {
             RequestResponseAmqpLink link = await _connectionScope.OpenManagementLinkAsync(
                 _entityPath,
-                _identifier,
+                Identifier,
                 timeout,
                 CancellationToken.None).ConfigureAwait(false);
             link.Closed += OnManagementLinkClosed;
@@ -203,7 +207,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             string identifier,
             CancellationToken cancellationToken)
         {
-            ServiceBusEventSource.Log.CreateReceiveLinkStart(_identifier);
+            ServiceBusEventSource.Log.CreateReceiveLinkStart(Identifier);
 
             try
             {
@@ -239,7 +243,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     // receiver.
                     SessionId = tempSessionId;
                 }
-                ServiceBusEventSource.Log.CreateReceiveLinkComplete(_identifier, SessionId);
+                ServiceBusEventSource.Log.CreateReceiveLinkComplete(Identifier, SessionId);
                 link.Closed += OnReceiverLinkClosed;
                 return link;
             }
@@ -259,7 +263,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             }
             catch (Exception ex)
             {
-                ServiceBusEventSource.Log.CreateReceiveLinkException(_identifier, ex.ToString());
+                ServiceBusEventSource.Log.CreateReceiveLinkException(Identifier, ex.ToString());
                 throw;
             }
         }
@@ -480,7 +484,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 {
                     // The link state is lost, We need to return a non-retriable error.
                     ServiceBusEventSource.Log.LinkStateLost(
-                        _identifier,
+                        Identifier,
                         receiveLink.Name,
                         receiveLink.State.ToString(),
                         _isSessionReceiver,
@@ -1350,14 +1354,14 @@ namespace Azure.Messaging.ServiceBus.Amqp
             }
 
             ServiceBusEventSource.Log.ReceiveLinkClosed(
-                _identifier,
+                Identifier,
                 SessionId,
                 receiver);
         }
 
         private void OnManagementLinkClosed(object managementLink, EventArgs e) =>
         ServiceBusEventSource.Log.ManagementLinkClosed(
-            _identifier,
+            Identifier,
             managementLink);
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -56,7 +56,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         public override bool IsSessionLinkClosed => _isSessionReceiver && LinkException != null;
 
         /// <summary>
-        /// The identifier for the sender.
+        /// The identifier for the receiver.
         /// </summary>
         public string Identifier { get; }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -47,7 +47,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         public override bool IsClosed => _closed;
 
         /// <summary>
-        /// The identifier for the sender.
+        /// The identifier of the sender.
         /// </summary>
         public string Identifier { get; }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -151,7 +151,7 @@ namespace Azure.Messaging.ServiceBus
             _options = options?.Clone() ?? new ServiceBusClientOptions();
             Connection = new ServiceBusConnection(connectionString, _options);
             Logger.ClientCreateStart(typeof(ServiceBusClient), FullyQualifiedNamespace);
-            Identifier = options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(FullyQualifiedNamespace);
+            Identifier = _options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(FullyQualifiedNamespace);
             TransportType = _options.TransportType;
             Logger.ClientCreateComplete(typeof(ServiceBusClient), Identifier);
         }
@@ -231,7 +231,7 @@ namespace Azure.Messaging.ServiceBus
         {
             Logger.ClientCreateStart(typeof(ServiceBusClient), fullyQualifiedNamespace);
             _options = options?.Clone() ?? new ServiceBusClientOptions();
-            Identifier = DiagnosticUtilities.GenerateIdentifier(fullyQualifiedNamespace);
+            Identifier = _options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(fullyQualifiedNamespace);
             Connection = ServiceBusConnection.CreateWithCredential(
                 fullyQualifiedNamespace,
                 credential,
@@ -285,7 +285,7 @@ namespace Azure.Messaging.ServiceBus
             return new ServiceBusSender(
                 entityPath: queueOrTopicName,
                 connection: Connection,
-                options: new ServiceBusSenderOptions());
+                options: options);
         }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -151,7 +151,7 @@ namespace Azure.Messaging.ServiceBus
             _options = options?.Clone() ?? new ServiceBusClientOptions();
             Connection = new ServiceBusConnection(connectionString, _options);
             Logger.ClientCreateStart(typeof(ServiceBusClient), FullyQualifiedNamespace);
-            Identifier = _options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(FullyQualifiedNamespace);
+            Identifier = string.IsNullOrEmpty(_options.Identifier) ? DiagnosticUtilities.GenerateIdentifier(FullyQualifiedNamespace) : _options.Identifier;
             TransportType = _options.TransportType;
             Logger.ClientCreateComplete(typeof(ServiceBusClient), Identifier);
         }
@@ -231,7 +231,7 @@ namespace Azure.Messaging.ServiceBus
         {
             Logger.ClientCreateStart(typeof(ServiceBusClient), fullyQualifiedNamespace);
             _options = options?.Clone() ?? new ServiceBusClientOptions();
-            Identifier = _options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(fullyQualifiedNamespace);
+            Identifier = string.IsNullOrEmpty(_options.Identifier) ? DiagnosticUtilities.GenerateIdentifier(fullyQualifiedNamespace) : _options.Identifier;
             Connection = ServiceBusConnection.CreateWithCredential(
                 fullyQualifiedNamespace,
                 credential,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -259,7 +259,33 @@ namespace Azure.Messaging.ServiceBus
 
             return new ServiceBusSender(
                 entityPath: queueOrTopicName,
-                connection: Connection);
+                connection: Connection,
+                options: new ServiceBusSenderOptions());
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ServiceBusSender"/> instance that can be used for sending messages to a specific
+        /// queue or topic.
+        /// </summary>
+        ///
+        /// <param name="queueOrTopicName">The queue or topic to create a <see cref="ServiceBusSender"/>
+        /// for.</param>
+        /// <param name="options">The set of <see cref="ServiceBusSenderOptions"/> to use when configuring
+        /// the <see cref="ServiceBusSender"/>.</param>
+        ///
+        /// <returns>A <see cref="ServiceBusSender"/> scoped to the specified queue or topic.</returns>
+        /// <exception cref="ArgumentException">
+        ///   The <see cref="ServiceBusClient"/> was constructed with a connection string containing the "EntityPath" token
+        ///   that has a different value than the <paramref name="queueOrTopicName"/> value specified here.
+        /// </exception>
+        public virtual ServiceBusSender CreateSender(string queueOrTopicName, ServiceBusSenderOptions options)
+        {
+            ValidateEntityName(queueOrTopicName);
+
+            return new ServiceBusSender(
+                entityPath: queueOrTopicName,
+                connection: Connection,
+                options: new ServiceBusSenderOptions());
         }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -149,8 +149,8 @@ namespace Azure.Messaging.ServiceBus
         public ServiceBusClient(string connectionString, ServiceBusClientOptions options)
         {
             _options = options?.Clone() ?? new ServiceBusClientOptions();
-            _options.Identifier ??= DiagnosticUtilities.GenerateIdentifier(FullyQualifiedNamespace);
             Connection = new ServiceBusConnection(connectionString, _options);
+            _options.Identifier ??= DiagnosticUtilities.GenerateIdentifier(FullyQualifiedNamespace);
             Logger.ClientCreateStart(typeof(ServiceBusClient), FullyQualifiedNamespace);
             Identifier = _options.Identifier;
             TransportType = _options.TransportType;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -149,9 +149,10 @@ namespace Azure.Messaging.ServiceBus
         public ServiceBusClient(string connectionString, ServiceBusClientOptions options)
         {
             _options = options?.Clone() ?? new ServiceBusClientOptions();
+            _options.Identifier ??= DiagnosticUtilities.GenerateIdentifier(FullyQualifiedNamespace);
             Connection = new ServiceBusConnection(connectionString, _options);
             Logger.ClientCreateStart(typeof(ServiceBusClient), FullyQualifiedNamespace);
-            Identifier = _options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(FullyQualifiedNamespace);
+            Identifier = _options.Identifier;
             TransportType = _options.TransportType;
             Logger.ClientCreateComplete(typeof(ServiceBusClient), Identifier);
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -232,7 +232,8 @@ namespace Azure.Messaging.ServiceBus
         {
             Logger.ClientCreateStart(typeof(ServiceBusClient), fullyQualifiedNamespace);
             _options = options?.Clone() ?? new ServiceBusClientOptions();
-            Identifier = _options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(fullyQualifiedNamespace);
+            _options.Identifier ??= DiagnosticUtilities.GenerateIdentifier(fullyQualifiedNamespace);
+            Identifier = _options.Identifier;
             Connection = ServiceBusConnection.CreateWithCredential(
                 fullyQualifiedNamespace,
                 credential,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -50,7 +50,7 @@ namespace Azure.Messaging.ServiceBus
         public ServiceBusTransportType TransportType { get; }
 
         /// <summary>
-        ///   A unique name used to identify this <see cref="ServiceBusClient"/>.
+        ///   The name used to identify this <see cref="ServiceBusClient"/>.
         /// </summary>
         public string Identifier { get; }
 
@@ -253,15 +253,7 @@ namespace Azure.Messaging.ServiceBus
         ///   The <see cref="ServiceBusClient"/> was constructed with a connection string containing the "EntityPath" token
         ///   that has a different value than the <paramref name="queueOrTopicName"/> value specified here.
         /// </exception>
-        public virtual ServiceBusSender CreateSender(string queueOrTopicName)
-        {
-            ValidateEntityName(queueOrTopicName);
-
-            return new ServiceBusSender(
-                entityPath: queueOrTopicName,
-                connection: Connection,
-                options: new ServiceBusSenderOptions());
-        }
+        public virtual ServiceBusSender CreateSender(string queueOrTopicName) => CreateSender(queueOrTopicName, new ServiceBusSenderOptions());
 
         /// <summary>
         /// Creates a <see cref="ServiceBusSender"/> instance that can be used for sending messages to a specific
@@ -301,16 +293,7 @@ namespace Azure.Messaging.ServiceBus
         ///   The <see cref="ServiceBusClient"/> was constructed with a connection string containing the "EntityPath" token
         ///   that has a different value than the <paramref name="queueName"/> value specified here.
         /// </exception>
-        public virtual ServiceBusReceiver CreateReceiver(string queueName)
-        {
-            ValidateEntityName(queueName);
-
-            return new ServiceBusReceiver(
-                connection: Connection,
-                entityPath: queueName,
-                isSessionEntity: false,
-                options: new ServiceBusReceiverOptions());
-        }
+        public virtual ServiceBusReceiver CreateReceiver(string queueName) => CreateReceiver(queueName, new ServiceBusReceiverOptions());
 
         /// <summary>
         /// Creates a <see cref="ServiceBusReceiver"/> instance that can be used for receiving and settling messages
@@ -359,16 +342,7 @@ namespace Azure.Messaging.ServiceBus
         /// </exception>
         public virtual ServiceBusReceiver CreateReceiver(
             string topicName,
-            string subscriptionName)
-        {
-            ValidateEntityName(topicName);
-
-            return new ServiceBusReceiver(
-                connection: Connection,
-                entityPath: EntityNameFormatter.FormatSubscriptionPath(topicName, subscriptionName),
-                isSessionEntity: false,
-                options: new ServiceBusReceiverOptions());
-        }
+            string subscriptionName) => CreateReceiver(topicName, subscriptionName, new ServiceBusReceiverOptions());
 
         /// <summary>
         /// Creates a <see cref="ServiceBusReceiver"/> instance that can be used for

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -52,7 +52,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         ///   A unique name used to identify this <see cref="ServiceBusClient"/>.
         /// </summary>
-        internal string Identifier { get; }
+        public string Identifier { get; }
 
         /// <summary>
         ///   The instance of <see cref="ServiceBusEventSource" /> which can be mocked for testing.
@@ -151,7 +151,7 @@ namespace Azure.Messaging.ServiceBus
             _options = options?.Clone() ?? new ServiceBusClientOptions();
             Connection = new ServiceBusConnection(connectionString, _options);
             Logger.ClientCreateStart(typeof(ServiceBusClient), FullyQualifiedNamespace);
-            Identifier = DiagnosticUtilities.GenerateIdentifier(FullyQualifiedNamespace);
+            Identifier = options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(FullyQualifiedNamespace);
             TransportType = _options.TransportType;
             Logger.ClientCreateComplete(typeof(ServiceBusClient), Identifier);
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -150,9 +150,8 @@ namespace Azure.Messaging.ServiceBus
         {
             _options = options?.Clone() ?? new ServiceBusClientOptions();
             Connection = new ServiceBusConnection(connectionString, _options);
-            _options.Identifier ??= DiagnosticUtilities.GenerateIdentifier(FullyQualifiedNamespace);
             Logger.ClientCreateStart(typeof(ServiceBusClient), FullyQualifiedNamespace);
-            Identifier = _options.Identifier;
+            Identifier = _options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(FullyQualifiedNamespace);
             TransportType = _options.TransportType;
             Logger.ClientCreateComplete(typeof(ServiceBusClient), Identifier);
         }
@@ -232,8 +231,7 @@ namespace Azure.Messaging.ServiceBus
         {
             Logger.ClientCreateStart(typeof(ServiceBusClient), fullyQualifiedNamespace);
             _options = options?.Clone() ?? new ServiceBusClientOptions();
-            _options.Identifier ??= DiagnosticUtilities.GenerateIdentifier(fullyQualifiedNamespace);
-            Identifier = _options.Identifier;
+            Identifier = _options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(fullyQualifiedNamespace);
             Connection = ServiceBusConnection.CreateWithCredential(
                 fullyQualifiedNamespace,
                 credential,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -52,7 +52,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         ///   The name used to identify this <see cref="ServiceBusClient"/>.
         /// </summary>
-        public string Identifier { get; }
+        public virtual string Identifier { get; }
 
         /// <summary>
         ///   The instance of <see cref="ServiceBusEventSource" /> which can be mocked for testing.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
@@ -41,7 +41,7 @@ namespace Azure.Messaging.ServiceBus
         /// </summary>
         /// <remarks>Every new client has a unique ID.</remarks>
         ///
-        public string Identifier { get; }
+        public string Identifier { get; set; }
 
         /// <summary>
         ///   A custom endpoint address that can be used when establishing the connection to the Service Bus
@@ -130,7 +130,8 @@ namespace Azure.Messaging.ServiceBus
                 RetryOptions = RetryOptions.Clone(),
                 EnableCrossEntityTransactions = EnableCrossEntityTransactions,
                 EnableTransportMetrics = EnableTransportMetrics,
-                CustomEndpointAddress = CustomEndpointAddress
+                CustomEndpointAddress = CustomEndpointAddress,
+                Identifier = Identifier
             };
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
@@ -37,9 +37,9 @@ namespace Azure.Messaging.ServiceBus
         public IWebProxy WebProxy { get; set; }
 
         /// <summary>
-        /// Gets the ID to identify this client. This can be used to correlate logs and exceptions.
+        /// A property used to set the <see cref="ServiceBusClient"/> ID to identify the client. This can be used to correlate logs
+        /// and exceptions. If <c>null</c> or empty, a random unique value will be used.
         /// </summary>
-        /// <remarks>Every new client has a unique ID.</remarks>
         ///
         public string Identifier { get; set; }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
@@ -37,6 +37,13 @@ namespace Azure.Messaging.ServiceBus
         public IWebProxy WebProxy { get; set; }
 
         /// <summary>
+        /// Gets the ID to identify this client. This can be used to correlate logs and exceptions.
+        /// </summary>
+        /// <remarks>Every new client has a unique ID.</remarks>
+        ///
+        public string Identifier { get; }
+
+        /// <summary>
         ///   A custom endpoint address that can be used when establishing the connection to the Service Bus
         ///   service.
         /// </summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessErrorEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessErrorEventArgs.cs
@@ -39,6 +39,30 @@ namespace Azure.Messaging.ServiceBus
             Identifier = identifier;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProcessErrorEventArgs" /> class.
+        /// </summary>
+        ///
+        /// <param name="exception">The exception that triggered the call to the error event handler.</param>
+        /// <param name="errorSource">The source associated with the error.</param>
+        /// <param name="fullyQualifiedNamespace">The endpoint used when this exception occurred.</param>
+        /// <param name="entityPath">The entity path used when this exception occurred.</param>
+        /// <param name="cancellationToken">The processor's <see cref="System.Threading.CancellationToken"/> instance which will be cancelled
+        /// in the event that <see cref="ServiceBusProcessor.StopProcessingAsync"/> is called.</param>
+        public ProcessErrorEventArgs(
+            Exception exception,
+            ServiceBusErrorSource errorSource,
+            string fullyQualifiedNamespace,
+            string entityPath,
+            CancellationToken cancellationToken)
+        {
+            Exception = exception;
+            ErrorSource = errorSource;
+            FullyQualifiedNamespace = fullyQualifiedNamespace;
+            EntityPath = entityPath;
+            CancellationToken = cancellationToken;
+        }
+
         /// <summary>Gets the exception that triggered the call to the error event handler.</summary>
         public Exception Exception { get; }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessErrorEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessErrorEventArgs.cs
@@ -48,7 +48,7 @@ namespace Azure.Messaging.ServiceBus
         /// This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</summary>
         public string FullyQualifiedNamespace { get; }
 
-        /// <summary>Gets the client identifier associated with the error event.</summary>
+        /// <summary>Gets the identifier of the processor that raised this event.</summary>
         public string Identifier { get; }
 
         /// <summary>Gets the entity path associated with the error event.</summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessErrorEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessErrorEventArgs.cs
@@ -20,6 +20,7 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="errorSource">The source associated with the error.</param>
         /// <param name="fullyQualifiedNamespace">The endpoint used when this exception occurred.</param>
         /// <param name="entityPath">The entity path used when this exception occurred.</param>
+        /// <param name="identifier">The identifier of the client entity that reported this error.</param>
         /// <param name="cancellationToken">The processor's <see cref="System.Threading.CancellationToken"/> instance which will be cancelled
         /// in the event that <see cref="ServiceBusProcessor.StopProcessingAsync"/> is called.</param>
         public ProcessErrorEventArgs(
@@ -27,6 +28,7 @@ namespace Azure.Messaging.ServiceBus
             ServiceBusErrorSource errorSource,
             string fullyQualifiedNamespace,
             string entityPath,
+            string identifier,
             CancellationToken cancellationToken)
         {
             Exception = exception;
@@ -34,6 +36,7 @@ namespace Azure.Messaging.ServiceBus
             FullyQualifiedNamespace = fullyQualifiedNamespace;
             EntityPath = entityPath;
             CancellationToken = cancellationToken;
+            Identifier = identifier;
         }
 
         /// <summary>Gets the exception that triggered the call to the error event handler.</summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessErrorEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessErrorEventArgs.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ComponentModel;
 using System.Threading;
 
 namespace Azure.Messaging.ServiceBus
@@ -20,7 +21,7 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="errorSource">The source associated with the error.</param>
         /// <param name="fullyQualifiedNamespace">The endpoint used when this exception occurred.</param>
         /// <param name="entityPath">The entity path used when this exception occurred.</param>
-        /// <param name="identifier">The identifier of the client entity that reported this error.</param>
+        /// <param name="identifier">The identifier of the processor that reported this error.</param>
         /// <param name="cancellationToken">The processor's <see cref="System.Threading.CancellationToken"/> instance which will be cancelled
         /// in the event that <see cref="ServiceBusProcessor.StopProcessingAsync"/> is called.</param>
         public ProcessErrorEventArgs(
@@ -29,13 +30,8 @@ namespace Azure.Messaging.ServiceBus
             string fullyQualifiedNamespace,
             string entityPath,
             string identifier,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken) : this(exception, errorSource, fullyQualifiedNamespace, entityPath, cancellationToken)
         {
-            Exception = exception;
-            ErrorSource = errorSource;
-            FullyQualifiedNamespace = fullyQualifiedNamespace;
-            EntityPath = entityPath;
-            CancellationToken = cancellationToken;
             Identifier = identifier;
         }
 
@@ -49,6 +45,7 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="entityPath">The entity path used when this exception occurred.</param>
         /// <param name="cancellationToken">The processor's <see cref="System.Threading.CancellationToken"/> instance which will be cancelled
         /// in the event that <see cref="ServiceBusProcessor.StopProcessingAsync"/> is called.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ProcessErrorEventArgs(
             Exception exception,
             ServiceBusErrorSource errorSource,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessErrorEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessErrorEventArgs.cs
@@ -48,6 +48,9 @@ namespace Azure.Messaging.ServiceBus
         /// This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</summary>
         public string FullyQualifiedNamespace { get; }
 
+        /// <summary>Gets the client identifier associated with the error event.</summary>
+        public string Identifier { get; }
+
         /// <summary>Gets the entity path associated with the error event.</summary>
         public string EntityPath { get; }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessMessageEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessMessageEventArgs.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -34,7 +35,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// The identifier of the processor that raised this event.
         /// </summary>
-        public string Identifier => _receiver.Identifier;
+        public string Identifier { get; }
 
         /// <summary>
         /// The fully qualified Service Bus namespace that the message was received from.
@@ -55,8 +56,25 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="cancellationToken">The processor's <see cref="System.Threading.CancellationToken"/> instance which will be cancelled
         /// in the event that <see cref="ServiceBusProcessor.StopProcessingAsync"/> is called.
         /// </param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ProcessMessageEventArgs(ServiceBusReceivedMessage message, ServiceBusReceiver receiver, CancellationToken cancellationToken) :
             this(message, manager: null, cancellationToken)
+        {
+            _receiver = receiver;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProcessMessageEventArgs"/> class.
+        /// </summary>
+        ///
+        /// <param name="message">The message to be processed.</param>
+        /// <param name="receiver">The receiver instance that can be used to perform message settlement.</param>
+        /// <param name="identifier">The identifier of the processor.</param>
+        /// <param name="cancellationToken">The processor's <see cref="System.Threading.CancellationToken"/> instance which will be cancelled
+        /// in the event that <see cref="ServiceBusProcessor.StopProcessingAsync"/> is called.
+        /// </param>
+        public ProcessMessageEventArgs(ServiceBusReceivedMessage message, ServiceBusReceiver receiver, string identifier, CancellationToken cancellationToken) :
+            this(message, manager: null, identifier, cancellationToken)
         {
             _receiver = receiver;
         }
@@ -70,6 +88,7 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="cancellationToken">The processor's <see cref="System.Threading.CancellationToken"/> instance which will be cancelled
         /// in the event that <see cref="ServiceBusProcessor.StopProcessingAsync"/> is called.
         /// </param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         internal ProcessMessageEventArgs(
             ServiceBusReceivedMessage message,
             ReceiverManager manager,
@@ -83,6 +102,25 @@ namespace Azure.Messaging.ServiceBus
 
             bool autoRenew = manager?.ShouldAutoRenewMessageLock() == true;
             _receiveActions = new ProcessorReceiveActions(message, manager, autoRenew);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProcessMessageEventArgs"/> class.
+        /// </summary>
+        ///
+        /// <param name="message">The message to be processed.</param>
+        /// <param name="manager">The receiver manager for these event args.</param>
+        /// <param name="identifier">The identifier of the processor.</param>
+        /// <param name="cancellationToken">The processor's <see cref="System.Threading.CancellationToken"/> instance which will be cancelled
+        /// in the event that <see cref="ServiceBusProcessor.StopProcessingAsync"/> is called.
+        /// </param>
+        internal ProcessMessageEventArgs(
+            ServiceBusReceivedMessage message,
+            ReceiverManager manager,
+            string identifier,
+            CancellationToken cancellationToken) : this(message, manager, cancellationToken)
+        {
+            Identifier = identifier;
         }
 
         ///<inheritdoc cref="ServiceBusReceiver.AbandonMessageAsync(ServiceBusReceivedMessage, IDictionary{string, object}, CancellationToken)"/>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessMessageEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessMessageEventArgs.cs
@@ -32,7 +32,7 @@ namespace Azure.Messaging.ServiceBus
         public string EntityPath => _receiver.EntityPath;
 
         /// <summary>
-        /// The identifier of the Service Bus entity that the message was received from.
+        /// The identifier of the processor that raised this event.
         /// </summary>
         public string Identifier => _receiver.Identifier;
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessMessageEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessMessageEventArgs.cs
@@ -32,6 +32,11 @@ namespace Azure.Messaging.ServiceBus
         public string EntityPath => _receiver.EntityPath;
 
         /// <summary>
+        /// The identifier of the Service Bus entity that the message was received from.
+        /// </summary>
+        public string Identifier => _receiver.Identifier;
+
+        /// <summary>
         /// The fully qualified Service Bus namespace that the message was received from.
         /// </summary>
         public string FullyQualifiedNamespace => _receiver.FullyQualifiedNamespace;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionEventArgs.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -32,9 +33,9 @@ namespace Azure.Messaging.ServiceBus
         public string SessionId => _sessionReceiver.SessionId;
 
         /// <summary>
-        /// The identifier of the Service Bus entity that the message was received from.
+        /// The identifier of the <see cref="ServiceBusSessionProcessor"/>.
         /// </summary>
-        public string Identifier => _sessionReceiver.Identifier;
+        public string Identifier { get; }
 
         /// <summary>
         /// Gets the <see cref="DateTimeOffset"/> that the current session is locked until.
@@ -59,6 +60,7 @@ namespace Azure.Messaging.ServiceBus
         /// for the args.</param>
         /// <param name="cancellationToken">The processor's <see cref="System.Threading.CancellationToken"/> instance which will be cancelled in the event that <see cref="ServiceBusProcessor.StopProcessingAsync"/> is called.
         /// </param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ProcessSessionEventArgs(
             ServiceBusSessionReceiver receiver,
             CancellationToken cancellationToken) : this(manager: null, cancellationToken)
@@ -66,6 +68,24 @@ namespace Azure.Messaging.ServiceBus
             _sessionReceiver = receiver;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProcessSessionEventArgs"/> class.
+        /// </summary>
+        ///
+        /// <param name="receiver">The <see cref="ServiceBusSessionReceiver"/> that will be used for all settlement methods
+        /// for the args.</param>
+        /// <param name="identifier">The identifier of the processor.</param>
+        /// <param name="cancellationToken">The processor's <see cref="System.Threading.CancellationToken"/> instance which will be cancelled in the event that <see cref="ServiceBusProcessor.StopProcessingAsync"/> is called.
+        /// </param>
+        public ProcessSessionEventArgs(
+            ServiceBusSessionReceiver receiver,
+            string identifier,
+            CancellationToken cancellationToken) : this(receiver, cancellationToken)
+        {
+            Identifier = identifier;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
         internal ProcessSessionEventArgs(
             SessionReceiverManager manager,
             CancellationToken cancellationToken)
@@ -75,6 +95,14 @@ namespace Azure.Messaging.ServiceBus
             // manager would be null in scenarios where customers are using the public constructor for testing purposes.
             _sessionReceiver = (ServiceBusSessionReceiver) _manager?.Receiver;
             CancellationToken = cancellationToken;
+        }
+
+        internal ProcessSessionEventArgs(
+            SessionReceiverManager manager,
+            string identifier,
+            CancellationToken cancellationToken) : this(manager, cancellationToken)
+        {
+            Identifier = identifier;
         }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionEventArgs.cs
@@ -32,6 +32,11 @@ namespace Azure.Messaging.ServiceBus
         public string SessionId => _sessionReceiver.SessionId;
 
         /// <summary>
+        /// The identifier of the Service Bus entity that the message was received from.
+        /// </summary>
+        public string Identifier => _sessionReceiver.Identifier;
+
+        /// <summary>
         /// Gets the <see cref="DateTimeOffset"/> that the current session is locked until.
         /// </summary>
         public DateTimeOffset SessionLockedUntil => _sessionReceiver.SessionLockedUntil;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionMessageEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionMessageEventArgs.cs
@@ -55,6 +55,11 @@ namespace Azure.Messaging.ServiceBus
         public string EntityPath => _sessionReceiver.EntityPath;
 
         /// <summary>
+        /// The identifier of the Service Bus entity that the message was received from.
+        /// </summary>
+        public string Identifier => _sessionReceiver.Identifier;
+
+        /// <summary>
         /// The fully qualified Service Bus namespace that the message was received from.
         /// </summary>
         public string FullyQualifiedNamespace => _sessionReceiver.FullyQualifiedNamespace;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionMessageEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionMessageEventArgs.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Net.Security;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -55,9 +57,9 @@ namespace Azure.Messaging.ServiceBus
         public string EntityPath => _sessionReceiver.EntityPath;
 
         /// <summary>
-        /// The identifier of the Service Bus entity that the message was received from.
+        /// The identifier of the <see cref="ServiceBusSessionProcessor"/>.
         /// </summary>
-        public string Identifier => _sessionReceiver.Identifier;
+        public string Identifier { get; }
 
         /// <summary>
         /// The fully qualified Service Bus namespace that the message was received from.
@@ -72,12 +74,31 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="receiver">The <see cref="ServiceBusSessionReceiver"/> that will be used for all settlement methods
         /// for the args.</param>
         /// <param name="cancellationToken">The processor's <see cref="System.Threading.CancellationToken"/> instance which will be cancelled in the event that <see cref="ServiceBusProcessor.StopProcessingAsync"/> is called.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ProcessSessionMessageEventArgs(
             ServiceBusReceivedMessage message,
             ServiceBusSessionReceiver receiver,
             CancellationToken cancellationToken) : this(message, manager: null, cancellationToken)
         {
             _sessionReceiver = receiver;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProcessSessionMessageEventArgs"/> class.
+        /// </summary>
+        ///
+        /// <param name="message">The current <see cref="ServiceBusReceivedMessage"/>.</param>
+        /// <param name="receiver">The <see cref="ServiceBusSessionReceiver"/> that will be used for all settlement methods
+        /// for the args.</param>
+        /// <param name="identifier">The identifier of the processor.</param>
+        /// <param name="cancellationToken">The processor's <see cref="System.Threading.CancellationToken"/> instance which will be cancelled in the event that <see cref="ServiceBusProcessor.StopProcessingAsync"/> is called.</param>
+        public ProcessSessionMessageEventArgs(
+            ServiceBusReceivedMessage message,
+            ServiceBusSessionReceiver receiver,
+            string identifier,
+            CancellationToken cancellationToken) : this(message, receiver, cancellationToken)
+        {
+            Identifier = identifier;
         }
 
         internal ProcessSessionMessageEventArgs(
@@ -92,6 +113,16 @@ namespace Azure.Messaging.ServiceBus
             _sessionReceiver = (ServiceBusSessionReceiver) _manager?.Receiver;
             _receiveActions = new ProcessorReceiveActions(message, manager, false);
             CancellationToken = cancellationToken;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal ProcessSessionMessageEventArgs(
+            ServiceBusReceivedMessage message,
+            SessionReceiverManager manager,
+            string identifier,
+            CancellationToken cancellationToken) : this(message, manager, cancellationToken)
+        {
+            Identifier = identifier;
         }
 
         /// <inheritdoc cref="ServiceBusSessionReceiver.GetSessionStateAsync(CancellationToken)"/>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
@@ -42,7 +42,7 @@ namespace Azure.Messaging.ServiceBus
                 // Pass None for subqueue since the subqueue has already
                 // been taken into account when computing the EntityPath of the processor.
                 SubQueue = SubQueue.None,
-                Identifier = processor.Identifier
+                Identifier = $"{processor.Identifier}-Receiver"
             };
             _maxReceiveWaitTime = ProcessorOptions.MaxReceiveWaitTime;
             Receiver = new ServiceBusReceiver(
@@ -254,6 +254,7 @@ namespace Azure.Messaging.ServiceBus
             new ProcessMessageEventArgs(
             message,
             this,
+            Processor.Identifier,
             cancellationToken);
 
         protected virtual async Task OnMessageHandler(EventArgs args) =>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
@@ -112,6 +112,7 @@ namespace Azure.Messaging.ServiceBus
                         errorSource,
                         Processor.FullyQualifiedNamespace,
                         Processor.EntityPath,
+                        Processor.Identifier,
                         cancellationToken))
                     .ConfigureAwait(false);
             }
@@ -189,6 +190,7 @@ namespace Azure.Messaging.ServiceBus
                             errorSource,
                             Processor.FullyQualifiedNamespace,
                             Processor.EntityPath,
+                            Processor.Identifier,
                             cancellationToken))
                     .ConfigureAwait(false);
 
@@ -221,6 +223,7 @@ namespace Azure.Messaging.ServiceBus
                                         ServiceBusErrorSource.Abandon,
                                         Processor.FullyQualifiedNamespace,
                                         Processor.EntityPath,
+                                        Processor.Identifier,
                                         cancellationToken))
                                 .ConfigureAwait(false);
                         }
@@ -331,6 +334,7 @@ namespace Azure.Messaging.ServiceBus
                         ServiceBusErrorSource.RenewLock,
                         Processor.FullyQualifiedNamespace,
                         Processor.EntityPath,
+                        Processor.Identifier,
                         cancellationToken)).ConfigureAwait(false);
             }
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
@@ -41,7 +41,8 @@ namespace Azure.Messaging.ServiceBus
                 PrefetchCount = ProcessorOptions.PrefetchCount,
                 // Pass None for subqueue since the subqueue has already
                 // been taken into account when computing the EntityPath of the processor.
-                SubQueue = SubQueue.None
+                SubQueue = SubQueue.None,
+                Identifier = processor.Identifier
             };
             _maxReceiveWaitTime = ProcessorOptions.MaxReceiveWaitTime;
             Receiver = new ServiceBusReceiver(

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -237,7 +237,7 @@ namespace Azure.Messaging.ServiceBus
             Options = options?.Clone() ?? new ServiceBusProcessorOptions();
             Connection = connection;
             EntityPath = EntityNameFormatter.FormatEntityPath(entityPath, Options.SubQueue);
-            Identifier = Options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(EntityPath);
+            Identifier = string.IsNullOrEmpty(Options.Identifier) ? DiagnosticUtilities.GenerateIdentifier(EntityPath) : Options.Identifier;
 
             ReceiveMode = Options.ReceiveMode;
             PrefetchCount = Options.PrefetchCount;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -889,6 +889,7 @@ namespace Azure.Messaging.ServiceBus
                                     ServiceBusErrorSource.Receive,
                                     FullyQualifiedNamespace,
                                     EntityPath,
+                                    Identifier,
                                     cancellationToken))
                             .ConfigureAwait(false);
                     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -70,7 +70,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Gets the ID used to identify this processor. This can be used to correlate logs and exceptions.
         /// </summary>
-        public string Identifier { get; }
+        public virtual string Identifier { get; }
 
         /// <summary>
         /// Gets the <see cref="ReceiveMode"/> used to specify how messages are received. Defaults to PeekLock mode.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -68,9 +68,8 @@ namespace Azure.Messaging.ServiceBus
         public virtual string EntityPath { get; }
 
         /// <summary>
-        /// Gets the ID to identify this processor. This can be used to correlate logs and exceptions.
+        /// Gets the ID used to identify this processor. This can be used to correlate logs and exceptions.
         /// </summary>
-        /// <remarks>Every new processor has a unique ID.</remarks>
         public string Identifier { get; }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -238,7 +238,7 @@ namespace Azure.Messaging.ServiceBus
             Options = options?.Clone() ?? new ServiceBusProcessorOptions();
             Connection = connection;
             EntityPath = EntityNameFormatter.FormatEntityPath(entityPath, Options.SubQueue);
-            Identifier = options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(EntityPath);
+            Identifier = Options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(EntityPath);
 
             ReceiveMode = Options.ReceiveMode;
             PrefetchCount = Options.PrefetchCount;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -71,7 +71,7 @@ namespace Azure.Messaging.ServiceBus
         /// Gets the ID to identify this processor. This can be used to correlate logs and exceptions.
         /// </summary>
         /// <remarks>Every new processor has a unique ID.</remarks>
-        internal string Identifier { get; }
+        public string Identifier { get; }
 
         /// <summary>
         /// Gets the <see cref="ReceiveMode"/> used to specify how messages are received. Defaults to PeekLock mode.
@@ -238,7 +238,7 @@ namespace Azure.Messaging.ServiceBus
             Options = options?.Clone() ?? new ServiceBusProcessorOptions();
             Connection = connection;
             EntityPath = EntityNameFormatter.FormatEntityPath(entityPath, Options.SubQueue);
-            Identifier = DiagnosticUtilities.GenerateIdentifier(EntityPath);
+            Identifier = options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(EntityPath);
 
             ReceiveMode = Options.ReceiveMode;
             PrefetchCount = Options.PrefetchCount;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
@@ -136,9 +136,8 @@ namespace Azure.Messaging.ServiceBus
         public SubQueue SubQueue { get; set; } = SubQueue.None;
 
         /// <summary>
-        /// Gets the ID to identify this client. This can be used to correlate logs and exceptions.
+        ///   A unique name used to identify the processor.  If <c>null</c> or empty, a random unique value will be will be used.
         /// </summary>
-        /// <remarks>Every new client has a unique ID.</remarks>
         public string Identifier { get; set; }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
@@ -136,6 +136,12 @@ namespace Azure.Messaging.ServiceBus
         public SubQueue SubQueue { get; set; } = SubQueue.None;
 
         /// <summary>
+        /// Gets the ID to identify this client. This can be used to correlate logs and exceptions.
+        /// </summary>
+        /// <remarks>Every new client has a unique ID.</remarks>
+        public string Identifier { get; set; }
+
+        /// <summary>
         /// Determines whether the specified <see cref="System.Object" /> is equal to this instance.
         /// </summary>
         ///

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
@@ -136,7 +136,8 @@ namespace Azure.Messaging.ServiceBus
         public SubQueue SubQueue { get; set; } = SubQueue.None;
 
         /// <summary>
-        ///   A unique name used to identify the processor.  If <c>null</c> or empty, a random unique value will be will be used.
+        /// A property used to set the <see cref="ServiceBusProcessor"/> ID to identify the client. This can be used to correlate logs
+        /// and exceptions. If <c>null</c> or empty, a random unique value will be used.
         /// </summary>
         public string Identifier { get; set; }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
@@ -136,7 +136,7 @@ namespace Azure.Messaging.ServiceBus
         public SubQueue SubQueue { get; set; } = SubQueue.None;
 
         /// <summary>
-        /// A property used to set the <see cref="ServiceBusProcessor"/> ID to identify the client. This can be used to correlate logs
+        /// A property used to set the <see cref="ServiceBusProcessor"/> ID to identify the processor. This can be used to correlate logs
         /// and exceptions. If <c>null</c> or empty, a random unique value will be used.
         /// </summary>
         public string Identifier { get; set; }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
@@ -184,7 +184,8 @@ namespace Azure.Messaging.ServiceBus
                 MaxAutoLockRenewalDuration = MaxAutoLockRenewalDuration,
                 MaxReceiveWaitTime = MaxReceiveWaitTime,
                 MaxConcurrentCalls = MaxConcurrentCalls,
-                SubQueue = SubQueue
+                SubQueue = SubQueue,
+                Identifier = Identifier
             };
         }
     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
@@ -32,7 +32,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Gets the Identifier used to identify this processor client.  If <c>null</c> or empty, a random unique value will be will be used.
         /// </summary>
-        public string Identifier => InnerProcessor.Identifier;
+        public virtual string Identifier => InnerProcessor.Identifier;
 
         /// <inheritdoc cref="ServiceBusProcessor.ReceiveMode"/>
         public virtual ServiceBusReceiveMode ReceiveMode => InnerProcessor.ReceiveMode;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
@@ -30,10 +30,9 @@ namespace Azure.Messaging.ServiceBus
         public virtual string EntityPath => InnerProcessor.EntityPath;
 
         /// <summary>
-        /// Gets the ID to identify this processor. This can be used to correlate logs and exceptions.
+        /// A unique name used to identify the processor.  If <c>null</c> or empty, a random unique value will be will be used.
         /// </summary>
-        /// <remarks>Every new processor has a unique ID.</remarks>
-        internal string Identifier => InnerProcessor.Identifier;
+        public string Identifier => InnerProcessor.Identifier;
 
         /// <inheritdoc cref="ServiceBusProcessor.ReceiveMode"/>
         public virtual ServiceBusReceiveMode ReceiveMode => InnerProcessor.ReceiveMode;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
@@ -30,7 +30,7 @@ namespace Azure.Messaging.ServiceBus
         public virtual string EntityPath => InnerProcessor.EntityPath;
 
         /// <summary>
-        /// A unique name used to identify the processor.  If <c>null</c> or empty, a random unique value will be will be used.
+        /// Gets the Identifier used to identify this processor client.  If <c>null</c> or empty, a random unique value will be will be used.
         /// </summary>
         public string Identifier => InnerProcessor.Identifier;
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessorOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessorOptions.cs
@@ -32,6 +32,9 @@ namespace Azure.Messaging.ServiceBus
         /// <inheritdoc cref="ServiceBusProcessorOptions.ReceiveMode"/>
         public ServiceBusReceiveMode ReceiveMode { get; set; } = ServiceBusReceiveMode.PeekLock;
 
+        /// <inheritdoc cref="ServiceBusProcessorOptions.Identifier"/>
+        public string Identifier { get; set; }
+
         /// <summary>Gets or sets a value that indicates whether the processor
         /// should automatically complete messages after the <see cref="ServiceBusSessionProcessor.ProcessMessageAsync"/>
         /// handler has completed processing. If the message handler triggers an exception,
@@ -184,6 +187,7 @@ namespace Azure.Messaging.ServiceBus
                 AutoCompleteMessages = AutoCompleteMessages,
                 MaxAutoLockRenewalDuration = MaxAutoLockRenewalDuration,
                 MaxReceiveWaitTime = SessionIdleTimeout,
+                Identifier = Identifier,
             };
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
@@ -52,6 +52,7 @@ namespace Azure.Messaging.ServiceBus
             {
                 ReceiveMode = sessionProcessor.InnerProcessor.Options.ReceiveMode,
                 PrefetchCount = sessionProcessor.InnerProcessor.Options.PrefetchCount,
+                Identifier = $"S{sessionId}-{sessionProcessor.Identifier}"
             };
             _sessionId = sessionId;
             _keepOpenOnReceiveTimeout = keepOpenOnReceiveTimeout;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
@@ -228,6 +228,7 @@ namespace Azure.Messaging.ServiceBus
                         ServiceBusErrorSource.CloseSession,
                         Processor.FullyQualifiedNamespace,
                         Processor.EntityPath,
+                        Processor.Identifier,
                         cancellationToken))
                     .ConfigureAwait(false);
             }
@@ -334,6 +335,7 @@ namespace Azure.Messaging.ServiceBus
                         errorSource,
                         Processor.FullyQualifiedNamespace,
                         Processor.EntityPath,
+                        Processor.Identifier,
                         processorCancellationToken))
                     .ConfigureAwait(false);
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
@@ -51,8 +51,7 @@ namespace Azure.Messaging.ServiceBus
             _sessionReceiverOptions = new ServiceBusSessionReceiverOptions
             {
                 ReceiveMode = sessionProcessor.InnerProcessor.Options.ReceiveMode,
-                PrefetchCount = sessionProcessor.InnerProcessor.Options.PrefetchCount,
-                Identifier = $"S{sessionId}-{sessionProcessor.Identifier}"
+                PrefetchCount = sessionProcessor.InnerProcessor.Options.PrefetchCount
             };
             _sessionId = sessionId;
             _keepOpenOnReceiveTimeout = keepOpenOnReceiveTimeout;
@@ -121,7 +120,7 @@ namespace Azure.Messaging.ServiceBus
 
             if (Processor._sessionInitializingAsync != null)
             {
-                var args = new ProcessSessionEventArgs(this, processorCancellationToken);
+                var args = new ProcessSessionEventArgs(this, Processor.Identifier, processorCancellationToken);
                 await Processor.OnSessionInitializingAsync(args).ConfigureAwait(false);
             }
         }
@@ -142,6 +141,7 @@ namespace Azure.Messaging.ServiceBus
                     sessionId: _sessionId,
                     cancellationToken: processorCancellationToken,
                     isProcessor: true).ConfigureAwait(false);
+                _receiver.Identifier = $"{Processor.Identifier}-S{_receiver.SessionId}";
             }
             catch (OperationCanceledException)
             {
@@ -216,7 +216,7 @@ namespace Azure.Messaging.ServiceBus
             {
                 if (Processor._sessionClosingAsync != null)
                 {
-                    var args = new ProcessSessionEventArgs(this, cancellationToken);
+                    var args = new ProcessSessionEventArgs(this, Processor.Identifier, cancellationToken);
                     await Processor.OnSessionClosingAsync(args).ConfigureAwait(false);
                 }
             }
@@ -396,6 +396,7 @@ namespace Azure.Messaging.ServiceBus
             new ProcessSessionMessageEventArgs(
                 message,
                 this,
+                Processor.Identifier,
                 cancellationToken);
 
         protected override async Task OnMessageHandler(EventArgs args) =>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -66,7 +66,7 @@ namespace Azure.Messaging.ServiceBus
         /// Gets the ID to identify this client. This can be used to correlate logs and exceptions.
         /// </summary>
         /// <remarks>Every new client has a unique ID.</remarks>
-        internal string Identifier { get; }
+        public string Identifier { get; }
 
         /// <summary>
         ///   Indicates whether or not this <see cref="ServiceBusReceiver"/> has been closed.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -156,7 +156,7 @@ namespace Azure.Messaging.ServiceBus
                 connection.ThrowIfClosed();
 
                 options = options?.Clone() ?? new ServiceBusReceiverOptions();
-                Identifier = DiagnosticUtilities.GenerateIdentifier(entityPath);
+                Identifier = options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(entityPath);
                 _connection = connection;
                 _retryPolicy = connection.RetryOptions.ToRetryPolicy();
                 ReceiveMode = options.ReceiveMode;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -65,7 +65,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// A name used to identify the receiver client.  If <c>null</c> or empty, a random unique value will be will be used.
         /// </summary>
-        public string Identifier { get; }
+        public string Identifier { get; internal set; }
 
         /// <summary>
         ///   Indicates whether or not this <see cref="ServiceBusReceiver"/> has been closed.
@@ -155,7 +155,7 @@ namespace Azure.Messaging.ServiceBus
                 connection.ThrowIfClosed();
 
                 options = options?.Clone() ?? new ServiceBusReceiverOptions();
-                Identifier = options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(entityPath);
+                Identifier = string.IsNullOrEmpty(options.Identifier) ? DiagnosticUtilities.GenerateIdentifier(entityPath) : options.Identifier;
                 _connection = connection;
                 _retryPolicy = connection.RetryOptions.ToRetryPolicy();
                 ReceiveMode = options.ReceiveMode;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -155,14 +155,14 @@ namespace Azure.Messaging.ServiceBus
                 Argument.AssertNotNullOrWhiteSpace(entityPath, nameof(entityPath));
                 connection.ThrowIfClosed();
 
-                var clonedOptions = options?.Clone() ?? new ServiceBusReceiverOptions();
-                Identifier = clonedOptions.Identifier ?? DiagnosticUtilities.GenerateIdentifier(entityPath);
+                options = options?.Clone() ?? new ServiceBusReceiverOptions();
+                Identifier = options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(entityPath);
                 _connection = connection;
                 _retryPolicy = connection.RetryOptions.ToRetryPolicy();
-                ReceiveMode = clonedOptions.ReceiveMode;
-                PrefetchCount = clonedOptions.PrefetchCount;
+                ReceiveMode = options.ReceiveMode;
+                PrefetchCount = options.PrefetchCount;
 
-                EntityPath = EntityNameFormatter.FormatEntityPath(entityPath, clonedOptions.SubQueue);
+                EntityPath = EntityNameFormatter.FormatEntityPath(entityPath, options.SubQueue);
 
                 IsSessionReceiver = isSessionEntity;
                 _innerReceiver = _connection.CreateTransportReceiver(

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -63,7 +63,7 @@ namespace Azure.Messaging.ServiceBus
         public virtual int PrefetchCount { get; }
 
         /// <summary>
-        /// A unique name used to identify the processor.  If <c>null</c> or empty, a random unique value will be will be used.
+        /// A name used to identify the receiver client.  If <c>null</c> or empty, a random unique value will be will be used.
         /// </summary>
         public string Identifier { get; }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -63,9 +63,8 @@ namespace Azure.Messaging.ServiceBus
         public virtual int PrefetchCount { get; }
 
         /// <summary>
-        /// Gets the ID to identify this client. This can be used to correlate logs and exceptions.
+        /// A unique name used to identify the processor.  If <c>null</c> or empty, a random unique value will be will be used.
         /// </summary>
-        /// <remarks>Every new client has a unique ID.</remarks>
         public string Identifier { get; }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -155,14 +155,14 @@ namespace Azure.Messaging.ServiceBus
                 Argument.AssertNotNullOrWhiteSpace(entityPath, nameof(entityPath));
                 connection.ThrowIfClosed();
 
-                options = options?.Clone() ?? new ServiceBusReceiverOptions();
-                Identifier = options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(entityPath);
+                var clonedOptions = options?.Clone() ?? new ServiceBusReceiverOptions();
+                Identifier = clonedOptions.Identifier ?? DiagnosticUtilities.GenerateIdentifier(entityPath);
                 _connection = connection;
                 _retryPolicy = connection.RetryOptions.ToRetryPolicy();
-                ReceiveMode = options.ReceiveMode;
-                PrefetchCount = options.PrefetchCount;
+                ReceiveMode = clonedOptions.ReceiveMode;
+                PrefetchCount = clonedOptions.PrefetchCount;
 
-                EntityPath = EntityNameFormatter.FormatEntityPath(entityPath, options.SubQueue);
+                EntityPath = EntityNameFormatter.FormatEntityPath(entityPath, clonedOptions.SubQueue);
 
                 IsSessionReceiver = isSessionEntity;
                 _innerReceiver = _connection.CreateTransportReceiver(

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -65,7 +65,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// A name used to identify the receiver client.  If <c>null</c> or empty, a random unique value will be will be used.
         /// </summary>
-        public string Identifier { get; internal set; }
+        public virtual string Identifier { get; internal set; }
 
         /// <summary>
         ///   Indicates whether or not this <see cref="ServiceBusReceiver"/> has been closed.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiverOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiverOptions.cs
@@ -41,10 +41,9 @@ namespace Azure.Messaging.ServiceBus
         public ServiceBusReceiveMode ReceiveMode { get; set; } = ServiceBusReceiveMode.PeekLock;
 
         /// <summary>
-        /// Gets the ID to identify this client. This can be used to correlate logs and exceptions.
+        /// A property used to set the <see cref="ServiceBusReceiver"/> ID to identify the client. This can be used to correlate logs
+        /// and exceptions. If <c>null</c> or empty, a random unique value will be used.
         /// </summary>
-        /// <remarks>Every new client has a unique ID.</remarks>
-        ///
         public string Identifier { get; set; }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiverOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiverOptions.cs
@@ -91,6 +91,7 @@ namespace Azure.Messaging.ServiceBus
                 ReceiveMode = ReceiveMode,
                 PrefetchCount = PrefetchCount,
                 SubQueue = SubQueue,
+                Identifier = Identifier
             };
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiverOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiverOptions.cs
@@ -41,6 +41,13 @@ namespace Azure.Messaging.ServiceBus
         public ServiceBusReceiveMode ReceiveMode { get; set; } = ServiceBusReceiveMode.PeekLock;
 
         /// <summary>
+        /// Gets the ID to identify this client. This can be used to correlate logs and exceptions.
+        /// </summary>
+        /// <remarks>Every new client has a unique ID.</remarks>
+        ///
+        public string Identifier { get; set; }
+
+        /// <summary>
         /// Gets or sets the subqueue to connect the receiver to. By default, the receiver will not connect to a subqueue.
         /// </summary>
         public SubQueue SubQueue { get; set; } = SubQueue.None;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiverOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiverOptions.cs
@@ -40,6 +40,9 @@ namespace Azure.Messaging.ServiceBus
         /// </summary>
         public ServiceBusReceiveMode ReceiveMode { get; set; } = ServiceBusReceiveMode.PeekLock;
 
+        /// <inheritdoc cref="ServiceBusReceiverOptions.Identifier"/>
+        public string Identifier { get; set; }
+
         /// <summary>
         /// Determines whether the specified <see cref="System.Object" /> is equal to this instance.
         /// </summary>
@@ -73,6 +76,7 @@ namespace Azure.Messaging.ServiceBus
             {
                 ReceiveMode = ReceiveMode,
                 PrefetchCount = PrefetchCount,
+                Identifier = Identifier
             };
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -66,6 +66,7 @@ namespace Azure.Messaging.ServiceBus
         /// Gets the ID to identify this client. This can be used to correlate logs and exceptions.
         /// </summary>
         /// <remarks>Every new client has a unique ID.</remarks>
+        ///
         internal string Identifier { get; private set; }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -99,7 +99,7 @@ namespace Azure.Messaging.ServiceBus
         internal ServiceBusSender(
             string entityPath,
             ServiceBusConnection connection,
-            ServiceBusSenderOptions options)
+            ServiceBusSenderOptions options = default)
         {
             Logger.ClientCreateStart(typeof(ServiceBusSender), connection?.FullyQualifiedNamespace, entityPath);
             try
@@ -127,18 +127,6 @@ namespace Azure.Messaging.ServiceBus
                 throw;
             }
             Logger.ClientCreateComplete(typeof(ServiceBusSender), Identifier);
-        }
-
-        /// <summary>
-        ///   Initializes a new instance of the <see cref="ServiceBusSender"/> class.
-        /// </summary>
-        /// <param name="entityPath">The entity path to send the message to.</param>
-        /// <param name="connection">The connection for the sender.</param>
-        internal ServiceBusSender(
-            string entityPath,
-            ServiceBusConnection connection) :
-            this(entityPath, connection, new ServiceBusSenderOptions())
-        {
         }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -140,6 +140,14 @@ namespace Azure.Messaging.ServiceBus
         }
 
         /// <summary>
+        ///   Initializes a new instance of the <see cref="ServiceBusSender"/> class for mocking.
+        /// </summary>
+        ///
+        protected ServiceBusSender()
+        {
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ServiceBusSender"/> class for use with derived types.
         /// </summary>
         /// <param name="client">The client instance to use for the sender.</param>
@@ -157,14 +165,6 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="options">The set of options to use when configuring the sender.</param>
         protected ServiceBusSender(ServiceBusClient client, string queueOrTopicName, ServiceBusSenderOptions options) :
             this(queueOrTopicName, client.Connection, options)
-        {
-        }
-
-        /// <summary>
-        ///   Initializes a new instance of the <see cref="ServiceBusSender"/> class for mocking.
-        /// </summary>
-        ///
-        protected ServiceBusSender()
         {
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
 using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Messaging.ServiceBus.Core;
@@ -108,6 +109,8 @@ namespace Azure.Messaging.ServiceBus
                 Argument.AssertNotNull(connection.RetryOptions, nameof(connection.RetryOptions));
                 Argument.AssertNotNullOrWhiteSpace(entityPath, nameof(entityPath));
                 connection.ThrowIfClosed();
+
+                options = options?.Clone() ?? new ServiceBusSenderOptions();
 
                 EntityPath = entityPath;
                 Identifier = options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(EntityPath);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -67,7 +67,7 @@ namespace Azure.Messaging.ServiceBus
         /// </summary>
         /// <remarks>Every new client has a unique ID.</remarks>
         ///
-        internal string Identifier { get; private set; }
+        public string Identifier { get; }
 
         /// <summary>
         ///   The policy to use for determining retry behavior for when an operation fails.
@@ -128,14 +128,6 @@ namespace Azure.Messaging.ServiceBus
         }
 
         /// <summary>
-        ///   Initializes a new instance of the <see cref="ServiceBusSender"/> class for mocking.
-        /// </summary>
-        ///
-        protected ServiceBusSender()
-        {
-        }
-
-        /// <summary>
         ///   Initializes a new instance of the <see cref="ServiceBusSender"/> class.
         /// </summary>
         /// <param name="entityPath">The entity path to send the message to.</param>
@@ -165,6 +157,14 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="options">The set of options to use when configuring the sender.</param>
         protected ServiceBusSender(ServiceBusClient client, string queueOrTopicName, ServiceBusSenderOptions options) :
             this(queueOrTopicName, client.Connection, options)
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="ServiceBusSender"/> class for mocking.
+        /// </summary>
+        ///
+        protected ServiceBusSender()
         {
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -94,9 +94,11 @@ namespace Azure.Messaging.ServiceBus
         /// </summary>
         /// <param name="entityPath">The entity path to send the message to.</param>
         /// <param name="connection">The connection for the sender.</param>
+        /// <param name="options">The set of options to use when configuring the sender.</param>
         internal ServiceBusSender(
             string entityPath,
-            ServiceBusConnection connection)
+            ServiceBusConnection connection,
+            ServiceBusSenderOptions options)
         {
             Logger.ClientCreateStart(typeof(ServiceBusSender), connection?.FullyQualifiedNamespace, entityPath);
             try
@@ -107,7 +109,7 @@ namespace Azure.Messaging.ServiceBus
                 connection.ThrowIfClosed();
 
                 EntityPath = entityPath;
-                Identifier = DiagnosticUtilities.GenerateIdentifier(EntityPath);
+                Identifier = options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(EntityPath);
                 _connection = connection;
                 _retryPolicy = _connection.RetryOptions.ToRetryPolicy();
                 _innerSender = _connection.CreateTransportSender(
@@ -137,8 +139,9 @@ namespace Azure.Messaging.ServiceBus
         /// </summary>
         /// <param name="client">The client instance to use for the sender.</param>
         /// <param name="queueOrTopicName">The name of the queue or topic to send to.</param>
-        protected ServiceBusSender(ServiceBusClient client, string queueOrTopicName) :
-            this(queueOrTopicName, client.Connection)
+        /// <param name="options">The set of options to use when configuring the sender.</param>
+        protected ServiceBusSender(ServiceBusClient client, string queueOrTopicName, ServiceBusSenderOptions options) :
+            this(queueOrTopicName, client.Connection, options)
         {
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -134,7 +134,7 @@ namespace Azure.Messaging.ServiceBus
         /// </summary>
         /// <param name="entityPath">The entity path to send the message to.</param>
         /// <param name="connection">The connection for the sender.</param>
-        internal ServiceBusSender(
+        protected ServiceBusSender(
             string entityPath,
             ServiceBusConnection connection) :
             this(entityPath, connection, new ServiceBusSenderOptions())

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -65,7 +65,6 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Gets the ID to identify this client. This can be used to correlate logs and exceptions.
         /// </summary>
-        /// <remarks>Every new client has a unique ID.</remarks>
         ///
         public string Identifier { get; }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -111,7 +111,7 @@ namespace Azure.Messaging.ServiceBus
                 options = options?.Clone() ?? new ServiceBusSenderOptions();
 
                 EntityPath = entityPath;
-                Identifier = options.Identifier ?? DiagnosticUtilities.GenerateIdentifier(EntityPath);
+                Identifier = string.IsNullOrEmpty(options.Identifier) ? DiagnosticUtilities.GenerateIdentifier(EntityPath) : options.Identifier;
                 _connection = connection;
                 _retryPolicy = _connection.RetryOptions.ToRetryPolicy();
                 _innerSender = _connection.CreateTransportSender(

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -135,6 +135,28 @@ namespace Azure.Messaging.ServiceBus
         }
 
         /// <summary>
+        ///   Initializes a new instance of the <see cref="ServiceBusSender"/> class.
+        /// </summary>
+        /// <param name="entityPath">The entity path to send the message to.</param>
+        /// <param name="connection">The connection for the sender.</param>
+        internal ServiceBusSender(
+            string entityPath,
+            ServiceBusConnection connection) :
+            this(entityPath, connection, new ServiceBusSenderOptions())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceBusSender"/> class for use with derived types.
+        /// </summary>
+        /// <param name="client">The client instance to use for the sender.</param>
+        /// <param name="queueOrTopicName">The name of the queue or topic to send to.</param>
+        protected ServiceBusSender(ServiceBusClient client, string queueOrTopicName) :
+            this(queueOrTopicName, client.Connection, new ServiceBusSenderOptions())
+        {
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ServiceBusSender"/> class for use with derived types.
         /// </summary>
         /// <param name="client">The client instance to use for the sender.</param>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -66,7 +66,7 @@ namespace Azure.Messaging.ServiceBus
         /// Gets the ID to identify this client. This can be used to correlate logs and exceptions.
         /// </summary>
         ///
-        public string Identifier { get; }
+        public virtual string Identifier { get; }
 
         /// <summary>
         ///   The policy to use for determining retry behavior for when an operation fails.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -134,7 +134,7 @@ namespace Azure.Messaging.ServiceBus
         /// </summary>
         /// <param name="entityPath">The entity path to send the message to.</param>
         /// <param name="connection">The connection for the sender.</param>
-        protected ServiceBusSender(
+        internal ServiceBusSender(
             string entityPath,
             ServiceBusConnection connection) :
             this(entityPath, connection, new ServiceBusSenderOptions())

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -9,7 +9,6 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml;
 using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Messaging.ServiceBus.Core;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSenderOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSenderOptions.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.ComponentModel;
+
+namespace Azure.Messaging.ServiceBus
+{
+    /// <summary>
+    /// The set of options that can be specified when creating a <see cref="ServiceBusSender"/>
+    /// to configure its behavior.
+    /// </summary>
+    public class ServiceBusSenderOptions
+    {
+        /// <summary>
+        /// A property used to set the <see cref="ServiceBusSender"/> ID to identify the client. This can be used to correlate logs
+        /// and exceptions.
+        /// </summary>
+        /// <remarks>Every new client has a unique ID.</remarks>
+        public string Identifier { get; set; }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="System.Object" /> is equal to this instance.
+        /// </summary>
+        ///
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+        ///
+        /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => base.Equals(obj);
+
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        ///
+        /// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => base.GetHashCode();
+
+        /// <summary>
+        /// Converts the instance to string representation.
+        /// </summary>
+        ///
+        /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString() => base.ToString();
+
+        /// <summary>
+        /// Creates a new copy of the current <see cref="ServiceBusReceiverOptions" />, cloning its attributes into a new instance.
+        /// </summary>
+        ///
+        /// <returns>A new copy of <see cref="ServiceBusReceiverOptions" />.</returns>
+        internal ServiceBusSenderOptions Clone() =>
+            new ServiceBusSenderOptions
+            {
+                Identifier = Identifier
+            };
+    }
+}

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSenderOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSenderOptions.cs
@@ -13,9 +13,8 @@ namespace Azure.Messaging.ServiceBus
     {
         /// <summary>
         /// A property used to set the <see cref="ServiceBusSender"/> ID to identify the client. This can be used to correlate logs
-        /// and exceptions.
+        /// and exceptions. If <c>null</c> or empty, a random unique value will be used.
         /// </summary>
-        /// <remarks>Every new client has a unique ID.</remarks>
         public string Identifier { get; set; }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Threading;
@@ -131,25 +132,127 @@ namespace Azure.Messaging.ServiceBus.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="AmqpConnectionScope" />
-        ///   construct.
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.OpenSenderLinkAsync(string, string, TimeSpan, CancellationToken)" />
+        ///   method.
         /// </summary>
         ///
         [Test]
-        public void ConstructorAssociatesLinkIdentifier()
+        public async Task ConstructorAssociatesSendLinkSource()
         {
             var credential = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
-            var endpoint = new Uri("sb://mine.hubs.com");
-            var mockScope = new MockConnectionScope(endpoint, endpoint, credential.Object, ServiceBusTransportType.AmqpTcp, null);
-            var currentTime = new DateTime(2015, 10, 27, 00, 00, 00);
-            var jitterBuffer = TimeSpan.FromSeconds(GetAuthorizationBaseJitterSeconds()).Add(TimeSpan.FromSeconds(5));
-            var minimumRefresh = GetMinimumAuthorizationRefresh();
-            var expireTime = currentTime.Add(minimumRefresh.Subtract(TimeSpan.FromMilliseconds(500)));
-            var calculatedRefresh = mockScope.InvokeCalculateLinkAuthorizationRefreshInterval(expireTime, currentTime);
-            var identifer = "MyAmqpConnectionScope";
+            var endpoint = new Uri("amqp://mine.hubs.com");
+            var linkIdentifier = "MyAmqpConnectionScope";
+            var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
+            var cancellationSource = new CancellationTokenSource();
+            var mockSession = new AmqpSession(mockConnection, new AmqpSessionSettings(), Mock.Of<ILinkFactory>());
 
-            Assert.That(calculatedRefresh, Is.GreaterThanOrEqualTo(minimumRefresh), "The minimum refresh duration should be violated.");
-            Assert.That(calculatedRefresh, Is.EqualTo(minimumRefresh).Within(jitterBuffer), "The minimum refresh duration should have been used.");
+            var mockScope = new Mock<AmqpConnectionScope>(endpoint, endpoint, credential.Object, ServiceBusTransportType.AmqpTcp, null, false, default, default, linkIdentifier)
+            {
+                CallBase = true,
+            };
+
+            mockScope
+                .Protected()
+                .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
+                ItExpr.IsAny<Version>(),
+                ItExpr.IsAny<Uri>(),
+                ItExpr.IsAny<Uri>(),
+                ItExpr.IsAny<ServiceBusTransportType>(),
+                ItExpr.IsAny<IWebProxy>(),
+                ItExpr.IsAny<string>(),
+                ItExpr.IsAny<TimeSpan>(),
+                ItExpr.IsAny<ServiceBusTransportMetrics>())
+                .Returns(Task.FromResult(mockConnection))
+                .Verifiable();
+
+            mockScope
+                .Protected()
+                .Setup<Task<DateTime>>("RequestAuthorizationUsingCbsAsync",
+                    ItExpr.IsAny<AmqpConnection>(),
+                    ItExpr.IsAny<CbsTokenProvider>(),
+                    ItExpr.IsAny<Uri>(),
+                    ItExpr.IsAny<string[]>(),
+                    ItExpr.IsAny<string[]>(),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<string>())
+                .Returns(Task.FromResult(DateTime.UtcNow.AddDays(1)))
+                .Verifiable();
+
+            mockScope
+                .Protected()
+                .Setup<Task>("OpenAmqpObjectAsync",
+                    ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>(),
+                    ItExpr.IsAny<string>())
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            var link = await mockScope.Object.OpenSenderLinkAsync("fake/path", linkIdentifier, TimeSpan.FromDays(1), cancellationSource.Token);
+            Assert.That(link, Is.Not.Null, "The link produced was null");
+            Assert.That(link.Settings.Source.ToString(), Contains.Substring(linkIdentifier));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.OpenReceiverLinkAsync(string, string, TimeSpan, uint, ServiceBusReceiveMode, string, bool, CancellationToken)" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConstructorAssociatesReceiveLinkTarget()
+        {
+            var credential = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
+            var endpoint = new Uri("amqp://mine.hubs.com");
+            var linkIdentifier = "MyAmqpConnectionScope";
+            var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
+            var cancellationSource = new CancellationTokenSource();
+            var mockSession = new AmqpSession(mockConnection, new AmqpSessionSettings(), Mock.Of<ILinkFactory>());
+
+            var mockScope = new Mock<AmqpConnectionScope>(endpoint, endpoint, credential.Object, ServiceBusTransportType.AmqpTcp, null, false, default, default, linkIdentifier)
+            {
+                CallBase = true,
+            };
+
+            mockScope
+                .Protected()
+                .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
+                ItExpr.IsAny<Version>(),
+                ItExpr.IsAny<Uri>(),
+                ItExpr.IsAny<Uri>(),
+                ItExpr.IsAny<ServiceBusTransportType>(),
+                ItExpr.IsAny<IWebProxy>(),
+                ItExpr.IsAny<string>(),
+                ItExpr.IsAny<TimeSpan>(),
+                ItExpr.IsAny<ServiceBusTransportMetrics>())
+                .Returns(Task.FromResult(mockConnection))
+                .Verifiable();
+
+            mockScope
+                .Protected()
+                .Setup<Task<DateTime>>("RequestAuthorizationUsingCbsAsync",
+                    ItExpr.IsAny<AmqpConnection>(),
+                    ItExpr.IsAny<CbsTokenProvider>(),
+                    ItExpr.IsAny<Uri>(),
+                    ItExpr.IsAny<string[]>(),
+                    ItExpr.IsAny<string[]>(),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<string>())
+                .Returns(Task.FromResult(DateTime.UtcNow.AddDays(1)))
+                .Verifiable();
+
+            mockScope
+                .Protected()
+                .Setup<Task>("OpenAmqpObjectAsync",
+                    ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>(),
+                    ItExpr.IsAny<string>())
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            var link = await mockScope.Object.OpenReceiverLinkAsync(linkIdentifier, "fake/path", TimeSpan.FromDays(1), 100, ServiceBusReceiveMode.ReceiveAndDelete, "0", false, cancellationSource.Token);
+            Assert.That(link, Is.Not.Null, "The link produced was null");
+            Assert.That(link.Settings.Target.ToString(), Contains.Substring(linkIdentifier));
         }
 
         /// <summary>
@@ -254,6 +357,18 @@ namespace Azure.Messaging.ServiceBus.Tests
             public TimeSpan InvokeCalculateLinkAuthorizationRefreshInterval(
                 DateTime expirationTimeUtc,
                 DateTime currentTimeUtc) => base.CalculateLinkAuthorizationRefreshInterval(expirationTimeUtc, currentTimeUtc);
+
+            protected override Task<AmqpConnection> CreateAndOpenConnectionAsync(Version amqpVersion,
+                                                                                Uri serviceEndpoint,
+                                                                                Uri connectionEndpoint,
+                                                                                ServiceBusTransportType transportType,
+                                                                                IWebProxy proxy,
+                                                                                string scopeIdentifier,
+                                                                                TimeSpan timeout,
+                                                                                ServiceBusTransportMetrics metrics)
+            {
+                return Task.FromResult(MockConnection.Object);
+            }
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
@@ -137,7 +137,7 @@ namespace Azure.Messaging.ServiceBus.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ConstructorAssociatesSendLinkSource()
+        public async Task OpenLinkAssociatesSendLinkSource()
         {
             var credential = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
             var endpoint = new Uri("amqp://mine.hubs.com");
@@ -199,7 +199,7 @@ namespace Azure.Messaging.ServiceBus.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ConstructorAssociatesReceiveLinkTarget()
+        public async Task OpenLinkAssociatesReceiveLinkTarget()
         {
             var credential = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
             var endpoint = new Uri("amqp://mine.hubs.com");

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
@@ -146,7 +146,7 @@ namespace Azure.Messaging.ServiceBus.Tests
             var cancellationSource = new CancellationTokenSource();
             var mockSession = new AmqpSession(mockConnection, new AmqpSessionSettings(), Mock.Of<ILinkFactory>());
 
-            var mockScope = new Mock<AmqpConnectionScope>(endpoint, endpoint, credential.Object, ServiceBusTransportType.AmqpTcp, null, false, default, default, linkIdentifier)
+            var mockScope = new Mock<AmqpConnectionScope>(endpoint, endpoint, credential.Object, ServiceBusTransportType.AmqpTcp, null, false, default, default)
             {
                 CallBase = true,
             };
@@ -208,7 +208,7 @@ namespace Azure.Messaging.ServiceBus.Tests
             var cancellationSource = new CancellationTokenSource();
             var mockSession = new AmqpSession(mockConnection, new AmqpSessionSettings(), Mock.Of<ILinkFactory>());
 
-            var mockScope = new Mock<AmqpConnectionScope>(endpoint, endpoint, credential.Object, ServiceBusTransportType.AmqpTcp, null, false, default, default, linkIdentifier)
+            var mockScope = new Mock<AmqpConnectionScope>(endpoint, endpoint, credential.Object, ServiceBusTransportType.AmqpTcp, null, false, default, default)
             {
                 CallBase = true,
             };

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
@@ -343,8 +343,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                 Uri customConnectionEndpoint,
                 ServiceBusTokenCredential credential,
                 ServiceBusTransportType transport,
-                IWebProxy proxy,
-                string identifier = default) : base(serviceEndpoint, customConnectionEndpoint, credential, transport, proxy, false, default, default, identifier)
+                IWebProxy proxy) : base(serviceEndpoint, customConnectionEndpoint, credential, transport, proxy, false, default, default)
             {
                 MockConnection = new Mock<AmqpConnection>(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
@@ -112,6 +112,42 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
             }
         }
 
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConnection" /> is able to
+        ///   connect to the Service Bus service.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ClientCanConnectWithConnectionStringAndCustomIdentifier()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: true, enableSession: false))
+            {
+                var options = new ServiceBusClientOptions
+                {
+                    Identifier = "MyServiceBusClient<3"
+                };
+                var audience = ServiceBusConnection.BuildConnectionResource(options.TransportType, TestEnvironment.FullyQualifiedNamespace, scope.QueueName);
+                var connectionString = TestEnvironment.BuildConnectionStringWithSharedAccessSignature(scope.QueueName, audience);
+
+                await using (var client = new ServiceBusClient(connectionString, options))
+                {
+                    Assert.That(async () =>
+                    {
+                        ServiceBusReceiver receiver = null;
+
+                        try
+                        {
+                            receiver = client.CreateReceiver(scope.QueueName);
+                        }
+                        finally
+                        {
+                            await (receiver?.DisposeAsync() ?? new ValueTask());
+                        }
+                    }, Throws.Nothing);
+                }
+            }
+        }
+
         [Test]
         [TestCase(true)]
         [TestCase(false)]

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
@@ -113,7 +113,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
         }
 
         /// <summary>
-        ///   Verifies that the <see cref="EventHubConnection" /> is able to
+        ///   Verifies that the <see cref="ServiceBusClient" /> is able to
         ///   connect to the Service Bus service.
         /// </summary>
         ///

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientTests.cs
@@ -85,11 +85,31 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
             {
                 TransportType = ServiceBusTransportType.AmqpWebSockets,
                 WebProxy = Mock.Of<IWebProxy>(),
-                CustomEndpointAddress = fakeEndpoint
+                CustomEndpointAddress = fakeEndpoint,
+                Identifier = "MySBClient"
             };
 
             yield return new object[] { new ReadableOptionsMock(fakeConnection, options), options, "connection string" };
             yield return new object[] { new ReadableOptionsMock("fullyQualifiedNamespace", credential.Object, options), options, "expanded argument" };
+        }
+
+        /// <summary>
+        ///   Provides test cases for the constructor tests.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> ConstructorSetsIdentifierCases()
+        {
+            var credential = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
+            var fakeConnection = "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake";
+            var fakeEndpoint = new Uri("sb://fake.com");
+
+            var customIdOptions = new ServiceBusClientOptions
+            {
+                Identifier = "MyServiceBusClient-abcdefg"
+            };
+
+            yield return new object[] { new ReadableOptionsMock(fakeConnection, customIdOptions), customIdOptions, "connection string" };
+            yield return new object[] { new ReadableOptionsMock("fullyQualifiedNamespace", credential.Object, customIdOptions), customIdOptions, "expanded argument" };
         }
 
         /// <summary>
@@ -226,6 +246,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
 
             Assert.That(options, Is.Not.Null, $"The { constructorDescription } constructor should have set default options.");
             Assert.That(options, Is.Not.SameAs(defaultOptions), $"The { constructorDescription } constructor should not have the same options instance.");
+            Assert.That(client.Identifier, Is.Not.Null, $"The {constructorDescription} constructor should have set the Identifier.");
             Assert.That(options.TransportType, Is.EqualTo(defaultOptions.TransportType), $"The { constructorDescription } constructor should have the correct connection type.");
             Assert.That(options.WebProxy, Is.EqualTo(defaultOptions.WebProxy), $"The { constructorDescription } constructor should have the correct proxy.");
             Assert.That(options.CustomEndpointAddress, Is.EqualTo(defaultOptions.CustomEndpointAddress), $"The {constructorDescription} constructor should have the correct custom endpoint.");
@@ -246,9 +267,26 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
 
             Assert.That(options, Is.Not.Null, $"The { constructorDescription } constructor should have set the options.");
             Assert.That(options, Is.Not.SameAs(constructorOptions), $"The { constructorDescription } constructor should have cloned the options.");
+            Assert.That(options.Identifier, Is.EqualTo(constructorOptions.Identifier), $"The {constructorDescription} constructor should have the correct Identifier.");
             Assert.That(options.TransportType, Is.EqualTo(constructorOptions.TransportType), $"The { constructorDescription } constructor should have the correct connection type.");
             Assert.That(options.WebProxy, Is.EqualTo(constructorOptions.WebProxy), $"The { constructorDescription } constructor should have the correct proxy.");
             Assert.That(options.CustomEndpointAddress, Is.EqualTo(constructorOptions.CustomEndpointAddress), $"The {constructorDescription} constructor should have the correct custom endpoint.");
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="ServiceBusClient" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(ConstructorSetsIdentifierCases))]
+        public void ConstructorSetsIdentifier(ReadableOptionsMock client,
+                                             ServiceBusClientOptions constructorOptions,
+                                             string constructorDescription)
+        {
+            ServiceBusClientOptions options = client.Options;
+
+            Assert.That(options.Identifier, Is.EqualTo(constructorOptions.Identifier), $"The {constructorDescription} constructor should have set the custom identifier");
         }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
@@ -95,6 +95,83 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         }
 
         [Test]
+        [TestCase(1, false)]
+        [TestCase(5, true)]
+        [TestCase(10, false)]
+        [TestCase(20, true)]
+        public async Task ProcessMessagesWithCustomIdentifier(int numThreads, bool autoComplete)
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(
+                enablePartitioning: false,
+                enableSession: false))
+            {
+                await using var client = CreateClient(60);
+                ServiceBusSender sender = client.CreateSender(scope.QueueName);
+
+                // use double the number of threads so we can make sure we test that we don't
+                // retrieve more messages than expected when there are more messages available
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
+                var messageSendCt = numThreads * 2;
+                ServiceBusMessageBatch messageBatch = ServiceBusTestUtilities.AddMessages(batch, messageSendCt);
+
+                await sender.SendMessagesAsync(messageBatch);
+
+                var options = new ServiceBusProcessorOptions
+                {
+                    MaxConcurrentCalls = numThreads,
+                    AutoCompleteMessages = autoComplete,
+                    PrefetchCount = 20,
+                    Identifier = "MyServiceBusProcessor"
+                };
+                await using var processor = client.CreateProcessor(scope.QueueName, options);
+                int messageCt = 0;
+
+                TaskCompletionSource<bool>[] completionSources = Enumerable
+                .Range(0, numThreads)
+                .Select(index => new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously))
+                .ToArray();
+                var completionSourceIndex = -1;
+
+                processor.ProcessMessageAsync += ProcessMessage;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
+                await processor.StartProcessingAsync();
+
+                async Task ProcessMessage(ProcessMessageEventArgs args)
+                {
+                    Assert.AreEqual(processor.EntityPath, args.EntityPath);
+                    Assert.AreEqual(processor.FullyQualifiedNamespace, args.FullyQualifiedNamespace);
+                    try
+                    {
+                        var message = args.Message;
+                        if (!autoComplete)
+                        {
+                            await args.CompleteMessageAsync(message, args.CancellationToken);
+                        }
+                        Interlocked.Increment(ref messageCt);
+                    }
+                    finally
+                    {
+                        var setIndex = Interlocked.Increment(ref completionSourceIndex);
+                        if (setIndex < numThreads)
+                        {
+                            completionSources[setIndex].SetResult(true);
+                        }
+                    }
+                }
+                await Task.WhenAll(completionSources.Select(source => source.Task));
+                var start = DateTime.UtcNow;
+                await processor.StopProcessingAsync();
+                var stop = DateTime.UtcNow;
+                Assert.Less(stop - start, TimeSpan.FromSeconds(10));
+
+                // we complete each task after one message being processed, so the total number of messages
+                // processed should equal the number of threads, but it's possible that we may process a few more per thread.
+                Assert.IsTrue(messageCt >= numThreads);
+                Assert.IsTrue(messageCt <= messageSendCt, messageCt.ToString());
+            }
+        }
+
+        [Test]
         [TestCase(1)]
         [TestCase(5)]
         [TestCase(10)]

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
@@ -139,6 +139,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 async Task ProcessMessage(ProcessMessageEventArgs args)
                 {
                     Assert.AreEqual(processor.EntityPath, args.EntityPath);
+                    Assert.AreEqual(processor.Identifier, args.Identifier);
                     Assert.AreEqual(processor.FullyQualifiedNamespace, args.FullyQualifiedNamespace);
                     try
                     {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
@@ -125,6 +125,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             var fullyQualifiedNamespace = new UriBuilder($"{account}.servicebus.windows.net/").Host;
             var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(64))}";
             var client = new ServiceBusClient(connString);
+            var identifier = "MyProcessor";
             var options = new ServiceBusProcessorOptions
             {
                 AutoCompleteMessages = false,
@@ -133,12 +134,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete,
                 MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(60),
                 MaxReceiveWaitTime = TimeSpan.FromSeconds(10),
-                SubQueue = SubQueue.DeadLetter
+                SubQueue = SubQueue.DeadLetter,
+                Identifier = identifier
             };
             var processor = client.CreateProcessor("queueName", options);
             Assert.AreEqual(options.AutoCompleteMessages, processor.AutoCompleteMessages);
             Assert.AreEqual(options.MaxConcurrentCalls, processor.MaxConcurrentCalls);
             Assert.AreEqual(options.PrefetchCount, processor.PrefetchCount);
+            Assert.AreEqual(options.Identifier, processor.Identifier);
             Assert.AreEqual(options.ReceiveMode, processor.ReceiveMode);
             Assert.AreEqual(options.MaxAutoLockRenewalDuration, processor.MaxAutoLockRenewalDuration);
             Assert.AreEqual(options.MaxReceiveWaitTime, processor.MaxReceiveWaitTime);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -153,6 +153,110 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 {
                     Assert.AreEqual(processor.EntityPath, args.EntityPath);
                     Assert.AreEqual(processor.FullyQualifiedNamespace, args.FullyQualifiedNamespace);
+                    Assert.AreEqual(processor.Identifier, args.Identifier);
+                    Interlocked.Increment(ref sessionCloseEventCt);
+                    var setIndex = Interlocked.Increment(ref completionSourceIndex);
+                    completionSources[setIndex].SetResult(true);
+                    sessions.TryRemove(args.SessionId, out byte[] state);
+                    BinaryData getState = await args.GetSessionStateAsync();
+                    Assert.AreEqual(state, getState.ToArray());
+                }
+
+                async Task ProcessMessage(ProcessSessionMessageEventArgs args)
+                {
+                    Assert.AreEqual(processor.EntityPath, args.EntityPath);
+                    Assert.AreEqual(processor.Identifier, args.Identifier);
+                    Assert.AreEqual(processor.FullyQualifiedNamespace, args.FullyQualifiedNamespace);
+                    var message = args.Message;
+                    if (!autoComplete)
+                    {
+                        await args.CompleteMessageAsync(message);
+                    }
+                    Interlocked.Increment(ref messageCt);
+                    Assert.AreEqual(message.SessionId, args.SessionId);
+                    Assert.IsNotNull(args.SessionLockedUntil);
+                }
+
+                await Task.WhenAll(completionSources.Select(source => source.Task));
+                var start = DateTime.UtcNow;
+                await processor.StopProcessingAsync();
+                var stop = DateTime.UtcNow;
+                Assert.Less(stop - start, TimeSpan.FromSeconds(10));
+
+                // there is only one message for each session, and one
+                // thread for each session, so the total messages processed
+                // should equal the number of threads
+                Assert.AreEqual(numThreads, messageCt);
+
+                // we should have received messages from each of the sessions
+                Assert.AreEqual(0, sessions.Count);
+
+                Assert.AreEqual(numThreads, sessionOpenEventCt);
+                Assert.AreEqual(sessionOpenEventCt, sessionCloseEventCt);
+            }
+        }
+
+        [Test]
+        [TestCase(1, true)]
+        [TestCase(5, true)]
+        [TestCase(10, false)]
+        [TestCase(20, false)]
+        public async Task CanProcessWithCustomIdentifier(int numThreads, bool autoComplete)
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(
+                enablePartitioning: false,
+                enableSession: true))
+            {
+                await using var client = CreateClient(60);
+                ServiceBusSender sender = client.CreateSender(scope.QueueName);
+
+                // send 1 message for each thread and use a different session for each message
+                ConcurrentDictionary<string, byte[]> sessions = new ConcurrentDictionary<string, byte[]>();
+                for (int i = 0; i < numThreads; i++)
+                {
+                    var sessionId = Guid.NewGuid().ToString();
+                    await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage(sessionId));
+                    sessions.TryAdd(sessionId, null);
+                }
+                var options = new ServiceBusSessionProcessorOptions
+                {
+                    MaxConcurrentSessions = numThreads,
+                    AutoCompleteMessages = autoComplete,
+                    Identifier = "MySessionProcessor"
+                };
+                await using var processor = client.CreateSessionProcessor(scope.QueueName, options);
+                int messageCt = 0;
+                int sessionOpenEventCt = 0;
+                int sessionCloseEventCt = 0;
+
+                TaskCompletionSource<bool>[] completionSources = Enumerable
+                .Range(0, numThreads)
+                .Select(index => new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously))
+                .ToArray();
+
+                var completionSourceIndex = -1;
+
+                processor.ProcessMessageAsync += ProcessMessage;
+                processor.ProcessErrorAsync += SessionErrorHandler;
+                processor.SessionInitializingAsync += SessionInitHandler;
+                processor.SessionClosingAsync += SessionCloseHandler;
+
+                await processor.StartProcessingAsync();
+
+                async Task SessionInitHandler(ProcessSessionEventArgs args)
+                {
+                    Assert.AreEqual(processor.EntityPath, args.EntityPath);
+                    Assert.AreEqual(processor.FullyQualifiedNamespace, args.FullyQualifiedNamespace);
+                    Interlocked.Increment(ref sessionOpenEventCt);
+                    byte[] state = ServiceBusTestUtilities.GetRandomBuffer(100);
+                    await args.SetSessionStateAsync(new BinaryData(state));
+                    sessions[args.SessionId] = state;
+                }
+
+                async Task SessionCloseHandler(ProcessSessionEventArgs args)
+                {
+                    Assert.AreEqual(processor.EntityPath, args.EntityPath);
+                    Assert.AreEqual(processor.FullyQualifiedNamespace, args.FullyQualifiedNamespace);
                     Interlocked.Increment(ref sessionCloseEventCt);
                     var setIndex = Interlocked.Increment(ref completionSourceIndex);
                     completionSources[setIndex].SetResult(true);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
@@ -136,6 +136,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             var fullyQualifiedNamespace = new UriBuilder($"{account}.servicebus.windows.net/").Host;
             var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(64))}";
             var client = new ServiceBusClient(connString);
+            var identifier = "MyProcessor";
             var options = new ServiceBusSessionProcessorOptions
             {
                 AutoCompleteMessages = false,
@@ -143,7 +144,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 PrefetchCount = 5,
                 ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete,
                 MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(60),
-                MaxConcurrentCallsPerSession = 4
+                MaxConcurrentCallsPerSession = 4,
+                Identifier = identifier
             };
             var processor = client.CreateSessionProcessor("queueName", options);
             Assert.AreEqual(options.AutoCompleteMessages, processor.AutoCompleteMessages);
@@ -154,6 +156,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             Assert.AreEqual(options.MaxAutoLockRenewalDuration, processor.MaxAutoLockRenewalDuration);
             Assert.AreEqual(options.SessionIdleTimeout, processor.SessionIdleTimeout);
             Assert.AreEqual(fullyQualifiedNamespace, processor.FullyQualifiedNamespace);
+            Assert.AreEqual(identifier, processor.Identifier);
             Assert.IsFalse(processor.IsClosed);
             Assert.IsFalse(processor.IsProcessing);
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
@@ -320,5 +320,33 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             await receiver.CloseAsync();
             Assert.IsTrue(receiver.IsClosed);
         }
+
+        [Test]
+        public async Task CreatingReceiverWithoutOptionsGeneratesIdentifier()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var receiver = client.CreateReceiver("fake");
+
+            var identifier = receiver.Identifier;
+            Assert.That(identifier, Is.Not.Null);
+        }
+
+        [Test]
+        public async Task CreatingReceiverWithIdentifierSetsIdentifier()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+
+            var setIdentifier = "UniqueIdentifier-abcedefg";
+
+            var options = new ServiceBusReceiverOptions
+            {
+                Identifier = setIdentifier
+            };
+
+            await using var receiver = client.CreateReceiver("fake", options);
+
+            var identifier = receiver.Identifier;
+            Assert.AreEqual(setIdentifier, identifier);
+        }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
@@ -554,5 +554,20 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 Assert.Less(end - start, TimeSpan.FromSeconds(5));
             }
         }
+
+        [Test]
+        public async Task SendConnStringWithCustomIdentifier()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                var options = new ServiceBusSenderOptions
+                {
+                    Identifier = "testIdent-abcdefg"
+                };
+
+                await using var sender = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString).CreateSender(scope.QueueName, options);
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
+            }
+        }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
@@ -40,7 +40,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
         [Test]
         public async Task SendEmptyListShouldNotThrow()
         {
-            var mock = new Mock<ServiceBusSender>("fake", ServiceBusTestUtilities.CreateMockConnection().Object)
+            var mock = new Mock<ServiceBusSender>("fake", ServiceBusTestUtilities.CreateMockConnection().Object, new ServiceBusSenderOptions())
             {
                 CallBase = true
             };
@@ -51,7 +51,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
         [Test]
         public async Task SendSingleDelegatesToSendList()
         {
-           var mock = new Mock<ServiceBusSender>("fake", ServiceBusTestUtilities.CreateMockConnection().Object)
+           var mock = new Mock<ServiceBusSender>("fake", ServiceBusTestUtilities.CreateMockConnection().Object, new ServiceBusSenderOptions())
             {
                 CallBase = true
             };
@@ -99,7 +99,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
         [Test]
         public async Task ScheduleEmptyListShouldNotThrow()
         {
-            var mock = new Mock<ServiceBusSender>("fake", ServiceBusTestUtilities.CreateMockConnection().Object)
+            var mock = new Mock<ServiceBusSender>("fake", ServiceBusTestUtilities.CreateMockConnection().Object, new ServiceBusSenderOptions())
             {
                 CallBase = true
             };

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
@@ -311,22 +311,5 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             var identifier = sender.Identifier;
             Assert.Equals(setIdentifier, identifier);
         }
-
-        [Test]
-        public async Task SenderPropagatesIdentifierToAMQPLink()
-        {
-            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
-
-            var setIdentifier = "UniqueIdentifier-abcedefg";
-
-            var options = new ServiceBusSenderOptions
-            {
-                Identifier = setIdentifier
-            };
-
-            await using var sender = client.CreateSender("fake", options);
-
-
-        }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
@@ -170,7 +170,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
 
             Assert.That(batch.TryAddMessage(new ServiceBusMessage(Array.Empty<byte>())), Is.True, "The batch should not be locked before sending.");
 
-            var sender = new ServiceBusSender("dummy", mockConnection.Object);
+            var sender = new ServiceBusSender("dummy", mockConnection.Object, new ServiceBusSenderOptions());
             var sendTask = sender.SendMessagesAsync(batch);
 
             Assert.That(() => batch.TryAddMessage(new ServiceBusMessage(Array.Empty<byte>())), Throws.InstanceOf<InvalidOperationException>(), "The batch should be locked while sending.");
@@ -279,9 +279,37 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                         It.IsAny<string>()))
                 .Returns(mockTransportSender.Object);
 
-            var sender = new ServiceBusSender("fake", mockConnection.Object);
+            var sender = new ServiceBusSender("fake", mockConnection.Object, new ServiceBusSenderOptions());
             await sender.CloseAsync(cts.Token);
             mockTransportSender.Verify(transportReceiver => transportReceiver.CloseAsync(It.Is<CancellationToken>(ct => ct == cts.Token)));
+        }
+
+        [Test]
+        public async Task CreatingSenderWithoutOptionsGeneratesIdentifier()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+            await using var sender = client.CreateSender("fake");
+
+            var identifier = sender.Identifier;
+            Assert.That(identifier, Is.Not.Null);
+        }
+
+        [Test]
+        public async Task CreatingSenderWithIdentifierSetsIdentifier()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+
+            var setIdentifier = "UniqueIdentifier-abcedefg";
+
+            var options = new ServiceBusSenderOptions
+            {
+                Identifier = setIdentifier
+            };
+
+            await using var sender = client.CreateSender("fake", options);
+
+            var identifier = sender.Identifier;
+            Assert.Equals(setIdentifier, identifier);
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
@@ -309,7 +309,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             await using var sender = client.CreateSender("fake", options);
 
             var identifier = sender.Identifier;
-            Assert.Equals(setIdentifier, identifier);
+            Assert.AreEqual(setIdentifier, identifier);
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
@@ -311,5 +311,22 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             var identifier = sender.Identifier;
             Assert.Equals(setIdentifier, identifier);
         }
+
+        [Test]
+        public async Task SenderPropagatesIdentifierToAMQPLink()
+        {
+            await using var client = new ServiceBusClient("not.real.com", Mock.Of<TokenCredential>());
+
+            var setIdentifier = "UniqueIdentifier-abcedefg";
+
+            var options = new ServiceBusSenderOptions
+            {
+                Identifier = setIdentifier
+            };
+
+            await using var sender = client.CreateSender("fake", options);
+
+
+        }
     }
 }


### PR DESCRIPTION
The changes here expose the client identifiers for each of the different client types in Service Bus (`ServiceBusClient`, `ServiceBusSender`, `ServiceBusReceiver`, and `ServiceBusProcessor`). They also allow for custom identifiers to be supplied to the clients through their respective options types.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
