### PR TITLE
[AzureMonitorExporter] refactor exporter extensions

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
@@ -1,9 +1,5 @@
 namespace Azure.Monitor.OpenTelemetry.Exporter
 {
-    public static partial class AzureMonitorExporterHelperExtensions
-    {
-        public static OpenTelemetry.Trace.TracerProviderBuilder AddAzureMonitorTraceExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions> configure = null) { throw null; }
-    }
     public static partial class AzureMonitorExporterLoggingExtensions
     {
         public static OpenTelemetry.Logs.OpenTelemetryLoggerOptions AddAzureMonitorLogExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions loggerOptions, System.Action<Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions> configure = null) { throw null; }
@@ -23,6 +19,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         {
             V2020_09_15_Preview = 1,
         }
+    }
+    public static partial class AzureMonitorExporterTraceExtensions
+    {
+        public static OpenTelemetry.Trace.TracerProviderBuilder AddAzureMonitorTraceExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions> configure = null) { throw null; }
     }
     public partial class AzureMonitorTraceExporter : OpenTelemetry.BaseExporter<System.Diagnostics.Activity>
     {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterLoggingExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterLoggingExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage;
 using OpenTelemetry;
 using OpenTelemetry.Logs;
 
@@ -28,12 +27,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
             var options = new AzureMonitorExporterOptions();
             configure?.Invoke(options);
-
-            // TODO: Fallback to default location if location provided via options does not work.
-            if (!options.DisableOfflineStorage && options.StorageDirectory == null)
-            {
-                options.StorageDirectory = StorageHelper.GetDefaultStorageDirectory();
-            }
 
             return loggerOptions.AddProcessor(new BatchLogRecordExportProcessor(new AzureMonitorLogExporter(options)));
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterMetricExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterMetricExtensions.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage;
-using OpenTelemetry.Metrics;
 using System;
+using OpenTelemetry.Metrics;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter
 {
@@ -18,19 +17,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         /// <param name="builder"><see cref="MeterProviderBuilder"/> builder to use.</param>
         /// <param name="configure">Exporter configuration options.</param>
         /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The objects should not be disposed.")]
         public static MeterProviderBuilder AddAzureMonitorMetricExporter(this MeterProviderBuilder builder, Action<AzureMonitorExporterOptions> configure = null)
         {
-            var options = new AzureMonitorExporterOptions();
-            configure?.Invoke(options);
-
-            // TODO: Fallback to default location if location provided via options does not work.
-            if (!options.DisableOfflineStorage && options.StorageDirectory == null)
+            if (builder == null)
             {
-                options.StorageDirectory = StorageHelper.GetDefaultStorageDirectory();
+                throw new ArgumentNullException(nameof(builder));
             }
 
-            var exporter = new AzureMonitorMetricExporter(options);
+            var options = new AzureMonitorExporterOptions();
+            configure?.Invoke(options);
 
             return builder.AddReader(new PeriodicExportingMetricReader(new AzureMonitorMetricExporter(options))
             { TemporalityPreference = MetricReaderTemporalityPreference.Delta });

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterTraceExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterTraceExtensions.cs
@@ -1,18 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Monitor.OpenTelemetry.Exporter.Internals;
-using Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage;
+using System;
 using OpenTelemetry;
 using OpenTelemetry.Trace;
-using System;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter
 {
     /// <summary>
     /// Extension methods to simplify registering of Azure Monitor Trace Exporter.
     /// </summary>
-    public static class AzureMonitorExporterHelperExtensions
+    public static class AzureMonitorExporterTraceExtensions
     {
         /// <summary>
         /// Registers an Azure Monitor trace exporter that will receive <see cref="System.Diagnostics.Activity"/> instances.
@@ -29,12 +27,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
             var options = new AzureMonitorExporterOptions();
             configure?.Invoke(options);
-
-            // TODO: Fallback to default location if location provided via options does not work.
-            if (!options.DisableOfflineStorage && options.StorageDirectory == null)
-            {
-                options.StorageDirectory = StorageHelper.GetDefaultStorageDirectory();
-            }
 
             // TODO: provide a way to turn off statsbeat
             // Statsbeat.InitializeAttachStatsbeat(options.ConnectionString);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -43,7 +43,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             {
                 try
                 {
-                    _fileBlobProvider = new FileBlobProvider(options.StorageDirectory);
+                    if (options.StorageDirectory == null)
+                    {
+                        _fileBlobProvider = new FileBlobProvider(StorageHelper.GetDefaultStorageDirectory());
+                    }
+                    else
+                    {
+                        // TODO: Fallback to default location if location provided via options does not work.
+                        _fileBlobProvider = new FileBlobProvider(options.StorageDirectory);
+                    }
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
### Changes
- rename `AzureMonitorExporterHelperExtensions` to `AzureMonitorExporterTraceExtensions`. 
  This better matches the naming convention of the two other exporters.
  Note: this triggered an API change check
- cleanup `AzureMonitorExporterMetricExtensions`
  - remove extra Exporter initialization
  - remove unnecessary `System.Diagnostics.CodeAnalysis.SuppressMessage`
  - added null check for `builder`, matching convention of two other exporters.
- all three Extension classes
  - moved `StorageHelper.GetDefaultStorageDirectory()` to the `AzureMonitorTransmitter`, removing duplicate code
  - cleanup usings