### PR TITLE
Azure Monitor Exporter - Refactor to avoid sampleRate on Exception.

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -48,6 +48,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                         this("Exception", FormatUtcTimestamp(activityEventTimeStamp.DateTime))
         {
             Tags[ContextTagKeys.AiOperationParentId.ToString()] = activitySpanId.ToHexString();
+            Tags[ContextTagKeys.AiOperationId.ToString()] = telemetryItem.Tags[ContextTagKeys.AiOperationId.ToString()];
 
             // todo: update swagger to include this key.
             Tags["ai.user.userAgent"] = telemetryItem.Tags["ai.user.userAgent"];
@@ -63,6 +64,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             Tags[ContextTagKeys.AiCloudRole.ToString()] = telemetryItem.Tags[ContextTagKeys.AiCloudRole.ToString()];
             Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()];
             Tags[ContextTagKeys.AiInternalSdkVersion.ToString()] = SdkVersionUtils.s_sdkVersion;
+            InstrumentationKey = telemetryItem.InstrumentationKey;
         }
 
         public TelemetryItem (LogRecord logRecord, string roleName, string roleInstance, string instrumentationKey) :

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -17,15 +17,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
     {
         private const string DateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fffffffZ";
 
-        public TelemetryItem(string name, Activity activity, ref TagEnumerationState monitorTags, string roleName, string roleInstance, string instrumentationKey) :
-            this(name, FormatUtcTimestamp(activity.StartTimeUtc))
+        public TelemetryItem(Activity activity, ref TagEnumerationState monitorTags, string roleName, string roleInstance, string instrumentationKey) :
+            this(activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency", FormatUtcTimestamp(activity.StartTimeUtc))
         {
-            // TODO: Move "Exception" to const/enum.
-            if (name == "Exception")
-            {
-                Tags[ContextTagKeys.AiOperationParentId.ToString()] = activity.SpanId.ToHexString();
-            }
-            else if (activity.ParentSpanId != default)
+            if (activity.ParentSpanId != default)
             {
                 Tags[ContextTagKeys.AiOperationParentId.ToString()] = activity.ParentSpanId.ToHexString();
             }
@@ -47,6 +42,27 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             {
                 SampleRate = sampleRate;
             }
+        }
+
+        public TelemetryItem(TelemetryItem telemetryItem, ActivitySpanId activitySpanId, ActivityKind kind, DateTimeOffset activityEventTimeStamp) :
+                        this("Exception", FormatUtcTimestamp(activityEventTimeStamp.DateTime))
+        {
+            Tags[ContextTagKeys.AiOperationParentId.ToString()] = activitySpanId.ToHexString();
+
+            // todo: update swagger to include this key.
+            Tags["ai.user.userAgent"] = telemetryItem.Tags["ai.user.userAgent"];
+
+            // we only have mapping for server spans
+            // todo: non-server spans
+            if (kind == ActivityKind.Server)
+            {
+                Tags[ContextTagKeys.AiOperationName.ToString()] = telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()];
+                Tags[ContextTagKeys.AiLocationIp.ToString()] = telemetryItem.Tags[ContextTagKeys.AiLocationIp.ToString()];
+            }
+
+            Tags[ContextTagKeys.AiCloudRole.ToString()] = telemetryItem.Tags[ContextTagKeys.AiCloudRole.ToString()];
+            Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()];
+            Tags[ContextTagKeys.AiInternalSdkVersion.ToString()] = SdkVersionUtils.s_sdkVersion;
         }
 
         public TelemetryItem (LogRecord logRecord, string roleName, string roleInstance, string instrumentationKey) :

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
@@ -27,8 +27,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             foreach (var activity in batchActivity)
             {
                 var monitorTags = EnumerateActivityTags(activity);
-                var telemetryName = activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency";
-                telemetryItem = new TelemetryItem(telemetryName, activity, ref monitorTags, roleName, roleInstance, instrumentationKey);
+                telemetryItem = new TelemetryItem(activity, ref monitorTags, roleName, roleInstance, instrumentationKey);
+
+                // Check for Exceptions events
+                if (activity.Events.Any())
+                {
+                    AddExceptionTelemetryFromActivityExceptionEvents(activity, telemetryItem, telemetryItems);
+                }
 
                 switch (activity.GetTelemetryType())
                 {
@@ -50,12 +55,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
                 monitorTags.Return();
                 telemetryItems.Add(telemetryItem);
-
-                // Check for Exceptions events
-                if (activity.Events.Any())
-                {
-                    AddExceptionTelemetryFromActivityExceptionEvents(activity, ref monitorTags, roleName, roleInstance, instrumentationKey, telemetryItems);
-                }
             }
 
             return telemetryItems;
@@ -176,7 +175,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             return activity.DisplayName;
         }
 
-        private static void AddExceptionTelemetryFromActivityExceptionEvents(Activity activity, ref TagEnumerationState monitorTags, string roleName, string roleInstance, string instrumentationKey, List<TelemetryItem> telemetryItems)
+        private static void AddExceptionTelemetryFromActivityExceptionEvents(Activity activity, TelemetryItem telemetryItem, List<TelemetryItem> telemetryItems)
         {
             foreach (var evnt in activity.Events)
             {
@@ -187,7 +186,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                         var exceptionData = GetExceptionDataDetailsOnTelemetryItem(evnt.Tags);
                         if (exceptionData != null)
                         {
-                            var exceptionTelemetryItem = new TelemetryItem("Exception", activity, ref monitorTags, roleName, roleInstance, instrumentationKey);
+                            var exceptionTelemetryItem = new TelemetryItem(telemetryItem, activity.SpanId, activity.Kind, evnt.Timestamp);
                             exceptionTelemetryItem.Data = exceptionData;
                             telemetryItems.Add(exceptionTelemetryItem);
                         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Program.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Program.cs
@@ -10,6 +10,8 @@ using OpenTelemetry.Resources;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 using OpenTelemetry.Extensions.AzureMonitor;
+using System.Threading.Tasks;
+using System;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Demo
 {
@@ -45,6 +47,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo
                 activity?.SetTag("foo", 1);
                 activity?.SetTag("baz", new int[] { 1, 2, 3 });
                 activity?.SetStatus(ActivityStatusCode.Ok);
+                Task.Delay(2000).Wait();
+                activity.RecordException(new Exception("test message"));
 
                 using (var nestedActivity = source.StartActivity("SayHelloAgain"))
                 {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Program.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Program.cs
@@ -47,8 +47,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo
                 activity?.SetTag("foo", 1);
                 activity?.SetTag("baz", new int[] { 1, 2, 3 });
                 activity?.SetStatus(ActivityStatusCode.Ok);
-                Task.Delay(2000).Wait();
-                activity.RecordException(new Exception("test message"));
 
                 using (var nestedActivity = source.StartActivity("SayHelloAgain"))
                 {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Program.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Program.cs
@@ -10,8 +10,6 @@ using OpenTelemetry.Resources;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 using OpenTelemetry.Extensions.AzureMonitor;
-using System.Threading.Tasks;
-using System;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Demo
 {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineStorageTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineStorageTests.cs
@@ -189,8 +189,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         private static TelemetryItem CreateTelemetryItem(Activity activity)
         {
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryName = activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency";
-            return new TelemetryItem(telemetryName, activity, ref monitorTags, null, null, null);
+            return new TelemetryItem(activity, ref monitorTags, null, null, null);
         }
 
         private class MockFileProvider : PersistentBlobProvider

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/SampleRateTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/SampleRateTests.cs
@@ -52,7 +52,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 tags: new Dictionary<string, object>() { ["sampleRate"] = SampleRate });
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem("Request", activity, ref monitorTags, "RoleName", "RoleInstance", "00000000-0000-0000-0000-000000000000");
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, "RoleName", "RoleInstance", "00000000-0000-0000-0000-000000000000");
 
             if (SampleRate is float)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
@@ -46,9 +46,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
             var resourceParser = new ResourceParser();
             resourceParser.UpdateRoleNameAndInstance(resource);
-
-            var telemetryName = activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency";
-            var telemetryItem = new TelemetryItem(telemetryName, activity, ref monitorTags, resourceParser.RoleName, resourceParser.RoleInstance, "00000000-0000-0000-0000-000000000000");
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, resourceParser.RoleName, resourceParser.RoleInstance, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("RemoteDependency", telemetryItem.Name);
             Assert.Equal(TelemetryItem.FormatUtcTimestamp(activity.StartTimeUtc), telemetryItem.Time);
@@ -75,8 +73,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             var resourceParser = new ResourceParser();
             resourceParser.UpdateRoleNameAndInstance(resource);
-            var telemetryName = activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency";
-            var telemetryItem = new TelemetryItem(telemetryName, activity, ref monitorTags, resourceParser.RoleName, resourceParser.RoleInstance, "00000000-0000-0000-0000-000000000000");
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, resourceParser.RoleName, resourceParser.RoleInstance, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("RemoteDependency", telemetryItem.Name);
             Assert.Equal(TelemetryItem.FormatUtcTimestamp(activity.StartTimeUtc), telemetryItem.Time);
@@ -102,9 +99,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             var resourceParser = new ResourceParser();
             resourceParser.UpdateRoleNameAndInstance(resource);
-
-            var telemetryName = activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency";
-            var telemetryItem = new TelemetryItem(telemetryName, activity, ref monitorTags, resourceParser.RoleName, resourceParser.RoleInstance, "00000000-0000-0000-0000-000000000000");
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, resourceParser.RoleName, resourceParser.RoleInstance, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("RemoteDependency", telemetryItem.Name);
             Assert.Equal(TelemetryItem.FormatUtcTimestamp(activity.StartTimeUtc), telemetryItem.Time);
@@ -146,9 +141,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             }
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-
-            var telemetryName = activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency";
-            var telemetryItem = new TelemetryItem(telemetryName, activity, ref monitorTags, null, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null, null);
 
             Assert.Equal(expectedOperationName, telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()]);
         }
@@ -170,9 +163,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activity.SetTag(SemanticConventions.AttributeHttpUrl, "https://www.foo.bar/path?id=1");
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-
-            var telemetryName = activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency";
-            var telemetryItem = new TelemetryItem(telemetryName, activity, ref monitorTags, null, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null, null);
 
             Assert.Equal("GET /path", telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()]);
         }
@@ -191,9 +182,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activity.DisplayName = "displayname";
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-
-            var telemetryName = activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency";
-            var telemetryItem = new TelemetryItem(telemetryName, activity, ref monitorTags, null, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null, null);
 
             Assert.Equal("displayname", telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()]);
         }
@@ -211,9 +200,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activity.SetTag(SemanticConventions.AttributeHttpClientIP, "127.0.0.1");
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-
-            var telemetryName = activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency";
-            var telemetryItem = new TelemetryItem(telemetryName, activity, ref monitorTags, null, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null, null);
 
             Assert.Equal("127.0.0.1", telemetryItem.Tags[ContextTagKeys.AiLocationIp.ToString()]);
         }
@@ -231,9 +218,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activity.SetTag(SemanticConventions.AttributeNetPeerIp, "127.0.0.1");
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-
-            var telemetryName = activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency";
-            var telemetryItem = new TelemetryItem(telemetryName, activity, ref monitorTags, null, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null, null);
 
             Assert.Equal("127.0.0.1", telemetryItem.Tags[ContextTagKeys.AiLocationIp.ToString()]);
         }
@@ -252,9 +237,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activity.SetTag(SemanticConventions.AttributeHttpUserAgent, userAgent);
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-
-            var telemetryName = activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency";
-            var telemetryItem = new TelemetryItem(telemetryName, activity, ref monitorTags, null, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null, null);
 
             Assert.Equal(userAgent, telemetryItem.Tags["ai.user.userAgent"]);
         }
@@ -270,9 +253,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 startTime: DateTime.UtcNow);
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-
-            var telemetryName = activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency";
-            var telemetryItem = new TelemetryItem(telemetryName, activity, ref monitorTags, null, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null, null);
 
             Assert.Null(telemetryItem.Tags[ContextTagKeys.AiLocationIp.ToString()]);
         }
@@ -288,9 +269,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 startTime: DateTime.UtcNow);
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-
-            var telemetryName = activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency";
-            var telemetryItem = new TelemetryItem(telemetryName, activity, ref monitorTags, null, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null, null);
 
             Assert.Null(telemetryItem.Tags["ai.user.userAgent"]);
         }
@@ -310,8 +289,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             var resourceParser = new ResourceParser();
             resourceParser.UpdateRoleNameAndInstance(resource);
-            var telemetryName = activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency";
-            var telemetryItem = new TelemetryItem(telemetryName, activity, ref monitorTags, resourceParser.RoleName, resourceParser.RoleInstance, "00000000-0000-0000-0000-000000000000");
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, resourceParser.RoleName, resourceParser.RoleInstance, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal(Dns.GetHostName(), telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()]);
         }
@@ -331,8 +309,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             var resourceParser = new ResourceParser();
             resourceParser.UpdateRoleNameAndInstance(resource);
-            var telemetryName = activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency";
-            var telemetryItem = new TelemetryItem(telemetryName, activity, ref monitorTags, resourceParser.RoleName, resourceParser.RoleInstance, "00000000-0000-0000-0000-000000000000");
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, resourceParser.RoleName, resourceParser.RoleInstance, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("serviceinstance", telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()]);
         }
@@ -355,9 +332,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 activity.SetTag(SemanticConventions.AttributeHttpMethod, httpMethod);
             }
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-
-            var telemetryName = activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency";
-            var telemetryItem = new TelemetryItem(telemetryName, activity, ref monitorTags, null, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null, null);
             var requestData = new RequestData(2, activity, ref monitorTags);
 
             Assert.Equal(requestData.Name, telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()]);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TraceHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TraceHelperTests.cs
@@ -233,14 +233,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activityList[0] = activity;
             Batch<Activity> batch = new Batch<Activity>(activityList, 1);
 
-            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, "roleName", "roleInstance", "00000000 - 0000 - 0000 - 0000 - 000000000000");
+            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, "roleName", "roleInstance", "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal(2, telemetryItems.Count());
-            Assert.Equal("Request", (IEnumerable<char>)telemetryItems[0].Name);
-            Assert.Equal("Exception", (IEnumerable<char>)telemetryItems[1].Name);
-            Assert.Equal(exceptionMessage, (IEnumerable<char>)(telemetryItems[1].Data.BaseData as TelemetryExceptionData).Exceptions.First().Message);
-            Assert.Equal("System.Exception", (IEnumerable<char>)(telemetryItems[1].Data.BaseData as TelemetryExceptionData).Exceptions.First().TypeName);
-            Assert.Equal("System.Exception: Exception Message", (IEnumerable<char>)(telemetryItems[1].Data.BaseData as TelemetryExceptionData).Exceptions.First().Stack);
+            Assert.Equal("Exception", (IEnumerable<char>)telemetryItems[0].Name);
+            Assert.Equal("Request", (IEnumerable<char>)telemetryItems[1].Name);
+            Assert.Equal(exceptionMessage, (IEnumerable<char>)(telemetryItems[0].Data.BaseData as TelemetryExceptionData).Exceptions.First().Message);
+            Assert.Equal("System.Exception", (IEnumerable<char>)(telemetryItems[0].Data.BaseData as TelemetryExceptionData).Exceptions.First().TypeName);
+            Assert.Equal("System.Exception: Exception Message", (IEnumerable<char>)(telemetryItems[0].Data.BaseData as TelemetryExceptionData).Exceptions.First().Stack);
         }
 
         [Fact]


### PR DESCRIPTION
* Refactored `TelemetryItem`
* Updated tests
* Added ActivityEvent.Timestamp to Exception Telemetry generated from Activity.Events.
* Validated time change with an Example below.

```
using (var activity = source.StartActivity("SayHello"))
            {
                activity?.SetTag("foo", 1);
                activity?.SetTag("baz", new int[] { 1, 2, 3 });
                activity?.SetStatus(ActivityStatusCode.Ok);
                Task.Delay(2000).Wait();
                activity.RecordException(new Exception("test message"));
            }

{"name":"Exception","time":"2022-09-14T22:34:00.3311452Z","iKey":"00000000-0000-0000-0000-000000000000","tags":{"ai.operation.parentId":"9a59996e5c4d932f","ai.operation.id":"5793f4d2ce1a1db7309a30b3bbec0d00","ai.cloud.role":"[my-namespace]/my-service","ai.cloud.roleInstance":"my-instance","ai.internal.sdkVersion":"dotnet4.8.4515.0:otel1.3.1:ext1.0.0-alpha.20220914.1"},"data":{"baseType":"ExceptionData","baseData":{"exceptions":[{"typeName":"System.Exception","message":"test message","stack":"System.Exception: test message"}],"ver":2}}}


{"name":"RemoteDependency","time":"2022-09-14T22:33:58.3081482Z","sampleRate":100,"iKey":"00000000-0000-0000-0000-000000000000","tags":{"ai.operation.id":"5793f4d2ce1a1db7309a30b3bbec0d00","ai.cloud.role":"[my-namespace]/my-service","ai.cloud.roleInstance":"my-instance","ai.internal.sdkVersion":"dotnet4.8.4515.0:otel1.3.1:ext1.0.0-alpha.20220914.1"},"data":{"baseType":"RemoteDependencyData","baseData":{"id":"9a59996e5c4d932f","name":"SayHello","duration":"00:00:02.0428860","success":true,"properties":{"foo":"1","baz":"1,2,3"},"ver":2}}}

```