### PR TITLE
[Identity] Updating scope validation

### DIFF
--- a/sdk/identity/Azure.Identity/src/ScopeUtilities.cs
+++ b/sdk/identity/Azure.Identity/src/ScopeUtilities.cs
@@ -13,7 +13,7 @@ namespace Azure.Identity
     internal static class ScopeUtilities
     {
         private const string DefaultSuffix = "/.default";
-        private const string ScopePattern = "^[0-9a-zA-Z-.:/]+$";
+        private const string ScopePattern = "^[0-9a-zA-Z-_.:/]+$";
 
         private const string InvalidScopeMessage = "The specified scope is not in expected format. Only alphanumeric characters, '.', '-', ':', and '/' are allowed";
         private static readonly Regex scopeRegex = new Regex(ScopePattern);

--- a/sdk/identity/Azure.Identity/tests/ScopeUtilitiesTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ScopeUtilitiesTests.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests
+{
+    public class ScopeUtilitiesTests
+    {
+        [TestCase("https://vaults.azure.net/.default")]
+        [TestCase("https://management.core.windows.net//.default")]
+        [TestCase("https://graph.microsoft.com/User.Read")]
+        [TestCase("api://0478121b-afdc-4ecd-91d8-fe015a9e1826/user_impersonation")]
+        public void ValidateScopesAcceptsValidScopes(string scope)
+        {
+            Assert.DoesNotThrow(() => ScopeUtilities.ValidateScope(scope));
+        }
+
+        [TestCase("api://0478121b-afdc-4ecd-91d8-fe015a9e1826/invalid scope")]
+        [TestCase("api://0478121b-afdc-4ecd-91d8-fe015a9e1826/invalid\"scope")]
+        [TestCase("api://0478121b-afdc-4ecd-91d8-fe015a9e1826/invalid\\scope")]
+        public void ValidateScopesRejectsInvalidScopes(string scope)
+        {
+            Assert.Throws<ArgumentException>(() => ScopeUtilities.ValidateScope(scope));
+        }
+    }
+}


### PR DESCRIPTION
 Relaxes scope validation to allow '_' character, for common scopes such as `user_impersonation`

Fixes #30647