### PR TITLE
MR Auth: Adjust account domain in East US 2

### DIFF
--- a/sdk/mixedreality/Azure.MixedReality.Authentication/Azure.MixedReality.Authentication.sln
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/Azure.MixedReality.Authentication.sln
@@ -1,7 +1,7 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29709.97
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32825.248
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.MixedReality.Authentication", "src\Azure.MixedReality.Authentication.csproj", "{E33D09D9-D809-472C-82E6-6A26BDB86FC2}"
 EndProject

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/CHANGELOG.md
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- If the `eastus2.mixedreality.azure.com` account domain is provided, it will be changed to `mixedreality.azure.com` in
+  order to prevent AAD authentication issues. Other regions are unaffected.
+
 ### Other Changes
 
 ## 1.1.0 (2022-07-28)

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/shared/AuthenticationEndpoint.cs
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/shared/AuthenticationEndpoint.cs
@@ -10,6 +10,8 @@ namespace Azure.MixedReality.Authentication
 {
     internal static class AuthenticationEndpoint
     {
+        private const string EastUS2Prefix = "eastus2.";
+
         /// <summary>
         /// Constructs an authentication endpoint from a service domain.
         /// </summary>
@@ -18,6 +20,13 @@ namespace Azure.MixedReality.Authentication
         public static Uri ConstructFromDomain(string accountDomain)
         {
             Argument.AssertNotNullOrWhiteSpace(accountDomain, nameof(accountDomain));
+
+            if (accountDomain.StartsWith(EastUS2Prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                // The Mixed Reality STS instance in East US 2 prefers "sts.mixedreality.azure.com" over "sts.eastus2.mixedreality.azure.com".
+                // AAD authentication will not work using "sts.eastus2.mixedreality.azure.com".
+                accountDomain = accountDomain.Substring(EastUS2Prefix.Length);
+            }
 
             if (!Uri.TryCreate($"https://sts.{accountDomain}", UriKind.Absolute, out Uri? result))
             {

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/tests/Shared.Azure.MixedReality.Authentication.Tests/AuthenticationEndpointTests.cs
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/tests/Shared.Azure.MixedReality.Authentication.Tests/AuthenticationEndpointTests.cs
@@ -8,13 +8,14 @@ namespace Azure.MixedReality.Authentication.Tests
 {
     public class AuthenticationEndpointTests
     {
-        [Test]
-        public void ConstructFromDomain()
+        [TestCase("mixedreality.com", "sts.mixedreality.com")]
+        [TestCase("eastus2.mixedreality.com", "sts.mixedreality.com")]
+        [TestCase("westus2.mixedreality.com", "sts.westus2.mixedreality.com")]
+        public void ConstructFromDomain(string input, string expected)
         {
-            Uri expected = new Uri("https://sts.eastus2.mixedreality.com");
-            Uri actual = AuthenticationEndpoint.ConstructFromDomain("eastus2.mixedreality.com");
+            Uri actual = AuthenticationEndpoint.ConstructFromDomain(input);
 
-            Assert.AreEqual(expected, actual);
+            Assert.AreEqual(expected, actual.Host);
         }
 
         [Test]


### PR DESCRIPTION
- This library failed to account for the state of the regionless domain name in East US 2. If the `eastus2.mixedreality.azure.com` account domain is provided, it will be changed to `mixedreality.azure.com` in order to prevent AAD authentication issues. Other regions are unaffected.
- Updated solution file for VS 17.