### PR TITLE
IsEnvironmentReady is better than static waits :)

### DIFF
--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerEnvironment.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerEnvironment.cs
@@ -2,7 +2,12 @@
 // Licensed under the MIT License.
 
 using System;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
 using Azure.Core.TestFramework;
+using Azure.Security.ConfidentialLedger.Certificate;
+using NUnit.Framework;
 
 namespace Azure.Security.ConfidentialLedger.Tests
 {
@@ -13,5 +18,28 @@ namespace Azure.Security.ConfidentialLedger.Tests
         public string ConfidentialLedgerAdminOid => GetRecordedVariable("CONFIDENTIALLEDGER_CLIENT_OBJECTID");
         public string ClientPEM => GetRecordedOptionalVariable("CONFIDENTIALLEDGER_CLIENT_PEM");
         public string ClientPEMPk => GetRecordedOptionalVariable("CONFIDENTIALLEDGER_CLIENT_PEM_PK");
+
+        protected override async ValueTask<bool> IsEnvironmentReadyAsync()
+        {
+            try
+            {
+                var IdentityClient = new ConfidentialLedgerCertificateClient(ConfidentialLedgerIdentityUrl);
+                var serviceCert = ConfidentialLedgerClient.GetIdentityServerTlsCert(ConfidentialLedgerUrl, new ConfidentialLedgerCertificateClientOptions(), IdentityClient);
+                var client = new ConfidentialLedgerClient(
+                       ConfidentialLedgerUrl,
+                       credential: Credential,
+                       clientCertificate: null,
+                       identityServiceCert: serviceCert.Cert);
+                var result = await client.GetEnclaveQuotesAsync(new());
+                var stringResult = new StreamReader(result.ContentStream).ReadToEnd();
+
+                return (int)HttpStatusCode.OK == result.Status;
+            }
+            catch (RequestFailedException ex)
+            {
+                Console.WriteLine($"IsEnvironmentReadyAsync: {ex.Message}");
+                return false;
+            }
+        }
     }
 }

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerEnvironment.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerEnvironment.cs
@@ -35,7 +35,7 @@ namespace Azure.Security.ConfidentialLedger.Tests
 
                 return (int)HttpStatusCode.OK == result.Status;
             }
-            catch (RequestFailedException ex)
+            catch (Exception ex)
             {
                 Console.WriteLine($"IsEnvironmentReadyAsync: {ex.Message}");
                 return false;

--- a/sdk/confidentialledger/test-resources-post.ps1
+++ b/sdk/confidentialledger/test-resources-post.ps1
@@ -1,3 +1,0 @@
-# Confidential Ledger resources can take a few minutes to resolve in DNS after being newly provisioned.
-Write-Host 'Waiting to let the new resource propagate to DNS'
-Start-Sleep -Seconds 360

--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -257,8 +257,8 @@ namespace Azure.Core.TestFramework
 
         private async Task WaitForEnvironmentInternalAsync()
         {
-            //if (GlobalIsRunningInCI)
-            //{
+            if (GlobalIsRunningInCI)
+            {
                 if (Mode == RecordedTestMode.Live)
                 {
                     int numberOfTries = 60;
@@ -277,11 +277,11 @@ namespace Azure.Core.TestFramework
                     throw new InvalidOperationException(
                         "The environment has not become ready, check your TestEnvironment.IsEnvironmentReady scenario.");
                 }
-            //}
-            //else
-            //{
-            //    await ExtendResourceGroupExpirationAsync();
-            //}
+            }
+            else
+            {
+                await ExtendResourceGroupExpirationAsync();
+            }
         }
 
         private async Task ExtendResourceGroupExpirationAsync()

--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -257,8 +257,8 @@ namespace Azure.Core.TestFramework
 
         private async Task WaitForEnvironmentInternalAsync()
         {
-            if (GlobalIsRunningInCI)
-            {
+            //if (GlobalIsRunningInCI)
+            //{
                 if (Mode == RecordedTestMode.Live)
                 {
                     int numberOfTries = 60;
@@ -277,11 +277,11 @@ namespace Azure.Core.TestFramework
                     throw new InvalidOperationException(
                         "The environment has not become ready, check your TestEnvironment.IsEnvironmentReady scenario.");
                 }
-            }
-            else
-            {
-                await ExtendResourceGroupExpirationAsync();
-            }
+            //}
+            //else
+            //{
+            //    await ExtendResourceGroupExpirationAsync();
+            //}
         }
 
         private async Task ExtendResourceGroupExpirationAsync()


### PR DESCRIPTION
Even with fairly long static wait times, the live tests still fail sometimes. This is more robust (Josh was right 😄)