### PR TITLE
Remove two more resource manager triggers

### DIFF
--- a/sdk/eventhub/ci.mgmt.yml
+++ b/sdk/eventhub/ci.mgmt.yml
@@ -24,7 +24,6 @@ pr:
     - sdk/eventhub/ci.mgmt.yml
     - sdk/eventhub/service.projects
     - sdk/eventhub/Azure.ResourceManager.EventHubs
-    - sdk/resourcemanager/
     - sdk/network/
 
 extends:

--- a/sdk/servicebus/ci.mgmt.yml
+++ b/sdk/servicebus/ci.mgmt.yml
@@ -24,7 +24,6 @@ pr:
     - sdk/servicebus/ci.mgmt.yml
     - sdk/eventhub/service.projects
     - sdk/servicebus/Azure.ResourceManager.ServiceBus
-    - sdk/resourcemanager/
     - sdk/network/
 
 extends:


### PR DESCRIPTION
# Contributing to the Azure SDK
Based on the checks of PR here, we still missed two more places for resource manager triggers.
https://github.com/Azure/azure-sdk-for-net/pull/30676


Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
