### PR TITLE
[Search] Enable national cloud support for Azure Search SDK

### DIFF
--- a/sdk/search/Azure.Search.Documents/README.md
+++ b/sdk/search/Azure.Search.Documents/README.md
@@ -203,6 +203,10 @@ much more.
 * [Retrieving a specific document from your index](#retrieving-a-specific-document-from-your-index)
 * [Async APIs](#async-apis)
 
+### Advanced authentication
+ 
+- [Create a client that can authenticate in a national cloud](#authenticate-in-a-national-cloud)
+
 ### Querying
 
 Let's start by importing our namespaces.
@@ -431,6 +435,29 @@ await foreach (SearchResult<Hotel> result in searchResponse.GetResultsAsync())
     Hotel doc = result.Document;
     Console.WriteLine($"{doc.Id}: {doc.Name}");
 }
+```
+
+### Authenticate in a National Cloud
+
+To authenticate in a [National Cloud](https://docs.microsoft.com/azure/active-directory/develop/authentication-national-cloud), you will need to make the following additions to your client configuration:
+
+- Set the `AuthorityHost` in the credential options or via the `AZURE_AUTHORITY_HOST` environment variable
+- Set the `Audience` in `SearchClientOptions`
+
+```C#
+// Create a SearchClient that will authenticate through AAD in the China national cloud
+string indexName = "nycjobs";
+Uri endpoint = new Uri(Environment.GetEnvironmentVariable("SEARCH_ENDPOINT"));
+SearchClient client = new SearchClient(endpoint, indexName,
+    new DefaultAzureCredential(
+        new DefaultAzureCredentialOptions()
+        {
+            AuthorityHost = AzureAuthorityHosts.AzureChina
+        }),
+    new SearchClientOptions()
+    {
+        Audience = SearchAudience.AzureChina
+    });
 ```
 
 ## Troubleshooting

--- a/sdk/search/Azure.Search.Documents/api/Azure.Search.Documents.netstandard2.0.cs
+++ b/sdk/search/Azure.Search.Documents/api/Azure.Search.Documents.netstandard2.0.cs
@@ -22,6 +22,25 @@ namespace Azure.Search.Documents
         public IndexDocumentsOptions() { }
         public bool ThrowOnAnyError { get { throw null; } set { } }
     }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct SearchAudience : System.IEquatable<Azure.Search.Documents.SearchAudience>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public SearchAudience(string value) { throw null; }
+        public static Azure.Search.Documents.SearchAudience AzureChina { get { throw null; } }
+        public static Azure.Search.Documents.SearchAudience AzureGovernment { get { throw null; } }
+        public static Azure.Search.Documents.SearchAudience AzurePublicCloud { get { throw null; } }
+        public bool Equals(Azure.Search.Documents.SearchAudience other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Search.Documents.SearchAudience left, Azure.Search.Documents.SearchAudience right) { throw null; }
+        public static implicit operator Azure.Search.Documents.SearchAudience (string value) { throw null; }
+        public static bool operator !=(Azure.Search.Documents.SearchAudience left, Azure.Search.Documents.SearchAudience right) { throw null; }
+        public override string ToString() { throw null; }
+    }
     public partial class SearchClient
     {
         protected SearchClient() { }
@@ -58,6 +77,7 @@ namespace Azure.Search.Documents
     public partial class SearchClientOptions : Azure.Core.ClientOptions
     {
         public SearchClientOptions(Azure.Search.Documents.SearchClientOptions.ServiceVersion version = Azure.Search.Documents.SearchClientOptions.ServiceVersion.V2021_04_30_Preview) { }
+        public Azure.Search.Documents.SearchAudience? Audience { get { throw null; } set { } }
         public Azure.Core.Serialization.ObjectSerializer Serializer { get { throw null; } set { } }
         public Azure.Search.Documents.SearchClientOptions.ServiceVersion Version { get { throw null; } }
         public enum ServiceVersion

--- a/sdk/search/Azure.Search.Documents/src/SearchAudience.cs
+++ b/sdk/search/Azure.Search.Documents/src/SearchAudience.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+using Azure.Core;
+
+namespace Azure.Search.Documents
+{
+    /// <summary> Cloud audiences available for Search. </summary>
+    public readonly partial struct SearchAudience : IEquatable<SearchAudience>
+    {
+        private readonly string _value;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SearchAudience"/> object.
+        /// </summary>
+        /// <param name="value">The Azure Active Directory audience to use when forming authorization scopes.For the Language service, this value corresponds to a URL that identifies the Azure cloud where the resource is located.</param>
+        /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
+        /// <remarks>Please use one of the constant members over creating a custom value unless you have special needs for doing so.</remarks>
+        public SearchAudience(string value)
+        {
+            Argument.AssertNotNullOrEmpty(value, nameof(value));
+            _value = value;
+        }
+
+        private const string AzureChinaValue = "https://search.azure.cn";
+        private const string AzureGovernmentValue = "https://search.azure.us";
+        private const string AzurePublicCloudValue = "https://search.azure.com";
+
+        /// <summary> Azure China. </summary>
+        public static SearchAudience AzureChina { get; } = new SearchAudience(AzureChinaValue);
+
+        /// <summary> Azure Government. </summary>
+        public static SearchAudience AzureGovernment { get; } = new SearchAudience(AzureGovernmentValue);
+
+        /// <summary> Azure Public Cloud. </summary>
+        public static SearchAudience AzurePublicCloud { get; } = new SearchAudience(AzurePublicCloudValue);
+
+        /// <summary> Determines if two <see cref="SearchAudience"/> values are the same. </summary>
+        public static bool operator ==(SearchAudience left, SearchAudience right) => left.Equals(right);
+        /// <summary> Determines if two <see cref="SearchAudience"/> values are not the same. </summary>
+        public static bool operator !=(SearchAudience left, SearchAudience right) => !left.Equals(right);
+        /// <summary> Converts a string to a <see cref="SearchAudience"/>. </summary>
+        public static implicit operator SearchAudience(string value) => new SearchAudience(value);
+
+        /// <inheritdoc />
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => obj is SearchAudience other && Equals(other);
+        /// <inheritdoc />
+        public bool Equals(SearchAudience other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
+
+        /// <inheritdoc />
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => _value?.GetHashCode() ?? 0;
+        /// <inheritdoc />
+        public override string ToString() => _value;
+    }
+}

--- a/sdk/search/Azure.Search.Documents/src/SearchClientOptions.cs
+++ b/sdk/search/Azure.Search.Documents/src/SearchClientOptions.cs
@@ -67,6 +67,12 @@ namespace Azure.Search.Documents
         public ObjectSerializer Serializer { get; set; }
 
         /// <summary>
+        /// Gets or sets the Audience to use for authentication with Azure Active Directory (AAD). The audience is not considered when using a shared key.
+        /// </summary>
+        /// <value>If <c>null</c>, <see cref="SearchAudience.AzurePublicCloud" /> will be assumed.</value>
+        public SearchAudience? Audience { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="SearchClientOptions"/>
         /// class.
         /// </summary>
@@ -120,9 +126,11 @@ namespace Azure.Search.Documents
         internal HttpPipeline Build(TokenCredential credential)
         {
             Debug.Assert(credential != null);
+            var authorizationScope = $"{(string.IsNullOrEmpty(Audience?.ToString()) ? SearchAudience.AzurePublicCloud : Audience)}/.default";
+
             return HttpPipelineBuilder.Build(
                 options: this,
-                perCallPolicies: new[] { new BearerTokenAuthenticationPolicy(credential, Constants.CredentialScopeName) },
+                perCallPolicies: new[] { new BearerTokenAuthenticationPolicy(credential, authorizationScope) },
                 perRetryPolicies: Array.Empty<HttpPipelinePolicy>(),
                 responseClassifier: null);
         }

--- a/sdk/search/Azure.Search.Documents/src/Utilities/Constants.cs
+++ b/sdk/search/Azure.Search.Documents/src/Utilities/Constants.cs
@@ -22,11 +22,6 @@ namespace Azure.Search.Documents
         public const string ApiKeyHeaderName = "api-key";
 
         /// <summary>
-        /// The name of the scope to authenticate for when creating a <see cref="Azure.Core.Pipeline.BearerTokenAuthenticationPolicy"/>
-        /// </summary>
-        public const string CredentialScopeName = "https://search.azure.com/.default";
-
-        /// <summary>
         /// Gets the representation of a NaN value.
         /// </summary>
         public const string NanValue = "NaN";

--- a/sdk/search/Azure.Search.Documents/tests/SearchClientTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/SearchClientTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Azure.Identity;
 using NUnit.Framework;
 
 namespace Azure.Search.Documents.Tests
@@ -33,6 +34,30 @@ namespace Azure.Search.Documents.Tests
             Assert.Throws<ArgumentException>(() => new SearchClient(new Uri("http://bing.com"), indexName, credential: null));
 
             Assert.Throws<ArgumentNullException>(() => new SearchClient(endpoint, indexName, tokenCredential: null));
+        }
+
+        [Test]
+        public void AuthenticateInChinaCloud()
+        {
+            var serviceName = "my-svc-name";
+            var indexName = "my-index-name";
+            var endpoint = new Uri($"https://{serviceName}.search.windows.net");
+            SearchClientOptions options = new SearchClientOptions()
+            {
+                Audience = SearchAudience.AzureChina
+            };
+            SearchClient client = new SearchClient(endpoint, indexName,
+                new DefaultAzureCredential(
+                    new DefaultAzureCredentialOptions()
+                    {
+                        AuthorityHost = AzureAuthorityHosts.AzureChina
+                    }),
+                options);
+            Assert.NotNull(client);
+            Assert.AreEqual(endpoint, client.Endpoint);
+            Assert.AreEqual(serviceName, client.ServiceName);
+            Assert.AreEqual(indexName, client.IndexName);
+            Assert.AreEqual(SearchAudience.AzureChina, options.Audience);
         }
 
         [Test]


### PR DESCRIPTION
In order to enable national cloud support for Azure Search SDK, adding configuration to allow the users to set the audience.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/30306
