### PR TITLE
[Event Hubs] Fix enumerable send

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## 5.8.0-beta.1 (Unreleased)
 
-### Features Added
+### Acknowledgments
 
-### Breaking Changes
+Thank you to our developer community members who helped to make the Event Hubs client libraries better with their contributions to this release:
 
-### Bugs Fixed
+- Daniel Marbach _([GitHub](https://github.com/danielmarbach))_
 
 ### Other Changes
+
+- Miscellaneous performance improvements by reducing memory allocations. _(A community contribution, courtesy of [danielmarbach](https://github.com/danielmarbach))_
 
 ## 5.7.1 (2022-07-07)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -8,11 +8,9 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 - Daniel Marbach _([GitHub](https://github.com/danielmarbach))_
 
-### Features Added
-
-### Breaking Changes
-
 ### Bugs Fixed
+
+- Fixed a regression with the `EventHubProducerClient` overloads of `SendAsync` which accept an enumerable of events.  When specifying a partition key, it was ignored when sending.  As a result, the Event Hub applied round-robin partition assignment, spreading events across partitions rather than grouping them in a single partition.
 
 ### Other Changes
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -479,7 +479,7 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                     try
                     {
-                        using AmqpMessage batchMessage = MessageConverter.CreateBatchFromMessages(messages);
+                        using AmqpMessage batchMessage = MessageConverter.CreateBatchFromMessages(messages, partitionKey);
 
                         if (!SendLink.TryGetOpenedObject(out link))
                         {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/MigrationGuideSnippetsLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/MigrationGuideSnippetsLiveTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Core;
 using Azure.Identity;
 using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Producer;


### PR DESCRIPTION
# Summary 

The focus of these changes is to fix a bug in the `SendAsync` overload that accepts and enumerable where the partition key is ignored. 

# References and Related

- [Same PartitionKey does not guarantee same Partition (#30361)](https://github.com/Azure/azure-sdk-for-net/issues/30361)