### PR TITLE
Change VM template link to point to main Azure repo azure-sdk-for-net

### DIFF
--- a/sdk/automanage/Azure.ResourceManager.Automanage/tests/AutomanageTestBase.cs
+++ b/sdk/automanage/Azure.ResourceManager.Automanage/tests/AutomanageTestBase.cs
@@ -5,7 +5,6 @@ using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Azure.Core;
-using Azure.Core.TestFramework;
 using Azure.ResourceManager.Automanage.Models;
 using Azure.ResourceManager.Compute;
 using Azure.ResourceManager.Resources;
@@ -121,8 +120,7 @@ namespace Azure.ResourceManager.Automanage.Tests
         {
             // get ARM template contents
             var httpClient = new HttpClient();
-            //string url = "https://raw.githubusercontent.com/Azure/azure-sdk-for-net/main/sdk/automanage/deploy-vm.json";
-            string url = "https://raw.githubusercontent.com/AndrewCS149/azure-sdk-for-net/andrsmith/automanageSDKTests/sdk/automanage/deploy-vm.json";
+            string url = "https://raw.githubusercontent.com/Azure/azure-sdk-for-net/main/sdk/automanage/deploy-vm.json";
             var templateContent = await httpClient.GetAsync(url).Result.Content.ReadAsStringAsync();
 
             var deploymentContent = new ArmDeploymentContent(new ArmDeploymentProperties(ArmDeploymentMode.Incremental)


### PR DESCRIPTION
- Change VM creation template link to point to main Azure azure-sdk-for-net repo instead of my fork. 