### PR TITLE
[Storage] Fixing broken management sample links

### DIFF
--- a/sdk/storage/Azure.ResourceManager.Storage/samples/README.md
+++ b/sdk/storage/Azure.ResourceManager.Storage/samples/README.md
@@ -11,5 +11,6 @@ description: Samples for the Azure.ResourceManager.Storage client library
 
 # Azure.ResourceManager.Storage Samples
 
-- [Managing Blob Containers](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Azure.ResourceManager.Storage/samples/Sample1_ManagingBlobContainers.md)
-- [Managing File Shares](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Azure.ResourceManager.Storage/samples/Sample2_ManagingFileShares.md)
+- [Managing Storage Accounts](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Azure.ResourceManager.Storage/samples/Sample1_ManagingStorageAccounts.md)
+- [Managing Blob Containers](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Azure.ResourceManager.Storage/samples/Sample2_ManagingBlobContainers.md)
+- [Managing File Shares](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Azure.ResourceManager.Storage/samples/Sample3_ManagingFileShares.md)


### PR DESCRIPTION
# Summary

The purpose of these changes is to fix the set of links in the `Azure.ResourceManager.Samples` README that were broken.  I've updated to the set included in the main README.

# References and Related

- [Link verification failures](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1743864&view=logs&j=d41e9505-d81b-5b3c-5b50-be71bc9b0ccb&t=2521f384-3a28-5bc9-41e5-2f3e6ef99ecd) _(Microsoft Internal)_

