### PR TITLE
remove options bag not in previous API from perf

### DIFF
--- a/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/Read.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Scenarios/Read.cs
@@ -29,10 +29,8 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
         {
             FileClient.ReadTo(
                 Stream.Null,
-                new Models.DataLakeFileReadToOptions
-                {
-                    TransferOptions = Options.StorageTransferOptions
-                },
+                conditions: default,
+                transferOptions: Options.StorageTransferOptions,
                 cancellationToken);
         }
 
@@ -44,10 +42,8 @@ namespace Azure.Storage.Files.DataLake.Perf.Scenarios
         {
             await FileClient.ReadToAsync(
                 Stream.Null,
-                new Models.DataLakeFileReadToOptions
-                {
-                    TransferOptions = Options.StorageTransferOptions
-                },
+                conditions: default,
+                transferOptions: Options.StorageTransferOptions,
                 cancellationToken);
         }
     }


### PR DESCRIPTION
Options bag causing compilation issues in perf pipelines when trying to compile against previous versions. Reverted to older api for now.