### PR TITLE
Remove double-slash from default scope for non-public clouds

### DIFF
--- a/sdk/identity/Azure.Identity/src/AzureAuthorityHosts.cs
+++ b/sdk/identity/Azure.Identity/src/AzureAuthorityHosts.cs
@@ -50,13 +50,13 @@ namespace Azure.Identity
             {
                 case AzurePublicCloudHostUrl:
                     // The double slash is intentional for public cloud.
-                    return "https://management.core.windows.net//.default";
+                    return "https://management.azure.com//.default";
                 case AzureChinaHostUrl:
-                    return "https://management.core.chinacloudapi.cn/.default";
+                    return "https://management.chinacloudapi.cn/.default";
                 case AzureGermanyHostUrl:
-                    return "https://management.core.cloudapi.de/.default";
+                    return "https://management.microsoftazure.de/.default";
                 case AzureGovernmentHostUrl:
-                    return "https://management.core.usgovcloudapi.net/.default";
+                    return "https://management.usgovcloudapi.net/.default";
                 default:
                     return null;
             }

--- a/sdk/identity/Azure.Identity/src/AzureAuthorityHosts.cs
+++ b/sdk/identity/Azure.Identity/src/AzureAuthorityHosts.cs
@@ -49,13 +49,14 @@ namespace Azure.Identity
             switch (authorityHost.AbsoluteUri)
             {
                 case AzurePublicCloudHostUrl:
+                    // The double slash is intentional for public cloud.
                     return "https://management.core.windows.net//.default";
                 case AzureChinaHostUrl:
-                    return "https://management.core.chinacloudapi.cn//.default";
+                    return "https://management.core.chinacloudapi.cn/.default";
                 case AzureGermanyHostUrl:
-                    return "https://management.core.cloudapi.de//.default";
+                    return "https://management.core.cloudapi.de/.default";
                 case AzureGovernmentHostUrl:
-                    return "https://management.core.usgovcloudapi.net//.default";
+                    return "https://management.core.usgovcloudapi.net/.default";
                 default:
                     return null;
             }


### PR DESCRIPTION
Fixes #29891