### PR TITLE
Update XML docs for ManagedIdentityCredential GetToken methods

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
@@ -86,7 +86,7 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains an <see cref="AccessToken"/> from the Managed Identity service if available. This method is called automatically by Azure SDK client libraries. You may call this method directly, but you must also handle token caching and token refreshing.
+        /// Obtains an <see cref="AccessToken"/> from the Managed Identity service, if available. This method is called automatically by Azure SDK client libraries, but you may call this method directly. Regardless of how it's called, tokens are cached and refreshed for you.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
@@ -97,7 +97,7 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains an <see cref="AccessToken"/> from the Managed Identity service if available. This method is called automatically by Azure SDK client libraries. You may call this method directly, but you must also handle token caching and token refreshing.
+        /// Obtains an <see cref="AccessToken"/> from the Managed Identity service, if available. This method is called automatically by Azure SDK client libraries, but you may call this method directly. Regardless of how it's called, tokens are cached and refreshed for you.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>

--- a/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
@@ -86,7 +86,7 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains an <see cref="AccessToken"/> from the Managed Identity service, if available. Acquired tokens are cached by the credential instance. Token lifetime and refreshing is handled automatically. Reuse credential instances, where possible, to optimize cache effectiveness.
+        /// Obtains an <see cref="AccessToken"/> from the Managed Identity service, if available. Acquired tokens are cached by the credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances to optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
@@ -97,7 +97,7 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains an <see cref="AccessToken"/> from the Managed Identity service, if available. Acquired tokens are cached by the credential instance. Token lifetime and refreshing is handled automatically. Reuse credential instances, where possible, to optimize cache effectiveness.
+        /// Obtains an <see cref="AccessToken"/> from the Managed Identity service, if available. Acquired tokens are cached by the credential instance. Token lifetime and refreshing is handled automatically. Where possible, reuse credential instances to optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>

--- a/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
@@ -86,7 +86,7 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains an <see cref="AccessToken"/> from the Managed Identity service, if available. This method is called automatically by Azure SDK client libraries, but you may call this method directly. Regardless of how it's called, tokens are cached and refreshed for you.
+        /// Obtains an <see cref="AccessToken"/> from the Managed Identity service, if available. Acquired tokens are cached by the credential instance. Token lifetime and refreshing is handled automatically. Reuse credential instances, where possible, to optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
@@ -97,7 +97,7 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Obtains an <see cref="AccessToken"/> from the Managed Identity service, if available. This method is called automatically by Azure SDK client libraries, but you may call this method directly. Regardless of how it's called, tokens are cached and refreshed for you.
+        /// Obtains an <see cref="AccessToken"/> from the Managed Identity service, if available. Acquired tokens are cached by the credential instance. Token lifetime and refreshing is handled automatically. Reuse credential instances, where possible, to optimize cache effectiveness.
         /// </summary>
         /// <param name="requestContext">The details of the authentication request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/30635

Now that the credential type has token caching, let's ensure the XML docs are accurate.