### PR TITLE
[AzureMonitorExporter] refactor demo projects

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/Azure.Monitor.OpenTelemetry.Exporter.sln
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/Azure.Monitor.OpenTelemetry.Exporter.sln
@@ -17,8 +17,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Monitor.OpenTelemetry
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Monitor.OpenTelemetry.Exporter.Benchmarks", "tests\Azure.Monitor.OpenTelemetry.Exporter.Benchmarks\Azure.Monitor.OpenTelemetry.Exporter.Benchmarks.csproj", "{D57D79BA-6D39-4E9E-970C-A5F73A4425BB}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Monitor.OpenTelemetry.Exporter.Tracing.Customization", "tests\Azure.Monitor.OpenTelemetry.Exporter.Tracing.Customization\Azure.Monitor.OpenTelemetry.Exporter.Tracing.Customization.csproj", "{57A53135-3C1B-4106-B873-434B2F606B17}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Monitor.OpenTelemetry.Exporter.E2E.Tests", "tests\E2E.Tests\Azure.Monitor.OpenTelemetry.Exporter.E2E.Tests.csproj", "{5083A0B8-24CE-4AC4-AC23-C9BD87EE2FC8}"
 EndProject
 Global
@@ -55,10 +53,6 @@ Global
 		{D57D79BA-6D39-4E9E-970C-A5F73A4425BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D57D79BA-6D39-4E9E-970C-A5F73A4425BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D57D79BA-6D39-4E9E-970C-A5F73A4425BB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{57A53135-3C1B-4106-B873-434B2F606B17}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{57A53135-3C1B-4106-B873-434B2F606B17}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{57A53135-3C1B-4106-B873-434B2F606B17}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{57A53135-3C1B-4106-B873-434B2F606B17}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5083A0B8-24CE-4AC4-AC23-C9BD87EE2FC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5083A0B8-24CE-4AC4-AC23-C9BD87EE2FC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5083A0B8-24CE-4AC4-AC23-C9BD87EE2FC8}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Logs/LogDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Logs/LogDemo.cs
@@ -21,10 +21,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Logs
             });
         }
 
+        /// <remarks>
+        /// Logs will be ingested as an Application Insights trace.
+        /// These can be differentiated by their severityLevel.
+        /// </remarks>
         public void GenerateLogs()
         {
             var logger = this.loggerFactory.CreateLogger<LogDemo>();
             logger.LogInformation("Hello from {name} {price}.", "tomato", 2.99);
+            logger.LogError("An error occurred.");
         }
 
         public void Dispose()

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Logs/LogDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Logs/LogDemo.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Logs
+{
+    internal class LogDemo : IDisposable
+    {
+        private readonly ILoggerFactory loggerFactory;
+
+        public LogDemo(string connectionString)
+        {
+            this.loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddOpenTelemetry(options =>
+                {
+                    options.AddAzureMonitorLogExporter(o => o.ConnectionString = connectionString);
+                });
+            });
+        }
+
+        public void GenerateLogs()
+        {
+            var logger = this.loggerFactory.CreateLogger<LogDemo>();
+            logger.LogInformation("Hello from {name} {price}.", "tomato", 2.99);
+        }
+
+        public void Dispose()
+        {
+            this.loggerFactory.Dispose();
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Metrics/MetricDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Metrics/MetricDemo.cs
@@ -23,6 +23,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Metrics
                                 .Build();
         }
 
+        /// <remarks>
+        /// These counters will be aggregated and ingested as Application Insights customMetrics.
+        /// </remarks>
         public void GenerateMetrics()
         {
             Counter<long> MyFruitCounter = meter.CreateCounter<long>("MyFruitCounter");
@@ -37,7 +40,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Metrics
 
         public void Dispose()
         {
-            this.meterProvider.Shutdown();
             this.meterProvider.Dispose();
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Metrics/MetricDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Metrics/MetricDemo.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.Metrics;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Metrics
+{
+    internal class MetricDemo : IDisposable
+    {
+        private const string meterName = "MyCompany.MyProduct.MyLibrary";
+        private static readonly Meter meter = new(meterName);
+
+        private readonly MeterProvider meterProvider;
+
+        public MetricDemo(string connectionString)
+        {
+            this.meterProvider = Sdk.CreateMeterProviderBuilder()
+                                .AddMeter(meterName)
+                                .AddAzureMonitorMetricExporter(o => o.ConnectionString = connectionString)
+                                .Build();
+        }
+
+        public void GenerateMetrics()
+        {
+            Counter<long> MyFruitCounter = meter.CreateCounter<long>("MyFruitCounter");
+
+            MyFruitCounter.Add(1, new("name", "apple"), new("color", "red"));
+            MyFruitCounter.Add(2, new("name", "lemon"), new("color", "yellow"));
+            MyFruitCounter.Add(1, new("name", "lemon"), new("color", "yellow"));
+            MyFruitCounter.Add(2, new("name", "apple"), new("color", "green"));
+            MyFruitCounter.Add(5, new("name", "apple"), new("color", "red"));
+            MyFruitCounter.Add(4, new("name", "lemon"), new("color", "yellow"));
+        }
+
+        public void Dispose()
+        {
+            this.meterProvider.Shutdown();
+            this.meterProvider.Dispose();
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Program.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Program.cs
@@ -1,88 +1,30 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.Metrics;
-using Microsoft.Extensions.Logging;
-using OpenTelemetry;
-using OpenTelemetry.Resources;
-using OpenTelemetry.Metrics;
-using OpenTelemetry.Trace;
-using OpenTelemetry.Extensions.AzureMonitor;
+using System;
+using Azure.Monitor.OpenTelemetry.Exporter.Demo.Logs;
+using Azure.Monitor.OpenTelemetry.Exporter.Demo.Metrics;
+using Azure.Monitor.OpenTelemetry.Exporter.Demo.Traces;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Demo
 {
     public class Program
     {
         private const string ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
-        private static readonly ActivitySource source = new ActivitySource("MyCompany.MyProduct.MyLibrary");
-        private static readonly Meter MyMeter = new("MyCompany.MyProduct.MyLibrary", "1.0");
 
         public static void Main()
         {
-            GenerateTraces();
-            GenerateLogs();
-            GenerateMetrics();
-        }
+            using var traceDemo = new TraceDemo(ConnectionString);
+            traceDemo.GenerateTraces();
 
-        private static void GenerateTraces()
-        {
-            var resourceAttributes = new Dictionary<string, object> { { "service.name", "my-service" }, { "service.namespace", "my-namespace" }, { "service.instance.id", "my-instance" } };
-            var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                            .SetResourceBuilder(resourceBuilder)
-                            .AddSource("MyCompany.MyProduct.MyLibrary")
-                            .SetSampler(new ApplicationInsightsSampler(1.0F))
-                            .AddAzureMonitorTraceExporter(o =>
-                            {
-                                o.ConnectionString = ConnectionString;
-                            })
-                            .Build();
+            using var metricDemo = new MetricDemo(ConnectionString);
+            metricDemo.GenerateMetrics();
 
-            using (var activity = source.StartActivity("SayHello"))
-            {
-                activity?.SetTag("foo", 1);
-                activity?.SetTag("baz", new int[] { 1, 2, 3 });
-                activity?.SetStatus(ActivityStatusCode.Ok);
+            using var logDemo = new LogDemo(ConnectionString);
+            logDemo.GenerateLogs();
 
-                using (var nestedActivity = source.StartActivity("SayHelloAgain"))
-                {
-                    nestedActivity?.SetTag("bar", "Hello, World!");
-                    nestedActivity?.SetStatus(ActivityStatusCode.Ok);
-                }
-            }
-        }
-
-        private static void GenerateLogs()
-        {
-            using var loggerFactory = LoggerFactory.Create(builder =>
-            {
-                builder.AddOpenTelemetry(options =>
-                {
-                    options.AddAzureMonitorLogExporter(o => o.ConnectionString = ConnectionString);
-                });
-            });
-
-            var logger = loggerFactory.CreateLogger<Program>();
-            logger.LogInformation("Hello from {name} {price}.", "tomato", 2.99);
-        }
-
-        private static void GenerateMetrics()
-        {
-            Counter<long> MyFruitCounter = MyMeter.CreateCounter<long>("MyFruitCounter");
-
-            using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                                         .AddMeter("MyCompany.MyProduct.MyLibrary")
-                                         .AddAzureMonitorMetricExporter(o => o.ConnectionString = ConnectionString)
-                                         .Build();
-
-            MyFruitCounter.Add(1, new("name", "apple"), new("color", "red"));
-            MyFruitCounter.Add(2, new("name", "lemon"), new("color", "yellow"));
-            MyFruitCounter.Add(1, new("name", "lemon"), new("color", "yellow"));
-            MyFruitCounter.Add(2, new("name", "apple"), new("color", "green"));
-            MyFruitCounter.Add(5, new("name", "apple"), new("color", "red"));
-            MyFruitCounter.Add(4, new("name", "lemon"), new("color", "yellow"));
+            Console.WriteLine("Press Enter key to exit.");
+            Console.ReadLine();
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/ActivityEnrichingProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/ActivityEnrichingProcessor.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using OpenTelemetry;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tracing.Customization
+{
+    public class ActivityEnrichingProcessor : BaseProcessor<Activity>
+    {
+        public override void OnEnd(Activity activity)
+        {
+            // The updated activity will be available to all processors which are called after this processor.
+            activity.DisplayName = "Updated-" + activity.DisplayName;
+            activity.SetTag("CustomDimension1", "Value1");
+            activity.SetTag("CustomDimension2", "Value2");
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/ActivityEnrichingProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/ActivityEnrichingProcessor.cs
@@ -11,9 +11,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tracing.Customization
         public override void OnEnd(Activity activity)
         {
             // The updated activity will be available to all processors which are called after this processor.
-            activity.DisplayName = "Updated-" + activity.DisplayName;
+            activity.DisplayName = "Enriched-" + activity.DisplayName;
             activity.SetTag("CustomDimension1", "Value1");
             activity.SetTag("CustomDimension2", "Value2");
+            activity.SetTag("ActivityKind", activity.Kind);
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/ActivityFilteringProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/ActivityFilteringProcessor.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using OpenTelemetry;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tracing.Customization
+{
+    internal class ActivityFilteringProcessor : BaseProcessor<Activity>
+    {
+        public override void OnStart(Activity activity)
+        {
+            // prevents all exporters from exporting internal activities
+            if (activity.Kind == ActivityKind.Internal)
+            {
+                activity.IsAllDataRequested = false;
+            }
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/ActivityFilteringProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/ActivityFilteringProcessor.cs
@@ -11,7 +11,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tracing.Customization
         public override void OnStart(Activity activity)
         {
             // prevents all exporters from exporting internal activities
-            if (activity.Kind == ActivityKind.Internal)
+            if (activity.Kind == ActivityKind.Producer)
             {
                 activity.IsAllDataRequested = false;
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/TraceDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/TraceDemo.cs
@@ -40,12 +40,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Traces
                             .Build();
         }
 
+        /// <remarks>
+        /// Activities will be ingested and stored in Application Insights
+        /// as either a request or dependency, according to their ActivityKind.
+        /// </remarks>
         public void GenerateTraces()
         {
-            using (var testActivity1 = activitySource.StartActivity("TestInternalActivity", ActivityKind.Internal))
+            // Note: This activity will be dropped due to the ActivityFilteringProcessor filtering ActivityKind.Producer.
+            using (var testActivity1 = activitySource.StartActivity("TestInternalActivity", ActivityKind.Producer))
             {
-                // Note: This activity will be dropped due to
-                // the ActivityFilteringProcessor filtering Internal Activities.
                 testActivity1?.SetTag("CustomTag1", "Value1");
                 testActivity1?.SetTag("CustomTag2", "Value2");
             }
@@ -56,7 +59,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Traces
                 activity?.SetTag("baz", new int[] { 1, 2, 3 });
                 activity?.SetStatus(ActivityStatusCode.Ok);
 
-                using (var nestedActivity = activitySource.StartActivity("SayHelloAgain", ActivityKind.Client))
+                using (var nestedActivity = activitySource.StartActivity("SayHelloAgain", ActivityKind.Server))
                 {
                     nestedActivity?.SetTag("bar", "Hello, World!");
                     nestedActivity?.SetStatus(ActivityStatusCode.Ok);
@@ -66,7 +69,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Traces
 
         public void Dispose()
         {
-            this.tracerProvider.Shutdown();
             this.tracerProvider.Dispose();
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/TraceDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/TraceDemo.cs
@@ -44,8 +44,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Traces
         {
             using (var testActivity1 = activitySource.StartActivity("TestInternalActivity", ActivityKind.Internal))
             {
-                // Note: These will not be ingested because
-                // the ActivityFilteringProcessor will drop Internal Activities.
+                // Note: This activity will be dropped due to
+                // the ActivityFilteringProcessor filtering Internal Activities.
                 testActivity1?.SetTag("CustomTag1", "Value1");
                 testActivity1?.SetTag("CustomTag2", "Value2");
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/TraceDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/TraceDemo.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Azure.Monitor.OpenTelemetry.Exporter.Tracing.Customization;
+using OpenTelemetry;
+using OpenTelemetry.Extensions.AzureMonitor;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Traces
+{
+    internal class TraceDemo : IDisposable
+    {
+        private const string activitySourceName = "MyCompany.MyProduct.MyLibrary";
+        private static readonly ActivitySource activitySource = new(activitySourceName);
+
+        private readonly TracerProvider tracerProvider;
+
+        public TraceDemo(string connectionString)
+        {
+            var resourceAttributes = new Dictionary<string, object>
+            {
+                { "service.name", "my-service" },
+                { "service.namespace", "my-namespace" },
+                { "service.instance.id", "my-instance" },
+            };
+
+            var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
+
+            this.tracerProvider = Sdk.CreateTracerProviderBuilder()
+                            .SetResourceBuilder(resourceBuilder)
+                            .AddSource(activitySourceName)
+                            .AddProcessor(new ActivityFilteringProcessor())
+                            .AddProcessor(new ActivityEnrichingProcessor())
+                            .SetSampler(new ApplicationInsightsSampler(1.0F))
+                            .AddAzureMonitorTraceExporter(o => o.ConnectionString = connectionString)
+                            .Build();
+        }
+
+        public void GenerateTraces()
+        {
+            using (var testActivity1 = activitySource.StartActivity("TestInternalActivity", ActivityKind.Internal))
+            {
+                // Note: These will not be ingested because
+                // the ActivityFilteringProcessor will drop Internal Activities.
+                testActivity1?.SetTag("CustomTag1", "Value1");
+                testActivity1?.SetTag("CustomTag2", "Value2");
+            }
+
+            using (var activity = activitySource.StartActivity("SayHello", ActivityKind.Client))
+            {
+                activity?.SetTag("foo", 1);
+                activity?.SetTag("baz", new int[] { 1, 2, 3 });
+                activity?.SetStatus(ActivityStatusCode.Ok);
+
+                using (var nestedActivity = activitySource.StartActivity("SayHelloAgain", ActivityKind.Client))
+                {
+                    nestedActivity?.SetTag("bar", "Hello, World!");
+                    nestedActivity?.SetStatus(ActivityStatusCode.Ok);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            this.tracerProvider.Shutdown();
+            this.tracerProvider.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Refactor demo project as was discussed here: https://github.com/Azure/azure-sdk-for-net/pull/30860#discussion_r965065100


### Changes
- Demo Project
  - created sub directories: "Logs", "Metrics", and "Traces".
    Future work: customization examples will be added to these directories to accompany public Documentation.
  - broke up the previous `Program.cs` into three new classes "LogDemo", "MetricDemo", and "TraceDemo".
- Traces.Customization project
  - removed project
  - moved `ActivityEnrichingProcessor` and `ActivityFilteringProcessor` to "Demo\Traces" directory.