### PR TITLE
Release of the Azure.Communication.Common[1.2.0]

### DIFF
--- a/sdk/communication/Azure.Communication.Common/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.Common/CHANGELOG.md
@@ -1,17 +1,11 @@
 # Release History
 
-## 1.2.0 (Unreleased)
+## 1.2.0 (2022-09-01)
 
 ### Features Added
 
 - Added `string RawID { get; }` and `static CommunicationIdentifier FromRawId(string rawId)` to `CommunicationIdentifier` to translate between a `CommunicationIdentifier` and its underlying canonical rawId representation. Developers can now use the rawId as an encoded format for identifiers to store in their databases or as stable keys in general.
 - Always include `rawId` when serializing identifiers to wire format.
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 1.1.0 (2022-02-23)
 - Optimization added: When the proactive refreshing is enabled and the token refresher fails to provide a token that's not about to expire soon, the subsequent refresh attempts will be scheduled for when the token reaches half of its remaining lifetime until a token with long enough validity (>10 minutes) is obtained.


### PR DESCRIPTION
# Description
Azure.Communication.Common GA release - 1.2.0
- the rawId changes are going to be released

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
