### PR TITLE
updated events

### DIFF
--- a/sdk/communication/Azure.Communication.CallingServer/README.md
+++ b/sdk/communication/Azure.Communication.CallingServer/README.md
@@ -75,7 +75,7 @@ Your app will receive mid-connection call back events via the callbackEndpoint y
             if (events != null)
             {
                 // Helper function to parse CloudEvent to a CallingServer event.
-                CallAutomationEventBase callBackEvent = EventParser.Parse(events.FirstOrDefault());
+                CallAutomationEventBase callBackEvent = CallAutomationEventParser.Parse(events.FirstOrDefault());
             
                 switch (callBackEvent)
                 {

--- a/sdk/communication/Azure.Communication.CallingServer/api/Azure.Communication.CallingServer.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/api/Azure.Communication.CallingServer.netstandard2.0.cs
@@ -3,12 +3,9 @@ namespace Azure.Communication.CallingServer
     public partial class AddParticipantsFailed : Azure.Communication.CallingServer.CallAutomationEventBase
     {
         internal AddParticipantsFailed() { }
-        public string EventSource { get { throw null; } }
-        public string OperationContext { get { throw null; } }
+        public override string OperationContext { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.Communication.CommunicationIdentifier> Participants { get { throw null; } }
-        public string PublicEventType { get { throw null; } }
-        public Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
-        public string Version { get { throw null; } }
+        public override Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
         public static Azure.Communication.CallingServer.AddParticipantsFailed Deserialize(string content) { throw null; }
     }
     public partial class AddParticipantsResult
@@ -20,12 +17,9 @@ namespace Azure.Communication.CallingServer
     public partial class AddParticipantsSucceeded : Azure.Communication.CallingServer.CallAutomationEventBase
     {
         internal AddParticipantsSucceeded() { }
-        public string EventSource { get { throw null; } }
-        public string OperationContext { get { throw null; } }
+        public override string OperationContext { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.Communication.CommunicationIdentifier> Participants { get { throw null; } }
-        public string PublicEventType { get { throw null; } }
-        public Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
-        public string Version { get { throw null; } }
+        public override Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
         public static Azure.Communication.CallingServer.AddParticipantsSucceeded Deserialize(string content) { throw null; }
     }
     public partial class AnswerCallOptions
@@ -76,11 +70,14 @@ namespace Azure.Communication.CallingServer
         protected CallAutomationEventBase() { }
         public string CallConnectionId { get { throw null; } }
         public string CorrelationId { get { throw null; } }
+        [System.Text.Json.Serialization.JsonIgnoreAttribute(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        public virtual string? OperationContext { get { throw null; } }
+        [System.Text.Json.Serialization.JsonIgnoreAttribute(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        public virtual Azure.Communication.CallingServer.ResultInformation? ResultInformation { get { throw null; } }
         public string ServerCallId { get { throw null; } }
     }
     public static partial class CallAutomationEventParser
     {
-        public const string EventPrefix = "Microsoft.Communication.";
         public static Azure.Communication.CallingServer.CallAutomationEventBase Parse(Azure.Messaging.CloudEvent cloudEvent) { throw null; }
         public static Azure.Communication.CallingServer.CallAutomationEventBase Parse(System.BinaryData json) { throw null; }
         public static Azure.Communication.CallingServer.CallAutomationEventBase Parse(string eventData, string eventType) { throw null; }
@@ -89,24 +86,24 @@ namespace Azure.Communication.CallingServer
     }
     public static partial class CallAutomationModelFactory
     {
-        public static Azure.Communication.CallingServer.AddParticipantsFailed AddParticipantsFailed(string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> participants = null, string version = null, string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
+        public static Azure.Communication.CallingServer.AddParticipantsFailed AddParticipantsFailed(string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> participants = null, string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
         public static Azure.Communication.CallingServer.AddParticipantsResult AddParticipantsResult(System.Collections.Generic.IEnumerable<Azure.Communication.CallingServer.CallParticipant> participants = null, string operationContext = null) { throw null; }
-        public static Azure.Communication.CallingServer.AddParticipantsSucceeded AddParticipantsSucceeded(string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> participants = null, string version = null, string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
+        public static Azure.Communication.CallingServer.AddParticipantsSucceeded AddParticipantsSucceeded(string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> participants = null, string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
         public static Azure.Communication.CallingServer.AnswerCallResult AnswerCallResult(Azure.Communication.CallingServer.CallConnection callConnection = null, Azure.Communication.CallingServer.CallConnectionProperties callConnectionProperties = null) { throw null; }
-        public static Azure.Communication.CallingServer.CallConnected CallConnected(string eventSource = null, string version = null, string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string publicEventType = null) { throw null; }
+        public static Azure.Communication.CallingServer.CallConnected CallConnected(string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
         public static Azure.Communication.CallingServer.CallConnectionProperties CallConnectionProperties(string callConnectionId = null, string serverCallId = null, Azure.Communication.CallingServer.CallSource callSource = null, System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> targets = null, Azure.Communication.CallingServer.CallConnectionState callConnectionState = default(Azure.Communication.CallingServer.CallConnectionState), string subject = null, System.Uri callbackEndpoint = null, string mediaSubscriptionId = null) { throw null; }
-        public static Azure.Communication.CallingServer.CallDisconnected CallDisconnected(string eventSource = null, string version = null, string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string publicEventType = null) { throw null; }
+        public static Azure.Communication.CallingServer.CallDisconnected CallDisconnected(string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
         public static Azure.Communication.CallingServer.CallParticipant CallParticipant(Azure.Communication.CommunicationIdentifier identifier = null, bool isMuted = false) { throw null; }
-        public static Azure.Communication.CallingServer.CallRecordingStateChanged CallRecordingStateChanged(string eventSource = null, string recordingId = null, Azure.Communication.CallingServer.RecordingState state = default(Azure.Communication.CallingServer.RecordingState), System.DateTimeOffset? startDateTime = default(System.DateTimeOffset?), string version = null, string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string publicEventType = null) { throw null; }
-        public static Azure.Communication.CallingServer.CallTransferAccepted CallTransferAccepted(string eventSource = null, string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, string version = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string publicEventType = null) { throw null; }
-        public static Azure.Communication.CallingServer.CallTransferFailed CallTransferFailed(string eventSource = null, string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, string version = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string publicEventType = null) { throw null; }
+        public static Azure.Communication.CallingServer.CallRecordingStateChanged CallRecordingStateChanged(string recordingId = null, Azure.Communication.CallingServer.RecordingState state = default(Azure.Communication.CallingServer.RecordingState), System.DateTimeOffset startDateTime = default(System.DateTimeOffset), string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
+        public static Azure.Communication.CallingServer.CallTransferAccepted CallTransferAccepted(string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
+        public static Azure.Communication.CallingServer.CallTransferFailed CallTransferFailed(string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
         public static Azure.Communication.CallingServer.CollectTonesResult CollectTonesResult(System.Collections.Generic.IEnumerable<Azure.Communication.CallingServer.DtmfTone> tones = null) { throw null; }
         public static Azure.Communication.CallingServer.CreateCallResult CreateCallResult(Azure.Communication.CallingServer.CallConnection callConnection = null, Azure.Communication.CallingServer.CallConnectionProperties callConnectionProperties = null) { throw null; }
-        public static Azure.Communication.CallingServer.ParticipantsUpdated ParticipantsUpdated(System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> participants = null, string version = null, string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
-        public static Azure.Communication.CallingServer.PlayCompleted PlayCompleted(string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, string version = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string publicEventType = null) { throw null; }
-        public static Azure.Communication.CallingServer.PlayFailed PlayFailed(string eventSource = null, string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, string version = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string publicEventType = null) { throw null; }
-        public static Azure.Communication.CallingServer.RecognizeCompleted RecognizeCompleted(string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, Azure.Communication.CallingServer.CallMediaRecognitionType recognitionType = default(Azure.Communication.CallingServer.CallMediaRecognitionType), Azure.Communication.CallingServer.CollectTonesResult collectTonesResult = null, string version = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string publicEventType = null) { throw null; }
-        public static Azure.Communication.CallingServer.RecognizeFailed RecognizeFailed(string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, string version = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string publicEventType = null) { throw null; }
+        public static Azure.Communication.CallingServer.ParticipantsUpdated ParticipantsUpdated(System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> participants = null, string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
+        public static Azure.Communication.CallingServer.PlayCompleted PlayCompleted(string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
+        public static Azure.Communication.CallingServer.PlayFailed PlayFailed(string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
+        public static Azure.Communication.CallingServer.RecognizeCompleted RecognizeCompleted(string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, Azure.Communication.CallingServer.CallMediaRecognitionType recognitionType = default(Azure.Communication.CallingServer.CallMediaRecognitionType), Azure.Communication.CallingServer.CollectTonesResult collectTonesResult = null, string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
+        public static Azure.Communication.CallingServer.RecognizeFailed RecognizeFailed(string operationContext = null, Azure.Communication.CallingServer.ResultInformation resultInformation = null, string callConnectionId = null, string serverCallId = null, string correlationId = null) { throw null; }
         public static Azure.Communication.CallingServer.RecordingStateResult RecordingStateResult(string recordingId = null, Azure.Communication.CallingServer.RecordingState? recordingState = default(Azure.Communication.CallingServer.RecordingState?)) { throw null; }
         public static Azure.Communication.CallingServer.RemoveParticipantsResult RemoveParticipantsResult(string operationContext = null) { throw null; }
         public static Azure.Communication.CallingServer.ResultInformation ResultInformation(int? code = default(int?), int? subCode = default(int?), string message = null) { throw null; }
@@ -115,11 +112,6 @@ namespace Azure.Communication.CallingServer
     public partial class CallConnected : Azure.Communication.CallingServer.CallAutomationEventBase
     {
         internal CallConnected() { }
-        public string EventSource { get { throw null; } }
-        public string OperationContext { get { throw null; } }
-        public string PublicEventType { get { throw null; } }
-        public Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
-        public string Version { get { throw null; } }
         public static Azure.Communication.CallingServer.CallConnected Deserialize(string content) { throw null; }
     }
     public partial class CallConnection
@@ -180,11 +172,6 @@ namespace Azure.Communication.CallingServer
     public partial class CallDisconnected : Azure.Communication.CallingServer.CallAutomationEventBase
     {
         internal CallDisconnected() { }
-        public string EventSource { get { throw null; } }
-        public string OperationContext { get { throw null; } }
-        public string PublicEventType { get { throw null; } }
-        public Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
-        public string Version { get { throw null; } }
         public static Azure.Communication.CallingServer.CallDisconnected Deserialize(string content) { throw null; }
     }
     public abstract partial class CallLocator : System.IEquatable<Azure.Communication.CallingServer.CallLocator>
@@ -274,14 +261,9 @@ namespace Azure.Communication.CallingServer
     public partial class CallRecordingStateChanged : Azure.Communication.CallingServer.CallAutomationEventBase
     {
         internal CallRecordingStateChanged() { }
-        public string EventSource { get { throw null; } }
-        public string OperationContext { get { throw null; } }
-        public string PublicEventType { get { throw null; } }
         public string RecordingId { get { throw null; } }
-        public Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
         public System.DateTimeOffset? StartDateTime { get { throw null; } }
         public Azure.Communication.CallingServer.RecordingState State { get { throw null; } set { } }
-        public string Version { get { throw null; } }
         public static Azure.Communication.CallingServer.CallRecordingStateChanged Deserialize(string content) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -312,21 +294,15 @@ namespace Azure.Communication.CallingServer
     public partial class CallTransferAccepted : Azure.Communication.CallingServer.CallAutomationEventBase
     {
         internal CallTransferAccepted() { }
-        public string EventSource { get { throw null; } }
-        public string OperationContext { get { throw null; } }
-        public string PublicEventType { get { throw null; } }
-        public Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
-        public string Version { get { throw null; } }
+        public override string OperationContext { get { throw null; } }
+        public override Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
         public static Azure.Communication.CallingServer.CallTransferAccepted Deserialize(string content) { throw null; }
     }
     public partial class CallTransferFailed : Azure.Communication.CallingServer.CallAutomationEventBase
     {
         internal CallTransferFailed() { }
-        public string EventSource { get { throw null; } }
-        public string OperationContext { get { throw null; } }
-        public string PublicEventType { get { throw null; } }
-        public Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
-        public string Version { get { throw null; } }
+        public override string OperationContext { get { throw null; } }
+        public override Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
         public static Azure.Communication.CallingServer.CallTransferFailed Deserialize(string content) { throw null; }
     }
     public partial class ChannelAffinity
@@ -526,31 +502,21 @@ namespace Azure.Communication.CallingServer
     public partial class ParticipantsUpdated : Azure.Communication.CallingServer.CallAutomationEventBase
     {
         internal ParticipantsUpdated() { }
-        public string EventSource { get { throw null; } }
-        public string OperationContext { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.Communication.CommunicationIdentifier> Participants { get { throw null; } }
-        public string PublicEventType { get { throw null; } }
-        public Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
-        public string Version { get { throw null; } }
         public static Azure.Communication.CallingServer.ParticipantsUpdated Deserialize(string content) { throw null; }
     }
     public partial class PlayCompleted : Azure.Communication.CallingServer.CallAutomationEventBase
     {
         internal PlayCompleted() { }
-        public string OperationContext { get { throw null; } }
-        public string PublicEventType { get { throw null; } }
-        public Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
-        public string Version { get { throw null; } }
+        public override string OperationContext { get { throw null; } }
+        public override Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
         public static Azure.Communication.CallingServer.PlayCompleted Deserialize(string content) { throw null; }
     }
     public partial class PlayFailed : Azure.Communication.CallingServer.CallAutomationEventBase
     {
         internal PlayFailed() { }
-        public string EventSource { get { throw null; } }
-        public string OperationContext { get { throw null; } }
-        public string PublicEventType { get { throw null; } }
-        public Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
-        public string Version { get { throw null; } }
+        public override string OperationContext { get { throw null; } }
+        public override Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
         public static Azure.Communication.CallingServer.PlayFailed Deserialize(string content) { throw null; }
     }
     public partial class PlayOptions
@@ -568,20 +534,16 @@ namespace Azure.Communication.CallingServer
     {
         internal RecognizeCompleted() { }
         public Azure.Communication.CallingServer.CollectTonesResult CollectTonesResult { get { throw null; } }
-        public string OperationContext { get { throw null; } }
-        public string PublicEventType { get { throw null; } }
-        public Azure.Communication.CallingServer.CallMediaRecognitionType RecognitionType { get { throw null; } set { } }
-        public Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
-        public string Version { get { throw null; } }
+        public override string OperationContext { get { throw null; } }
+        public Azure.Communication.CallingServer.CallMediaRecognitionType RecognitionType { get { throw null; } }
+        public override Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
         public static Azure.Communication.CallingServer.RecognizeCompleted Deserialize(string content) { throw null; }
     }
     public partial class RecognizeFailed : Azure.Communication.CallingServer.CallAutomationEventBase
     {
         internal RecognizeFailed() { }
-        public string OperationContext { get { throw null; } }
-        public string PublicEventType { get { throw null; } }
-        public Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
-        public string Version { get { throw null; } }
+        public override string OperationContext { get { throw null; } }
+        public override Azure.Communication.CallingServer.ResultInformation ResultInformation { get { throw null; } }
         public static Azure.Communication.CallingServer.RecognizeFailed Deserialize(string content) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/sdk/communication/Azure.Communication.CallingServer/src/Azure.Communication.CallingServer.csproj
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Azure.Communication.CallingServer.csproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Communication.Common" />
-    <PackageReference Include="System.Text.Json" VersionOverride="6.0.6" />
+    <PackageReference Include="System.Text.Json" VersionOverride="5.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Generated\" />

--- a/sdk/communication/Azure.Communication.CallingServer/src/Azure.Communication.CallingServer.csproj
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Azure.Communication.CallingServer.csproj
@@ -29,9 +29,12 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Communication.Common" />
-    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="System.Text.Json" VersionOverride="6.0.6" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Generated\" />
   </ItemGroup>
 </Project>
+
+
+

--- a/sdk/communication/Azure.Communication.CallingServer/src/Generated/CallAutomationModelFactory.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Generated/CallAutomationModelFactory.cs
@@ -5,7 +5,6 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -49,132 +48,6 @@ namespace Azure.Communication.CallingServer
             return new ResultInformation(code, subCode, message);
         }
 
-        /// <summary> Initializes a new instance of CallConnected. </summary>
-        /// <param name="eventSource"></param>
-        /// <param name="version"> Used to determine the version of the event. </param>
-        /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
-        /// <param name="resultInformation"> Contains the resulting SIP code/sub-code and message from NGC services. </param>
-        /// <param name="callConnectionId"> Call connection ID. </param>
-        /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
-        /// <param name="publicEventType"> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </param>
-        /// <returns> A new <see cref="CallingServer.CallConnected"/> instance for mocking. </returns>
-        public static CallConnected CallConnected(string eventSource = null, string version = null, string operationContext = null, ResultInformation resultInformation = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string publicEventType = null)
-        {
-            return new CallConnected(eventSource, version, operationContext, resultInformation, callConnectionId, serverCallId, correlationId, publicEventType);
-        }
-
-        /// <summary> Initializes a new instance of CallDisconnected. </summary>
-        /// <param name="eventSource"></param>
-        /// <param name="version"> Used to determine the version of the event. </param>
-        /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
-        /// <param name="resultInformation"> Contains the resulting SIP code/sub-code and message from NGC services. </param>
-        /// <param name="callConnectionId"> Call connection ID. </param>
-        /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
-        /// <param name="publicEventType"> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </param>
-        /// <returns> A new <see cref="CallingServer.CallDisconnected"/> instance for mocking. </returns>
-        public static CallDisconnected CallDisconnected(string eventSource = null, string version = null, string operationContext = null, ResultInformation resultInformation = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string publicEventType = null)
-        {
-            return new CallDisconnected(eventSource, version, operationContext, resultInformation, callConnectionId, serverCallId, correlationId, publicEventType);
-        }
-
-        /// <summary> Initializes a new instance of CallTransferAccepted. </summary>
-        /// <param name="eventSource"></param>
-        /// <param name="operationContext"></param>
-        /// <param name="resultInformation"></param>
-        /// <param name="version"> Used to determine the version of the event. </param>
-        /// <param name="callConnectionId"> Call connection ID. </param>
-        /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
-        /// <param name="publicEventType"> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </param>
-        /// <returns> A new <see cref="CallingServer.CallTransferAccepted"/> instance for mocking. </returns>
-        public static CallTransferAccepted CallTransferAccepted(string eventSource = null, string operationContext = null, ResultInformation resultInformation = null, string version = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string publicEventType = null)
-        {
-            return new CallTransferAccepted(eventSource, operationContext, resultInformation, version, callConnectionId, serverCallId, correlationId, publicEventType);
-        }
-
-        /// <summary> Initializes a new instance of CallTransferFailed. </summary>
-        /// <param name="eventSource"></param>
-        /// <param name="operationContext"></param>
-        /// <param name="resultInformation"></param>
-        /// <param name="version"> Used to determine the version of the event. </param>
-        /// <param name="callConnectionId"> Call connection ID. </param>
-        /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
-        /// <param name="publicEventType"> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </param>
-        /// <returns> A new <see cref="CallingServer.CallTransferFailed"/> instance for mocking. </returns>
-        public static CallTransferFailed CallTransferFailed(string eventSource = null, string operationContext = null, ResultInformation resultInformation = null, string version = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string publicEventType = null)
-        {
-            return new CallTransferFailed(eventSource, operationContext, resultInformation, version, callConnectionId, serverCallId, correlationId, publicEventType);
-        }
-
-        /// <summary> Initializes a new instance of CallRecordingStateChanged. </summary>
-        /// <param name="eventSource"></param>
-        /// <param name="recordingId"> The call recording id. </param>
-        /// <param name="state"></param>
-        /// <param name="startDateTime"> The time of the recording started. </param>
-        /// <param name="version"> Used to determine the version of the event. </param>
-        /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
-        /// <param name="resultInformation"> Contains the resulting SIP code/sub-code and message from NGC services. </param>
-        /// <param name="callConnectionId"> Call connection ID. </param>
-        /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
-        /// <param name="publicEventType"> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </param>
-        /// <returns> A new <see cref="CallingServer.CallRecordingStateChanged"/> instance for mocking. </returns>
-        public static CallRecordingStateChanged CallRecordingStateChanged(string eventSource = null, string recordingId = null, RecordingState state = default, DateTimeOffset? startDateTime = null, string version = null, string operationContext = null, ResultInformation resultInformation = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string publicEventType = null)
-        {
-            return new CallRecordingStateChanged(eventSource, recordingId, state, startDateTime, version, operationContext, resultInformation, callConnectionId, serverCallId, correlationId, publicEventType);
-        }
-
-        /// <summary> Initializes a new instance of PlayCompleted. </summary>
-        /// <param name="operationContext"></param>
-        /// <param name="resultInformation"></param>
-        /// <param name="version"> Used to determine the version of the event. </param>
-        /// <param name="callConnectionId"> Call connection ID. </param>
-        /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
-        /// <param name="publicEventType"> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </param>
-        /// <returns> A new <see cref="CallingServer.PlayCompleted"/> instance for mocking. </returns>
-        public static PlayCompleted PlayCompleted(string operationContext = null, ResultInformation resultInformation = null, string version = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string publicEventType = null)
-        {
-            return new PlayCompleted(operationContext, resultInformation, version, callConnectionId, serverCallId, correlationId, publicEventType);
-        }
-
-        /// <summary> Initializes a new instance of PlayFailed. </summary>
-        /// <param name="eventSource"></param>
-        /// <param name="operationContext"></param>
-        /// <param name="resultInformation"></param>
-        /// <param name="version"> Used to determine the version of the event. </param>
-        /// <param name="callConnectionId"> Call connection ID. </param>
-        /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
-        /// <param name="publicEventType"> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </param>
-        /// <returns> A new <see cref="CallingServer.PlayFailed"/> instance for mocking. </returns>
-        public static PlayFailed PlayFailed(string eventSource = null, string operationContext = null, ResultInformation resultInformation = null, string version = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string publicEventType = null)
-        {
-            return new PlayFailed(eventSource, operationContext, resultInformation, version, callConnectionId, serverCallId, correlationId, publicEventType);
-        }
-
-        /// <summary> Initializes a new instance of RecognizeCompleted. </summary>
-        /// <param name="operationContext"></param>
-        /// <param name="resultInformation"> Result information defines the code, subcode and message. </param>
-        /// <param name="recognitionType">
-        /// Determines the sub-type of the recognize operation.
-        /// In case of cancel operation the this field is not set and is returned empty
-        /// </param>
-        /// <param name="collectTonesResult"> Defines the result for RecognitionType = Dtmf. </param>
-        /// <param name="version"> Used to determine the version of the event. </param>
-        /// <param name="callConnectionId"> Call connection ID. </param>
-        /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
-        /// <param name="publicEventType"> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </param>
-        /// <returns> A new <see cref="CallingServer.RecognizeCompleted"/> instance for mocking. </returns>
-        public static RecognizeCompleted RecognizeCompleted(string operationContext = null, ResultInformation resultInformation = null, CallMediaRecognitionType recognitionType = default, CollectTonesResult collectTonesResult = null, string version = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string publicEventType = null)
-        {
-            return new RecognizeCompleted(operationContext, resultInformation, recognitionType, collectTonesResult, version, callConnectionId, serverCallId, correlationId, publicEventType);
-        }
-
         /// <summary> Initializes a new instance of CollectTonesResult. </summary>
         /// <param name="tones"></param>
         /// <returns> A new <see cref="CallingServer.CollectTonesResult"/> instance for mocking. </returns>
@@ -183,20 +56,6 @@ namespace Azure.Communication.CallingServer
             tones ??= new List<DtmfTone>();
 
             return new CollectTonesResult(tones?.ToList());
-        }
-
-        /// <summary> Initializes a new instance of RecognizeFailed. </summary>
-        /// <param name="operationContext"></param>
-        /// <param name="resultInformation"></param>
-        /// <param name="version"> Used to determine the version of the event. </param>
-        /// <param name="callConnectionId"> Call connection ID. </param>
-        /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
-        /// <param name="publicEventType"> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </param>
-        /// <returns> A new <see cref="CallingServer.RecognizeFailed"/> instance for mocking. </returns>
-        public static RecognizeFailed RecognizeFailed(string operationContext = null, ResultInformation resultInformation = null, string version = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string publicEventType = null)
-        {
-            return new RecognizeFailed(operationContext, resultInformation, version, callConnectionId, serverCallId, correlationId, publicEventType);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallConnectedInternal.Serialization.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallConnectedInternal.Serialization.cs
@@ -10,19 +10,30 @@ using Azure.Core;
 
 namespace Azure.Communication.CallingServer
 {
-    public partial class PlayCompleted
+    internal partial class CallConnectedInternal
     {
-        internal static PlayCompleted DeserializePlayCompleted(JsonElement element)
+        internal static CallConnectedInternal DeserializeCallConnectedInternal(JsonElement element)
         {
+            Optional<string> eventSource = default;
+            Optional<string> version = default;
             Optional<string> operationContext = default;
             Optional<ResultInformation> resultInformation = default;
-            Optional<string> version = default;
             Optional<string> callConnectionId = default;
             Optional<string> serverCallId = default;
             Optional<string> correlationId = default;
             Optional<string> publicEventType = default;
             foreach (var property in element.EnumerateObject())
             {
+                if (property.NameEquals("eventSource"))
+                {
+                    eventSource = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("version"))
+                {
+                    version = property.Value.GetString();
+                    continue;
+                }
                 if (property.NameEquals("operationContext"))
                 {
                     operationContext = property.Value.GetString();
@@ -36,11 +47,6 @@ namespace Azure.Communication.CallingServer
                         continue;
                     }
                     resultInformation = ResultInformation.DeserializeResultInformation(property.Value);
-                    continue;
-                }
-                if (property.NameEquals("version"))
-                {
-                    version = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("callConnectionId"))
@@ -64,7 +70,7 @@ namespace Azure.Communication.CallingServer
                     continue;
                 }
             }
-            return new PlayCompleted(operationContext.Value, resultInformation.Value, version.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, publicEventType.Value);
+            return new CallConnectedInternal(eventSource.Value, version.Value, operationContext.Value, resultInformation.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, publicEventType.Value);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallConnectedInternal.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallConnectedInternal.cs
@@ -7,15 +7,15 @@
 
 namespace Azure.Communication.CallingServer
 {
-    /// <summary> The CallDisconnectedEvent. </summary>
-    public partial class CallDisconnected
+    /// <summary> The CallConnectedEvent. </summary>
+    internal partial class CallConnectedInternal
     {
-        /// <summary> Initializes a new instance of CallDisconnected. </summary>
-        internal CallDisconnected()
+        /// <summary> Initializes a new instance of CallConnectedInternal. </summary>
+        internal CallConnectedInternal()
         {
         }
 
-        /// <summary> Initializes a new instance of CallDisconnected. </summary>
+        /// <summary> Initializes a new instance of CallConnectedInternal. </summary>
         /// <param name="eventSource"></param>
         /// <param name="version"> Used to determine the version of the event. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
@@ -24,7 +24,7 @@ namespace Azure.Communication.CallingServer
         /// <param name="serverCallId"> Server call ID. </param>
         /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
         /// <param name="publicEventType"> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </param>
-        internal CallDisconnected(string eventSource, string version, string operationContext, ResultInformation resultInformation, string callConnectionId, string serverCallId, string correlationId, string publicEventType)
+        internal CallConnectedInternal(string eventSource, string version, string operationContext, ResultInformation resultInformation, string callConnectionId, string serverCallId, string correlationId, string publicEventType)
         {
             EventSource = eventSource;
             Version = version;
@@ -44,6 +44,12 @@ namespace Azure.Communication.CallingServer
         public string OperationContext { get; }
         /// <summary> Contains the resulting SIP code/sub-code and message from NGC services. </summary>
         public ResultInformation ResultInformation { get; }
+        /// <summary> Call connection ID. </summary>
+        public string CallConnectionId { get; }
+        /// <summary> Server call ID. </summary>
+        public string ServerCallId { get; }
+        /// <summary> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </summary>
+        public string CorrelationId { get; }
         /// <summary> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </summary>
         public string PublicEventType { get; }
     }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallDisconnectedInternal.Serialization.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallDisconnectedInternal.Serialization.cs
@@ -10,14 +10,14 @@ using Azure.Core;
 
 namespace Azure.Communication.CallingServer
 {
-    public partial class CallTransferAccepted
+    internal partial class CallDisconnectedInternal
     {
-        internal static CallTransferAccepted DeserializeCallTransferAccepted(JsonElement element)
+        internal static CallDisconnectedInternal DeserializeCallDisconnectedInternal(JsonElement element)
         {
             Optional<string> eventSource = default;
+            Optional<string> version = default;
             Optional<string> operationContext = default;
             Optional<ResultInformation> resultInformation = default;
-            Optional<string> version = default;
             Optional<string> callConnectionId = default;
             Optional<string> serverCallId = default;
             Optional<string> correlationId = default;
@@ -27,6 +27,11 @@ namespace Azure.Communication.CallingServer
                 if (property.NameEquals("eventSource"))
                 {
                     eventSource = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("version"))
+                {
+                    version = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("operationContext"))
@@ -42,11 +47,6 @@ namespace Azure.Communication.CallingServer
                         continue;
                     }
                     resultInformation = ResultInformation.DeserializeResultInformation(property.Value);
-                    continue;
-                }
-                if (property.NameEquals("version"))
-                {
-                    version = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("callConnectionId"))
@@ -70,7 +70,7 @@ namespace Azure.Communication.CallingServer
                     continue;
                 }
             }
-            return new CallTransferAccepted(eventSource.Value, operationContext.Value, resultInformation.Value, version.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, publicEventType.Value);
+            return new CallDisconnectedInternal(eventSource.Value, version.Value, operationContext.Value, resultInformation.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, publicEventType.Value);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallDisconnectedInternal.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallDisconnectedInternal.cs
@@ -5,23 +5,18 @@
 
 #nullable disable
 
-using System;
-
 namespace Azure.Communication.CallingServer
 {
-    /// <summary> The RecordingStateChangedEvent. </summary>
-    public partial class CallRecordingStateChanged
+    /// <summary> The CallDisconnectedEvent. </summary>
+    internal partial class CallDisconnectedInternal
     {
-        /// <summary> Initializes a new instance of CallRecordingStateChanged. </summary>
-        internal CallRecordingStateChanged()
+        /// <summary> Initializes a new instance of CallDisconnectedInternal. </summary>
+        internal CallDisconnectedInternal()
         {
         }
 
-        /// <summary> Initializes a new instance of CallRecordingStateChanged. </summary>
+        /// <summary> Initializes a new instance of CallDisconnectedInternal. </summary>
         /// <param name="eventSource"></param>
-        /// <param name="recordingId"> The call recording id. </param>
-        /// <param name="state"></param>
-        /// <param name="startDateTime"> The time of the recording started. </param>
         /// <param name="version"> Used to determine the version of the event. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
         /// <param name="resultInformation"> Contains the resulting SIP code/sub-code and message from NGC services. </param>
@@ -29,12 +24,9 @@ namespace Azure.Communication.CallingServer
         /// <param name="serverCallId"> Server call ID. </param>
         /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
         /// <param name="publicEventType"> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </param>
-        internal CallRecordingStateChanged(string eventSource, string recordingId, RecordingState state, DateTimeOffset? startDateTime, string version, string operationContext, ResultInformation resultInformation, string callConnectionId, string serverCallId, string correlationId, string publicEventType)
+        internal CallDisconnectedInternal(string eventSource, string version, string operationContext, ResultInformation resultInformation, string callConnectionId, string serverCallId, string correlationId, string publicEventType)
         {
             EventSource = eventSource;
-            RecordingId = recordingId;
-            State = state;
-            StartDateTime = startDateTime;
             Version = version;
             OperationContext = operationContext;
             ResultInformation = resultInformation;
@@ -46,16 +38,18 @@ namespace Azure.Communication.CallingServer
 
         /// <summary> Gets the event source. </summary>
         public string EventSource { get; }
-        /// <summary> The call recording id. </summary>
-        public string RecordingId { get; }
-        /// <summary> The time of the recording started. </summary>
-        public DateTimeOffset? StartDateTime { get; }
         /// <summary> Used to determine the version of the event. </summary>
         public string Version { get; }
         /// <summary> Used by customers when calling mid-call actions to correlate the request to the response event. </summary>
         public string OperationContext { get; }
         /// <summary> Contains the resulting SIP code/sub-code and message from NGC services. </summary>
         public ResultInformation ResultInformation { get; }
+        /// <summary> Call connection ID. </summary>
+        public string CallConnectionId { get; }
+        /// <summary> Server call ID. </summary>
+        public string ServerCallId { get; }
+        /// <summary> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </summary>
+        public string CorrelationId { get; }
         /// <summary> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </summary>
         public string PublicEventType { get; }
     }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallRecordingStateChangedInternal.Serialization.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallRecordingStateChangedInternal.Serialization.cs
@@ -5,16 +5,20 @@
 
 #nullable disable
 
+using System;
 using System.Text.Json;
 using Azure.Core;
 
 namespace Azure.Communication.CallingServer
 {
-    public partial class CallConnected
+    internal partial class CallRecordingStateChangedInternal
     {
-        internal static CallConnected DeserializeCallConnected(JsonElement element)
+        internal static CallRecordingStateChangedInternal DeserializeCallRecordingStateChangedInternal(JsonElement element)
         {
             Optional<string> eventSource = default;
+            Optional<string> recordingId = default;
+            Optional<RecordingState> state = default;
+            Optional<DateTimeOffset> startDateTime = default;
             Optional<string> version = default;
             Optional<string> operationContext = default;
             Optional<ResultInformation> resultInformation = default;
@@ -27,6 +31,31 @@ namespace Azure.Communication.CallingServer
                 if (property.NameEquals("eventSource"))
                 {
                     eventSource = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("recordingId"))
+                {
+                    recordingId = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("state"))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        property.ThrowNonNullablePropertyIsNull();
+                        continue;
+                    }
+                    state = new RecordingState(property.Value.GetString());
+                    continue;
+                }
+                if (property.NameEquals("startDateTime"))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        property.ThrowNonNullablePropertyIsNull();
+                        continue;
+                    }
+                    startDateTime = property.Value.GetDateTimeOffset("O");
                     continue;
                 }
                 if (property.NameEquals("version"))
@@ -70,7 +99,7 @@ namespace Azure.Communication.CallingServer
                     continue;
                 }
             }
-            return new CallConnected(eventSource.Value, version.Value, operationContext.Value, resultInformation.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, publicEventType.Value);
+            return new CallRecordingStateChangedInternal(eventSource.Value, recordingId.Value, state, Optional.ToNullable(startDateTime), version.Value, operationContext.Value, resultInformation.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, publicEventType.Value);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallRecordingStateChangedInternal.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallRecordingStateChangedInternal.cs
@@ -5,18 +5,23 @@
 
 #nullable disable
 
+using System;
+
 namespace Azure.Communication.CallingServer
 {
-    /// <summary> The CallConnectedEvent. </summary>
-    public partial class CallConnected
+    /// <summary> The RecordingStateChangedEvent. </summary>
+    internal partial class CallRecordingStateChangedInternal
     {
-        /// <summary> Initializes a new instance of CallConnected. </summary>
-        internal CallConnected()
+        /// <summary> Initializes a new instance of CallRecordingStateChangedInternal. </summary>
+        internal CallRecordingStateChangedInternal()
         {
         }
 
-        /// <summary> Initializes a new instance of CallConnected. </summary>
+        /// <summary> Initializes a new instance of CallRecordingStateChangedInternal. </summary>
         /// <param name="eventSource"></param>
+        /// <param name="recordingId"> The call recording id. </param>
+        /// <param name="state"></param>
+        /// <param name="startDateTime"> The time of the recording started. </param>
         /// <param name="version"> Used to determine the version of the event. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
         /// <param name="resultInformation"> Contains the resulting SIP code/sub-code and message from NGC services. </param>
@@ -24,9 +29,12 @@ namespace Azure.Communication.CallingServer
         /// <param name="serverCallId"> Server call ID. </param>
         /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
         /// <param name="publicEventType"> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </param>
-        internal CallConnected(string eventSource, string version, string operationContext, ResultInformation resultInformation, string callConnectionId, string serverCallId, string correlationId, string publicEventType)
+        internal CallRecordingStateChangedInternal(string eventSource, string recordingId, RecordingState state, DateTimeOffset? startDateTime, string version, string operationContext, ResultInformation resultInformation, string callConnectionId, string serverCallId, string correlationId, string publicEventType)
         {
             EventSource = eventSource;
+            RecordingId = recordingId;
+            State = state;
+            StartDateTime = startDateTime;
             Version = version;
             OperationContext = operationContext;
             ResultInformation = resultInformation;
@@ -38,12 +46,22 @@ namespace Azure.Communication.CallingServer
 
         /// <summary> Gets the event source. </summary>
         public string EventSource { get; }
+        /// <summary> The call recording id. </summary>
+        public string RecordingId { get; }
+        /// <summary> The time of the recording started. </summary>
+        public DateTimeOffset? StartDateTime { get; }
         /// <summary> Used to determine the version of the event. </summary>
         public string Version { get; }
         /// <summary> Used by customers when calling mid-call actions to correlate the request to the response event. </summary>
         public string OperationContext { get; }
         /// <summary> Contains the resulting SIP code/sub-code and message from NGC services. </summary>
         public ResultInformation ResultInformation { get; }
+        /// <summary> Call connection ID. </summary>
+        public string CallConnectionId { get; }
+        /// <summary> Server call ID. </summary>
+        public string ServerCallId { get; }
+        /// <summary> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </summary>
+        public string CorrelationId { get; }
         /// <summary> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </summary>
         public string PublicEventType { get; }
     }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallTransferAcceptedInternal.Serialization.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallTransferAcceptedInternal.Serialization.cs
@@ -10,10 +10,11 @@ using Azure.Core;
 
 namespace Azure.Communication.CallingServer
 {
-    public partial class RecognizeFailed
+    internal partial class CallTransferAcceptedInternal
     {
-        internal static RecognizeFailed DeserializeRecognizeFailed(JsonElement element)
+        internal static CallTransferAcceptedInternal DeserializeCallTransferAcceptedInternal(JsonElement element)
         {
+            Optional<string> eventSource = default;
             Optional<string> operationContext = default;
             Optional<ResultInformation> resultInformation = default;
             Optional<string> version = default;
@@ -23,6 +24,11 @@ namespace Azure.Communication.CallingServer
             Optional<string> publicEventType = default;
             foreach (var property in element.EnumerateObject())
             {
+                if (property.NameEquals("eventSource"))
+                {
+                    eventSource = property.Value.GetString();
+                    continue;
+                }
                 if (property.NameEquals("operationContext"))
                 {
                     operationContext = property.Value.GetString();
@@ -64,7 +70,7 @@ namespace Azure.Communication.CallingServer
                     continue;
                 }
             }
-            return new RecognizeFailed(operationContext.Value, resultInformation.Value, version.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, publicEventType.Value);
+            return new CallTransferAcceptedInternal(eventSource.Value, operationContext.Value, resultInformation.Value, version.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, publicEventType.Value);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallTransferAcceptedInternal.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallTransferAcceptedInternal.cs
@@ -8,14 +8,14 @@
 namespace Azure.Communication.CallingServer
 {
     /// <summary> The CallTransferAcceptedEvent. </summary>
-    public partial class CallTransferAccepted
+    internal partial class CallTransferAcceptedInternal
     {
-        /// <summary> Initializes a new instance of CallTransferAccepted. </summary>
-        internal CallTransferAccepted()
+        /// <summary> Initializes a new instance of CallTransferAcceptedInternal. </summary>
+        internal CallTransferAcceptedInternal()
         {
         }
 
-        /// <summary> Initializes a new instance of CallTransferAccepted. </summary>
+        /// <summary> Initializes a new instance of CallTransferAcceptedInternal. </summary>
         /// <param name="eventSource"></param>
         /// <param name="operationContext"></param>
         /// <param name="resultInformation"></param>
@@ -24,7 +24,7 @@ namespace Azure.Communication.CallingServer
         /// <param name="serverCallId"> Server call ID. </param>
         /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
         /// <param name="publicEventType"> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </param>
-        internal CallTransferAccepted(string eventSource, string operationContext, ResultInformation resultInformation, string version, string callConnectionId, string serverCallId, string correlationId, string publicEventType)
+        internal CallTransferAcceptedInternal(string eventSource, string operationContext, ResultInformation resultInformation, string version, string callConnectionId, string serverCallId, string correlationId, string publicEventType)
         {
             EventSource = eventSource;
             OperationContext = operationContext;
@@ -44,6 +44,12 @@ namespace Azure.Communication.CallingServer
         public ResultInformation ResultInformation { get; }
         /// <summary> Used to determine the version of the event. </summary>
         public string Version { get; }
+        /// <summary> Call connection ID. </summary>
+        public string CallConnectionId { get; }
+        /// <summary> Server call ID. </summary>
+        public string ServerCallId { get; }
+        /// <summary> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </summary>
+        public string CorrelationId { get; }
         /// <summary> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </summary>
         public string PublicEventType { get; }
     }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallTransferFailedInternal.Serialization.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallTransferFailedInternal.Serialization.cs
@@ -10,14 +10,13 @@ using Azure.Core;
 
 namespace Azure.Communication.CallingServer
 {
-    public partial class RecognizeCompleted
+    internal partial class CallTransferFailedInternal
     {
-        internal static RecognizeCompleted DeserializeRecognizeCompleted(JsonElement element)
+        internal static CallTransferFailedInternal DeserializeCallTransferFailedInternal(JsonElement element)
         {
+            Optional<string> eventSource = default;
             Optional<string> operationContext = default;
             Optional<ResultInformation> resultInformation = default;
-            Optional<CallMediaRecognitionType> recognitionType = default;
-            Optional<CollectTonesResult> collectTonesResult = default;
             Optional<string> version = default;
             Optional<string> callConnectionId = default;
             Optional<string> serverCallId = default;
@@ -25,6 +24,11 @@ namespace Azure.Communication.CallingServer
             Optional<string> publicEventType = default;
             foreach (var property in element.EnumerateObject())
             {
+                if (property.NameEquals("eventSource"))
+                {
+                    eventSource = property.Value.GetString();
+                    continue;
+                }
                 if (property.NameEquals("operationContext"))
                 {
                     operationContext = property.Value.GetString();
@@ -38,26 +42,6 @@ namespace Azure.Communication.CallingServer
                         continue;
                     }
                     resultInformation = ResultInformation.DeserializeResultInformation(property.Value);
-                    continue;
-                }
-                if (property.NameEquals("recognitionType"))
-                {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        property.ThrowNonNullablePropertyIsNull();
-                        continue;
-                    }
-                    recognitionType = new CallMediaRecognitionType(property.Value.GetString());
-                    continue;
-                }
-                if (property.NameEquals("collectTonesResult"))
-                {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        property.ThrowNonNullablePropertyIsNull();
-                        continue;
-                    }
-                    collectTonesResult = CollectTonesResult.DeserializeCollectTonesResult(property.Value);
                     continue;
                 }
                 if (property.NameEquals("version"))
@@ -86,7 +70,7 @@ namespace Azure.Communication.CallingServer
                     continue;
                 }
             }
-            return new RecognizeCompleted(operationContext.Value, resultInformation.Value, recognitionType, collectTonesResult.Value, version.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, publicEventType.Value);
+            return new CallTransferFailedInternal(eventSource.Value, operationContext.Value, resultInformation.Value, version.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, publicEventType.Value);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallTransferFailedInternal.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/CallTransferFailedInternal.cs
@@ -7,15 +7,16 @@
 
 namespace Azure.Communication.CallingServer
 {
-    /// <summary> The RecognizeFailed. </summary>
-    public partial class RecognizeFailed
+    /// <summary> The CallTransferFailedEvent. </summary>
+    internal partial class CallTransferFailedInternal
     {
-        /// <summary> Initializes a new instance of RecognizeFailed. </summary>
-        internal RecognizeFailed()
+        /// <summary> Initializes a new instance of CallTransferFailedInternal. </summary>
+        internal CallTransferFailedInternal()
         {
         }
 
-        /// <summary> Initializes a new instance of RecognizeFailed. </summary>
+        /// <summary> Initializes a new instance of CallTransferFailedInternal. </summary>
+        /// <param name="eventSource"></param>
         /// <param name="operationContext"></param>
         /// <param name="resultInformation"></param>
         /// <param name="version"> Used to determine the version of the event. </param>
@@ -23,8 +24,9 @@ namespace Azure.Communication.CallingServer
         /// <param name="serverCallId"> Server call ID. </param>
         /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
         /// <param name="publicEventType"> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </param>
-        internal RecognizeFailed(string operationContext, ResultInformation resultInformation, string version, string callConnectionId, string serverCallId, string correlationId, string publicEventType)
+        internal CallTransferFailedInternal(string eventSource, string operationContext, ResultInformation resultInformation, string version, string callConnectionId, string serverCallId, string correlationId, string publicEventType)
         {
+            EventSource = eventSource;
             OperationContext = operationContext;
             ResultInformation = resultInformation;
             Version = version;
@@ -34,12 +36,20 @@ namespace Azure.Communication.CallingServer
             PublicEventType = publicEventType;
         }
 
+        /// <summary> Gets the event source. </summary>
+        public string EventSource { get; }
         /// <summary> Gets the operation context. </summary>
         public string OperationContext { get; }
         /// <summary> Gets the result information. </summary>
         public ResultInformation ResultInformation { get; }
         /// <summary> Used to determine the version of the event. </summary>
         public string Version { get; }
+        /// <summary> Call connection ID. </summary>
+        public string CallConnectionId { get; }
+        /// <summary> Server call ID. </summary>
+        public string ServerCallId { get; }
+        /// <summary> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </summary>
+        public string CorrelationId { get; }
         /// <summary> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </summary>
         public string PublicEventType { get; }
     }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/PlayCompletedInternal.Serialization.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/PlayCompletedInternal.Serialization.cs
@@ -10,30 +10,19 @@ using Azure.Core;
 
 namespace Azure.Communication.CallingServer
 {
-    public partial class CallDisconnected
+    internal partial class PlayCompletedInternal
     {
-        internal static CallDisconnected DeserializeCallDisconnected(JsonElement element)
+        internal static PlayCompletedInternal DeserializePlayCompletedInternal(JsonElement element)
         {
-            Optional<string> eventSource = default;
-            Optional<string> version = default;
             Optional<string> operationContext = default;
             Optional<ResultInformation> resultInformation = default;
+            Optional<string> version = default;
             Optional<string> callConnectionId = default;
             Optional<string> serverCallId = default;
             Optional<string> correlationId = default;
             Optional<string> publicEventType = default;
             foreach (var property in element.EnumerateObject())
             {
-                if (property.NameEquals("eventSource"))
-                {
-                    eventSource = property.Value.GetString();
-                    continue;
-                }
-                if (property.NameEquals("version"))
-                {
-                    version = property.Value.GetString();
-                    continue;
-                }
                 if (property.NameEquals("operationContext"))
                 {
                     operationContext = property.Value.GetString();
@@ -47,6 +36,11 @@ namespace Azure.Communication.CallingServer
                         continue;
                     }
                     resultInformation = ResultInformation.DeserializeResultInformation(property.Value);
+                    continue;
+                }
+                if (property.NameEquals("version"))
+                {
+                    version = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("callConnectionId"))
@@ -70,7 +64,7 @@ namespace Azure.Communication.CallingServer
                     continue;
                 }
             }
-            return new CallDisconnected(eventSource.Value, version.Value, operationContext.Value, resultInformation.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, publicEventType.Value);
+            return new PlayCompletedInternal(operationContext.Value, resultInformation.Value, version.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, publicEventType.Value);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/PlayCompletedInternal.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/PlayCompletedInternal.cs
@@ -7,16 +7,15 @@
 
 namespace Azure.Communication.CallingServer
 {
-    /// <summary> The PlayFailed. </summary>
-    public partial class PlayFailed
+    /// <summary> The PlayCompleted. </summary>
+    internal partial class PlayCompletedInternal
     {
-        /// <summary> Initializes a new instance of PlayFailed. </summary>
-        internal PlayFailed()
+        /// <summary> Initializes a new instance of PlayCompletedInternal. </summary>
+        internal PlayCompletedInternal()
         {
         }
 
-        /// <summary> Initializes a new instance of PlayFailed. </summary>
-        /// <param name="eventSource"></param>
+        /// <summary> Initializes a new instance of PlayCompletedInternal. </summary>
         /// <param name="operationContext"></param>
         /// <param name="resultInformation"></param>
         /// <param name="version"> Used to determine the version of the event. </param>
@@ -24,9 +23,8 @@ namespace Azure.Communication.CallingServer
         /// <param name="serverCallId"> Server call ID. </param>
         /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
         /// <param name="publicEventType"> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </param>
-        internal PlayFailed(string eventSource, string operationContext, ResultInformation resultInformation, string version, string callConnectionId, string serverCallId, string correlationId, string publicEventType)
+        internal PlayCompletedInternal(string operationContext, ResultInformation resultInformation, string version, string callConnectionId, string serverCallId, string correlationId, string publicEventType)
         {
-            EventSource = eventSource;
             OperationContext = operationContext;
             ResultInformation = resultInformation;
             Version = version;
@@ -36,14 +34,18 @@ namespace Azure.Communication.CallingServer
             PublicEventType = publicEventType;
         }
 
-        /// <summary> Gets the event source. </summary>
-        public string EventSource { get; }
         /// <summary> Gets the operation context. </summary>
         public string OperationContext { get; }
         /// <summary> Gets the result information. </summary>
         public ResultInformation ResultInformation { get; }
         /// <summary> Used to determine the version of the event. </summary>
         public string Version { get; }
+        /// <summary> Call connection ID. </summary>
+        public string CallConnectionId { get; }
+        /// <summary> Server call ID. </summary>
+        public string ServerCallId { get; }
+        /// <summary> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </summary>
+        public string CorrelationId { get; }
         /// <summary> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </summary>
         public string PublicEventType { get; }
     }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/PlayFailedInternal.Serialization.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/PlayFailedInternal.Serialization.cs
@@ -5,23 +5,19 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
 using Azure.Core;
 
 namespace Azure.Communication.CallingServer
 {
-    public partial class CallRecordingStateChanged
+    internal partial class PlayFailedInternal
     {
-        internal static CallRecordingStateChanged DeserializeCallRecordingStateChanged(JsonElement element)
+        internal static PlayFailedInternal DeserializePlayFailedInternal(JsonElement element)
         {
             Optional<string> eventSource = default;
-            Optional<string> recordingId = default;
-            Optional<RecordingState> state = default;
-            Optional<DateTimeOffset> startDateTime = default;
-            Optional<string> version = default;
             Optional<string> operationContext = default;
             Optional<ResultInformation> resultInformation = default;
+            Optional<string> version = default;
             Optional<string> callConnectionId = default;
             Optional<string> serverCallId = default;
             Optional<string> correlationId = default;
@@ -31,36 +27,6 @@ namespace Azure.Communication.CallingServer
                 if (property.NameEquals("eventSource"))
                 {
                     eventSource = property.Value.GetString();
-                    continue;
-                }
-                if (property.NameEquals("recordingId"))
-                {
-                    recordingId = property.Value.GetString();
-                    continue;
-                }
-                if (property.NameEquals("state"))
-                {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        property.ThrowNonNullablePropertyIsNull();
-                        continue;
-                    }
-                    state = new RecordingState(property.Value.GetString());
-                    continue;
-                }
-                if (property.NameEquals("startDateTime"))
-                {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        property.ThrowNonNullablePropertyIsNull();
-                        continue;
-                    }
-                    startDateTime = property.Value.GetDateTimeOffset("O");
-                    continue;
-                }
-                if (property.NameEquals("version"))
-                {
-                    version = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("operationContext"))
@@ -76,6 +42,11 @@ namespace Azure.Communication.CallingServer
                         continue;
                     }
                     resultInformation = ResultInformation.DeserializeResultInformation(property.Value);
+                    continue;
+                }
+                if (property.NameEquals("version"))
+                {
+                    version = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("callConnectionId"))
@@ -99,7 +70,7 @@ namespace Azure.Communication.CallingServer
                     continue;
                 }
             }
-            return new CallRecordingStateChanged(eventSource.Value, recordingId.Value, state, Optional.ToNullable(startDateTime), version.Value, operationContext.Value, resultInformation.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, publicEventType.Value);
+            return new PlayFailedInternal(eventSource.Value, operationContext.Value, resultInformation.Value, version.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, publicEventType.Value);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/PlayFailedInternal.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/PlayFailedInternal.cs
@@ -7,15 +7,16 @@
 
 namespace Azure.Communication.CallingServer
 {
-    /// <summary> The PlayCompleted. </summary>
-    public partial class PlayCompleted
+    /// <summary> The PlayFailed. </summary>
+    internal partial class PlayFailedInternal
     {
-        /// <summary> Initializes a new instance of PlayCompleted. </summary>
-        internal PlayCompleted()
+        /// <summary> Initializes a new instance of PlayFailedInternal. </summary>
+        internal PlayFailedInternal()
         {
         }
 
-        /// <summary> Initializes a new instance of PlayCompleted. </summary>
+        /// <summary> Initializes a new instance of PlayFailedInternal. </summary>
+        /// <param name="eventSource"></param>
         /// <param name="operationContext"></param>
         /// <param name="resultInformation"></param>
         /// <param name="version"> Used to determine the version of the event. </param>
@@ -23,8 +24,9 @@ namespace Azure.Communication.CallingServer
         /// <param name="serverCallId"> Server call ID. </param>
         /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
         /// <param name="publicEventType"> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </param>
-        internal PlayCompleted(string operationContext, ResultInformation resultInformation, string version, string callConnectionId, string serverCallId, string correlationId, string publicEventType)
+        internal PlayFailedInternal(string eventSource, string operationContext, ResultInformation resultInformation, string version, string callConnectionId, string serverCallId, string correlationId, string publicEventType)
         {
+            EventSource = eventSource;
             OperationContext = operationContext;
             ResultInformation = resultInformation;
             Version = version;
@@ -34,12 +36,20 @@ namespace Azure.Communication.CallingServer
             PublicEventType = publicEventType;
         }
 
+        /// <summary> Gets the event source. </summary>
+        public string EventSource { get; }
         /// <summary> Gets the operation context. </summary>
         public string OperationContext { get; }
         /// <summary> Gets the result information. </summary>
         public ResultInformation ResultInformation { get; }
         /// <summary> Used to determine the version of the event. </summary>
         public string Version { get; }
+        /// <summary> Call connection ID. </summary>
+        public string CallConnectionId { get; }
+        /// <summary> Server call ID. </summary>
+        public string ServerCallId { get; }
+        /// <summary> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </summary>
+        public string CorrelationId { get; }
         /// <summary> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </summary>
         public string PublicEventType { get; }
     }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/RecognizeCompletedInternal.Serialization.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/RecognizeCompletedInternal.Serialization.cs
@@ -10,13 +10,14 @@ using Azure.Core;
 
 namespace Azure.Communication.CallingServer
 {
-    public partial class CallTransferFailed
+    internal partial class RecognizeCompletedInternal
     {
-        internal static CallTransferFailed DeserializeCallTransferFailed(JsonElement element)
+        internal static RecognizeCompletedInternal DeserializeRecognizeCompletedInternal(JsonElement element)
         {
-            Optional<string> eventSource = default;
             Optional<string> operationContext = default;
             Optional<ResultInformation> resultInformation = default;
+            Optional<CallMediaRecognitionType> recognitionType = default;
+            Optional<CollectTonesResult> collectTonesResult = default;
             Optional<string> version = default;
             Optional<string> callConnectionId = default;
             Optional<string> serverCallId = default;
@@ -24,11 +25,6 @@ namespace Azure.Communication.CallingServer
             Optional<string> publicEventType = default;
             foreach (var property in element.EnumerateObject())
             {
-                if (property.NameEquals("eventSource"))
-                {
-                    eventSource = property.Value.GetString();
-                    continue;
-                }
                 if (property.NameEquals("operationContext"))
                 {
                     operationContext = property.Value.GetString();
@@ -42,6 +38,26 @@ namespace Azure.Communication.CallingServer
                         continue;
                     }
                     resultInformation = ResultInformation.DeserializeResultInformation(property.Value);
+                    continue;
+                }
+                if (property.NameEquals("recognitionType"))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        property.ThrowNonNullablePropertyIsNull();
+                        continue;
+                    }
+                    recognitionType = new CallMediaRecognitionType(property.Value.GetString());
+                    continue;
+                }
+                if (property.NameEquals("collectTonesResult"))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        property.ThrowNonNullablePropertyIsNull();
+                        continue;
+                    }
+                    collectTonesResult = CollectTonesResult.DeserializeCollectTonesResult(property.Value);
                     continue;
                 }
                 if (property.NameEquals("version"))
@@ -70,7 +86,7 @@ namespace Azure.Communication.CallingServer
                     continue;
                 }
             }
-            return new CallTransferFailed(eventSource.Value, operationContext.Value, resultInformation.Value, version.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, publicEventType.Value);
+            return new RecognizeCompletedInternal(operationContext.Value, resultInformation.Value, recognitionType, collectTonesResult.Value, version.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, publicEventType.Value);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/RecognizeCompletedInternal.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/RecognizeCompletedInternal.cs
@@ -8,14 +8,14 @@
 namespace Azure.Communication.CallingServer
 {
     /// <summary> The RecognizeCompleted. </summary>
-    public partial class RecognizeCompleted
+    internal partial class RecognizeCompletedInternal
     {
-        /// <summary> Initializes a new instance of RecognizeCompleted. </summary>
-        internal RecognizeCompleted()
+        /// <summary> Initializes a new instance of RecognizeCompletedInternal. </summary>
+        internal RecognizeCompletedInternal()
         {
         }
 
-        /// <summary> Initializes a new instance of RecognizeCompleted. </summary>
+        /// <summary> Initializes a new instance of RecognizeCompletedInternal. </summary>
         /// <param name="operationContext"></param>
         /// <param name="resultInformation"> Result information defines the code, subcode and message. </param>
         /// <param name="recognitionType">
@@ -28,7 +28,7 @@ namespace Azure.Communication.CallingServer
         /// <param name="serverCallId"> Server call ID. </param>
         /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
         /// <param name="publicEventType"> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </param>
-        internal RecognizeCompleted(string operationContext, ResultInformation resultInformation, CallMediaRecognitionType recognitionType, CollectTonesResult collectTonesResult, string version, string callConnectionId, string serverCallId, string correlationId, string publicEventType)
+        internal RecognizeCompletedInternal(string operationContext, ResultInformation resultInformation, CallMediaRecognitionType recognitionType, CollectTonesResult collectTonesResult, string version, string callConnectionId, string serverCallId, string correlationId, string publicEventType)
         {
             OperationContext = operationContext;
             ResultInformation = resultInformation;
@@ -49,6 +49,12 @@ namespace Azure.Communication.CallingServer
         public CollectTonesResult CollectTonesResult { get; }
         /// <summary> Used to determine the version of the event. </summary>
         public string Version { get; }
+        /// <summary> Call connection ID. </summary>
+        public string CallConnectionId { get; }
+        /// <summary> Server call ID. </summary>
+        public string ServerCallId { get; }
+        /// <summary> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </summary>
+        public string CorrelationId { get; }
         /// <summary> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </summary>
         public string PublicEventType { get; }
     }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/RecognizeFailedInternal.Serialization.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/RecognizeFailedInternal.Serialization.cs
@@ -10,11 +10,10 @@ using Azure.Core;
 
 namespace Azure.Communication.CallingServer
 {
-    public partial class PlayFailed
+    internal partial class RecognizeFailedInternal
     {
-        internal static PlayFailed DeserializePlayFailed(JsonElement element)
+        internal static RecognizeFailedInternal DeserializeRecognizeFailedInternal(JsonElement element)
         {
-            Optional<string> eventSource = default;
             Optional<string> operationContext = default;
             Optional<ResultInformation> resultInformation = default;
             Optional<string> version = default;
@@ -24,11 +23,6 @@ namespace Azure.Communication.CallingServer
             Optional<string> publicEventType = default;
             foreach (var property in element.EnumerateObject())
             {
-                if (property.NameEquals("eventSource"))
-                {
-                    eventSource = property.Value.GetString();
-                    continue;
-                }
                 if (property.NameEquals("operationContext"))
                 {
                     operationContext = property.Value.GetString();
@@ -70,7 +64,7 @@ namespace Azure.Communication.CallingServer
                     continue;
                 }
             }
-            return new PlayFailed(eventSource.Value, operationContext.Value, resultInformation.Value, version.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, publicEventType.Value);
+            return new RecognizeFailedInternal(operationContext.Value, resultInformation.Value, version.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, publicEventType.Value);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/RecognizeFailedInternal.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Generated/Models/RecognizeFailedInternal.cs
@@ -7,16 +7,15 @@
 
 namespace Azure.Communication.CallingServer
 {
-    /// <summary> The CallTransferFailedEvent. </summary>
-    public partial class CallTransferFailed
+    /// <summary> The RecognizeFailed. </summary>
+    internal partial class RecognizeFailedInternal
     {
-        /// <summary> Initializes a new instance of CallTransferFailed. </summary>
-        internal CallTransferFailed()
+        /// <summary> Initializes a new instance of RecognizeFailedInternal. </summary>
+        internal RecognizeFailedInternal()
         {
         }
 
-        /// <summary> Initializes a new instance of CallTransferFailed. </summary>
-        /// <param name="eventSource"></param>
+        /// <summary> Initializes a new instance of RecognizeFailedInternal. </summary>
         /// <param name="operationContext"></param>
         /// <param name="resultInformation"></param>
         /// <param name="version"> Used to determine the version of the event. </param>
@@ -24,9 +23,8 @@ namespace Azure.Communication.CallingServer
         /// <param name="serverCallId"> Server call ID. </param>
         /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
         /// <param name="publicEventType"> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </param>
-        internal CallTransferFailed(string eventSource, string operationContext, ResultInformation resultInformation, string version, string callConnectionId, string serverCallId, string correlationId, string publicEventType)
+        internal RecognizeFailedInternal(string operationContext, ResultInformation resultInformation, string version, string callConnectionId, string serverCallId, string correlationId, string publicEventType)
         {
-            EventSource = eventSource;
             OperationContext = operationContext;
             ResultInformation = resultInformation;
             Version = version;
@@ -36,14 +34,18 @@ namespace Azure.Communication.CallingServer
             PublicEventType = publicEventType;
         }
 
-        /// <summary> Gets the event source. </summary>
-        public string EventSource { get; }
         /// <summary> Gets the operation context. </summary>
         public string OperationContext { get; }
         /// <summary> Gets the result information. </summary>
         public ResultInformation ResultInformation { get; }
         /// <summary> Used to determine the version of the event. </summary>
         public string Version { get; }
+        /// <summary> Call connection ID. </summary>
+        public string CallConnectionId { get; }
+        /// <summary> Server call ID. </summary>
+        public string ServerCallId { get; }
+        /// <summary> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </summary>
+        public string CorrelationId { get; }
         /// <summary> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </summary>
         public string PublicEventType { get; }
     }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/CallAutomationModelFactory.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/CallAutomationModelFactory.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Azure.Core;
 
 namespace Azure.Communication.CallingServer
@@ -64,37 +63,21 @@ namespace Azure.Communication.CallingServer
             return new CreateCallResult(callConnection, callConnectionProperties);
         }
 
-        /// <summary> Create an EventSource. </summary>
-        /// <param name="callConnectionId"> Call connection id for the event. </param>
-        /// <param name="eventName"> Optional event name; used for events related to content. </param>
-        /// <returns> A new <see cref="CallingServer.CreateCallResult"/> instance for mocking. </returns>
-        private static string CreateEventSource(string callConnectionId, string eventName = "")
-        {
-            var eventSourcePrefix = "calling/callConnections/";
-            StringBuilder eventSource = new StringBuilder();
-            eventSource.Append(eventSourcePrefix + "/" + callConnectionId);
-            if (eventName.Length > 0)
-            {
-                eventSource.Append("/" + eventName);
-            }
-            return eventSource.ToString();
-        }
-
         /// <summary>
         /// Initializes a new instance of add participant failed event.
         /// </summary>
-        public static AddParticipantsFailed AddParticipantsFailed(string operationContext = default, ResultInformation resultInformation = default, IEnumerable<CommunicationIdentifier> participants = default, string version = default, string callConnectionId = default, string serverCallId = default, string correlationId = default)
+        public static AddParticipantsFailed AddParticipantsFailed(string operationContext = default, ResultInformation resultInformation = default, IEnumerable<CommunicationIdentifier> participants = default, string callConnectionId = default, string serverCallId = default, string correlationId = default)
         {
             var internalObject = new AddParticipantsFailedInternal(
-                CreateEventSource(callConnectionId),
+                "",
                 operationContext,
                 resultInformation,
                 participants == null ? new List<CommunicationIdentifierModel>() : participants.Select(t => CommunicationIdentifierSerializer.Serialize(t)).ToList(),
-                version,
+                "",
                 callConnectionId,
                 serverCallId,
                 correlationId,
-                CallAutomationEventParser.EventPrefix + nameof(AddParticipantsFailed)
+                ""
                 );
 
             return new AddParticipantsFailed(internalObject);
@@ -103,41 +86,214 @@ namespace Azure.Communication.CallingServer
         /// <summary>
         /// Initializes a new instance of add participant success event.
         /// </summary>
-        public static AddParticipantsSucceeded AddParticipantsSucceeded(string operationContext = default, ResultInformation resultInformation = default, IEnumerable<CommunicationIdentifier> participants = default, string version = default, string callConnectionId = default, string serverCallId = default, string correlationId = default)
+        public static AddParticipantsSucceeded AddParticipantsSucceeded(string operationContext = default, ResultInformation resultInformation = default, IEnumerable<CommunicationIdentifier> participants = default, string callConnectionId = default, string serverCallId = default, string correlationId = default)
         {
             var internalObject = new AddParticipantsSucceededInternal(
-                CreateEventSource(callConnectionId),
+                "",
                 operationContext,
                 resultInformation,
                 participants == null ? new List<CommunicationIdentifierModel>() : participants.Select(t => CommunicationIdentifierSerializer.Serialize(t)).ToList(),
-                version,
+                "",
                 callConnectionId,
                 serverCallId,
                 correlationId,
-                CallAutomationEventParser.EventPrefix + nameof(AddParticipantsFailed)
+                ""
                 );
 
             return new AddParticipantsSucceeded(internalObject);
         }
 
         /// <summary>
-        /// Initializes a new instance of Participants Updated event.
+        /// Initializes a new instance of Call Connected event.
         /// </summary>
-        public static ParticipantsUpdated ParticipantsUpdated(IEnumerable<CommunicationIdentifier> participants = default, string version = default, string operationContext = default, ResultInformation resultInformation = default, string callConnectionId = default, string serverCallId = default, string correlationId = default)
+        public static CallConnected CallConnected(string callConnectionId = default, string serverCallId = default, string correlationId = default)
         {
-            var internalObject = new ParticipantsUpdatedInternal(
-                CreateEventSource(callConnectionId),
-                participants == null ? new List<CommunicationIdentifierModel>() : participants.Select(t => CommunicationIdentifierSerializer.Serialize(t)).ToList(),
-                version,
-                operationContext,
-                resultInformation,
+            var internalObject = new CallConnectedInternal(
+                "",
+                "",
+                "",
+                new ResultInformation(),
                 callConnectionId,
                 serverCallId,
                 correlationId,
-                CallAutomationEventParser.EventPrefix + nameof(ParticipantsUpdated)
+                ""
+                );
+
+            return new CallConnected(internalObject);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of Call Disconnected event.
+        /// </summary>
+        public static CallDisconnected CallDisconnected(string callConnectionId = default, string serverCallId = default, string correlationId = default)
+        {
+            var internalObject = new CallDisconnectedInternal(
+                "",
+                "",
+                "",
+                new ResultInformation(),
+                callConnectionId,
+                serverCallId,
+                correlationId,
+                ""
+                );
+
+            return new CallDisconnected(internalObject);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of Call Transfer Accepted event.
+        /// </summary>
+        public static CallTransferAccepted CallTransferAccepted(string operationContext = default, ResultInformation resultInformation = default, string callConnectionId = default, string serverCallId = default, string correlationId = default)
+        {
+            var internalObject = new CallTransferAcceptedInternal(
+                "",
+                operationContext,
+                resultInformation,
+                "",
+                callConnectionId,
+                serverCallId,
+                correlationId,
+                ""
+                );
+
+            return new CallTransferAccepted(internalObject);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of Call CallTransfer Failed event.
+        /// </summary>
+        public static CallTransferFailed CallTransferFailed(string operationContext = default, ResultInformation resultInformation = default, string callConnectionId = default, string serverCallId = default, string correlationId = default)
+        {
+            var internalObject = new CallTransferFailedInternal(
+                "",
+                operationContext,
+                resultInformation,
+                "",
+                callConnectionId,
+                serverCallId,
+                correlationId,
+                ""
+                );
+
+            return new CallTransferFailed(internalObject);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of Participants Updated event.
+        /// </summary>
+        public static ParticipantsUpdated ParticipantsUpdated(IEnumerable<CommunicationIdentifier> participants = default, string callConnectionId = default, string serverCallId = default, string correlationId = default)
+        {
+            var internalObject = new ParticipantsUpdatedInternal(
+                "",
+                participants == null ? new List<CommunicationIdentifierModel>() : participants.Select(t => CommunicationIdentifierSerializer.Serialize(t)).ToList(),
+                "",
+                "",
+                new ResultInformation(),
+                callConnectionId,
+                serverCallId,
+                correlationId,
+                ""
                 );
 
             return new ParticipantsUpdated(internalObject);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of Play Completed event.
+        /// </summary>
+        public static PlayCompleted PlayCompleted(string operationContext = default, ResultInformation resultInformation = default, string callConnectionId = default, string serverCallId = default, string correlationId = default)
+        {
+            var internalObject =  new PlayCompletedInternal(
+                operationContext,
+                resultInformation,
+                "",
+                callConnectionId,
+                serverCallId,
+                correlationId,
+                ""
+                );
+
+            return new PlayCompleted(internalObject);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of Play failed event.
+        /// </summary>
+        public static PlayFailed PlayFailed(string operationContext = default, ResultInformation resultInformation = default, string callConnectionId = default, string serverCallId = default, string correlationId = default)
+        {
+            var internalObject = new PlayFailedInternal(
+                "",
+                operationContext,
+                resultInformation,
+                "",
+                callConnectionId,
+                serverCallId,
+                correlationId,
+                ""
+                );
+
+            return new PlayFailed(internalObject);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of Recognize Completed event.
+        /// </summary>
+        public static RecognizeCompleted RecognizeCompleted(string operationContext = default, ResultInformation resultInformation = default, CallMediaRecognitionType recognitionType = default, CollectTonesResult collectTonesResult = default, string callConnectionId = default, string serverCallId = default, string correlationId = default)
+        {
+            var internalObject = new RecognizeCompletedInternal(
+                operationContext,
+                resultInformation,
+                recognitionType,
+                collectTonesResult,
+                "",
+                callConnectionId,
+                serverCallId,
+                correlationId,
+                ""
+                );
+
+            return new RecognizeCompleted(internalObject);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of Recognize Failed event
+        /// </summary>
+        public static RecognizeFailed RecognizeFailed(string operationContext = default, ResultInformation resultInformation = default, string callConnectionId = default, string serverCallId = default, string correlationId = default)
+        {
+            var internalObject = new RecognizeFailedInternal(
+                operationContext,
+                resultInformation,
+                "",
+                callConnectionId,
+                serverCallId,
+                correlationId,
+                ""
+                );
+
+            return new RecognizeFailed(internalObject);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of Call Recording State Changed Event
+        /// </summary>
+        public static CallRecordingStateChanged CallRecordingStateChanged(string recordingId = default, RecordingState state = default, DateTimeOffset startDateTime = default, string callConnectionId = default, string serverCallId = default, string correlationId = default)
+        {
+            var internalObject = new CallRecordingStateChangedInternal(
+                "",
+                recordingId,
+                state,
+                startDateTime,
+                "",
+                "",
+                new ResultInformation(),
+                callConnectionId,
+                serverCallId,
+                correlationId,
+                ""
+                );
+
+            return new CallRecordingStateChanged(internalObject);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/AddParticipantsFailed.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/AddParticipantsFailed.cs
@@ -13,39 +13,29 @@ namespace Azure.Communication.CallingServer
     /// </summary>
     public class AddParticipantsFailed : CallAutomationEventBase
     {
-        /// <summary> Initializes a new instance of AddParticipantsFailedEvent. </summary>
+        /// <summary> Initializes a new instance of AddParticipantsFailed event. </summary>
         internal AddParticipantsFailed()
         {
             Participants = new ChangeTrackingList<CommunicationIdentifier>();
         }
 
-        /// <summary> Initializes a new instance of AddParticipantsFailedEvent. </summary>
-        /// <param name="internalEvent">Internal Representation of the AddParticipantsFailedEvent. </param>
+        /// <summary> Initializes a new instance of AddParticipantsFailed event. </summary>
+        /// <param name="internalEvent">Internal Representation of the AddParticipantsFailed event. </param>
         internal AddParticipantsFailed(AddParticipantsFailedInternal internalEvent)
         {
-            EventSource = internalEvent.EventSource;
             OperationContext = internalEvent.OperationContext;
             ResultInformation = internalEvent.ResultInformation;
             Participants = internalEvent.Participants.Select(t => CommunicationIdentifierSerializer.Deserialize(t)).ToList();
-            Version = internalEvent.Version;
             CallConnectionId = internalEvent.CallConnectionId;
             ServerCallId = internalEvent.ServerCallId;
             CorrelationId = internalEvent.CorrelationId;
-            PublicEventType = internalEvent.PublicEventType;
         }
-
-        /// <summary> EventSource. </summary>
-        public string EventSource { get; }
         /// <summary> Operation context. </summary>
-        public string OperationContext { get; }
+        public override string OperationContext { get; internal set; }
         /// <summary> Gets the result info. </summary>
-        public ResultInformation ResultInformation { get; }
+        public override ResultInformation ResultInformation { get; internal set; }
         /// <summary> Participants failed to be added. </summary>
         public IReadOnlyList<CommunicationIdentifier> Participants { get; }
-        /// <summary> Used to determine the version of the event. </summary>
-        public string Version { get; }
-        /// <summary> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </summary>
-        public string PublicEventType { get; }
 
         /// <summary>
         /// Deserialize <see cref="AddParticipantsFailed"/> event.

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/AddParticipantsSucceeded.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/AddParticipantsSucceeded.cs
@@ -13,39 +13,29 @@ namespace Azure.Communication.CallingServer
     /// </summary>
     public class AddParticipantsSucceeded: CallAutomationEventBase
     {
-        /// <summary> Initializes a new instance of AddParticipantsSucceededEventInternal. </summary>
+        /// <summary> Initializes a new instance of AddParticipantsSucceeded event. </summary>
         internal AddParticipantsSucceeded()
         {
             Participants = new ChangeTrackingList<CommunicationIdentifier>();
         }
 
-        /// <summary> Initializes a new instance of AddParticipantsSucceededEventInternal. </summary>
+        /// <summary> Initializes a new instance of AddParticipantsSucceeded event. </summary>
         /// <param name="internalEvent"> Internal Representation of the AddParticipantsSucceededEvent. </param>
         internal AddParticipantsSucceeded(AddParticipantsSucceededInternal internalEvent)
         {
-            EventSource = internalEvent.EventSource;
             OperationContext = internalEvent.OperationContext;
             ResultInformation = internalEvent.ResultInformation;
             Participants = internalEvent.Participants.Select(t => CommunicationIdentifierSerializer.Deserialize(t)).ToList();
-            Version = internalEvent.Version;
             CallConnectionId = internalEvent.CallConnectionId;
             ServerCallId = internalEvent.ServerCallId;
             CorrelationId = internalEvent.CorrelationId;
-            PublicEventType = internalEvent.PublicEventType;
         }
-
-        /// <summary> EventSource. </summary>
-        public string EventSource { get; }
         /// <summary> Operation context. </summary>
-        public string OperationContext { get; }
+        public override string OperationContext { get; internal set; }
         /// <summary> Gets the result info. </summary>
-        public ResultInformation ResultInformation { get; }
+        public override ResultInformation ResultInformation { get; internal set; }
         /// <summary> Participants added. </summary>
         public IReadOnlyList<CommunicationIdentifier> Participants { get; }
-        /// <summary> Used to determine the version of the event. </summary>
-        public string Version { get; }
-        /// <summary> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </summary>
-        public string PublicEventType { get; }
 
         /// <summary>
         /// Deserialize <see cref="AddParticipantsSucceeded"/> event.

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallAutomationEventBase.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallAutomationEventBase.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Core;
+using System.Text.Json.Serialization;
 
 namespace Azure.Communication.CallingServer
 {
@@ -18,5 +18,14 @@ namespace Azure.Communication.CallingServer
 
         /// <summary> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </summary>
         public string CorrelationId { get; internal set; }
+
+#nullable enable
+        /// <summary> The ResultInformation. </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public virtual ResultInformation? ResultInformation { get; internal set; }
+
+        /// <summary> Operation context. </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public virtual string? OperationContext { get; internal set; }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallAutomationEventParser.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallAutomationEventParser.cs
@@ -14,7 +14,7 @@ namespace Azure.Communication.CallingServer
         /// <summary>
         /// Parsing a CallAutomation event from a CloudEvent.
         /// </summary>
-        public const string EventPrefix = "Microsoft.Communication.";
+        private static string EventPrefix = "Microsoft.Communication.";
 
         /// <summary>
         /// Parsing a CallAutomation event from a CloudEvent.

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallConnected.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallConnected.cs
@@ -2,16 +2,23 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using Azure.Core;
 
 namespace Azure.Communication.CallingServer
 {
     /// <summary>
     /// The call connected event.
     /// </summary>
-    [CodeGenModel("CallConnectedEvent", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
-    public partial class CallConnected: CallAutomationEventBase
+    public class CallConnected : CallAutomationEventBase
     {
+        /// <summary> Initializes a new instance of CallConnected Event. </summary>
+        /// <param name="internalEvent"> Internal Representation of the CallConnected Event. </param>
+        internal CallConnected(CallConnectedInternal internalEvent)
+        {
+            CallConnectionId = internalEvent.CallConnectionId;
+            ServerCallId = internalEvent.ServerCallId;
+            CorrelationId = internalEvent.CorrelationId;
+        }
+
         /// <summary>
         /// Deserialize <see cref="CallConnected"/> event.
         /// </summary>
@@ -22,7 +29,8 @@ namespace Azure.Communication.CallingServer
             using var document = JsonDocument.Parse(content);
             JsonElement element = document.RootElement;
 
-            return DeserializeCallConnected(element);
+            var internalEvent = CallConnectedInternal.DeserializeCallConnectedInternal(element);
+            return new CallConnected(internalEvent);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallConnectedInternal.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallConnectedInternal.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Azure.Core;
+
+namespace Azure.Communication.CallingServer
+{
+    /// <summary>
+    /// The call connected event internal
+    /// </summary>
+    [CodeGenModel("CallConnectedEvent", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
+    internal partial class CallConnectedInternal
+    {
+    }
+}

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallDisconnected.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallDisconnected.cs
@@ -2,16 +2,23 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using Azure.Core;
 
 namespace Azure.Communication.CallingServer
 {
     /// <summary>
     /// The call disconnected event.
     /// </summary>
-    [CodeGenModel("CallDisconnectedEvent", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
-    public partial class CallDisconnected : CallAutomationEventBase
+    public class CallDisconnected : CallAutomationEventBase
     {
+        /// <summary> Initializes a new instance of CallDisconnected Event. </summary>
+        /// <param name="internalEvent"> Internal Representation of the CallDisconnected Event. </param>
+        internal CallDisconnected(CallDisconnectedInternal internalEvent)
+        {
+            CallConnectionId = internalEvent.CallConnectionId;
+            ServerCallId = internalEvent.ServerCallId;
+            CorrelationId = internalEvent.CorrelationId;
+        }
+
         /// <summary>
         /// Deserialize <see cref="CallDisconnected"/> event.
         /// </summary>
@@ -22,7 +29,8 @@ namespace Azure.Communication.CallingServer
             using var document = JsonDocument.Parse(content);
             JsonElement element = document.RootElement;
 
-            return DeserializeCallDisconnected(element);
+            var internalEvent = CallDisconnectedInternal.DeserializeCallDisconnectedInternal(element);
+            return new CallDisconnected(internalEvent);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallDisconnectedInternal.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallDisconnectedInternal.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core;
+
+namespace Azure.Communication.CallingServer
+{
+    /// <summary>
+    /// The call disconnected event internal.
+    /// </summary>
+    [CodeGenModel("CallDisconnectedEvent", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
+    internal partial class CallDisconnectedInternal
+    {
+    }
+}

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallRecordingStateChanged.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallRecordingStateChanged.cs
@@ -1,24 +1,42 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
-using Azure.Communication.CallingServer.Converters;
-using Azure.Core;
 
 namespace Azure.Communication.CallingServer
 {
     /// <summary>
     /// The Call Recording state changed event
     /// </summary>
-    [CodeGenModel("RecordingStateChangedEvent", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
-    public partial class CallRecordingStateChanged : CallAutomationEventBase
+    public class CallRecordingStateChanged : CallAutomationEventBase
     {
+        /// <summary> Initializes a new instance of CallRecordingStateChangedInternal. </summary>
+        /// <param name="internalEvent"></param>
+        internal CallRecordingStateChanged(CallRecordingStateChangedInternal internalEvent)
+        {
+            RecordingId = internalEvent.RecordingId;
+            State = internalEvent.State;
+            StartDateTime = internalEvent.StartDateTime;
+            CallConnectionId = internalEvent.CallConnectionId;
+            ServerCallId = internalEvent.ServerCallId;
+            CorrelationId = internalEvent.CorrelationId;
+        }
+
         /// <summary>
-        /// THe recording state
+        /// The call recording id
         /// </summary>
-        [JsonConverter(typeof(EquatableEnumJsonConverter<RecordingState>))]
+        public string RecordingId { get; internal set; }
+
+        /// <summary>
+        /// The call recording state.
+        /// </summary>
         public RecordingState State { get; set; }
+
+        /// <summary>
+        /// The time of the recording started
+        /// </summary>
+        public DateTimeOffset? StartDateTime { get; internal set; }
 
         /// <summary>
         /// Deserialize <see cref="CallRecordingStateChanged"/> event.
@@ -30,7 +48,8 @@ namespace Azure.Communication.CallingServer
             using var document = JsonDocument.Parse(content);
             JsonElement element = document.RootElement;
 
-            return DeserializeCallRecordingStateChanged(element);
+            var internalEvent = CallRecordingStateChangedInternal.DeserializeCallRecordingStateChangedInternal(element);
+            return new CallRecordingStateChanged(internalEvent);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallRecordingStateChangedInternal.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallRecordingStateChangedInternal.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Azure.Communication.CallingServer.Converters;
+using Azure.Core;
+
+namespace Azure.Communication.CallingServer
+{
+    /// <summary>
+    /// The Call Recording state changed event internal.
+    /// </summary>
+    [CodeGenModel("RecordingStateChangedEvent", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
+    internal partial class CallRecordingStateChangedInternal
+    {
+        /// <summary>
+        /// THe recording state
+        /// </summary>
+        [JsonConverter(typeof(EquatableEnumJsonConverter<RecordingState>))]
+        public RecordingState State { get; set; }
+    }
+}

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallTransferAccepted.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallTransferAccepted.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Linq;
 using System.Text.Json;
 using Azure.Core;
 
@@ -9,9 +10,24 @@ namespace Azure.Communication.CallingServer
     /// <summary>
     /// The call transfer accepted event.
     /// </summary>
-    [CodeGenModel("CallTransferAcceptedEvent", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
     public partial class CallTransferAccepted : CallAutomationEventBase
     {
+        /// <summary> Initializes a new instance of CallTransferAccepted.</summary>
+        /// <param name="internalEvent"> Internal Representation of the CallTransferAccepted event. </param>
+        internal CallTransferAccepted(CallTransferAcceptedInternal internalEvent)
+        {
+            OperationContext = internalEvent.OperationContext;
+            ResultInformation = internalEvent.ResultInformation;
+            CallConnectionId = internalEvent.CallConnectionId;
+            ServerCallId = internalEvent.ServerCallId;
+            CorrelationId = internalEvent.CorrelationId;
+        }
+
+        /// <summary> Operation context. </summary>
+        public override string OperationContext { get; internal set; }
+        /// <summary> Gets the result info. </summary>
+        public override ResultInformation ResultInformation { get; internal set; }
+
         /// <summary>
         /// Deserialize <see cref="CallTransferAccepted"/> event.
         /// </summary>
@@ -22,7 +38,8 @@ namespace Azure.Communication.CallingServer
             using var document = JsonDocument.Parse(content);
             JsonElement element = document.RootElement;
 
-            return DeserializeCallTransferAccepted(element);
+            var internalEvent = CallTransferAcceptedInternal.DeserializeCallTransferAcceptedInternal(element);
+            return new CallTransferAccepted(internalEvent);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallTransferAcceptedInternal.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallTransferAcceptedInternal.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core;
+
+namespace Azure.Communication.CallingServer
+{
+    /// <summary>
+    /// The call transfer accepted event internal.
+    /// </summary>
+    [CodeGenModel("CallTransferAcceptedEvent", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
+    internal partial class CallTransferAcceptedInternal
+    {
+    }
+}

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallTransferFailed.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallTransferFailed.cs
@@ -9,9 +9,24 @@ namespace Azure.Communication.CallingServer
     /// <summary>
     /// The call transfer failed event.
     /// </summary>
-    [CodeGenModel("CallTransferFailedEvent", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
     public partial class CallTransferFailed : CallAutomationEventBase
     {
+        /// <summary> Initializes a new instance of CallTransferFailed.</summary>
+        /// <param name="internalEvent"> Internal Representation of the CallTransferFailed event. </param>
+        internal CallTransferFailed(CallTransferFailedInternal internalEvent)
+        {
+            OperationContext = internalEvent.OperationContext;
+            ResultInformation = internalEvent.ResultInformation;
+            CallConnectionId = internalEvent.CallConnectionId;
+            ServerCallId = internalEvent.ServerCallId;
+            CorrelationId = internalEvent.CorrelationId;
+        }
+
+        /// <summary> Operation context. </summary>
+        public override string OperationContext { get; internal set; }
+        /// <summary> Gets the result info. </summary>
+        public override ResultInformation ResultInformation { get; internal set; }
+
         /// <summary>
         /// Deserialize <see cref="CallTransferFailed"/> event.
         /// </summary>
@@ -22,7 +37,8 @@ namespace Azure.Communication.CallingServer
             using var document = JsonDocument.Parse(content);
             JsonElement element = document.RootElement;
 
-            return DeserializeCallTransferFailed(element);
+            var internalEvent = CallTransferFailedInternal.DeserializeCallTransferFailedInternal(element);
+            return new CallTransferFailed(internalEvent);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallTransferFailedInternal.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/CallTransferFailedInternal.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core;
+
+namespace Azure.Communication.CallingServer
+{
+    /// <summary>
+    /// The call transfer failed event internal.
+    /// </summary>
+    [CodeGenModel("CallTransferFailedEvent", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
+    internal partial class CallTransferFailedInternal
+    {
+    }
+}

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/ParticipantsUpdated.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/ParticipantsUpdated.cs
@@ -23,31 +23,14 @@ namespace Azure.Communication.CallingServer
         /// <param name="internalEvent"> Internal Representation of the ParticipantsUpdatedEvent. </param>
         internal ParticipantsUpdated(ParticipantsUpdatedInternal internalEvent)
         {
-            EventSource = internalEvent.EventSource;
-            OperationContext = internalEvent.OperationContext;
-            ResultInformation = internalEvent.ResultInformation;
             Participants = internalEvent.Participants.Select(t => CommunicationIdentifierSerializer.Deserialize(t)).ToList();
-            Version = internalEvent.Version;
             CallConnectionId = internalEvent.CallConnectionId;
             ServerCallId = internalEvent.ServerCallId;
             CorrelationId = internalEvent.CorrelationId;
-            PublicEventType = internalEvent.PublicEventType;
         }
-
-        /// <summary> EventSource. </summary>
-        public string EventSource { get; }
-        /// <summary> Operation context. </summary>
-        public string OperationContext { get; }
-        /// <summary> Gets the result info. </summary>
-        public ResultInformation ResultInformation { get; }
-        /// <summary> Participants failed to be added. </summary>
 
         /// <summary> List of current participants in the call. </summary>
         public IReadOnlyList<CommunicationIdentifier> Participants { get; }
-        /// <summary> Used to determine the version of the event. </summary>
-        public string Version { get; }
-        /// <summary> The public event namespace used as the &quot;type&quot; property in the CloudEvent. </summary>
-        public string PublicEventType { get; }
 
         /// <summary>
         /// Deserialize <see cref="ParticipantsUpdated"/> event.

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/PlayCompleted.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/PlayCompleted.cs
@@ -9,9 +9,24 @@ namespace Azure.Communication.CallingServer
     /// <summary>
     /// The play completed event.
     /// </summary>
-    [CodeGenModel("PlayCompleted", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
-    public partial class PlayCompleted : CallAutomationEventBase
+    public class PlayCompleted : CallAutomationEventBase
     {
+        /// <summary> Initializes a new instance of PlayCompleted.</summary>
+        /// <param name="internalEvent"> Internal Representation of the PlayCompleted event. </param>
+        internal PlayCompleted(PlayCompletedInternal internalEvent)
+        {
+            OperationContext = internalEvent.OperationContext;
+            ResultInformation = internalEvent.ResultInformation;
+            CallConnectionId = internalEvent.CallConnectionId;
+            ServerCallId = internalEvent.ServerCallId;
+            CorrelationId = internalEvent.CorrelationId;
+        }
+
+        /// <summary> Operation context. </summary>
+        public override string OperationContext { get; internal set; }
+        /// <summary> Gets the result info. </summary>
+        public override ResultInformation ResultInformation { get; internal set; }
+
         /// <summary>
         /// Deserialize <see cref="PlayCompleted"/> event.
         /// </summary>
@@ -22,7 +37,8 @@ namespace Azure.Communication.CallingServer
             using var document = JsonDocument.Parse(content);
             JsonElement element = document.RootElement;
 
-            return DeserializePlayCompleted(element);
+            var internalEvent = PlayCompletedInternal.DeserializePlayCompletedInternal(element);
+            return new PlayCompleted(internalEvent);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/PlayCompletedInternal.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/PlayCompletedInternal.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core;
+
+namespace Azure.Communication.CallingServer
+{
+    /// <summary>
+    /// The play completed event internal.
+    /// </summary>
+    [CodeGenModel("PlayCompleted", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
+    internal partial class PlayCompletedInternal
+    {
+    }
+}

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/PlayFailed.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/PlayFailed.cs
@@ -9,9 +9,24 @@ namespace Azure.Communication.CallingServer
     /// <summary>
     /// The Play Failed event.
     /// </summary>
-    [CodeGenModel("PlayFailed", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
-    public partial class PlayFailed : CallAutomationEventBase
+    public class PlayFailed : CallAutomationEventBase
     {
+        /// <summary> Initializes a new instance of PlayFailed.</summary>
+        /// <param name="internalEvent"> Internal Representation of the PlayFailed event. </param>
+        internal PlayFailed(PlayFailedInternal internalEvent)
+        {
+            OperationContext = internalEvent.OperationContext;
+            ResultInformation = internalEvent.ResultInformation;
+            CallConnectionId = internalEvent.CallConnectionId;
+            ServerCallId = internalEvent.ServerCallId;
+            CorrelationId = internalEvent.CorrelationId;
+        }
+
+        /// <summary> Operation context. </summary>
+        public override string OperationContext { get; internal set; }
+        /// <summary> Gets the result info. </summary>
+        public override ResultInformation ResultInformation { get; internal set; }
+
         /// <summary>
         /// Deserialize <see cref="PlayFailed"/> event.
         /// </summary>
@@ -22,7 +37,8 @@ namespace Azure.Communication.CallingServer
             using var document = JsonDocument.Parse(content);
             JsonElement element = document.RootElement;
 
-            return DeserializePlayFailed(element);
+            var internalEvent = PlayFailedInternal.DeserializePlayFailedInternal(element);
+            return new PlayFailed(internalEvent);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/PlayFailedInternal.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/PlayFailedInternal.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Azure.Core;
+
+namespace Azure.Communication.CallingServer
+{
+    /// <summary>
+    /// The Play Failed event internal.
+    /// </summary>
+    [CodeGenModel("PlayFailed", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
+    internal partial class PlayFailedInternal
+    {
+    }
+}

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/RecognizeCompleted.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/RecognizeCompleted.cs
@@ -2,24 +2,39 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using System.Text.Json.Serialization;
-using Azure.Communication.CallingServer.Converters;
-using Azure.Core;
 
 namespace Azure.Communication.CallingServer
 {
     /// <summary>
-    /// The play completed event.
+    /// The recognize completed event.
     /// </summary>
-    [CodeGenModel("RecognizeCompleted", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
-    public partial class RecognizeCompleted : CallAutomationEventBase
+    public class RecognizeCompleted : CallAutomationEventBase
     {
+        /// <summary> Initializes a new instance of RecognizeCompleted event.</summary>
+        /// <param name="internalEvent"> Internal Representation of the RecognizeCompleted event. </param>
+        internal RecognizeCompleted(RecognizeCompletedInternal internalEvent)
+        {
+            OperationContext = internalEvent.OperationContext;
+            ResultInformation = internalEvent.ResultInformation;
+            CallConnectionId = internalEvent.CallConnectionId;
+            ServerCallId = internalEvent.ServerCallId;
+            CorrelationId = internalEvent.CorrelationId;
+            RecognitionType = internalEvent.RecognitionType;
+            CollectTonesResult = internalEvent.CollectTonesResult;
+        }
+
+        /// <summary> Operation context. </summary>
+        public override string OperationContext { get; internal set; }
+        /// <summary> Gets the result info. </summary>
+        public override ResultInformation ResultInformation { get; internal set; }
+        /// <summary>
+        /// Defines the result for RecognitionType = Dtmf
+        /// </summary>
+        public CollectTonesResult CollectTonesResult { get; internal set; }
         /// <summary>
         /// The recognition type.
         /// </summary>
-        [CodeGenMember("RecognitionType")]
-        [JsonConverter(typeof(EquatableEnumJsonConverter<CallMediaRecognitionType>))]
-        public CallMediaRecognitionType RecognitionType { get; set; }
+        public CallMediaRecognitionType RecognitionType { get; internal set; }
 
         /// <summary>
         /// Deserialize <see cref="RecognizeCompleted"/> event.
@@ -31,7 +46,8 @@ namespace Azure.Communication.CallingServer
             using var document = JsonDocument.Parse(content);
             JsonElement element = document.RootElement;
 
-            return DeserializeRecognizeCompleted(element);
+            var internalEvent = RecognizeCompletedInternal.DeserializeRecognizeCompletedInternal(element);
+            return new RecognizeCompleted(internalEvent);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/RecognizeCompletedInternal.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/RecognizeCompletedInternal.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+using Azure.Communication.CallingServer.Converters;
+using Azure.Core;
+
+namespace Azure.Communication.CallingServer
+{
+    /// <summary>
+    /// The recognize completed event internal
+    /// </summary>
+    [CodeGenModel("RecognizeCompleted", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
+    internal partial class RecognizeCompletedInternal
+    {
+        /// <summary>
+        /// The recognition type.
+        /// </summary>
+        [CodeGenMember("RecognitionType")]
+        [JsonConverter(typeof(EquatableEnumJsonConverter<CallMediaRecognitionType>))]
+        public CallMediaRecognitionType RecognitionType { get; set; }
+    }
+}

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/RecognizeFailed.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/RecognizeFailed.cs
@@ -2,27 +2,42 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using Azure.Core;
 
 namespace Azure.Communication.CallingServer
 {
     /// <summary>
-    /// The play completed event.
+    /// The recognize failed event.
     /// </summary>
-    [CodeGenModel("RecognizeFailed", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
-    public partial class RecognizeFailed : CallAutomationEventBase
+    public class RecognizeFailed : CallAutomationEventBase
     {
+        /// <summary> Initializes a new instance of RecognizeFailed event.</summary>
+        /// <param name="internalEvent"> Internal Representation of the RecognizeFailed event. </param>
+        internal RecognizeFailed(RecognizeFailedInternal internalEvent)
+        {
+            OperationContext = internalEvent.OperationContext;
+            ResultInformation = internalEvent.ResultInformation;
+            CallConnectionId = internalEvent.CallConnectionId;
+            ServerCallId = internalEvent.ServerCallId;
+            CorrelationId = internalEvent.CorrelationId;
+        }
+
+        /// <summary> Operation context. </summary>
+        public override string OperationContext { get; internal set; }
+        /// <summary> Gets the result info. </summary>
+        public override ResultInformation ResultInformation { get; internal set; }
+
         /// <summary>
         /// Deserialize <see cref="RecognizeFailed"/> event.
         /// </summary>
         /// <param name="content">The json content.</param>
         /// <returns>The new <see cref="RecognizeFailed"/> object.</returns>
-        public static RecognizeFailed Deserialize(string content)
+            public static RecognizeFailed Deserialize(string content)
         {
             using var document = JsonDocument.Parse(content);
             JsonElement element = document.RootElement;
 
-            return DeserializeRecognizeFailed(element);
+            var internalEvent = RecognizeFailedInternal.DeserializeRecognizeFailedInternal(element);
+            return new RecognizeFailed(internalEvent);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/RecognizeFailedInternal.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/Events/RecognizeFailedInternal.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core;
+
+namespace Azure.Communication.CallingServer
+{
+    /// <summary>
+    /// The recognize failed event internal.
+    /// </summary>
+    [CodeGenModel("RecognizeFailed", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
+    internal partial class RecognizeFailedInternal
+    {
+    }
+}

--- a/sdk/communication/Azure.Communication.CallingServer/src/Models/RecordingState.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Models/RecordingState.cs
@@ -7,9 +7,9 @@ using Azure.Core;
 
 namespace Azure.Communication.CallingServer
 {
-    [CodeGenModel("RecognitionType", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
-    [JsonConverter(typeof(EquatableEnumJsonConverter<CallMediaRecognitionType>))]
-    public partial struct CallMediaRecognitionType
+    [CodeGenModel("RecordingState", Usage = new string[] { "output" }, Formats = new string[] { "json" })]
+    [JsonConverter(typeof(EquatableEnumJsonConverter<RecordingState>))]
+    public readonly partial struct RecordingState
     {
     }
 }

--- a/sdk/communication/Azure.Communication.CallingServer/tests/Events/CallAutomationEventParserTests.cs
+++ b/sdk/communication/Azure.Communication.CallingServer/tests/Events/CallAutomationEventParserTests.cs
@@ -19,9 +19,10 @@ namespace Azure.Communication.CallingServer.Tests.Events
             var callConnectionId = Guid.NewGuid().ToString();
             var serverCallId = Guid.NewGuid().ToString();
             var correlationId = Guid.NewGuid().ToString();
-            var resultInformation = new ResultInformation(200, 0, "success");
-            JsonSerializerOptions jsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
-            CallConnected @event = CallAutomationModelFactory.CallConnected(resultInformation: resultInformation, callConnectionId: callConnectionId, serverCallId: serverCallId, correlationId: correlationId);
+            JsonSerializerOptions jsonOptions = new() {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            };
+            CallConnected @event = CallAutomationModelFactory.CallConnected(callConnectionId, serverCallId, correlationId);
             string jsonEvent = JsonSerializer.Serialize(@event, jsonOptions);
 
             // act
@@ -183,8 +184,8 @@ namespace Azure.Communication.CallingServer.Tests.Events
                 startDateTime: DateTimeOffset.UtcNow,
                 callConnectionId: "callConnectionId",
                 serverCallId: "serverCallId",
-                correlationId: "correlationId",
-                resultInformation: new ResultInformation(200, 0, "success"));
+                correlationId: "correlationId"
+                );
             JsonSerializerOptions jsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
             string jsonEvent = JsonSerializer.Serialize(@event, jsonOptions);
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.CallRecordingStateChanged");


### PR DESCRIPTION
- hid EventSource, PublicEventType, and Version from sdk users
- added ResultInformation and OperationContext to appropriate events and make them nullable properties
- addressed comments related to events in https://github.com/Azure/azure-sdk-for-net/pull/31063