### PR TITLE
Clean up IsClosed usage in AMQP layer

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
 using Azure.Core;
-using Azure.Core.Diagnostics;
 using Azure.Messaging.ServiceBus.Core;
 using Azure.Messaging.ServiceBus.Diagnostics;
 using Microsoft.Azure.Amqp;
@@ -44,7 +43,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///   <c>true</c> if the sender is closed; otherwise, <c>false</c>.
         /// </value>
         ///
-        public override bool IsClosed => _closed;
+        public bool IsClosed => _closed;
 
         /// <summary>
         /// The identifier of the sender.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
@@ -17,16 +17,6 @@ namespace Azure.Messaging.ServiceBus.Core
     internal abstract class TransportReceiver
     {
         /// <summary>
-        /// Indicates whether or not this receiver has been closed by the user.
-        /// </summary>
-        ///
-        /// <value>
-        /// <c>true</c> if the consumer is closed; otherwise, <c>false</c>.
-        /// </value>
-        ///
-        public abstract bool WasClosedExplicitly { get; }
-
-        /// <summary>
         /// Indicates whether the session link has been closed. This is useful for session receiver scenarios because once the link is closed for a
         /// session receiver it will not be reopened.
         /// </summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportSender.cs
@@ -18,16 +18,6 @@ namespace Azure.Messaging.ServiceBus.Core
     internal abstract class TransportSender
     {
         /// <summary>
-        ///   Indicates whether or not this producer has been closed.
-        /// </summary>
-        ///
-        /// <value>
-        ///   <c>true</c> if the producer is closed; otherwise, <c>false</c>.
-        /// </value>
-        ///
-        public virtual bool IsClosed { get; }
-
-        /// <summary>
         ///   Creates a size-constraint batch to which <see cref="ServiceBusMessage" /> may be added using a try-based pattern.  If a message would
         ///   exceed the maximum allowable size of the batch, the batch will not allow adding the message and signal that scenario using its
         ///   return value.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
@@ -105,14 +105,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         /// </summary>
         ///
         [Test]
-        public async Task CloseMarksTheConsumerAsClosed()
+        public async Task CloseMarksTheReceiverAsClosed()
         {
             var receiver = CreateReceiver();
 
-            Assert.That(receiver.WasClosedExplicitly, Is.False, "The receiver should not be closed on creation");
+            Assert.That(receiver.IsClosed, Is.False, "The receiver should not be closed on creation");
 
             await receiver.CloseAsync(CancellationToken.None);
-            Assert.That(receiver.WasClosedExplicitly, Is.True, "The receiver should be marked as closed after closing");
+            Assert.That(receiver.IsClosed, Is.True, "The receiver should be marked as closed after closing");
         }
 
         /// <summary>


### PR DESCRIPTION
The IsClosed flag doesn't need to be exposed in TransportReceiver/Sender - it is only used by tests.