### PR TITLE
[Communication-Common] fix CommunicationIdentifier equality operator override

### DIFF
--- a/sdk/communication/Azure.Communication.Common/src/CommunicationIdentifier.cs
+++ b/sdk/communication/Azure.Communication.Common/src/CommunicationIdentifier.cs
@@ -33,7 +33,8 @@ namespace Azure.Communication
         /// <param name="left">The first identifier to compare.</param>
         /// <param name="right">The second identifier to compare.</param>
         /// <returns>True if the types and <see cref="RawId"/> match.</returns>
-        public static bool operator ==(CommunicationIdentifier left, CommunicationIdentifier right) => left.GetType() == right.GetType() && Equals(left, right);
+        public static bool operator ==(CommunicationIdentifier left, CommunicationIdentifier right)
+            => ReferenceEquals(left, right) || left is not null && right is not null && Equals(left, right);
 
         /// <summary>
         /// Overrides the non-equality operator.
@@ -41,7 +42,7 @@ namespace Azure.Communication
         /// <param name="left">The first identifier to compare.</param>
         /// <param name="right">The second identifier to compare.</param>
         /// <returns>True if the types or <see cref="RawId"/> values are different.</returns>
-        public static bool operator !=(CommunicationIdentifier left, CommunicationIdentifier right) => left.GetType() != right.GetType() || !Equals(left, right);
+        public static bool operator !=(CommunicationIdentifier left, CommunicationIdentifier right) => !(left == right);
 
         /// <summary>
         /// Creates a <see cref="CommunicationIdentifier"/> from a given rawId.

--- a/sdk/communication/Azure.Communication.Common/tests/CommunicationIdentifierTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/CommunicationIdentifierTest.cs
@@ -119,11 +119,21 @@ namespace Azure.Communication
             var sameIdentifier = new CommunicationUserIdentifier("123");
             var otherIdentifier = new CommunicationUserIdentifier("124");
             var otherTypeIdentifier = new MicrosoftTeamsUserIdentifier("123");
+            CommunicationIdentifier? nullIdentifier = null;
 
             Assert.False(identifier == null);
             Assert.False(null == identifier);
             Assert.True(identifier != null);
             Assert.True(null != identifier);
+
+            Assert.True(null as CommunicationIdentifier == null as CommunicationIdentifier);
+            Assert.False(identifier == null as CommunicationIdentifier);
+            Assert.False(null as CommunicationIdentifier == identifier);
+            Assert.True(identifier != null as CommunicationIdentifier);
+            Assert.True(null as CommunicationIdentifier != identifier);
+
+            Assert.True(null == nullIdentifier);
+            Assert.False(nullIdentifier == identifier);
 
 #pragma warning disable CS1718 // Comparison made to same variable
             Assert.True(identifier == identifier);

--- a/sdk/communication/Azure.Communication.Common/tests/CommunicationIdentifierTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/CommunicationIdentifierTest.cs
@@ -111,5 +111,31 @@ namespace Azure.Communication
                 Assert.AreNotEqual(baseType, implementation.GetProperty(nameof(CommunicationIdentifier.RawId))?.DeclaringType);
             }
         }
+
+        [Test]
+        public void EqualityOperatorOverrideDoesntThrow()
+        {
+            var identifier = new CommunicationUserIdentifier("123");
+            var sameIdentifier = new CommunicationUserIdentifier("123");
+            var otherIdentifier = new CommunicationUserIdentifier("124");
+            var otherTypeIdentifier = new MicrosoftTeamsUserIdentifier("123");
+
+            Assert.False(identifier == null);
+            Assert.False(null == identifier);
+            Assert.True(identifier != null);
+            Assert.True(null != identifier);
+
+#pragma warning disable CS1718 // Comparison made to same variable
+            Assert.True(identifier == identifier);
+#pragma warning restore CS1718 // Comparison made to same variable
+            Assert.True(identifier == sameIdentifier);
+            Assert.False(identifier != sameIdentifier);
+            Assert.True(sameIdentifier == identifier);
+            Assert.False(sameIdentifier != identifier);
+            Assert.False(identifier == otherIdentifier);
+            Assert.True(identifier != otherIdentifier);
+            Assert.False(identifier == otherTypeIdentifier);
+            Assert.True(identifier != otherTypeIdentifier);
+        }
     }
 }


### PR DESCRIPTION
Fixes a bug in the `CommunicationIdentifier`'s `==` operator override.

```c#
if (identifier == null)
``` 
would always throw, thanks @minnieliu for discovering this.

No customer has been impacted as the operator override is new, and package hasn't been released yet.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
