### PR TITLE
[Extensions] DataProtection Storage version update

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -97,8 +97,8 @@
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.2.0" />
     <PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.2.0" />
     <PackageReference Update="Azure.Security.KeyVault.Certificates" Version="4.2.0" />
-    <PackageReference Update="Azure.Storage.Blobs" Version="12.12.0" />
-    <PackageReference Update="Azure.Storage.Queues" Version="12.10.0" />
+    <PackageReference Update="Azure.Storage.Blobs" Version="12.13.1" />
+    <PackageReference Update="Azure.Storage.Queues" Version="12.11.1" />
     <PackageReference Update="Azure.ResourceManager" Version="1.3.1" />
 
     <!-- Other approved packages -->
@@ -188,7 +188,7 @@
     <PackageReference Update="Azure.ResourceManager.Storage" Version="1.0.0-beta.11" />
     <PackageReference Update="Azure.Search.Documents" Version="11.2.0" />
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.2.0-beta.4" />
-    <PackageReference Update="Azure.Storage.Blobs" Version="12.12.0" />
+    <PackageReference Update="Azure.Storage.Blobs" Version="12.13.1" />
     <PackageReference Update="Azure.Storage.Files.DataLake" Version="12.8.0" />
     <PackageReference Update="BenchmarkDotNet" Version="0.13.1" />
     <PackageReference Update="Castle.Core" Version="4.4.0" />

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Release History
 
-## 1.3.0-beta.1 (Unreleased)
+## 1.2.2 (2022-09-06)
 
+### Other Changes
+
+- Updating the `Azure.Storage.Blobs` package to 12.13.1 to mitigate warnings for [CVE-2022-30187](https://github.com/advisories/GHSA-64x4-9hc6-r2h6).  Note that no vulnerability exists, as the feature under advisement is not used by the `Azure.Extensions.AspNetCore.DataProtection.Blobs` package.
 
 ## 1.2.1 (2021-05-14)
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/Azure.Extensions.AspNetCore.DataProtection.Blobs.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/Azure.Extensions.AspNetCore.DataProtection.Blobs.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Description>Microsoft Azure Blob storage support as key store (https://docs.microsoft.com/aspnet/core/security/data-protection/implementation/key-storage-providers).</Description>
     <PackageTags>aspnetcore;dataprotection;azure;blob;key store</PackageTags>
-    <Version>1.3.0-beta.1</Version>
+    <Version>1.2.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.2.1</ApiCompatVersion>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>


### PR DESCRIPTION
# Summary

The focus of these changes is to update the version of the `Azure.Storage.Blobs` library referenced to mitigate warnings for [CVE-2022-30187](https://github.com/advisories/GHSA-64x4-9hc6-r2h6).  Note that no vulnerability exists, as the feature under advisement is not in use.