### PR TITLE
Remove preview suffix from service version

### DIFF
--- a/sdk/mixedreality/Azure.MixedReality.Authentication/api/Azure.MixedReality.Authentication.netstandard2.0.cs
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/api/Azure.MixedReality.Authentication.netstandard2.0.cs
@@ -17,9 +17,9 @@ namespace Azure.MixedReality.Authentication
         public MixedRealityStsClientOptions(Azure.MixedReality.Authentication.MixedRealityStsClientOptions.ServiceVersion version = Azure.MixedReality.Authentication.MixedRealityStsClientOptions.ServiceVersion.V2019_02_28_preview) { }
         public enum ServiceVersion
         {
+            V2019_02_28 = 1,
             [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
             V2019_02_28_preview = 1,
-            V2019_02_28_Preview = 1,
         }
     }
 }

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/src/MixedRealityStsClientOptions.cs
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/src/MixedRealityStsClientOptions.cs
@@ -20,11 +20,11 @@ namespace Azure.MixedReality.Authentication
         /// Initializes a new instance of the <see cref="MixedRealityStsClientOptions"/> class.
         /// </summary>
         /// <param name="version">The version.</param>
-        public MixedRealityStsClientOptions(ServiceVersion version = ServiceVersion.V2019_02_28_Preview)
+        public MixedRealityStsClientOptions(ServiceVersion version = ServiceVersion.V2019_02_28)
         {
             Version = version switch
             {
-                ServiceVersion.V2019_02_28_Preview => "2019-02-28-preview",
+                ServiceVersion.V2019_02_28 => "2019-02-28-preview",
                 _ => throw new ArgumentException($"The service version {version} is not supported by this library.", nameof(version))
             };
         }
@@ -43,10 +43,14 @@ namespace Azure.MixedReality.Authentication
             V2019_02_28_preview = 1,
 #pragma warning restore AZC0016 // Invalid ServiceVersion member name.
             /// <summary>
-            /// Version 2019-02-28-preview of the Mixed Reality STS service.
+            /// Version 2019-02-28 of the Mixed Reality STS service.
             /// </summary>
+            /// <remarks>
+            /// Unfortunately, the service GA'd with a preview API version. We've removed the preview suffix from the
+            /// enum name to better indicate that we're calling a GA endpoint.
+            /// </remarks>
 #pragma warning disable CA1069 // Enums values should not be duplicated
-            V2019_02_28_Preview = 1,
+            V2019_02_28 = 1,
 #pragma warning restore CA1069 // Enums values should not be duplicated
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }


### PR DESCRIPTION
There is a concern that we're not properly communicating that the API is GA since the service version includes a "preview" suffix. Unfortunately, the service GA'd with a preview API version and will not be changing that. This change simply removes the "Preview" suffix in the `ServiceVersion` enum and will continue to route to the preview service API in order to better indicate to consumers that they're calling a GA endpoint.
