### PR TITLE
Enable the test splitting for core

### DIFF
--- a/eng/pipelines/templates/steps/dependency.tests.yml
+++ b/eng/pipelines/templates/steps/dependency.tests.yml
@@ -24,6 +24,7 @@ parameters:
   type: string
   default: 'not-specific'
 steps:
+  - template: /eng/pipelines/templates/steps/install-dotnet.yml
   - pwsh: |
       dotnet build /t:ProjectDependsOn ./eng/service.proj `
         /p:TestDependsOnDependency="${{parameters.TestDependsOnDependency}}" `

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -56,3 +56,4 @@ extends:
     TestSetupSteps:
     - template: /sdk/storage/tests-install-azurite.yml
     TestTimeoutInMinutes: 100
+    TestDependsOnDependency: Azure.Core

--- a/sdk/core/tests.yml
+++ b/sdk/core/tests.yml
@@ -4,4 +4,3 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: core
-    TestDependsOnDependency: Azure.Core


### PR DESCRIPTION
# Contributing to the Azure SDK
The PR is to enable the test splitting feature for core. We add sdk install step to rely on a stable msbuild engine version. Also, removed the extra parameters from live tests.

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
