### PR TITLE
Don't skip checkout exclusion in release config

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -165,7 +165,6 @@ stages:
                       steps:
                         - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
                           parameters:
-                            SkipDefaultCheckout: true
                             Paths:
                               - sdk/**/*.md
                               - .github/CODEOWNERS
@@ -289,7 +288,6 @@ stages:
       steps:
         - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
           parameters:
-            SkipDefaultCheckout: true
             Paths:
               - sdk/**/*.md
               - .github/CODEOWNERS


### PR DESCRIPTION
This is not necessary and is causing us to do a full checkout unnecessarily.