### PR TITLE
Changing names to callconnectionproperties for all names to avoid confusion

### DIFF
--- a/sdk/communication/Azure.Communication.CallingServer/README.md
+++ b/sdk/communication/Azure.Communication.CallingServer/README.md
@@ -57,7 +57,7 @@ CreateCallResult createCallResult = await callAutomationClient.CreateCallAsync(
     targets: new List<CommunicationIdentifier>() { new PhoneNumberIdentifier("<targets-phone-number>") }, // E.164 formatted recipient phone number
     callbackEndpoint: new Uri(TestEnvironment.AppCallbackUrl)
     );
-Console.WriteLine($"Call connection id: {createCallResult.CallProperties.CallConnectionId}");
+Console.WriteLine($"Call connection id: {createCallResult.CallConnectionProperties.CallConnectionId}");
 ```
 
 ### Handle Mid-Connection call back events

--- a/sdk/communication/Azure.Communication.CallingServer/api/Azure.Communication.CallingServer.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/api/Azure.Communication.CallingServer.netstandard2.0.cs
@@ -33,7 +33,7 @@ namespace Azure.Communication.CallingServer
     {
         internal AnswerCallResult() { }
         public Azure.Communication.CallingServer.CallConnection CallConnection { get { throw null; } }
-        public Azure.Communication.CallingServer.CallConnectionProperties CallProperties { get { throw null; } }
+        public Azure.Communication.CallingServer.CallConnectionProperties CallConnectionProperties { get { throw null; } }
     }
     public partial class CallAutomationClient
     {
@@ -73,14 +73,14 @@ namespace Azure.Communication.CallingServer
         public static Azure.Communication.CallingServer.AddParticipantsFailed AddParticipantsFailed(string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> participants = null, string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
         public static Azure.Communication.CallingServer.AddParticipantsResult AddParticipantsResult(System.Collections.Generic.IEnumerable<Azure.Communication.CallingServer.CallParticipant> participants = null, string operationContext = null) { throw null; }
         public static Azure.Communication.CallingServer.AddParticipantsSucceeded AddParticipantsSucceeded(string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> participants = null, string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
-        public static Azure.Communication.CallingServer.AnswerCallResult AnswerCallResult(Azure.Communication.CallingServer.CallConnection callConnection = null, Azure.Communication.CallingServer.CallConnectionProperties callProperties = null) { throw null; }
+        public static Azure.Communication.CallingServer.AnswerCallResult AnswerCallResult(Azure.Communication.CallingServer.CallConnection callConnection = null, Azure.Communication.CallingServer.CallConnectionProperties callConnectionProperties = null) { throw null; }
         public static Azure.Communication.CallingServer.CallConnected CallConnected(string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
         public static Azure.Communication.CallingServer.CallConnectionProperties CallConnectionProperties(string callConnectionId = null, string serverCallId = null, Azure.Communication.CallingServer.CallSource callSource = null, System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> targets = null, Azure.Communication.CallingServer.CallConnectionState callConnectionState = default(Azure.Communication.CallingServer.CallConnectionState), string subject = null, System.Uri callbackEndpoint = null) { throw null; }
         public static Azure.Communication.CallingServer.CallDisconnected CallDisconnected(string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
         public static Azure.Communication.CallingServer.CallParticipant CallParticipant(Azure.Communication.CommunicationIdentifier identifier = null, bool isMuted = false) { throw null; }
         public static Azure.Communication.CallingServer.CallTransferAccepted CallTransferAccepted(string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
         public static Azure.Communication.CallingServer.CallTransferFailed CallTransferFailed(string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
-        public static Azure.Communication.CallingServer.CreateCallResult CreateCallResult(Azure.Communication.CallingServer.CallConnection callConnection = null, Azure.Communication.CallingServer.CallConnectionProperties callProperties = null) { throw null; }
+        public static Azure.Communication.CallingServer.CreateCallResult CreateCallResult(Azure.Communication.CallingServer.CallConnection callConnection = null, Azure.Communication.CallingServer.CallConnectionProperties callConnectionProperties = null) { throw null; }
         public static Azure.Communication.CallingServer.ParticipantsUpdated ParticipantsUpdated(System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> participants = null, string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
         public static Azure.Communication.CallingServer.RecordingStatusResult RecordingStatusResult(string recordingId = null, Azure.Communication.CallingServer.RecordingStatus? recordingStatus = default(Azure.Communication.CallingServer.RecordingStatus?)) { throw null; }
         public static Azure.Communication.CallingServer.RemoveParticipantsResult RemoveParticipantsResult(string operationContext = null) { throw null; }
@@ -98,13 +98,13 @@ namespace Azure.Communication.CallingServer
         public virtual string CallConnectionId { get { throw null; } }
         public virtual Azure.Response<Azure.Communication.CallingServer.AddParticipantsResult> AddParticipants(System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> participantsToAdd, Azure.Communication.CallingServer.AddParticipantsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Communication.CallingServer.AddParticipantsResult>> AddParticipantsAsync(System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> participantsToAdd, Azure.Communication.CallingServer.AddParticipantsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.Communication.CallingServer.CallConnectionProperties> GetCallConnectionProperties(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Communication.CallingServer.CallConnectionProperties>> GetCallConnectionPropertiesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Communication.CallingServer.CallMedia GetCallMedia() { throw null; }
         public virtual Azure.Response<Azure.Communication.CallingServer.CallParticipant> GetParticipant(string participantMri, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Communication.CallingServer.CallParticipant>> GetParticipantAsync(string participantMri, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<System.Collections.Generic.IReadOnlyList<Azure.Communication.CallingServer.CallParticipant>> GetParticipants(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<System.Collections.Generic.IReadOnlyList<Azure.Communication.CallingServer.CallParticipant>>> GetParticipantsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.Communication.CallingServer.CallConnectionProperties> GetProperties(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Communication.CallingServer.CallConnectionProperties>> GetPropertiesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response HangUp(bool forEveryone, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> HangUpAsync(bool forEveryone, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Communication.CallingServer.RemoveParticipantsResult> RemoveParticipants(System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> participantsToRemove, Azure.Communication.CallingServer.RemoveParticipantsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -271,7 +271,7 @@ namespace Azure.Communication.CallingServer
     {
         internal CreateCallResult() { }
         public Azure.Communication.CallingServer.CallConnection CallConnection { get { throw null; } }
-        public Azure.Communication.CallingServer.CallConnectionProperties CallProperties { get { throw null; } }
+        public Azure.Communication.CallingServer.CallConnectionProperties CallConnectionProperties { get { throw null; } }
     }
     public static partial class EventParser
     {

--- a/sdk/communication/Azure.Communication.CallingServer/samples/Sample1_CreateCall.md
+++ b/sdk/communication/Azure.Communication.CallingServer/samples/Sample1_CreateCall.md
@@ -28,7 +28,7 @@ CreateCallResult createCallResult = callAutomationClient.CreateCall(
     targets: new List<CommunicationIdentifier>() { new PhoneNumberIdentifier("<targets-phone-number>") }, // E.164 formatted recipient phone number
     callbackEndpoint: new Uri(TestEnvironment.AppCallbackUrl)
     );
-Console.WriteLine($"Call connection id: {createCallResult.CallProperties.CallConnectionId}");
+Console.WriteLine($"Call connection id: {createCallResult.CallConnectionProperties.CallConnectionId}");
 ```
 
 To see the full example source files, see:

--- a/sdk/communication/Azure.Communication.CallingServer/samples/Sample1_CreateCallAsync.md
+++ b/sdk/communication/Azure.Communication.CallingServer/samples/Sample1_CreateCallAsync.md
@@ -28,7 +28,7 @@ CreateCallResult createCallResult = await callAutomationClient.CreateCallAsync(
     targets: new List<CommunicationIdentifier>() { new PhoneNumberIdentifier("<targets-phone-number>") }, // E.164 formatted recipient phone number
     callbackEndpoint: new Uri(TestEnvironment.AppCallbackUrl)
     );
-Console.WriteLine($"Call connection id: {createCallResult.CallProperties.CallConnectionId}");
+Console.WriteLine($"Call connection id: {createCallResult.CallConnectionProperties.CallConnectionId}");
 ```
 
 To see the full example source files, see:

--- a/sdk/communication/Azure.Communication.CallingServer/src/CallConnection.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/CallConnection.cs
@@ -43,9 +43,9 @@ namespace Azure.Communication.CallingServer
 
         /// <summary> Get various properties of the call. <see cref="CallConnectionProperties"/>.</summary>
         /// <param name="cancellationToken"> The cancellation token. </param>
-        public virtual async Task<Response<CallConnectionProperties>> GetPropertiesAsync(CancellationToken cancellationToken = default)
+        public virtual async Task<Response<CallConnectionProperties>> GetCallConnectionPropertiesAsync(CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(CallAutomationClient)}.{nameof(GetProperties)}");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(CallAutomationClient)}.{nameof(GetCallConnectionProperties)}");
             scope.Start();
             try
             {
@@ -64,9 +64,9 @@ namespace Azure.Communication.CallingServer
 
         /// <summary> Get various properties of a ongoing call. <see cref="CallConnectionProperties"/>.</summary>
         /// <param name="cancellationToken"> The cancellation token. </param>
-        public virtual Response<CallConnectionProperties> GetProperties(CancellationToken cancellationToken = default)
+        public virtual Response<CallConnectionProperties> GetCallConnectionProperties(CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(CallAutomationClient)}.{nameof(GetProperties)}");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(CallAutomationClient)}.{nameof(GetCallConnectionProperties)}");
             scope.Start();
             try
             {

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/AnswerCallResult.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/AnswerCallResult.cs
@@ -6,16 +6,16 @@ namespace Azure.Communication.CallingServer
     /// <summary> The result from creating a call. </summary>
     public class AnswerCallResult
     {
-        internal AnswerCallResult(CallConnection callConnection, CallConnectionProperties callProperties)
+        internal AnswerCallResult(CallConnection callConnection, CallConnectionProperties callConnectionProperties)
         {
             CallConnection = callConnection;
-            CallProperties = callProperties;
+            CallConnectionProperties = callConnectionProperties;
         }
 
         /// <summary> CallConnection instance. </summary>
         public CallConnection CallConnection { get; }
 
         /// <summary> Properties of the call. </summary>
-        public CallConnectionProperties CallProperties { get; }
+        public CallConnectionProperties CallConnectionProperties { get; }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/CallAutomationModelFactory.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/CallAutomationModelFactory.cs
@@ -24,11 +24,11 @@ namespace Azure.Communication.CallingServer
 
         /// <summary> Initializes a new instance of AnswerCallResult. </summary>
         /// <param name="callConnection"> CallConnection Client. </param>
-        /// <param name="callProperties"> Properties of the call. </param>
+        /// <param name="callConnectionProperties"> Properties of the call. </param>
         /// <returns> A new <see cref="CallingServer.AnswerCallResult"/> instance for mocking. </returns>
-        public static AnswerCallResult AnswerCallResult(CallConnection callConnection = default, CallConnectionProperties callProperties = default)
+        public static AnswerCallResult AnswerCallResult(CallConnection callConnection = default, CallConnectionProperties callConnectionProperties = default)
         {
-            return new AnswerCallResult(callConnection, callProperties);
+            return new AnswerCallResult(callConnection, callConnectionProperties);
         }
 
         /// <summary> Initializes a new instance of CallConnectionProperties. </summary>
@@ -56,11 +56,11 @@ namespace Azure.Communication.CallingServer
 
         /// <summary> Initializes a new instance of CallParticipant. </summary>
         /// <param name="callConnection">The instance of callConnection.</param>
-        /// <param name="callProperties">The properties of the call.</param>
+        /// <param name="callConnectionProperties">The properties of the call.</param>
         /// <returns> A new <see cref="CallingServer.CreateCallResult"/> instance for mocking. </returns>
-        public static CreateCallResult CreateCallResult(CallConnection callConnection = default, CallConnectionProperties callProperties = default)
+        public static CreateCallResult CreateCallResult(CallConnection callConnection = default, CallConnectionProperties callConnectionProperties = default)
         {
-            return new CreateCallResult(callConnection, callProperties);
+            return new CreateCallResult(callConnection, callConnectionProperties);
         }
 
         /// <summary>

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/CreateCallResult.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/CreateCallResult.cs
@@ -6,16 +6,16 @@ namespace Azure.Communication.CallingServer
     /// <summary> The result from creating a call. </summary>
     public class CreateCallResult
     {
-        internal CreateCallResult(CallConnection callConnection, CallConnectionProperties callProperties)
+        internal CreateCallResult(CallConnection callConnection, CallConnectionProperties callConnectionProperties)
         {
             CallConnection = callConnection;
-            CallProperties = callProperties;
+            CallConnectionProperties = callConnectionProperties;
         }
 
         /// <summary> CallConnection instance. </summary>
         public CallConnection CallConnection { get; }
 
         /// <summary> Properties of the call. </summary>
-        public CallConnectionProperties CallProperties { get; }
+        public CallConnectionProperties CallConnectionProperties { get; }
     }
 }


### PR DESCRIPTION
- Changing names to callconnectionproperties for all names to avoid confusion

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
