### PR TITLE
Exclude CodeGenModelAttribute from API compat check

### DIFF
--- a/eng/ApiListing.exclude-attributes.txt
+++ b/eng/ApiListing.exclude-attributes.txt
@@ -4,5 +4,6 @@ T:System.Runtime.CompilerServices.CompilerGeneratedAttribute
 T:System.Runtime.CompilerServices.NullableContextAttribute
 T:System.Runtime.CompilerServices.NullableAttribute
 T:Azure.Core.CodeGenSuppressAttribute
+T:Azure.Core.CodeGenModelAttribute
 T:Azure.Core.CodeGenMemberAttribute
 T:Azure.Core.PropertyReferenceTypeAttribute


### PR DESCRIPTION
Other codegen attributes are in the list already