### PR TITLE
Add attach statsbeat dimensions

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SdkVersionUtils.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SdkVersionUtils.cs
@@ -33,7 +33,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             }
         }
 
-        private static string GetVersion(Type type)
+        internal static string GetVersion(Type type)
         {
             try
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
@@ -26,7 +26,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         internal static string s_runtimeVersion => SdkVersionUtils.GetVersion(typeof(object));
 
-        internal static string s_sdkVersion = SdkVersionUtils.GetVersion(typeof(AzureMonitorTraceExporter));
+        internal static string s_sdkVersion => SdkVersionUtils.GetVersion(typeof(AzureMonitorTraceExporter));
 
         static Statsbeat()
         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
@@ -61,12 +61,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             {
                 SetResourceProviderDetails();
             }
-            else if (s_resourceProviderId == "vm")
-            {
-                // Query again as Id might have been updated.
-                VmMetadataResponse vmMetadata = GetVmMetadataResponse();
-                s_resourceProviderId = vmMetadata.vmId + "/"  + vmMetadata.subscriptionId;
-            }
 
             // TODO: Add os to the list
             return

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
@@ -16,6 +16,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         private const string StatsBeat_ConnectionString = "<StatsBeat_ConnectionString>";
 
+        private const string AMS_Uri = "http://169.254.169.254/metadata/instance/compute";
+
+        private const string AMS_Version = "api-version=2017-08-01";
+
+        private const string AMS_Format = "format=json";
+
         internal const int AttachStatsBeatInterval = 86400000;
 
         internal static string s_resourceProviderId;
@@ -81,8 +87,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 using (var httpClient = new HttpClient())
                 {
                     httpClient.DefaultRequestHeaders.Add("Metadata", "True");
-                    var responseString = httpClient.GetStringAsync("http://169.254.169.254/metadata/instance/compute?api-version=2017-08-01&format=json");
-
+                    var requestUri = AMS_Uri + "?" + AMS_Version + "&" + AMS_Format;
+                    var responseString = httpClient.GetStringAsync(requestUri);
                     var vmMetadata = JsonSerializer.Deserialize<VmMetadataResponse>(responseString.Result);
 
                     return vmMetadata;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
@@ -64,6 +64,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
             // TODO: Add os to the list
             return
+                new Measurement<int>(1,
+                     new("rp", s_resourceProvider),
+                      new("rpId", s_resourceProviderId),
+                      new("attach", "sdk"),
+                      new("cikey", Customer_Ikey),
+                      new("runtimeVersion", s_runtimeVersion),
+                      new("language", "dotnet"),
+                      new("version", s_sdkVersion));
                 new(1,
                 new("rp", s_resourceProvider),
                 new("rpId", s_resourceProviderId),

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
@@ -20,15 +20,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         internal const int AttachStatsBeatInterval = 86400000;
 
-        internal static string s_resourceProviderId;
+        private static string s_resourceProviderId;
 
-        internal static string s_resourceProvider;
+        private static string s_resourceProvider;
 
-        internal static string s_operatingSystem;
+        private static string s_runtimeVersion => SdkVersionUtils.GetVersion(typeof(object));
 
-        internal static string s_runtimeVersion => SdkVersionUtils.GetVersion(typeof(object));
-
-        internal static string s_sdkVersion => SdkVersionUtils.GetVersion(typeof(AzureMonitorTraceExporter));
+        private static string s_sdkVersion => SdkVersionUtils.GetVersion(typeof(AzureMonitorTraceExporter));
 
         static Statsbeat()
         {
@@ -83,8 +81,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     return vmMetadata;
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                AzureMonitorExporterEventSource.Log.WriteWarning("Failed to get VM metadata details", ex);
                 return null;
             }
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
@@ -88,7 +88,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     return vmMetadata;
                 }
             }
-            catch (Exception)
+            catch
             {
                 return null;
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
@@ -24,7 +24,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         internal static string s_operatingSystem;
 
-        internal static string s_runtimeVersion = SdkVersionUtils.GetVersion(typeof(object));
+        internal static string s_runtimeVersion => SdkVersionUtils.GetVersion(typeof(object));
 
         internal static string s_sdkVersion = SdkVersionUtils.GetVersion(typeof(AzureMonitorTraceExporter));
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
@@ -16,11 +16,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         private const string StatsBeat_ConnectionString = "<StatsBeat_ConnectionString>";
 
-        private const string AMS_Uri = "http://169.254.169.254/metadata/instance/compute";
-
-        private const string AMS_Version = "api-version=2017-08-01";
-
-        private const string AMS_Format = "format=json";
+        private const string AMS_Url = "http://169.254.169.254/metadata/instance/compute?api-version=2017-08-01&format=json";
 
         internal const int AttachStatsBeatInterval = 86400000;
 
@@ -65,13 +61,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             // TODO: Add os to the list
             return
                 new Measurement<int>(1,
-                new("rp", s_resourceProvider),
-                new("rpId", s_resourceProviderId),
-                new("attach", "sdk"),
-                new("cikey", Customer_Ikey),
-                new("runtimeVersion", s_runtimeVersion),
-                new("language", "dotnet"),
-                new("version", s_sdkVersion));
+                    new("rp", s_resourceProvider),
+                    new("rpId", s_resourceProviderId),
+                    new("attach", "sdk"),
+                    new("cikey", Customer_Ikey),
+                    new("runtimeVersion", s_runtimeVersion),
+                    new("language", "dotnet"),
+                    new("version", s_sdkVersion));
         }
 
         private static VmMetadataResponse GetVmMetadataResponse()
@@ -81,8 +77,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 using (var httpClient = new HttpClient())
                 {
                     httpClient.DefaultRequestHeaders.Add("Metadata", "True");
-                    var requestUri = AMS_Uri + "?" + AMS_Version + "&" + AMS_Format;
-                    var responseString = httpClient.GetStringAsync(requestUri);
+                    var responseString = httpClient.GetStringAsync(AMS_Url);
                     var vmMetadata = JsonSerializer.Deserialize<VmMetadataResponse>(responseString.Result);
 
                     return vmMetadata;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
@@ -65,14 +65,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             // TODO: Add os to the list
             return
                 new Measurement<int>(1,
-                     new("rp", s_resourceProvider),
-                      new("rpId", s_resourceProviderId),
-                      new("attach", "sdk"),
-                      new("cikey", Customer_Ikey),
-                      new("runtimeVersion", s_runtimeVersion),
-                      new("language", "dotnet"),
-                      new("version", s_sdkVersion));
-                new(1,
                 new("rp", s_resourceProvider),
                 new("rpId", s_resourceProviderId),
                 new("attach", "sdk"),

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Diagnostics.Metrics;
+using System.Net.Http;
+using System.Text.Json;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 
@@ -14,6 +17,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         private const string StatsBeat_ConnectionString = "<StatsBeat_ConnectionString>";
 
         internal const int AttachStatsBeatInterval = 86400000;
+
+        internal static string s_resourceProviderId;
+
+        internal static string s_resourceProvider;
+
+        internal static string s_operatingSystem;
+
+        internal static string s_runtimeVersion = SdkVersionUtils.GetVersion(typeof(object));
+
+        internal static string s_sdkVersion = SdkVersionUtils.GetVersion(typeof(AzureMonitorTraceExporter));
 
         static Statsbeat()
         {
@@ -38,8 +51,86 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         private static Measurement<int> GetAttachStatsBeat()
         {
-            // TODO: Add additional properties required for statbeat
-            return new(1, new("cikey", Customer_Ikey), new("language", "dotnet"));
+            if (s_resourceProvider == null)
+            {
+                SetResourceProviderDetails();
+            }
+            else if (s_resourceProviderId == "vm")
+            {
+                // Query again as Id might have been updated.
+                VmMetadataResponse vmMetadata = GetVmMetadataResponse();
+                s_resourceProviderId = vmMetadata.vmId + "/"  + vmMetadata.subscriptionId;
+            }
+
+            // TODO: Add os to the list
+            return
+                new(1,
+                new("rp", s_resourceProvider),
+                new("rpId", s_resourceProviderId),
+                new("attach", "sdk"),
+                new("cikey", Customer_Ikey),
+                new("runtimeVersion", s_runtimeVersion),
+                new("language", "dotnet"),
+                new("version", s_sdkVersion));
+        }
+
+        private static VmMetadataResponse GetVmMetadataResponse()
+        {
+            try
+            {
+                using (var httpClient = new HttpClient())
+                {
+                    httpClient.DefaultRequestHeaders.Add("Metadata", "True");
+                    var responseString = httpClient.GetStringAsync("http://169.254.169.254/metadata/instance/compute?api-version=2017-08-01&format=json");
+
+                    var vmMetadata = JsonSerializer.Deserialize<VmMetadataResponse>(responseString.Result);
+
+                    return vmMetadata;
+                }
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        private static void SetResourceProviderDetails()
+        {
+            var appSvcWebsiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
+            if (appSvcWebsiteName != null)
+            {
+                s_resourceProvider = "appsvc";
+                s_resourceProviderId = appSvcWebsiteName;
+                var appSvcWebsiteHostName = Environment.GetEnvironmentVariable("WEBSITE_HOME_STAMPNAME");
+                if (!string.IsNullOrEmpty(appSvcWebsiteHostName))
+                {
+                    s_resourceProviderId += "/" + appSvcWebsiteHostName;
+                }
+
+                return;
+            }
+
+            var functionsWorkerRuntime = Environment.GetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME");
+            if (functionsWorkerRuntime != null)
+            {
+                s_resourceProvider = "functions";
+                s_resourceProviderId = Environment.GetEnvironmentVariable("WEBSITE_HOSTNAME");
+
+                return;
+            }
+
+            var vmMetadata = GetVmMetadataResponse();
+
+            if (vmMetadata != null)
+            {
+                s_resourceProvider = "vm";
+                s_resourceProviderId = s_resourceProviderId = vmMetadata.vmId + "/" + vmMetadata.subscriptionId;
+
+                return;
+            }
+
+            s_resourceProvider = "unknown";
+            s_resourceProviderId = "unknown";
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/VmMetadataResponse.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/VmMetadataResponse.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
+{
+    internal class VmMetadataResponse
+    {
+        public string osType { get; set; }
+
+        public string subscriptionId { get; set; }
+
+        public string vmId { get; set; }
+    }
+}


### PR DESCRIPTION
Additional dimensions for Attach Statsbeat

**rp**: the name of a resource provider, e.g., appsvc, vm, functions, aks, and unknown,
**rpId** : the unique identifier of the resource provider,
**attach**: codeless or sdk (only sdk supported for now)
**runtimeVersion**: runtime version of a specific platform.
**version**: version of the application insights SDK/Agent