### PR TITLE
[AzureMonitorExporter] fix Readme link to Demo project

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
@@ -35,7 +35,7 @@ This exporter sends traces to the configured Azure Monitor Resource using HTTPS.
 
 ## Examples
 
-Refer to [`DemoTrace.cs`](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing/DemoTrace.cs) for a complete demo.
+Refer to [`Program.cs`](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Program.cs) for a complete demo.
 
 ```csharp
 using Azure.Monitor.OpenTelemetry.Exporter;


### PR DESCRIPTION
Follow up to #31002

Demo project was renamed, which broke the link on our Readme.
See also: https://dev.azure.com/azure-sdk/public/_build/results?buildId=1842303&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=a880e989-7d1a-5c96-a41f-d540b383cc43