### PR TITLE
Respect timeout when no cancellation token passed to OpenAmqpObject

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
@@ -117,7 +117,7 @@ namespace Azure.Messaging.ServiceBus.Tests
 
             try
             {
-                await mockScope.InvokeOpenAmqpObjectAsync(mockScope.MockConnection.Object, TimeSpan.FromMinutes(5), CancellationToken.None);
+                await mockScope.InvokeOpenAmqpObjectAsync(mockScope.MockConnection.Object, TimeSpan.FromMinutes(5));
             }
             catch (Exception ex)
             {
@@ -182,8 +182,15 @@ namespace Azure.Messaging.ServiceBus.Tests
                 .Protected()
                 .Setup<Task>("OpenAmqpObjectAsync",
                     ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            mockScope
+                .Protected()
+                .Setup<Task>("OpenAmqpLinkAsync",
+                    ItExpr.IsAny<SendingAmqpLink>(),
                     ItExpr.IsAny<string>(),
-                    ItExpr.IsAny<TimeSpan?>(),
                     ItExpr.IsAny<CancellationToken>())
                 .Returns(Task.CompletedTask)
                 .Verifiable();
@@ -244,8 +251,15 @@ namespace Azure.Messaging.ServiceBus.Tests
                 .Protected()
                 .Setup<Task>("OpenAmqpObjectAsync",
                     ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            mockScope
+                .Protected()
+                .Setup<Task>("OpenAmqpLinkAsync",
+                    ItExpr.IsAny<ReceivingAmqpLink>(),
                     ItExpr.IsAny<string>(),
-                    ItExpr.IsAny<TimeSpan?>(),
                     ItExpr.IsAny<CancellationToken>())
                 .Returns(Task.CompletedTask)
                 .Verifiable();
@@ -350,8 +364,8 @@ namespace Azure.Messaging.ServiceBus.Tests
 
             public Task InvokeOpenAmqpObjectAsync(
                 AmqpObject target,
-                TimeSpan timeout,
-                CancellationToken cancellationToken) => base.OpenAmqpObjectAsync(target, timeout: timeout, cancellationToken: cancellationToken);
+                TimeSpan timeout) =>
+                base.OpenAmqpObjectAsync(target, timeout);
 
             public TimeSpan InvokeCalculateLinkAuthorizationRefreshInterval(
                 DateTime expirationTimeUtc,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
@@ -351,7 +351,7 @@ namespace Azure.Messaging.ServiceBus.Tests
             public Task InvokeOpenAmqpObjectAsync(
                 AmqpObject target,
                 TimeSpan timeout,
-                CancellationToken cancellationToken) => base.OpenAmqpObjectAsync(target, timeout, cancellationToken);
+                CancellationToken cancellationToken) => base.OpenAmqpObjectAsync(target, timeout: timeout, cancellationToken: cancellationToken);
 
             public TimeSpan InvokeCalculateLinkAuthorizationRefreshInterval(
                 DateTime expirationTimeUtc,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
@@ -183,7 +183,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                 .Setup<Task>("OpenAmqpObjectAsync",
                     ItExpr.IsAny<AmqpObject>(),
                     ItExpr.IsAny<string>(),
-                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<TimeSpan?>(),
                     ItExpr.IsAny<CancellationToken>())
                 .Returns(Task.CompletedTask)
                 .Verifiable();
@@ -245,7 +245,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                 .Setup<Task>("OpenAmqpObjectAsync",
                     ItExpr.IsAny<AmqpObject>(),
                     ItExpr.IsAny<string>(),
-                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<TimeSpan?>(),
                     ItExpr.IsAny<CancellationToken>())
                 .Returns(Task.CompletedTask)
                 .Verifiable();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
@@ -182,9 +182,9 @@ namespace Azure.Messaging.ServiceBus.Tests
                 .Protected()
                 .Setup<Task>("OpenAmqpObjectAsync",
                     ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<TimeSpan>(),
-                    ItExpr.IsAny<CancellationToken>(),
-                    ItExpr.IsAny<string>())
+                    ItExpr.IsAny<CancellationToken>())
                 .Returns(Task.CompletedTask)
                 .Verifiable();
 
@@ -244,9 +244,9 @@ namespace Azure.Messaging.ServiceBus.Tests
                 .Protected()
                 .Setup<Task>("OpenAmqpObjectAsync",
                     ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<string>(),
                     ItExpr.IsAny<TimeSpan>(),
-                    ItExpr.IsAny<CancellationToken>(),
-                    ItExpr.IsAny<string>())
+                    ItExpr.IsAny<CancellationToken>())
                 .Returns(Task.CompletedTask)
                 .Verifiable();
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -1974,7 +1974,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: true))
             {
-                await using var client = CreateNoRetryClient();
+                await using var client = CreateClient();
                 var sender = client.CreateSender(scope.QueueName);
                 int messageCount = 10;
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
@@ -44,10 +44,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                     sessionId);
 
                 sequenceNumber ??= 1;
-                var regularReceiver = client.CreateReceiver(scope.QueueName);
+
                 // verify peeked == send
                 var ct = 0;
-                foreach (ServiceBusReceivedMessage peekedMessage in await regularReceiver.PeekMessagesAsync(
+                foreach (ServiceBusReceivedMessage peekedMessage in await receiver.PeekMessagesAsync(
                     messageCt,
                     sequenceNumber))
                 {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
@@ -44,10 +44,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                     sessionId);
 
                 sequenceNumber ??= 1;
-
+                var regularReceiver = client.CreateReceiver(scope.QueueName);
                 // verify peeked == send
                 var ct = 0;
-                foreach (ServiceBusReceivedMessage peekedMessage in await receiver.PeekMessagesAsync(
+                foreach (ServiceBusReceivedMessage peekedMessage in await regularReceiver.PeekMessagesAsync(
                     messageCt,
                     sequenceNumber))
                 {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample03_SendReceiveSessions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample03_SendReceiveSessions.cs
@@ -122,7 +122,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 ServiceBusMessage message = new ServiceBusMessage("Hello world!") { SessionId = "mySessionId" };
 
                 // send the message
-                await sender.SendMessageAsync(message);
+                // await sender.SendMessageAsync(message);
 
                 // create a receiver that we can use to receive and settle the message
                 ServiceBusSessionReceiver receiver = await client.AcceptNextSessionAsync(queueName);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample03_SendReceiveSessions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample03_SendReceiveSessions.cs
@@ -122,7 +122,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 ServiceBusMessage message = new ServiceBusMessage("Hello world!") { SessionId = "mySessionId" };
 
                 // send the message
-                // await sender.SendMessageAsync(message);
+                await sender.SendMessageAsync(message);
 
                 // create a receiver that we can use to receive and settle the message
                 ServiceBusSessionReceiver receiver = await client.AcceptNextSessionAsync(queueName);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample03_SendReceiveSessions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample03_SendReceiveSessions.cs
@@ -118,8 +118,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 // create the sender
                 ServiceBusSender sender = client.CreateSender(queueName);
 
-                // create a message that we can send
-                ServiceBusMessage message = new ServiceBusMessage("Hello world!");
+                // create a message and set the SessionId
+                ServiceBusMessage message = new ServiceBusMessage("Hello world!") { SessionId = "mySessionId" };
 
                 // send the message
                 await sender.SendMessageAsync(message);
@@ -140,7 +140,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 // complete the message, thereby deleting it from the service
                 await receiver.CompleteMessageAsync(receivedMessage);
                 #endregion
-                Assert.IsNull(await CreateNoRetryClient().CreateReceiver(queueName).ReceiveMessageAsync());
             }
         }
     }


### PR DESCRIPTION
CancellationToken should be used when opening links, as the link timeout is already set in the link settings which is what the service will use. Using the same timeout on the client could result in race conditions where the client times out first. We could increase the client timeout, but instead we will just rely on the service timeout here.
For opening AMQP session/connection, we use a client timeout because there is no corresponding service level timeout.