### PR TITLE
Removed storage dependency on FxCopAnalyzers reference and NUnit in Storage AesGcm Tests when upgrading to VS2022 17.3

### DIFF
--- a/sdk/storage/Azure.Storage.Common/tests/AesGcmTests/Azure.Storage.Common.AesGcm.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Common/tests/AesGcmTests/Azure.Storage.Common.AesGcm.Tests.csproj
@@ -22,9 +22,6 @@
     <Compile Include="$(AzureStorageSharedSources)AesGcm\**\*.cs" LinkBase="Shared" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" />
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="Resources\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/sdk/storage/Directory.Build.props
+++ b/sdk/storage/Directory.Build.props
@@ -37,6 +37,12 @@
       $(NoWarn);
       AZC0006;
       AZC0007;
+	  
+	  <!-- 
+	  Mitigation for the following issue, until the solution is publicly released.
+	  https://github.com/dotnet/sdk/issues/24747#issuecomment-1126298533 -->
+	  NU1504;
+      NU1505;
 
       <!--
         Netstandard2.1 warnings that netstandard2.0 cannot adhere to.

--- a/sdk/storage/Directory.Build.props
+++ b/sdk/storage/Directory.Build.props
@@ -38,10 +38,11 @@
       AZC0006;
       AZC0007;
 	  
-	  <!-- 
-	  Mitigation for the following issue, until the solution is publicly released.
-	  https://github.com/dotnet/sdk/issues/24747#issuecomment-1126298533 -->
-	  NU1504;
+      <!-- 
+        Mitigation for the following issue, until the solution is publicly released.
+        https://github.com/dotnet/sdk/issues/24747#issuecomment-1126298533
+      -->
+      NU1504;
       NU1505;
 
       <!--

--- a/sdk/storage/Directory.Build.props
+++ b/sdk/storage/Directory.Build.props
@@ -37,13 +37,6 @@
       $(NoWarn);
       AZC0006;
       AZC0007;
-	  
-      <!-- 
-        Mitigation for the following issue, until the solution is publicly released.
-        https://github.com/dotnet/sdk/issues/24747#issuecomment-1126298533
-      -->
-      NU1504;
-      NU1505;
 
       <!--
         Netstandard2.1 warnings that netstandard2.0 cannot adhere to.
@@ -75,14 +68,6 @@
     <!-- Turn on the DEBUG constant -->
     <DefineConstants>DEBUG;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
-
-  <!-- Add references for CLIENT LIBRARY projects -->
-  <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(IsClientLibrary)' == 'true'">
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 
   <!-- Add references for TEST projects -->
   <ItemGroup Condition="'$(IsTestProject)' == 'true' and '$(IsClientLibrary)' == 'true'">


### PR DESCRIPTION
~See github discussion https://github.com/dotnet/sdk/issues/24747#issuecomment-1126374678~

~This NoWarn is added to mitigate this issue for the storage SDK when upgrading to Visual Studio 2022 17.3.0. Without it we cannot build while using 17.3.0. Downgrading will run into a different bug where we cannot load various test projects in the storage solution.~

When upgrading to Visual Studio 2022 17.3.0, it pointed out double dependencies we had in the storage solutions. Removed the FxCopAnalyzer dependencies from the storage Directory.Build.props file, since it's in the repo wide file and the NUnit dependency in the AesGcm.Tests csproj file. 