### PR TITLE
[Search] Enable snippet compilation

### DIFF
--- a/sdk/search/Azure.Search.Documents/README.md
+++ b/sdk/search/Azure.Search.Documents/README.md
@@ -425,8 +425,8 @@ support for async APIs as well.  You'll generally just add an `Async` suffix to
 the name of the method and `await` it.
 
 ```C# Snippet:Azure_Search_Tests_Samples_Readme_StaticQueryAsync
-SearchResults<Hotel> response = await client.SearchAsync<Hotel>("luxury");
-await foreach (SearchResult<Hotel> result in response.GetResultsAsync())
+SearchResults<Hotel> searchResponse = await client.SearchAsync<Hotel>("luxury");
+await foreach (SearchResult<Hotel> result in searchResponse.GetResultsAsync())
 {
     Hotel doc = result.Document;
     Console.WriteLine($"{doc.Id}: {doc.Name}");

--- a/sdk/search/Azure.Search.Documents/samples/Sample02_Service.md
+++ b/sdk/search/Azure.Search.Documents/samples/Sample02_Service.md
@@ -143,7 +143,7 @@ SearchClientOptions options = new SearchClientOptions()
     {
         // Increase timeout for each request to 5 minutes
         Timeout = TimeSpan.FromMinutes(5)
-    });
+    })
 };
 
 // Increase retry attempts to 6

--- a/sdk/search/Azure.Search.Documents/tests/Samples/Readme.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Samples/Readme.cs
@@ -58,14 +58,14 @@ namespace Azure.Search.Documents.Tests.Samples
             await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this);
             Environment.SetEnvironmentVariable("SEARCH_ENDPOINT", resources.Endpoint.ToString());
             Environment.SetEnvironmentVariable("SEARCH_API_KEY", resources.PrimaryApiKey);
-            string indexName = resources.IndexName;
 
             #region Snippet:Azure_Search_Tests_Samples_Readme_Client
             // Get the service endpoint and API key from the environment
             Uri endpoint = new Uri(Environment.GetEnvironmentVariable("SEARCH_ENDPOINT"));
             string key = Environment.GetEnvironmentVariable("SEARCH_API_KEY");
-#if SNIPPET
             string indexName = "hotels";
+#if !SNIPPET
+            indexName = resources.IndexName;
 #endif
 
             // Create a client
@@ -92,11 +92,6 @@ namespace Azure.Search.Documents.Tests.Samples
             }
             #endregion Snippet:Azure_Search_Tests_Samples_Readme_Dict
 
-#if SNIPPET
-            SearchResults<SearchDocument> response = client.Search<SearchDocument>("luxury");
-#else
-            response = client.Search<SearchDocument>("luxury");
-#endif
             foreach (SearchResult<SearchDocument> result in response.GetResults())
             {
                 dynamic doc = result.Document;
@@ -171,7 +166,7 @@ namespace Azure.Search.Documents.Tests.Samples
         }
         #endregion Snippet:Azure_Search_Tests_Samples_Readme_StaticType
 
-            [Test]
+        [Test]
         [SyncOnly]
         public async Task QueryStatic()
         {
@@ -188,12 +183,8 @@ namespace Azure.Search.Documents.Tests.Samples
             #endregion Snippet:Azure_Search_Tests_Samples_Readme_StaticQuery
 
             #region Snippet:Azure_Search_Tests_Samples_Readme_StaticQueryAsync
-#if SNIPPET
-            SearchResults<Hotel> response = await client.SearchAsync<Hotel>("luxury");
-#else
-            response = await client.SearchAsync<Hotel>("luxury");
-#endif
-            await foreach (SearchResult<Hotel> result in response.GetResultsAsync())
+            SearchResults<Hotel> searchResponse = await client.SearchAsync<Hotel>("luxury");
+            await foreach (SearchResult<Hotel> result in searchResponse.GetResultsAsync())
             {
                 Hotel doc = result.Document;
                 Console.WriteLine($"{doc.Id}: {doc.Name}");

--- a/sdk/search/Azure.Search.Documents/tests/Samples/Sample01_HelloWorld.Data.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Samples/Sample01_HelloWorld.Data.cs
@@ -3,12 +3,11 @@
 
 namespace Azure.Search.Documents.Tests.Samples
 {
-    public partial class HelloWorld
+    public partial class HelloWorldData
     {
-#if !SNIPPET
         // Rather than store these in a file and fix EOL to be \n in the root .gitattributes (making this less portable)
         // define a string literal with \n for new lines to be used in the sample to normalize line endings across test platforms.
-        private static readonly string CountriesSolrSynonymMap =
+        public static readonly string CountriesSolrSynonymMap =
             "Afghanistan,AF,AFG\n" +
             "Åland Islands,AX,ALA\n" +
             "Albania,AL,ALB\n" +
@@ -258,6 +257,5 @@ namespace Azure.Search.Documents.Tests.Samples
             "Yemen,YE,YEM\n" +
             "Zambia,ZM,ZMB\n" +
             "Zimbabwe,ZW,ZWE\n";
-#endif
     }
 }

--- a/sdk/search/Azure.Search.Documents/tests/Samples/Sample01_HelloWorld.Data.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Samples/Sample01_HelloWorld.Data.cs
@@ -5,6 +5,7 @@ namespace Azure.Search.Documents.Tests.Samples
 {
     public partial class HelloWorld
     {
+#if !SNIPPET
         // Rather than store these in a file and fix EOL to be \n in the root .gitattributes (making this less portable)
         // define a string literal with \n for new lines to be used in the sample to normalize line endings across test platforms.
         private static readonly string CountriesSolrSynonymMap =
@@ -257,5 +258,6 @@ namespace Azure.Search.Documents.Tests.Samples
             "Yemen,YE,YEM\n" +
             "Zambia,ZM,ZMB\n" +
             "Zimbabwe,ZW,ZWE\n";
+#endif
     }
 }

--- a/sdk/search/Azure.Search.Documents/tests/Samples/Sample01_HelloWorld.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Samples/Sample01_HelloWorld.cs
@@ -208,7 +208,7 @@ namespace Azure.Search.Documents.Tests.Samples
                     synonyms = new SynonymMap(synonymMapName, file);
                 }
 #else
-                synonyms = new SynonymMap(synonymMapName, CountriesSolrSynonymMap);
+                synonyms = new SynonymMap(synonymMapName, HelloWorldData.CountriesSolrSynonymMap);
 #endif
 
                 await indexClient.CreateSynonymMapAsync(synonyms);

--- a/sdk/search/Azure.Search.Documents/tests/Samples/Sample01_HelloWorld.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Samples/Sample01_HelloWorld.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 #region Snippet:Azure_Search_Tests_Samples_Namespaces
 using Azure.Search.Documents;
@@ -285,7 +287,7 @@ namespace Azure.Search.Documents.Tests.Samples
                     {
                         // Increase timeout for each request to 5 minutes
                         Timeout = TimeSpan.FromMinutes(5)
-                    });
+                    })
                 };
 
                 // Increase retry attempts to 6
@@ -425,8 +427,9 @@ namespace Azure.Search.Documents.Tests.Samples
                     Console.WriteLine($"  Description (French):  {hotel.DescriptionFr}");
                 }
                 #endregion Snippet:Azure_Search_Tests_Samples_CreateIndexerAsync_Query
-
+#if !SNIPPET
                 Assert.IsTrue(found, "Expected hotel #6 not found in search results");
+#endif
             }
             finally
             {

--- a/sdk/search/Azure.Search.Documents/tests/Samples/Sample05_IndexingDocuments.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Samples/Sample05_IndexingDocuments.cs
@@ -175,17 +175,18 @@ namespace Azure.Search.Documents.Tests.Samples
                         new SearchIndexingBufferedSender<Product>(searchClient);
                     await indexer.UploadDocumentsAsync(GenerateCatalog(count: 100000));
                     #endregion
+#if SNIPPET
+                    #region Snippet:Azure_Search_Documents_Tests_Samples_Sample05_IndexingDocuments_BufferedSender2
+                    await indexer.FlushAsync();
+                    Assert.AreEqual(100000, (int)await searchClient.GetDocumentCountAsync());
+                    #endregion
+#endif
                 }
 
                 await WaitForDocumentCountAsync(searchClient, 100000);
 
                 // Check
-                #region Snippet:Azure_Search_Documents_Tests_Samples_Sample05_IndexingDocuments_BufferedSender2
-#if SNIPPET
-                await indexer.FlushAsync();
-#endif
                 Assert.AreEqual(100000, (int)await searchClient.GetDocumentCountAsync());
-                #endregion
             }
             finally
             {

--- a/sdk/search/Azure.Search.Documents/tests/Samples/Sample06_EncryptedIndex.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Samples/Sample06_EncryptedIndex.cs
@@ -158,8 +158,9 @@ namespace Azure.Search.Documents.Tests.Samples
                     Console.WriteLine($"  Description: {hotel.Description}");
                 }
                 #endregion Snippet:Azure_Search_Tests_Sample06_EncryptedIndex_CreateDoubleEncryptedIndex_Query
-
+#if !SNIPPET
                 Assert.IsTrue(found, "No luxury hotels were found in index");
+#endif
             }
             finally
             {

--- a/sdk/search/ci.yml
+++ b/sdk/search/ci.yml
@@ -25,6 +25,7 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: search
+    BuildSnippets: true
     ArtifactName: packages
     Artifacts:
     - name: Azure.Search.Documents


### PR DESCRIPTION
Enabled snippet compilation by setting the `BuildSnippets` flag to `true`, so ci can check if snippets can build successfully. Found some snippet build errors and fixed in this PR.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/29322
Part of https://github.com/Azure/azure-sdk-for-net/issues/27619