### PR TITLE
[FormRecognizer] Added sample to illustrate mocking (V3)

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -759,6 +759,7 @@ Samples showing how to use the Cognitive Services Form Recognizer library are av
 - [Get and List document model operations][get_and_list]
 - [Compose a model][compose_model]
 - [Copy a custom model between Form Recognizer resources][copy_custom_models]
+- [Mock a client for testing using the Moq library][mock_client]
 
 > Note that these samples use SDK version `4.0.0`. For lower versions of the SDK, please see [Form Recognizer Samples for V3.1.X][formrecov3_samples].
 
@@ -817,6 +818,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [copy_custom_models]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_CopyCustomModel.md
 [compose_model]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ModelCompose.md
 [get_and_list]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_GetAndListOperations.md
+[mock_client]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_MockClient.md
 
 [azure_cli]: https://docs.microsoft.com/cli/azure
 [azure_sub]: https://azure.microsoft.com/free/dotnet/

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/README.md
@@ -34,6 +34,7 @@ Azure Cognitive Services Form Recognizer is a cloud service that uses machine le
 - [Compose a model](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ModelCompose.md)
 - [Get and List document model operations](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_GetAndListOperations.md)
 - [Copy a custom model between Form Recognizer resources](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_CopyCustomModel.md)
+- [Mock a client for testing using the Moq library](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_MockClient.md)
 
 ## Samples for client library versions 3.1.x and below
 Please see the samples [here][v31samples].

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_MockClient.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_MockClient.md
@@ -1,0 +1,105 @@
+# Mock a client for testing using the Moq library
+
+This sample illustrates how to use [Moq][moq] to create a unit test that mocks the response from a `DocumentAnalysisClient` method. For more examples of mocking, see [Moq samples][moq_samples].
+
+## Define a method that uses a DocumentAnalysisClient
+To show the usage of mocks, define a method that will be tested with mocked objects. For this case, assume we have a custom model that's able to analyze groceries lists. We are going to create a method that will calculate whether the total price of a list is expensive (total price > $100), only if the recognized field has a confidence greater than 70%.
+
+```C# Snippet:DocumentAnalysisMethodToTest
+private static async Task<bool> IsExpensiveAsync(string modelId, Uri documentUri, DocumentAnalysisClient client)
+{
+    AnalyzeDocumentOperation operation = await client.AnalyzeDocumentFromUriAsync(WaitUntil.Completed, modelId, documentUri);
+    AnalyzedDocument document = operation.Value.Documents[0];
+
+    if (document.Fields.TryGetValue("totalPrice", out DocumentField totalPriceField)
+        && totalPriceField.FieldType == DocumentFieldType.Double)
+    {
+        return totalPriceField.Confidence > 0.7f && totalPriceField.Value.AsDouble() > 100.0;
+    }
+    else
+    {
+        return false;
+    }
+}
+```
+
+## Create and set up mocks
+To start, create a mock for the `DocumentAnalysisClient`. Most methods in this service make use of [Long-Running Operations][lros], so you'll likely need to create a mock operation as well.
+
+```C# Snippet:DocumentAnalysisCreateMocks
+var mockClient = new Mock<DocumentAnalysisClient>();
+var mockOperation = new Mock<AnalyzeDocumentOperation>();
+```
+
+Then, set up the client methods that will be executed. In this case, we will call the `AnalyzeDocumentFromUriAsync` method.
+
+```C# Snippet:DocumentAnalysisSetUpClientMock
+var fakeModelId = Guid.NewGuid().ToString();
+var fakeDocumentUri = new Uri("https://fake.document.uri");
+
+mockClient.Setup(client => client.AnalyzeDocumentFromUriAsync(
+        WaitUntil.Completed,
+        fakeModelId,
+        fakeDocumentUri,
+        It.IsAny<AnalyzeDocumentOptions>(),
+        It.IsAny<CancellationToken>()))
+    .Returns(Task.FromResult(mockOperation.Object));
+```
+
+If you're mocking an operation object, you will also need to set up the methods that will be called from it. In this sample, we only need to set the property `Value`.
+
+```C# Snippet:DocumentAnalysisSetUpOperationMock
+var fieldValue = DocumentAnalysisModelFactory.DocumentFieldValueWithDoubleFieldType(150.0);
+
+var fieldPolygon = new List<PointF>()
+{
+    new PointF(1f, 2f), new PointF(2f, 2f), new PointF(2f, 1f), new PointF(1f, 1f)
+};
+var fieldRegion = DocumentAnalysisModelFactory.BoundingRegion(1, fieldPolygon);
+var fieldRegions = new List<BoundingRegion>() { fieldRegion };
+
+var fieldSpans = new List<DocumentSpan>()
+{
+    DocumentAnalysisModelFactory.DocumentSpan(25, 32)
+};
+
+var field = DocumentAnalysisModelFactory.DocumentField(DocumentFieldType.Double, fieldValue, "$150.00", fieldRegions, fieldSpans, confidence: 0.85f);
+var fields = new Dictionary<string, DocumentField>
+{
+    { "totalPrice", field }
+};
+
+var documentPolygon = new List<PointF>()
+{
+    new PointF(0f, 10f), new PointF(10f, 10f), new PointF(10f, 0f), new PointF(0f, 0f)
+};
+var documentRegion = DocumentAnalysisModelFactory.BoundingRegion(1, documentPolygon);
+var documentRegions = new List<BoundingRegion>() { documentRegion };
+
+var documentSpans = new List<DocumentSpan>()
+{
+    DocumentAnalysisModelFactory.DocumentSpan(0, 105)
+};
+
+var document = DocumentAnalysisModelFactory.AnalyzedDocument("groceries:groceries", documentRegions, documentSpans, fields, 0.95f);
+var documents = new List<AnalyzedDocument>() { document };
+
+var result = DocumentAnalysisModelFactory.AnalyzeResult("groceries", documents: documents);
+
+mockOperation.SetupGet(op => op.Value)
+    .Returns(result);
+```
+
+To keep the setup simple, we suggest that you only add the properties required by your tests when building your models. In this case, we only needed the `DocumentFieldType`, the field's `Confidence`, and the field's `Value`, while other properties could be set to `null`, `default`, or empty.
+
+## Use mocks
+Now, to validate if the groceries are expensive without making a network call, use the `DocumentAnalysisClient` mock.
+
+```C# Snippet:DocumentAnalysisUseMocks
+bool isExpensive = await IsExpensiveAsync(fakeModelId, fakeDocumentUri, mockClient.Object);
+Assert.IsTrue(isExpensive);
+```
+
+[moq]: https://github.com/Moq/moq4/
+[moq_samples]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_MockClient.cs
+[lros]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#long-running-operations

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_MockClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_MockClient.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
+{
+    [IgnoreServiceError(200, "3014", Message = "Generic error during training.", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28913")]
+    public partial class DocumentAnalysisSamples
+    {
+        [RecordedTest]
+        public async Task AnalyzeDocumentAsync()
+        {
+            #region Snippet:DocumentAnalysisCreateMocks
+            var mockClient = new Mock<DocumentAnalysisClient>();
+            var mockOperation = new Mock<AnalyzeDocumentOperation>();
+            #endregion
+
+            #region Snippet:DocumentAnalysisSetUpClientMock
+            var fakeModelId = Guid.NewGuid().ToString();
+            var fakeDocumentUri = new Uri("https://fake.document.uri");
+
+            mockClient.Setup(client => client.AnalyzeDocumentFromUriAsync(
+                    WaitUntil.Completed,
+                    fakeModelId,
+                    fakeDocumentUri,
+                    It.IsAny<AnalyzeDocumentOptions>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(mockOperation.Object));
+            #endregion
+
+            #region Snippet:DocumentAnalysisSetUpOperationMock
+            var fieldValue = DocumentAnalysisModelFactory.DocumentFieldValueWithDoubleFieldType(150.0);
+
+            var fieldPolygon = new List<PointF>()
+            {
+                new PointF(1f, 2f), new PointF(2f, 2f), new PointF(2f, 1f), new PointF(1f, 1f)
+            };
+            var fieldRegion = DocumentAnalysisModelFactory.BoundingRegion(1, fieldPolygon);
+            var fieldRegions = new List<BoundingRegion>() { fieldRegion };
+
+            var fieldSpans = new List<DocumentSpan>()
+            {
+                DocumentAnalysisModelFactory.DocumentSpan(25, 32)
+            };
+
+            var field = DocumentAnalysisModelFactory.DocumentField(DocumentFieldType.Double, fieldValue, "$150.00", fieldRegions, fieldSpans, confidence: 0.85f);
+            var fields = new Dictionary<string, DocumentField>
+            {
+                { "totalPrice", field }
+            };
+
+            var documentPolygon = new List<PointF>()
+            {
+                new PointF(0f, 10f), new PointF(10f, 10f), new PointF(10f, 0f), new PointF(0f, 0f)
+            };
+            var documentRegion = DocumentAnalysisModelFactory.BoundingRegion(1, documentPolygon);
+            var documentRegions = new List<BoundingRegion>() { documentRegion };
+
+            var documentSpans = new List<DocumentSpan>()
+            {
+                DocumentAnalysisModelFactory.DocumentSpan(0, 105)
+            };
+
+            var document = DocumentAnalysisModelFactory.AnalyzedDocument("groceries:groceries", documentRegions, documentSpans, fields, 0.95f);
+            var documents = new List<AnalyzedDocument>() { document };
+
+            var result = DocumentAnalysisModelFactory.AnalyzeResult("groceries", documents: documents);
+
+            mockOperation.SetupGet(op => op.Value)
+                .Returns(result);
+            #endregion
+
+            #region Snippet:DocumentAnalysisUseMocks
+            bool isExpensive = await IsExpensiveAsync(fakeModelId, fakeDocumentUri, mockClient.Object);
+            Assert.IsTrue(isExpensive);
+            #endregion
+        }
+
+        #region Snippet:DocumentAnalysisMethodToTest
+        private static async Task<bool> IsExpensiveAsync(string modelId, Uri documentUri, DocumentAnalysisClient client)
+        {
+            AnalyzeDocumentOperation operation = await client.AnalyzeDocumentFromUriAsync(WaitUntil.Completed, modelId, documentUri);
+            AnalyzedDocument document = operation.Value.Documents[0];
+
+            if (document.Fields.TryGetValue("totalPrice", out DocumentField totalPriceField)
+                && totalPriceField.FieldType == DocumentFieldType.Double)
+            {
+                return totalPriceField.Confidence > 0.7f && totalPriceField.Value.AsDouble() > 100.0;
+            }
+            else
+            {
+                return false;
+            }
+        }
+        #endregion
+
+        [RecordedTest]
+        public async Task GetDocumentModelsAsync()
+        {
+            var mockClient = new Mock<DocumentModelAdministrationClient>();
+
+            var page = Page<DocumentModelSummary>.FromValues(new[]
+            {
+                DocumentAnalysisModelFactory.DocumentModelSummary("groceries", "Analyzes groceries lists",
+                    DateTimeOffset.Parse("2022-09-01T00:00:00Z")),
+                DocumentAnalysisModelFactory.DocumentModelSummary("custom_invoices", "Analyzes custom invoices",
+                    DateTimeOffset.Parse("2022-09-15T00:00:00Z"))
+            }, null, Mock.Of<Response>());
+
+            mockClient.Setup(client => client.GetDocumentModelsAsync(
+                    It.IsAny<CancellationToken>()))
+                .Returns(AsyncPageable<DocumentModelSummary>.FromPages(new[] { page }));
+
+            DocumentModelAdministrationClient client = mockClient.Object;
+
+            // Get the IDs of all models created before 2022/September/10.
+
+            var dateLimit = DateTimeOffset.Parse("2022-09-10T00:00:00Z");
+            var oldModelIds = new List<string>();
+
+            await foreach (DocumentModelSummary modelSummary in client.GetDocumentModelsAsync())
+            {
+                if (modelSummary.CreatedOn < dateLimit)
+                {
+                    oldModelIds.Add(modelSummary.ModelId);
+                }
+            }
+
+            Assert.AreEqual(1, oldModelIds.Count);
+            Assert.AreEqual("groceries", oldModelIds[0]);
+        }
+    }
+}


### PR DESCRIPTION
Based on customer feedback (#30941).

We already had a mocking sample for Form Recognizer versions 3.1.x and below ([link here](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample_MockClient.md)). We're basically transcribing what we had before to 4.0.0, making some changes to fit the new design.