### PR TITLE
MR Auth: Fix AAD authentication scope for 1.2.0

### DIFF
--- a/sdk/mixedreality/Azure.MixedReality.Authentication/CHANGELOG.md
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/CHANGELOG.md
@@ -1,17 +1,11 @@
 # Release History
 
-## 1.2.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.2.0 (2022-09-09)
 
 ### Bugs Fixed
 
 - Fixed an issue that prevented proper AAD authentication in regions other than East US 2 using the
   `mixedreality.azure.com` account domain.
-
-### Other Changes
 
 ## 1.1.0 (2022-07-28)
 

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/CHANGELOG.md
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Fixed an issue that prevented proper AAD authentication in regions other than East US 2 using the
+  `mixedreality.azure.com` account domain.
+
 ### Other Changes
 
 ## 1.1.0 (2022-07-28)

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/src/Azure.MixedReality.Authentication.csproj
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/src/Azure.MixedReality.Authentication.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>Microsoft Azure Mixed Reality STS Client</AssemblyTitle>
-    <Version>1.2.0-beta.1</Version>
+    <Version>1.2.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.1.0</ApiCompatVersion>
     <PackageTags>Azure MixedReality</PackageTags>

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/src/MixedRealityStsClient.cs
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/src/MixedRealityStsClient.cs
@@ -14,6 +14,12 @@ namespace Azure.MixedReality.Authentication
     /// </summary>
     public class MixedRealityStsClient
     {
+        /// <summary>
+        /// The token request scope.
+        /// See https://docs.microsoft.com/azure/spatial-anchors/concepts/authentication.
+        /// </summary>
+        private const string TokenRequestScope = "https://sts.mixedreality.azure.com//.default";
+
         private readonly ClientDiagnostics _clientDiagnostics;
 
         private readonly HttpPipeline _pipeline;
@@ -78,7 +84,7 @@ namespace Azure.MixedReality.Authentication
             AccountId = accountId;
             Endpoint = endpoint;
             _clientDiagnostics = new ClientDiagnostics(options);
-            _pipeline = HttpPipelineBuilder.Build(options, new BearerTokenAuthenticationPolicy(credential, GetDefaultScope(endpoint)));
+            _pipeline = HttpPipelineBuilder.Build(options, new BearerTokenAuthenticationPolicy(credential, TokenRequestScope));
             _restClient = new MixedRealityStsRestClient(_clientDiagnostics, _pipeline, endpoint, options.Version);
         }
 
@@ -147,8 +153,5 @@ namespace Azure.MixedReality.Authentication
                 throw;
             }
         }
-
-        private static string GetDefaultScope(Uri uri)
-            => $"{uri.GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped)}/.default";
     }
 }


### PR DESCRIPTION
Fixed an issue that prevented proper AAD authentication in regions other than East US 2 using the `mixedreality.azure.com` account domain.