### PR TITLE
Stop defaulting region as it breaks UsGov/China resource deployments

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
@@ -606,10 +606,9 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 // start the host and wait for all messages to be processed
                 await host.StartAsync();
-                await TestHelpers.Await(() =>
-                {
-                    return DynamicConcurrencyTestJob.InvocationCount >= numMessages;
-                });
+                await TestHelpers.Await(
+                    () => DynamicConcurrencyTestJob.InvocationCount >= numMessages,
+                    timeout: 100 * 1000);
 
                 // ensure we've dynamically increased concurrency
                 concurrencyStatus = concurrencyManager.GetStatus(functionId);

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
@@ -88,10 +88,9 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 // start the host and wait for all messages to be processed
                 await host.StartAsync();
-                await TestHelpers.Await(() =>
-                {
-                    return DynamicConcurrencyTestJob.InvocationCount >= numMessages;
-                });
+                await TestHelpers.Await(
+                    () => DynamicConcurrencyTestJob.InvocationCount >= numMessages,
+                    timeout: 100 * 1000);
 
                 // ensure we've dynamically increased concurrency
                 // in the case of sessions, we should have at least increased

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -9,4 +9,3 @@ extends:
     TimeoutInMinutes: 240
     Clouds: 'Public,Canary'
     SupportedClouds: 'Public,UsGov,China,Canary'
-    Location: 'westus3'


### PR DESCRIPTION
We hardcoded the region to westus3 when the default was changed because we were seeing latency and flaky tests. This broke the weekly test pipelines since the default region doesn't get picked up for other clouds. Testing out removing the hardcoded westus3 to see if tests are stable.