### PR TITLE
[AzureMonitorExporter] storage updates

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -20,7 +20,8 @@
 * [Request and Dependency Success criteria will now be decided based on
   `Activity.Status`](https://github.com/Azure/azure-sdk-for-net/pull/31024)
 * [Changed `AzureMonitorTraceExporter` to internal](https://github.com/Azure/azure-sdk-for-net/pull/31067)
-* [Changed offline storage directory from "Microsoft\ApplicationInsights" to "Microsoft\AzureMonitor"](https://github.com/Azure/azure-sdk-for-net/pull/31073)
+* [Changed default offline storage directory from "Microsoft\ApplicationInsights" to "Microsoft\AzureMonitor"](https://github.com/Azure/azure-sdk-for-net/pull/31073).
+  Users may override the default location by setting `AzureMonitorExporterOptions.StorageDirectory`.
 
 ### Bugs Fixed
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -20,7 +20,7 @@
 * [Request and Dependency Success criteria will now be decided based on
   `Activity.Status`](https://github.com/Azure/azure-sdk-for-net/pull/31024)
 * [Changed `AzureMonitorTraceExporter` to internal](https://github.com/Azure/azure-sdk-for-net/pull/31067)
-* Changed offline storage directory from "Microsoft\ApplicationInsights" to "Microsoft\AzureMonitor".
+* [Changed offline storage directory from "Microsoft\ApplicationInsights" to "Microsoft\AzureMonitor"](https://github.com/Azure/azure-sdk-for-net/pull/31073)
 
 ### Bugs Fixed
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [Request and Dependency Success criteria will now be decided based on
   `Activity.Status`](https://github.com/Azure/azure-sdk-for-net/pull/31024)
 * [Changed `AzureMonitorTraceExporter` to internal](https://github.com/Azure/azure-sdk-for-net/pull/31067)
+* Changed offline storage directory from "Microsoft\ApplicationInsights" to "Microsoft\AzureMonitor".
 
 ### Bugs Fixed
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 * [Request and Dependency Success criteria will now be decided based on
   `Activity.Status`](https://github.com/Azure/azure-sdk-for-net/pull/31024)
+* [Changed `AzureMonitorTraceExporter` to internal](https://github.com/Azure/azure-sdk-for-net/pull/31067)
 
 ### Bugs Fixed
 


### PR DESCRIPTION
### Changes
- refactor `StorageHelper`. 
  - Removed multiple nested if statements
  - Changed `CreateTelemetryDirectory` method to `TryCreateTelemetryDirectory`
  - Simplified `IsWindowsOS` method
- changed directory name to "Microsoft\AzureMonitor` according to spec.
- updated Changelog since this is technically a breaking change