### PR TITLE
[Bot Rules] Update Synapse contacts

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -2737,7 +2737,7 @@
           ],
           "mentionees": [
             "wonner",
-            "zesluo"
+            "yanjungao718"
           ]
         },
         {


### PR DESCRIPTION
# Summary

The focus of these changes is to update the contacts for Synapse to match the updates from #30899.