### PR TITLE
[FormRecognizer] Flattened DocumentModelDetails

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
@@ -11,8 +11,9 @@
 - Updated all long-running operation client methods to a new pattern. This affects `StartAnalyzeDocument`, `StartAnalyzeDocumentFromUri`, `StartBuildModel`, `StartCopyModelTo`, and `StartCreateComposedModel` methods. Changes are:
   - Removed the "Start" prefix. For example, `StartAnalyzeDocument` was renamed to `AnalyzeDocument`.
   - Added a new required parameter: `waitUntil`. It specifies whether the operation should run to completion before returning or not, removing the need to call `WaitForCompletion` in most scenarios.
-- Renamed `DocumentModel` to `DocumentModelDetails`.
-- Renamed `DocumentModelInfo` to `DocumentModelSummary`.
+- Updated `DocumentModelInfo` and `DocumentModel`:
+  - Renamed them to `DocumentModelSummary` and `DocumentModelDetails`, respectively.
+  - Removed the inheritance between them.
 - Updated `ModelOperationInfo` and `ModelOperation`:
   - Renamed them to `DocumentModelOperationSummary` and `DocumentModelOperationDetails`, respectively.
   - Removed the inheritance between them.
@@ -24,8 +25,8 @@
 - Renamed `modelDescription` parameters to `description` in methods `GetCopyAuthorization` and `StartCreateComposedModel` (now called `ComposeModel`).
 - Renamed `CopyAuthorization.ExpirationDateTime` to `ExpiresOn`.
 - Removed `DocumentCaption` and `DocumentFootnote` features.
-- Renamed parameter `analyzeDocumentOptions` to `options` in the `StartAnalyzeDocument` and `StartAnalyzeDocumentFromUri` methods.
-- Renamed parameter `buildModelOptions` to `options` in the `StartBuildModel` method.
+- Renamed parameter `analyzeDocumentOptions` to `options` in the `StartAnalyzeDocument` and `StartAnalyzeDocumentFromUri` methods (now called `AnalyzeDocument` and `AnalyzeDocumentFromUri`).
+- Renamed parameter `buildModelOptions` to `options` in the `StartBuildModel` method (now called `BuildModel`).
 - `FormRecognizerClientOptions.Audience` and `DocumentAnalysisClientOptions.Audience` now default to `null`.
 - In the `DocumentAnalysis` namespace, `CopyModelOperation.PercentCompleted` and `BuildModelOperation.PercentCompleted` now throw an `InvalidOperationException` if called before a call to `UpdateStatus`.
 - Updated `CopyAuthorization.TargetModelLocation` to be a `Uri` instead of `string`.

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/api/Azure.AI.FormRecognizer.netstandard2.0.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/api/Azure.AI.FormRecognizer.netstandard2.0.cs
@@ -581,10 +581,14 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         public virtual Azure.Response<Azure.AI.FormRecognizer.DocumentAnalysis.ResourceDetails> GetResourceDetails(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.FormRecognizer.DocumentAnalysis.ResourceDetails>> GetResourceDetailsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
-    public partial class DocumentModelDetails : Azure.AI.FormRecognizer.DocumentAnalysis.DocumentModelSummary
+    public partial class DocumentModelDetails
     {
         internal DocumentModelDetails() { }
+        public System.DateTimeOffset CreatedOn { get { throw null; } }
+        public string Description { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, Azure.AI.FormRecognizer.DocumentAnalysis.DocTypeInfo> DocTypes { get { throw null; } }
+        public string ModelId { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get { throw null; } }
     }
     public partial class DocumentModelOperationDetails
     {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/BuildModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/BuildModelOperation.cs
@@ -177,7 +177,8 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
 
             if (status == DocumentOperationStatus.Succeeded)
             {
-                return OperationState<DocumentModelDetails>.Success(rawResponse, response.Value.Result);
+                var modelDetails = new DocumentModelDetails(response.Value.Result);
+                return OperationState<DocumentModelDetails>.Success(rawResponse, modelDetails);
             }
             else if (status == DocumentOperationStatus.Failed)
             {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyModelOperation.cs
@@ -183,7 +183,8 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
 
             if (status == DocumentOperationStatus.Succeeded)
             {
-                return OperationState<DocumentModelDetails>.Success(rawResponse, response.Value.Result);
+                var modelDetails = new DocumentModelDetails(response.Value.Result);
+                return OperationState<DocumentModelDetails>.Success(rawResponse, modelDetails);
             }
             else if (status == DocumentOperationStatus.Failed)
             {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentAnalysisModelFactory.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentAnalysisModelFactory.cs
@@ -403,7 +403,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             tags ??= new Dictionary<string, string>();
             docTypes ??= new Dictionary<string, DocTypeInfo>();
 
-            return new DocumentModelDetails(modelId, description, createdOn, apiVersion: null, tags, docTypes);
+            return new DocumentModelDetails(modelId, description, createdOn, tags, docTypes);
         }
 
         /// <summary> Initializes a new instance of DocumentModelSummary. </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelAdministrationClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelAdministrationClient.cs
@@ -305,8 +305,10 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
 
             try
             {
-                Response<DocumentModelDetails> response = ServiceClient.GetModel(modelId, cancellationToken);
-                return Response.FromValue(response.Value, response.GetRawResponse());
+                Response<DocumentModel> response = ServiceClient.GetModel(modelId, cancellationToken);
+                DocumentModelDetails modelDetails = new DocumentModelDetails(response.Value);
+
+                return Response.FromValue(modelDetails, response.GetRawResponse());
             }
             catch (Exception e)
             {
@@ -331,8 +333,10 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
 
             try
             {
-                Response<DocumentModelDetails> response = await ServiceClient.GetModelAsync(modelId, cancellationToken).ConfigureAwait(false);
-                return Response.FromValue(response.Value, response.GetRawResponse());
+                Response<DocumentModel> response = await ServiceClient.GetModelAsync(modelId, cancellationToken).ConfigureAwait(false);
+                var modelDetails = new DocumentModelDetails(response.Value);
+
+                return Response.FromValue(modelDetails, response.GetRawResponse());
             }
             catch (Exception e)
             {
@@ -528,7 +532,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// </summary>
         /// <param name="operationId">The operation ID.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        /// <returns>A <see cref="Response{T}"/> representing the result of the operation. It can be cast to a <see cref="DocumentModelDetails"/> containing
+        /// <returns>A <see cref="Response{T}"/> representing the result of the operation. It can be cast to a <see cref="DocumentModelOperationDetails"/> containing
         /// information about the requested model.</returns>
         public virtual Response<DocumentModelOperationDetails> GetOperation(string operationId, CancellationToken cancellationToken = default)
         {
@@ -556,7 +560,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// </summary>
         /// <param name="operationId">The operation ID.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        /// <returns>A <see cref="Response{T}"/> representing the result of the operation. It can be cast to a <see cref="DocumentModelDetails"/> containing
+        /// <returns>A <see cref="Response{T}"/> representing the result of the operation. It can be cast to a <see cref="DocumentModelOperationDetails"/> containing
         /// information about the requested model.</returns>
         public virtual async Task<Response<DocumentModelOperationDetails>> GetOperationAsync(string operationId, CancellationToken cancellationToken = default)
         {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelDetails.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelDetails.cs
@@ -1,12 +1,53 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Core;
+using System;
+using System.Collections.Generic;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis
 {
-    [CodeGenModel("DocumentModel")]
-    public partial class DocumentModelDetails
+    /// <summary>
+    /// Model info.
+    /// </summary>
+    public class DocumentModelDetails
     {
+        internal DocumentModelDetails(DocumentModel model)
+            : this(model.ModelId, model.Description, model.CreatedOn, model.Tags, model.DocTypes)
+        {
+        }
+
+        internal DocumentModelDetails(string modelId, string description, DateTimeOffset createdOn, IReadOnlyDictionary<string, string> tags, IReadOnlyDictionary<string, DocTypeInfo> docTypes)
+        {
+            ModelId = modelId;
+            Description = description;
+            CreatedOn = createdOn;
+            Tags = tags;
+            DocTypes = docTypes;
+        }
+
+        /// <summary>
+        /// Unique model name.
+        /// </summary>
+        public string ModelId { get; }
+
+        /// <summary>
+        /// Model description.
+        /// </summary>
+        public string Description { get; }
+
+        /// <summary>
+        /// Date and time (UTC) when the model was created.
+        /// </summary>
+        public DateTimeOffset CreatedOn { get; }
+
+        /// <summary>
+        /// List of key-value tag attributes associated with the model.
+        /// </summary>
+        public IReadOnlyDictionary<string, string> Tags { get; }
+
+        /// <summary>
+        /// Supported document types.
+        /// </summary>
+        public IReadOnlyDictionary<string, DocTypeInfo> DocTypes { get; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelOperationDetails.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelOperationDetails.cs
@@ -12,7 +12,8 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     public class DocumentModelOperationDetails
     {
         internal DocumentModelOperationDetails(GetOperationResponse response)
-            : this(response.OperationId, response.Status, response.PercentCompleted, response.CreatedOn, response.LastUpdatedOn, response.Kind, response.ResourceLocation, response.Tags, response.Error, new DocumentModelDetails(response.Result))
+            : this(response.OperationId, response.Status, response.PercentCompleted, response.CreatedOn, response.LastUpdatedOn, response.Kind, response.ResourceLocation, response.Tags, response.Error,
+                  response.Result == null ? null : new DocumentModelDetails(response.Result))
         {
         }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelOperationDetails.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelOperationDetails.cs
@@ -12,7 +12,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     public class DocumentModelOperationDetails
     {
         internal DocumentModelOperationDetails(GetOperationResponse response)
-            : this(response.OperationId, response.Status, response.PercentCompleted, response.CreatedOn, response.LastUpdatedOn, response.Kind, response.ResourceLocation, response.Tags, response.Error, response.Result)
+            : this(response.OperationId, response.Status, response.PercentCompleted, response.CreatedOn, response.LastUpdatedOn, response.Kind, response.ResourceLocation, response.Tags, response.Error, new DocumentModelDetails(response.Result))
         {
         }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelSummary.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelSummary.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis
@@ -15,11 +14,6 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// </summary>
         [CodeGenMember("CreatedDateTime")]
         public DateTimeOffset CreatedOn { get; }
-
-        /// <summary>
-        /// A list of user-defined key-value tag attributes associated with the model.
-        /// </summary>
-        public IReadOnlyDictionary<string, string> Tags { get; }
 
         /// <summary> API version used to create this model. </summary>
         internal string ApiVersion { get; }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/FormRecognizerModelFactory.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/FormRecognizerModelFactory.cs
@@ -719,20 +719,20 @@ namespace Azure.AI.FormRecognizer.Models
             return new DocumentModelSummary(modelId, description, createdOn, apiVersion, tags);
         }
 
-        /// <summary> Initializes a new instance of DocumentModelDetails. </summary>
+        /// <summary> Initializes a new instance of DocumentModel. </summary>
         /// <param name="modelId"> Unique model name. </param>
         /// <param name="description"> Model description. </param>
         /// <param name="createdOn"> Date and time (UTC) when the model was created. </param>
         /// <param name="apiVersion"> API version used to create this model. </param>
         /// <param name="tags"> List of key-value tag attributes associated with the model. </param>
         /// <param name="docTypes"> Supported document types. </param>
-        /// <returns> A new <see cref="DocumentAnalysis.DocumentModelDetails"/> instance for mocking. </returns>
-        internal static DocumentModelDetails DocumentModelDetails(string modelId = null, string description = null, DateTimeOffset createdOn = default, string apiVersion = null, IReadOnlyDictionary<string, string> tags = null, IReadOnlyDictionary<string, DocTypeInfo> docTypes = null)
+        /// <returns> A new <see cref="DocumentAnalysis.DocumentModel"/> instance for mocking. </returns>
+        internal static DocumentModel DocumentModel(string modelId = null, string description = null, DateTimeOffset createdOn = default, string apiVersion = null, IReadOnlyDictionary<string, string> tags = null, IReadOnlyDictionary<string, DocTypeInfo> docTypes = null)
         {
             tags ??= new Dictionary<string, string>();
             docTypes ??= new Dictionary<string, DocTypeInfo>();
 
-            return new DocumentModelDetails(modelId, description, createdOn, apiVersion, tags, docTypes);
+            return new DocumentModel(modelId, description, createdOn, apiVersion, tags, docTypes);
         }
 
         /// <summary> Initializes a new instance of DocumentModelOperationSummary. </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/DocumentAnalysisRestClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/DocumentAnalysisRestClient.cs
@@ -890,7 +890,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="modelId"/> is null. </exception>
         /// <remarks> Gets detailed model information. </remarks>
-        public async Task<Response<DocumentModelDetails>> GetModelAsync(string modelId, CancellationToken cancellationToken = default)
+        public async Task<Response<DocumentModel>> GetModelAsync(string modelId, CancellationToken cancellationToken = default)
         {
             if (modelId == null)
             {
@@ -903,9 +903,9 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             {
                 case 200:
                     {
-                        DocumentModelDetails value = default;
+                        DocumentModel value = default;
                         using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                        value = DocumentModelDetails.DeserializeDocumentModelDetails(document.RootElement);
+                        value = DocumentModel.DeserializeDocumentModel(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -918,7 +918,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="modelId"/> is null. </exception>
         /// <remarks> Gets detailed model information. </remarks>
-        public Response<DocumentModelDetails> GetModel(string modelId, CancellationToken cancellationToken = default)
+        public Response<DocumentModel> GetModel(string modelId, CancellationToken cancellationToken = default)
         {
             if (modelId == null)
             {
@@ -931,9 +931,9 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             {
                 case 200:
                     {
-                        DocumentModelDetails value = default;
+                        DocumentModel value = default;
                         using var document = JsonDocument.Parse(message.Response.ContentStream);
-                        value = DocumentModelDetails.DeserializeDocumentModelDetails(document.RootElement);
+                        value = DocumentModel.DeserializeDocumentModel(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DocumentModel.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DocumentModel.Serialization.cs
@@ -12,9 +12,9 @@ using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis
 {
-    public partial class DocumentModelDetails
+    internal partial class DocumentModel
     {
-        internal static DocumentModelDetails DeserializeDocumentModelDetails(JsonElement element)
+        internal static DocumentModel DeserializeDocumentModel(JsonElement element)
         {
             Optional<IReadOnlyDictionary<string, DocTypeInfo>> docTypes = default;
             string modelId = default;
@@ -75,7 +75,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
                     continue;
                 }
             }
-            return new DocumentModelDetails(modelId, description.Value, createdDateTime, apiVersion.Value, Optional.ToDictionary(tags), Optional.ToDictionary(docTypes));
+            return new DocumentModel(modelId, description.Value, createdDateTime, apiVersion.Value, Optional.ToDictionary(tags), Optional.ToDictionary(docTypes));
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DocumentModel.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DocumentModel.cs
@@ -12,13 +12,13 @@ using Azure.Core;
 namespace Azure.AI.FormRecognizer.DocumentAnalysis
 {
     /// <summary> Model info. </summary>
-    public partial class DocumentModelDetails : DocumentModelSummary
+    internal partial class DocumentModel : DocumentModelSummary
     {
-        /// <summary> Initializes a new instance of DocumentModelDetails. </summary>
+        /// <summary> Initializes a new instance of DocumentModel. </summary>
         /// <param name="modelId"> Unique model name. </param>
         /// <param name="createdOn"> Date and time (UTC) when the model was created. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="modelId"/> is null. </exception>
-        internal DocumentModelDetails(string modelId, DateTimeOffset createdOn) : base(modelId, createdOn)
+        internal DocumentModel(string modelId, DateTimeOffset createdOn) : base(modelId, createdOn)
         {
             if (modelId == null)
             {
@@ -28,14 +28,14 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             DocTypes = new ChangeTrackingDictionary<string, DocTypeInfo>();
         }
 
-        /// <summary> Initializes a new instance of DocumentModelDetails. </summary>
+        /// <summary> Initializes a new instance of DocumentModel. </summary>
         /// <param name="modelId"> Unique model name. </param>
         /// <param name="description"> Model description. </param>
         /// <param name="createdOn"> Date and time (UTC) when the model was created. </param>
         /// <param name="apiVersion"> API version used to create this model. </param>
         /// <param name="tags"> List of key-value tag attributes associated with the model. </param>
         /// <param name="docTypes"> Supported document types. </param>
-        internal DocumentModelDetails(string modelId, string description, DateTimeOffset createdOn, string apiVersion, IReadOnlyDictionary<string, string> tags, IReadOnlyDictionary<string, DocTypeInfo> docTypes) : base(modelId, description, createdOn, apiVersion, tags)
+        internal DocumentModel(string modelId, string description, DateTimeOffset createdOn, string apiVersion, IReadOnlyDictionary<string, string> tags, IReadOnlyDictionary<string, DocTypeInfo> docTypes) : base(modelId, description, createdOn, apiVersion, tags)
         {
             DocTypes = docTypes;
         }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DocumentModelSummary.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DocumentModelSummary.cs
@@ -49,5 +49,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         public string ModelId { get; }
         /// <summary> Model description. </summary>
         public string Description { get; }
+        /// <summary> List of key-value tag attributes associated with the model. </summary>
+        public IReadOnlyDictionary<string, string> Tags { get; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/GetOperationResponse.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/GetOperationResponse.Serialization.cs
@@ -17,7 +17,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         internal static GetOperationResponse DeserializeGetOperationResponse(JsonElement element)
         {
             Optional<JsonElement> error = default;
-            Optional<DocumentModelDetails> result = default;
+            Optional<DocumentModel> result = default;
             string operationId = default;
             DocumentOperationStatus status = default;
             Optional<int> percentCompleted = default;
@@ -41,7 +41,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
                         property.ThrowNonNullablePropertyIsNull();
                         continue;
                     }
-                    result = DocumentModelDetails.DeserializeDocumentModelDetails(property.Value);
+                    result = DocumentModel.DeserializeDocumentModel(property.Value);
                     continue;
                 }
                 if (property.NameEquals("operationId"))

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/GetOperationResponse.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/GetOperationResponse.cs
@@ -46,7 +46,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// <param name="tags"> List of key-value tag attributes associated with the model. </param>
         /// <param name="jsonError"> Encountered error. </param>
         /// <param name="result"> Operation result upon success. </param>
-        internal GetOperationResponse(string operationId, DocumentOperationStatus status, int? percentCompleted, DateTimeOffset createdOn, DateTimeOffset lastUpdatedOn, DocumentOperationKind kind, Uri resourceLocation, string apiVersion, IReadOnlyDictionary<string, string> tags, JsonElement jsonError, DocumentModelDetails result) : base(operationId, status, percentCompleted, createdOn, lastUpdatedOn, kind, resourceLocation, apiVersion, tags)
+        internal GetOperationResponse(string operationId, DocumentOperationStatus status, int? percentCompleted, DateTimeOffset createdOn, DateTimeOffset lastUpdatedOn, DocumentOperationKind kind, Uri resourceLocation, string apiVersion, IReadOnlyDictionary<string, string> tags, JsonElement jsonError, DocumentModel result) : base(operationId, status, percentCompleted, createdOn, lastUpdatedOn, kind, resourceLocation, apiVersion, tags)
         {
             JsonError = jsonError;
             Result = result;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/GetOperationResponse.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/GetOperationResponse.cs
@@ -27,6 +27,6 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
 
         public ResponseError Error { get; private set; }
 
-        public DocumentModelDetails Result { get; }
+        public DocumentModel Result { get; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationClientLiveTests.cs
@@ -67,7 +67,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
 
             DocumentModelDetails model = operation.Value;
 
-            ValidateDocumentModel(model);
+            ValidateDocumentModelDetails(model);
 
             Assert.AreEqual(1, model.DocTypes.Count);
             Assert.IsTrue(model.DocTypes.ContainsKey(modelId));
@@ -101,7 +101,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
 
             DocumentModelDetails model = operation.Value;
 
-            ValidateDocumentModel(model);
+            ValidateDocumentModelDetails(model);
 
             Assert.AreEqual(1, model.DocTypes.Count);
             Assert.IsTrue(model.DocTypes.ContainsKey(modelId));
@@ -191,7 +191,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
 
             DocumentModelDetails model = await client.GetModelAsync("prebuilt-businessCard");
 
-            ValidateDocumentModel(model);
+            ValidateDocumentModelDetails(model);
             Assert.NotNull(model.Description);
         }
 
@@ -219,7 +219,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
             BuildModelOperation operation = await client.BuildModelAsync(WaitUntil.Completed, trainingFilesUri, DocumentBuildMode.Template, modelId, options);
             DocumentModelDetails resultModel = await client.GetModelAsync(modelId);
 
-            ValidateDocumentModel(resultModel, description, TestingTags);
+            ValidateDocumentModelDetails(resultModel, description, TestingTags);
 
             DocumentModelSummary modelSummary = client.GetModelsAsync().ToEnumerableAsync().Result
                 .FirstOrDefault(m => m.ModelId == modelId);
@@ -325,7 +325,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
 
             DocumentModelDetails copiedModel = operation.Value;
 
-            ValidateDocumentModel(copiedModel);
+            ValidateDocumentModelDetails(copiedModel);
             Assert.AreEqual(targetAuth.TargetModelId, copiedModel.ModelId);
             Assert.AreNotEqual(trainedModel.ModelId, copiedModel.ModelId);
 
@@ -413,7 +413,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
 
             DocumentModelDetails composedModel = operation.Value;
 
-            ValidateDocumentModel(composedModel);
+            ValidateDocumentModelDetails(composedModel);
 
             Assert.AreEqual(2, composedModel.DocTypes.Count);
             Assert.IsTrue(composedModel.DocTypes.ContainsKey(modelAId));
@@ -493,7 +493,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
             if (operationDetails.Status == DocumentOperationStatus.Succeeded)
             {
                 Assert.AreEqual(100, operationDetails.PercentCompleted);
-                ValidateDocumentModel(operationDetails.Result);
+                ValidateDocumentModelDetails(operationDetails.Result);
             }
             else if (operationDetails.Status == DocumentOperationStatus.Failed)
             {
@@ -503,9 +503,20 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
             }
         }
 
-        private void ValidateDocumentModel(DocumentModelDetails model, string description = null, IReadOnlyDictionary<string, string> tags = null)
+        private void ValidateDocumentModelDetails(DocumentModelDetails model, string description = null, IReadOnlyDictionary<string, string> tags = null)
         {
-            ValidateDocumentModelSummary(model, description, tags);
+            if (description != null)
+            {
+                Assert.AreEqual(description, model.Description);
+            }
+
+            if (tags != null)
+            {
+                CollectionAssert.AreEquivalent(tags, model.Tags);
+            }
+
+            Assert.IsNotNull(model.ModelId);
+            Assert.AreNotEqual(default(DateTimeOffset), model.CreatedOn);
 
             // TODO add validation for Doctypes https://github.com/Azure/azure-sdk-for-net-pr/issues/1432
         }
@@ -523,8 +534,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
             }
 
             Assert.IsNotNull(model.ModelId);
-            Assert.IsNotNull(model.CreatedOn);
-            Assert.AreNotEqual(new DateTimeOffset(), model.CreatedOn);
+            Assert.AreNotEqual(default(DateTimeOffset), model.CreatedOn);
         }
     }
 }


### PR DESCRIPTION
### Changes

- Removed the inheritance between `DocumentModelDetails` and `DocumentModelSummary`. Based on the swagger specification, CodeGen generates `Details` as a subclass of `Summary`. We want to avoid the inheritance in the SDK. If the service ever decides to evolve these differently in the future, we could end up breaking users. An example would be adding a new property to `Summary` but not to `Details`.

### Strategy for flattening `DocumentModelDetails`

In the swagger, `DocumentModelDetails` and `DocumentModelSummary` are called `DocumentModel` and `ModelSummary`, respectively. The only thing the SDK did before this PR was renaming these models in code:

```cs
[CodeGenModel("ModelSummary")]
public class DocumentModelSummary{}

[CodeGenModel("DocumentModel")]
public class DocumentModelDetails : DocumentModelSummary {}
```

Since we **cannot** prevent CodeGen from adding the inheritance, we need to create a whole new `DocumentModelDetails` class. The generated one will be hidden from the public API:

```cs
[CodeGenModel("ModelSummary")]
public class DocumentModelSummary {}

// Keep it internal.
[CodeGenModel("DocumentModel")]
internal class DocumentModel : DocumentModelSummary {}

// NOT generated. Written manually without inheritance.
public class DocumentModelDetails {}
```