### PR TITLE
Allow publishing to DevOps feed from mgmt pipeline

### DIFF
--- a/eng/pipelines/mgmt.yml
+++ b/eng/pipelines/mgmt.yml
@@ -6,7 +6,10 @@ resources:
       ref: refs/tags/azure-sdk-build-tools_20211215.1
 
 parameters: 
-- name: ShouldPublish
+- name: ShouldPublishToNuget
+  type: boolean
+  default: false
+- name: ShouldPublishToDevOps
   type: boolean
   default: false
 - name: Scope
@@ -201,10 +204,12 @@ stages:
       - template: /eng/pipelines/templates/jobs/ci.mgmt.yml
         parameters:
           Scope: ${{ parameters.Scope }}
-          ShouldPublish: ${{ parameters.ShouldPublish }}
+          ${{ if or(eq(parameters.ShouldPublishToNuget, 'true'), eq(parameters.ShouldPublishToDevOps, 'true')) }}:
+            ShouldPublish: true
 
       - ${{ if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal')) }}:
         - template: /eng/pipelines/templates/jobs/mgmt-release.yml
           parameters:
             DependsOn: Build
-            ShouldPublish: ${{ parameters.ShouldPublish }}
+            ShouldPublishToNuget: ${{ parameters.ShouldPublishToNuget }}
+            ShouldPublishToDevOps: ${{ parameters.ShouldPublishToDevOps }}

--- a/eng/pipelines/templates/jobs/mgmt-release.yml
+++ b/eng/pipelines/templates/jobs/mgmt-release.yml
@@ -8,7 +8,10 @@ parameters:
 - name: DependsOn
   type: string
   default: Build
-- name: ShouldPublish
+- name: ShouldPublishToNuget
+  type: boolean
+  default: false
+- name: ShouldPublishToDevOps
   type: boolean
   default: false
 
@@ -22,6 +25,7 @@ jobs:
   
     steps:
       - checkout: self
+
       - checkout: azure-sdk-build-tools
 
       - download: current
@@ -33,7 +37,8 @@ jobs:
           PackagesPath: '$(PIPELINE.WORKSPACE)/packages'
           BuildToolsPath: '${{ parameters.BuildToolsPath }}'
 
-      - ${{ if and(eq(parameters.ShouldPublish, 'true'), eq(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net')) }}:
+      - ${{ if and(eq(parameters.ShouldPublishToNuget, 'true'), eq(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net')) }}:
+
         - task: Powershell@2
           displayName: 'Verify Package Tags and Create Git Releases'
           inputs:
@@ -64,7 +69,7 @@ jobs:
           displayName: 'Use NuGet ${{ parameters.NugetVersion }}'
           inputs:
             versionSpec: ${{ parameters.NugetVersion }}
-
+        
         - task: NuGetCommand@2
           displayName: 'Publish to Nuget'
           inputs:
@@ -72,6 +77,27 @@ jobs:
             packagesToPush: '$(PIPELINE.WORKSPACE)/packages/**/*.nupkg;!$(PIPELINE.WORKSPACE)/packages/**/*.symbols.nupkg'
             nuGetFeedType: external
             publishFeedCredentials: Nuget.org
+      
+      - ${{ if eq(parameters.ShouldPublishToDevOps, 'true') }}:
+      
+        - pwsh: |
+            # For safety default to publishing to the private feed.
+            # Publish to https://dev.azure.com/azure-sdk/internal/_packaging?_a=feed&feed=azure-sdk-for-net-pr
+            $devopsFeedId = '590cfd2a-581c-4dcb-a12e-6568ce786175/fa8b2d77-74d9-48d7-bb96-badb2b9c6ca4'
+            if ('$(Build.Repository.Name)' -eq 'Azure/azure-sdk-for-net') {
+              # Publish to https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-net
+              $devopsFeedId = '29ec6040-b234-4e31-b139-33dc4287b756/fa8c16a3-dbe0-4de2-a297-03065ec1ba3f'
+            }
+            echo "##vso[task.setvariable variable=DevOpsFeedID]$devopsFeedId"
+            echo "Using DevopsFeedId = $devopsFeedId"
+          displayName: Setup DevOpsFeedId
+
+        - task: NuGetCommand@2
+          displayName: 'Publish to DevOps Feed'
+          inputs:
+            command: push
+            packagesToPush: '$(PIPELINE.WORKSPACE)/packages/**/*.nupkg;!$(PIPELINE.WORKSPACE)/packages/**/*.symbols.nupkg'
+            publishVstsFeed: $(DevOpsFeedID)
 
       - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
         parameters:


### PR DESCRIPTION
- Add step for publishing to DevOps feeds.
- Set separate options for publishing to Nuget vs DevOps
- should resolve https://github.com/Azure/azure-sdk-tools/issues/4006