### PR TITLE
[ACR] Remove "seal-single-value-enum-by-default" autorest flag

### DIFF
--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/src/autorest.md
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/src/autorest.md
@@ -9,8 +9,6 @@ input-file:
  
 model-namespace: false
 generation1-convenience-client: true
-modelerfour:
-    seal-single-value-enum-by-default: true
 ```
 
 ## Customizations for Code Generator


### PR DESCRIPTION
As per https://github.com/Azure/azure-sdk-for-net/pull/24567#discussion_r724546945, removing `seal-single-value-enum-by-default` flag from autorest config. This flag will eventually be deprecated.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/24620