### PR TITLE
make sure the `AsyncPageableInterceptor` could support polymorphism

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/Instrumentation/AsyncPageableInterceptor.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/Instrumentation/AsyncPageableInterceptor.cs
@@ -19,7 +19,7 @@ namespace Azure.Core.TestFramework
             _inner = inner;
         }
 
-        public T Current => _testBase.InstrumentClient(typeof(T), _inner.Current, new IInterceptor[] { new ManagementInterceptor(_testBase) }) as T;
+        public T Current => _testBase.InstrumentClient(_inner.Current.GetType(), _inner.Current, new IInterceptor[] { new ManagementInterceptor(_testBase) }) as T;
 
         public ValueTask<bool> MoveNextAsync()
         {


### PR DESCRIPTION
More background information here: https://github.com/Azure/autorest.csharp/issues/2562

Long story short:
Our test framework now always use a Proxy type inherits from its generic type parameter T, instead of its actual type. For instance, we have an operation in our client
```
public IAsyncEnumerable<Base> GetAll()
```
while actually the elements in this collection are the derived class type of `Base`, in our test case (say those are `A` and `B`), this snippet will fail:
```csharp
await foreach (var item in client.GetAll())
{
Assert.IsTrue(item is A || item is B); // this will fail because every item will be of type `BaseProxy : Base` instead of `AProxy : A` or `BProxy : B`
}
```

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
