### PR TITLE
Bug9663 azPowershell Updated AzureOperation Response from Object to String for GetReportContent API

### DIFF
--- a/sdk/automation/CHANGELOG.md
+++ b/sdk/automation/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Release History
+
+<!--
+    Please leave this section at the top of the change log.
+
+    Changes for the upcoming release should go under the section titled "Upcoming Release", and should adhere to the following format:
+
+    ## Upcoming Release
+    * Overview of change #1
+        - Additional information about change #1
+    * Overview of change #2
+        - Additional information about change #2
+        - Additional information about change #2
+    * Overview of change #3
+    * Overview of change #4
+        - Additional information about change #4
+
+    ## YYYY.MM.DD - Version X.Y.Z (Previous Release)
+    * Overview of change #1
+        - Additional information about change #1
+-->
+## Upcoming Release
+* Fixed bug: Azure/azure-powershell - Export-AzAutomationDscNodeReportContent : Unable to deserialize the response. [#9663]
+

--- a/sdk/automation/Microsoft.Azure.Management.Automation/src/Generated/INodeReportsOperations.cs
+++ b/sdk/automation/Microsoft.Azure.Management.Automation/src/Generated/INodeReportsOperations.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Management.Automation
     using Microsoft.Rest.Azure;
     using Microsoft.Rest.Azure.OData;
     using Models;
+    using System;
     using System.Collections;
     using System.Collections.Generic;
     using System.Threading;
@@ -119,7 +120,7 @@ namespace Microsoft.Azure.Management.Automation
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        Task<AzureOperationResponse<object>> GetContentWithHttpMessagesAsync(string resourceGroupName, string automationAccountName, string nodeId, string reportId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<AzureOperationResponse<String>> GetContentWithHttpMessagesAsync(string resourceGroupName, string automationAccountName, string nodeId, string reportId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Retrieve the Dsc node report list by node id.
         /// <see href="http://aka.ms/azureautomationsdk/dscnodereportoperations" />

--- a/sdk/automation/Microsoft.Azure.Management.Automation/src/Generated/NodeReportsOperations.cs
+++ b/sdk/automation/Microsoft.Azure.Management.Automation/src/Generated/NodeReportsOperations.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Management.Automation
     using Microsoft.Rest.Azure.OData;
     using Models;
     using Newtonsoft.Json;
+    using System;
     using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
@@ -537,7 +538,7 @@ namespace Microsoft.Azure.Management.Automation
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<AzureOperationResponse<object>> GetContentWithHttpMessagesAsync(string resourceGroupName, string automationAccountName, string nodeId, string reportId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<AzureOperationResponse<String>> GetContentWithHttpMessagesAsync(string resourceGroupName, string automationAccountName, string nodeId, string reportId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (resourceGroupName == null)
             {
@@ -691,7 +692,7 @@ namespace Microsoft.Azure.Management.Automation
                 throw ex;
             }
             // Create Result
-            var _result = new AzureOperationResponse<object>();
+            var _result = new AzureOperationResponse<String>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("x-ms-request-id"))
@@ -704,7 +705,7 @@ namespace Microsoft.Azure.Management.Automation
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Rest.Serialization.SafeJsonConvert.DeserializeObject<object>(_responseContent, Client.DeserializationSettings);
+                    _result.Body = _responseContent;
                 }
                 catch (JsonException ex)
                 {

--- a/sdk/automation/Microsoft.Azure.Management.Automation/src/Generated/NodeReportsOperationsExtensions.cs
+++ b/sdk/automation/Microsoft.Azure.Management.Automation/src/Generated/NodeReportsOperationsExtensions.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Management.Automation
     using Microsoft.Rest.Azure;
     using Microsoft.Rest.Azure.OData;
     using Models;
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -149,7 +150,7 @@ namespace Microsoft.Azure.Management.Automation
             /// <param name='reportId'>
             /// The report id.
             /// </param>
-            public static object GetContent(this INodeReportsOperations operations, string resourceGroupName, string automationAccountName, string nodeId, string reportId)
+            public static String GetContent(this INodeReportsOperations operations, string resourceGroupName, string automationAccountName, string nodeId, string reportId)
             {
                 return operations.GetContentAsync(resourceGroupName, automationAccountName, nodeId, reportId).GetAwaiter().GetResult();
             }
@@ -176,7 +177,7 @@ namespace Microsoft.Azure.Management.Automation
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<object> GetContentAsync(this INodeReportsOperations operations, string resourceGroupName, string automationAccountName, string nodeId, string reportId, CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<String> GetContentAsync(this INodeReportsOperations operations, string resourceGroupName, string automationAccountName, string nodeId, string reportId, CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.GetContentWithHttpMessagesAsync(resourceGroupName, automationAccountName, nodeId, reportId, null, cancellationToken).ConfigureAwait(false))
                 {


### PR DESCRIPTION
Updated AzureOperationResponse from Object to String for GetReportContent API
Export-AzAutomationDscNodeReportContent : Unable to deserialize the response. [#9663](https://github.com/Azure/azure-powershell/issues/9663)

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
