### PR TITLE
[ACR] Enable snippet compilation

### DIFF
--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/README.md
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/README.md
@@ -173,9 +173,6 @@ image.UpdateTagProperties("latest", new ArtifactTagProperties()
 ### Delete images
 
 ```C# Snippet:ContainerRegistry_Tests_Samples_DeleteImage
-using Azure.Containers.ContainerRegistry;
-using Azure.Identity;
-
 // Get the service endpoint from the environment
 Uri endpoint = new Uri(Environment.GetEnvironmentVariable("REGISTRY_ENDPOINT"));
 
@@ -285,10 +282,6 @@ await image.UpdateTagPropertiesAsync("latest", new ArtifactTagProperties()
 ### Delete images asynchronously
 
 ```C# Snippet:ContainerRegistry_Tests_Samples_DeleteImageAsync
-using System.Linq;
-using Azure.Containers.ContainerRegistry;
-using Azure.Identity;
-
 // Get the service endpoint from the environment
 Uri endpoint = new Uri(Environment.GetEnvironmentVariable("REGISTRY_ENDPOINT"));
 

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/samples/Sample02a_DeleteImages.md
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/samples/Sample02a_DeleteImages.md
@@ -3,9 +3,6 @@
 A common use case for Azure Container Registries is to scan the repositories in a registry and delete all but the most recent *n* images, or all images older than a certain date.  This sample illustrates how to use the .NET ACR SDK to delete all but the latest three images.
 
 ```C# Snippet:ContainerRegistry_Tests_Samples_DeleteImage
-using Azure.Containers.ContainerRegistry;
-using Azure.Identity;
-
 // Get the service endpoint from the environment
 Uri endpoint = new Uri(Environment.GetEnvironmentVariable("REGISTRY_ENDPOINT"));
 

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/samples/Sample02b_DeleteImagesAsync.md
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/samples/Sample02b_DeleteImagesAsync.md
@@ -9,10 +9,6 @@ Please note:
 - The operations in this sample are run in series, but could be parallelized using the new `Parallel.ForEachAsync` method in [.NET 6](https://dotnet.microsoft.com/download/dotnet/6.0).
 
 ```C# Snippet:ContainerRegistry_Tests_Samples_DeleteImageAsync
-using System.Linq;
-using Azure.Containers.ContainerRegistry;
-using Azure.Identity;
-
 // Get the service endpoint from the environment
 Uri endpoint = new Uri(Environment.GetEnvironmentVariable("REGISTRY_ENDPOINT"));
 

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/Samples/Sample02_DeleteImages.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/Samples/Sample02_DeleteImages.cs
@@ -20,11 +20,6 @@ namespace Azure.Containers.ContainerRegistry.Tests.Samples
             Environment.SetEnvironmentVariable("REGISTRY_ENDPOINT", TestEnvironment.Endpoint);
 
             #region Snippet:ContainerRegistry_Tests_Samples_DeleteImage
-#if SNIPPET
-            using Azure.Containers.ContainerRegistry;
-            using Azure.Identity;
-#endif
-
             // Get the service endpoint from the environment
             Uri endpoint = new Uri(Environment.GetEnvironmentVariable("REGISTRY_ENDPOINT"));
 
@@ -69,12 +64,6 @@ namespace Azure.Containers.ContainerRegistry.Tests.Samples
             Environment.SetEnvironmentVariable("REGISTRY_ENDPOINT", TestEnvironment.Endpoint);
 
             #region Snippet:ContainerRegistry_Tests_Samples_DeleteImageAsync
-#if SNIPPET
-            using System.Linq;
-            using Azure.Containers.ContainerRegistry;
-            using Azure.Identity;
-#endif
-
             // Get the service endpoint from the environment
             Uri endpoint = new Uri(Environment.GetEnvironmentVariable("REGISTRY_ENDPOINT"));
 
@@ -109,7 +98,6 @@ namespace Azure.Containers.ContainerRegistry.Tests.Samples
                     await image.DeleteAsync();
                 }
             }
-
             #endregion
         }
     }

--- a/sdk/containerregistry/ci.yml
+++ b/sdk/containerregistry/ci.yml
@@ -32,6 +32,7 @@ extends:
   parameters:
     SDKType: client
     ServiceDirectory: containerregistry
+    BuildSnippets: true
     ArtifactName: packages
     Artifacts:
     - name: Azure.Containers.ContainerRegistry


### PR DESCRIPTION
Enabled snippet compilation by setting the `BuildSnippets` flag to `true`, so ci can check if snippets can build successfully. Found some snippet build errors and fixed in this PR.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/30277
Part of https://github.com/Azure/azure-sdk-for-net/issues/27619