### PR TITLE
Allow diagnostic scopes names without dot

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -61,13 +61,12 @@ namespace Azure.Core.Pipeline
                 return null;
             }
 
+            string clientName = ns;
             int indexOfDot = name.IndexOf(".", StringComparison.OrdinalIgnoreCase);
-            if (indexOfDot == -1)
+            if (indexOfDot != -1)
             {
-                return null;
+                clientName += "." + name.Substring(0, indexOfDot);
             }
-
-            string clientName = ns + "." + name.Substring(0, indexOfDot);
 
             return ActivitySources.GetOrAdd(clientName, static n => ActivityExtensions.CreateActivitySource(n));
         }


### PR DESCRIPTION
ServiceBus message scope name consists of one word - `Message`:

https://github.com/azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/DiagnosticProperty.cs#L31

However, ActivitySource (OTel) path ignores scopes that don't contain dot, i.e. servicebus tracing does not work in OTel.
We can't change scope name in ServiceBus because it'll affect the stable  (AI SDK) path, so let's just allow such names as it seems to be harmless.