### PR TITLE
Resolving Error Checks for AzurePowerShellCredential Fall Back

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/AzurePowerShellCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzurePowerShellCredential.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -38,7 +37,6 @@ namespace Azure.Identity
         private const string DefaultWorkingDirNonWindows = "/bin/";
         private static readonly string DefaultWorkingDir = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? DefaultWorkingDirWindows : DefaultWorkingDirNonWindows;
         private readonly string _tenantId;
-        private const int ERROR_FILE_NOT_FOUND = 2;
         private readonly bool _logPII;
         private readonly bool _logAccountDetails;
         internal const string AzurePowerShellNotLogInError = "Please run 'Connect-AzAccount' to set up account.";
@@ -178,10 +176,6 @@ namespace Azure.Identity
             if (output.IndexOf(AzurePowerShellNoAzAccountModule, StringComparison.OrdinalIgnoreCase) != -1)
             {
                 throw new CredentialUnavailableException(AzurePowerShellModuleNotInstalledError);
-            }
-            if (output.IndexOf("is not recognized as an internal or external command", StringComparison.OrdinalIgnoreCase) != -1)
-            {
-                throw new Win32Exception(ERROR_FILE_NOT_FOUND);
             }
 
             var needsLogin = output.IndexOf(RunConnectAzAccountToLogin, StringComparison.OrdinalIgnoreCase) != -1 ||

--- a/sdk/identity/Azure.Identity/src/Credentials/AzurePowerShellCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzurePowerShellCredential.cs
@@ -105,7 +105,10 @@ namespace Azure.Identity
                 }
                 return scope.Succeeded(token);
             }
-            catch (Win32Exception ex) when (ex.NativeErrorCode == ERROR_FILE_NOT_FOUND && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            // External execution is wrapped in a "cmd /c" command which will never throw a native Win32Exception ERROR_FILE_NOT_FOUND
+            // Check against the message for constant PowerShellNotInstalledError
+            // Do not retry if already using legacy PowerShell to prevent delays
+            catch (CredentialUnavailableException ex) when (UseLegacyPowerShell == false && ex.Message == PowerShellNotInstalledError && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 UseLegacyPowerShell = true;
                 try

--- a/sdk/identity/Azure.Identity/src/Credentials/AzurePowerShellCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzurePowerShellCredential.cs
@@ -107,7 +107,7 @@ namespace Azure.Identity
             }
             // External execution is wrapped in a "cmd /c" command which will never throw a native Win32Exception ERROR_FILE_NOT_FOUND
             // Check against the message for constant PowerShellNotInstalledError
-            // Do not retry if already using legacy PowerShell to prevent delays
+            // Do not retry if already using legacy PowerShell to prevent delays, also used in tests to ensure a single process result
             catch (CredentialUnavailableException ex) when (UseLegacyPowerShell == false && ex.Message == PowerShellNotInstalledError && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 UseLegacyPowerShell = true;

--- a/sdk/identity/Azure.Identity/tests/AzurePowerShellCredentialsTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzurePowerShellCredentialsTests.cs
@@ -73,9 +73,6 @@ namespace Azure.Identity.Tests
 
         private static IEnumerable<object[]> ErrorScenarios()
         {
-            yield return new object[] { "'pwsh' is not recognized", AzurePowerShellCredential.PowerShellNotInstalledError };
-            yield return new object[] { "pwsh: command not found", AzurePowerShellCredential.PowerShellNotInstalledError };
-            yield return new object[] { "pwsh: not found", AzurePowerShellCredential.PowerShellNotInstalledError };
             yield return new object[] { "Run Connect-AzAccount to login", AzurePowerShellCredential.AzurePowerShellNotLogInError };
             yield return new object[] { "NoAzAccountModule", AzurePowerShellCredential.AzurePowerShellModuleNotInstalledError };
             yield return new object[] { "Get-AzAccessToken: Run Connect-AzAccount to login.", AzurePowerShellCredential.AzurePowerShellNotLogInError };
@@ -90,6 +87,27 @@ namespace Azure.Identity.Tests
             var testProcess = new TestProcess { Error = errorMessage };
             AzurePowerShellCredential credential = InstrumentClient(
                 new AzurePowerShellCredential(new AzurePowerShellCredentialOptions(), CredentialPipeline.GetInstance(null), new TestProcessService(testProcess)));
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            Assert.AreEqual(expectedError, ex.Message);
+        }
+
+        /// <summary>
+        /// Requires 2 TestProcess results falling back from pwsh to powershell
+        /// </summary>
+        private static IEnumerable<object[]> FallBackErrorScenarios()
+        {
+            yield return new object[] { "'pwsh' is not recognized", AzurePowerShellCredential.PowerShellNotInstalledError };
+            yield return new object[] { "pwsh: command not found", AzurePowerShellCredential.PowerShellNotInstalledError };
+            yield return new object[] { "pwsh: not found", AzurePowerShellCredential.PowerShellNotInstalledError };
+        }
+
+        [Test]
+        [TestCaseSource(nameof(FallBackErrorScenarios))]
+        public void AuthenticateWithAzurePowerShellCredential_FallBackErrorScenarios(string errorMessage, string expectedError)
+        {
+            var testProcesses = new TestProcess[] { new TestProcess { Error = errorMessage }, new TestProcess { Error = errorMessage } };
+            AzurePowerShellCredential credential = InstrumentClient(
+                new AzurePowerShellCredential(new AzurePowerShellCredentialOptions(), CredentialPipeline.GetInstance(null), new TestProcessService(testProcesses)));
             var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
             Assert.AreEqual(expectedError, ex.Message);
         }
@@ -151,7 +169,10 @@ namespace Azure.Identity.Tests
         {
             var testProcess = new TestProcess { Error = errorMessage };
             AzurePowerShellCredential credential = InstrumentClient(
-                new AzurePowerShellCredential(new AzurePowerShellCredentialOptions(), CredentialPipeline.GetInstance(null), new TestProcessService(testProcess)));
+                new AzurePowerShellCredential(new AzurePowerShellCredentialOptions(), CredentialPipeline.GetInstance(null), new TestProcessService(testProcess))
+                {
+                    UseLegacyPowerShell = true
+                });
             var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
             Assert.AreEqual(AzurePowerShellCredential.PowerShellNotInstalledError, ex.Message);
         }

--- a/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialLiveTests.cs
@@ -221,7 +221,7 @@ namespace Azure.Identity.Tests
             });
 
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", "{}");
-            var factory = new TestDefaultAzureCredentialFactory(options, new TestFileSystemService(), new TestProcessService(new TestProcess { Error = "'az' is not recognized" }, new TestProcess{Error = "'PowerShell' is not recognized"}), vscAdapter);
+            var factory = new TestDefaultAzureCredentialFactory(options, new TestFileSystemService(), new TestProcessService(new TestProcess { Error = "'az' is not recognized" }, new TestProcess{Error = "'PowerShell' is not recognized"}, new TestProcess{Error = "'PowerShell' is not recognized"}), vscAdapter);
             var credential = InstrumentClient(new DefaultAzureCredential(factory, options));
 
             List<ClientDiagnosticListener.ProducedDiagnosticScope> scopes;


### PR DESCRIPTION
The AzurePowerShellCredential had two checks for missing PowerShell installations. The fallback catch to try again with legacy PowerShell was looking for a specific Win32Exception and it was never generated. This PR modifies that catch statement and removes the need for the `Win32Exception` reference. Tests are updated to match.

Fixes #28030