### PR TITLE
[.NET] CTE tests are included in the pipelines test and samples run 

### DIFF
--- a/sdk/communication/Azure.Communication.Identity/tests/CommunicationIdentityClient/CommunicationIdentityClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.Identity/tests/CommunicationIdentityClient/CommunicationIdentityClientLiveTests.cs
@@ -143,10 +143,6 @@ namespace Azure.Communication.Identity.Tests
         [Test]
         public async Task GetTokenForTeamsUserWithValidParameters()
         {
-            if (TestEnvironment.ShouldIgnoreIdentityExchangeTokenTest) {
-                Assert.Ignore("Ignore exchange teams token test if flag is enabled.");
-            }
-
             CommunicationIdentityClient client = CreateClientWithConnectionString();
             Response<AccessToken> tokenResponse = await client.GetTokenForTeamsUserAsync(CTEOptions);
             Assert.IsNotNull(tokenResponse.Value);
@@ -219,11 +215,6 @@ namespace Azure.Communication.Identity.Tests
         [TestCase("invalid", TestName = "GetTokenForTeamsUserWithInvalidClientIdShouldThrow")]
         public async Task GetTokenForTeamsUserWithInvalidClientIdShouldThrow(string clientId)
         {
-            if (TestEnvironment.ShouldIgnoreIdentityExchangeTokenTest)
-            {
-                Assert.Ignore("Ignore exchange teams token test if flag is enabled.");
-            }
-
             try
             {
                 CommunicationIdentityClient client = CreateClientWithConnectionString();
@@ -242,11 +233,6 @@ namespace Azure.Communication.Identity.Tests
         [Test]
         public async Task GetTokenForTeamsUserWithWrongClientIdShouldThrow()
         {
-            if (TestEnvironment.ShouldIgnoreIdentityExchangeTokenTest)
-            {
-                Assert.Ignore("Ignore exchange teams token test if flag is enabled.");
-            }
-
             try
             {
                 CommunicationIdentityClient client = CreateClientWithConnectionString();
@@ -267,11 +253,6 @@ namespace Azure.Communication.Identity.Tests
         [TestCase("invalid", TestName = "GetTokenForTeamsUserWithInvalidUserObjectIdShouldThrow")]
         public async Task GetTokenForTeamsUserWithInvalidUserObjectIdShouldThrow(string userObjectId)
         {
-            if (TestEnvironment.ShouldIgnoreIdentityExchangeTokenTest)
-            {
-                Assert.Ignore("Ignore exchange teams token test if flag is enabled.");
-            }
-
             try
             {
                 CommunicationIdentityClient client = CreateClientWithConnectionString();
@@ -290,11 +271,6 @@ namespace Azure.Communication.Identity.Tests
         [Test]
         public async Task GetTokenForTeamsUserWithWrongUserObjectIdShouldThrow()
         {
-            if (TestEnvironment.ShouldIgnoreIdentityExchangeTokenTest)
-            {
-                Assert.Ignore("Ignore exchange teams token test if flag is enabled.");
-            }
-
             try
             {
                 CommunicationIdentityClient client = CreateClientWithConnectionString();

--- a/sdk/communication/Azure.Communication.Identity/tests/Infrastructure/CommunicationIdentityClientLiveTestBase.cs
+++ b/sdk/communication/Azure.Communication.Identity/tests/Infrastructure/CommunicationIdentityClientLiveTestBase.cs
@@ -62,7 +62,7 @@ namespace Azure.Communication.Identity.Tests
         protected async Task<GetTokenForTeamsUserOptions> CreateTeamsUserParams()
         {
             GetTokenForTeamsUserOptions options = new GetTokenForTeamsUserOptions("Sanitized", "Sanitized", "Sanitized");
-            if (!TestEnvironment.ShouldIgnoreIdentityExchangeTokenTest && Mode != RecordedTestMode.Playback)
+            if (Mode != RecordedTestMode.Playback)
             {
                 IPublicClientApplication publicClientApplication = PublicClientApplicationBuilder.Create(TestEnvironment.CommunicationM365AppId)
                                                     .WithAuthority(TestEnvironment.CommunicationM365AadAuthority + "/" + TestEnvironment.CommunicationM365AadTenant)

--- a/sdk/communication/Azure.Communication.Identity/tests/Infrastructure/CommunicationIdentityClientTestEnvironment.cs
+++ b/sdk/communication/Azure.Communication.Identity/tests/Infrastructure/CommunicationIdentityClientTestEnvironment.cs
@@ -14,7 +14,6 @@ namespace Azure.Communication.Identity.Tests
         public const string CommunicationM365AadTenantEnvironmentVariableName  = "COMMUNICATION_M365_AAD_TENANT";
         public const string CommunicationM365RedirectUriEnvironmentVariableName  = "COMMUNICATION_M365_REDIRECT_URI";
         public const string CommunicationExpiredTeamsTokenEnvironmentVariableName  = "COMMUNICATION_EXPIRED_TEAMS_TOKEN";
-        private const string SkipIntIdentityExchangeTokenTestEnvironmentVariableName = "SKIP_INT_IDENTITY_EXCHANGE_TOKEN_TEST";
 
         public string CommunicationMsalUsername => GetOptionalVariable(CommunicationMsalUsernameEnvironmentVariableName) ?? "Sanitized";
 
@@ -29,8 +28,5 @@ namespace Azure.Communication.Identity.Tests
         public string CommunicationM365RedirectUri => GetOptionalVariable(CommunicationM365RedirectUriEnvironmentVariableName) ?? "Sanitized";
 
         public string CommunicationExpiredTeamsToken => GetOptionalVariable(CommunicationExpiredTeamsTokenEnvironmentVariableName) ?? "Sanitized";
-
-        public string SkipIntIdentityExchangeTokenTest => GetOptionalVariable(SkipIntIdentityExchangeTokenTestEnvironmentVariableName) ?? "False";
-        public bool ShouldIgnoreIdentityExchangeTokenTest => bool.Parse(SkipIntIdentityExchangeTokenTest);
     }
 }

--- a/sdk/communication/Azure.Communication.Identity/tests/samples/Sample1_CommunicationIdentityClient.cs
+++ b/sdk/communication/Azure.Communication.Identity/tests/samples/Sample1_CommunicationIdentityClient.cs
@@ -154,11 +154,6 @@ namespace Azure.Communication.Identity.Samples
         [SyncOnly]
         public void GetTokenForTeamsUser()
         {
-            if (TestEnvironment.ShouldIgnoreIdentityExchangeTokenTest)
-            {
-                Assert.Ignore("Ignore exchange teams token test if flag is enabled.");
-            }
-
             var options = CreateTeamsUserParams().Result;
             var teamsUserAadToken = options.TeamsUserAadToken;
             var clientId = options.ClientId;
@@ -177,10 +172,6 @@ namespace Azure.Communication.Identity.Samples
         [AsyncOnly]
         public async Task GetTokenForTeamsUserAsync()
         {
-            if (TestEnvironment.ShouldIgnoreIdentityExchangeTokenTest) {
-                Assert.Ignore("Ignore exchange teams token test if flag is enabled.");
-            }
-
             var options = await CreateTeamsUserParams();
             var teamsUserAadToken = options.TeamsUserAadToken;
             var clientId = options.ClientId;


### PR DESCRIPTION
# Description
Got rid of the skipping CTE tests and samples configuration during pipeline run.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
