### PR TITLE
[ServiceBus] ServicebusRetryPolicy remove locking

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusRetryPolicy.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusRetryPolicy.cs
@@ -30,7 +30,7 @@ namespace Azure.Messaging.ServiceBus
         /// Represents a state flag that is used to make sure the server busy value can be observed with
         /// reasonable fresh values without having to acquire a lock.
         /// </summary>
-        private volatile int serverBusyState;
+        private volatile int _serverBusyState;
 
         private const int ServerNotBusyState = 0; // default value of serverBusy
         private const int ServerBusyState = 1;
@@ -38,7 +38,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Determines whether or not the server returned a busy error.
         /// </summary>
-        internal bool IsServerBusy => serverBusyState == ServerBusyState;
+        internal bool IsServerBusy => _serverBusyState == ServerBusyState;
 
         /// <summary>
         /// Gets the exception message when a server busy error is returned.
@@ -195,26 +195,26 @@ namespace Azure.Messaging.ServiceBus
         private void SetServerBusy(string exceptionMessage, CancellationToken cancellationToken)
         {
             // multiple call to this method will not prolong the timer.
-            if (serverBusyState == ServerBusyState)
+            if (_serverBusyState == ServerBusyState)
             {
                 return;
             }
 
             ServerBusyExceptionMessage = string.IsNullOrWhiteSpace(exceptionMessage) ?
                 Resources.DefaultServerBusyException : exceptionMessage;
-            Interlocked.Exchange(ref serverBusyState, ServerBusyState);
+            Interlocked.Exchange(ref _serverBusyState, ServerBusyState);
             _ = ScheduleResetServerBusy(cancellationToken);
         }
 
         private void ResetServerBusy()
         {
-            if (serverBusyState == ServerNotBusyState)
+            if (_serverBusyState == ServerNotBusyState)
             {
                 return;
             }
 
             ServerBusyExceptionMessage = Resources.DefaultServerBusyException;
-            Interlocked.Exchange(ref serverBusyState, ServerNotBusyState);
+            Interlocked.Exchange(ref _serverBusyState, ServerNotBusyState);
         }
 
         private async Task ScheduleResetServerBusy(CancellationToken cancellationToken)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusRetryPolicy.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusRetryPolicy.cs
@@ -148,7 +148,6 @@ namespace Azure.Messaging.ServiceBus
                 {
                     return await operation(t1, tryTimeout, cancellationToken).ConfigureAwait(false);
                 }
-
                 catch (Exception ex)
                 {
                     Exception activeEx = AmqpExceptionHelper.TranslateException(ex);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusRetryPolicy.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusRetryPolicy.cs
@@ -26,8 +26,6 @@ namespace Azure.Messaging.ServiceBus
     ///
     public abstract class ServiceBusRetryPolicy
     {
-        private static readonly TimeSpan ServerBusyBaseSleepTime = TimeSpan.FromSeconds(10);
-
         /// <summary>
         /// Represents a state flag that is used to make sure the server busy value can be observed with
         /// reasonable fresh values without having to acquire a lock.
@@ -40,12 +38,18 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Determines whether or not the server returned a busy error.
         /// </summary>
-        private bool IsServerBusy => serverBusyState == ServerBusyState;
+        internal bool IsServerBusy => serverBusyState == ServerBusyState;
 
         /// <summary>
         /// Gets the exception message when a server busy error is returned.
         /// </summary>
-        private string ServerBusyExceptionMessage { get; set; }
+        internal string ServerBusyExceptionMessage { get; set; }
+
+        /// <summary>
+        /// Gets the server busy base sleep time
+        /// </summary>
+        /// <remarks>Defaults to TimeSpan.FromSeconds(10)</remarks>
+        internal TimeSpan ServerBusyBaseSleepTime { get; set; } = TimeSpan.FromSeconds(10);
 
         /// <summary>
         ///   The instance of <see cref="ServiceBusEventSource" /> which can be mocked for testing.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusRetryPolicy.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusRetryPolicy.cs
@@ -186,7 +186,7 @@ namespace Azure.Messaging.ServiceBus
             throw new TaskCanceledException();
         }
 
-        internal void SetServerBusy(string exceptionMessage, CancellationToken cancellationToken)
+        private void SetServerBusy(string exceptionMessage, CancellationToken cancellationToken)
         {
             // multiple call to this method will not prolong the timer.
             if (Interlocked.CompareExchange(ref serverBusyLock, 1, 0) != 0)
@@ -201,7 +201,7 @@ namespace Azure.Messaging.ServiceBus
             _ = ScheduleResetServerBusy(cancellationToken);
         }
 
-        internal void ResetServerBusy()
+        private void ResetServerBusy()
         {
             if (Interlocked.CompareExchange(ref serverBusyLock, 1, 0) != 0)
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Core/ServiceBusRetryPolicyTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Core/ServiceBusRetryPolicyTests.cs
@@ -22,7 +22,7 @@ namespace Azure.Messaging.ServiceBus.Tests
             var policy = new MockServiceBusRetryPolicy();
 
             Assert.That(policy.IsServerBusy, Is.False);
-            Assert.That(policy.ServerBusyBaseSleepTime, Is.EqualTo(TimeSpan.FromSeconds(10)));
+            Assert.That(policy.ServerBusyBaseSleepTime, Is.GreaterThan(TimeSpan.FromSeconds(0)));
             Assert.That(policy.ServerBusyExceptionMessage, Is.Null);
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Core/ServiceBusRetryPolicyTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Core/ServiceBusRetryPolicyTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Azure.Messaging.ServiceBus.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="ServiceBusRetryPolicy" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class ServiceBusRetryPolicyTests
+    {
+        [Test]
+        public void HasDefaultValues()
+        {
+            var policy = new MockServiceBusRetryPolicy();
+
+            Assert.That(policy.IsServerBusy, Is.False);
+            Assert.That(policy.ServerBusyBaseSleepTime, Is.EqualTo(TimeSpan.FromSeconds(10)));
+            Assert.That(policy.ServerBusyExceptionMessage, Is.Null);
+        }
+
+        [Test]
+        public async Task ExecutesRunOperationWithState()
+        {
+            var policy = new MockServiceBusRetryPolicy();
+
+            var operationResult = await policy.RunOperation((state, timeout, token) => new ValueTask<bool>(!state), false, null,
+                CancellationToken.None);
+
+            Assert.That(operationResult, Is.True);
+        }
+
+        [Test]
+        public void SetsServerBusy()
+        {
+            var policy = new MockServiceBusRetryPolicy();
+
+            Assert.ThrowsAsync<ServiceBusException>(async () =>
+            {
+                await policy.RunOperation((state, timeout, token) =>
+                    {
+                        throw new ServiceBusException("Busy", ServiceBusFailureReason.ServiceBusy);
+                    }, false, null,
+                    CancellationToken.None);
+            });
+            Assert.That(policy.IsServerBusy, Is.True);
+        }
+
+        [Test]
+        public void ResetsServerBusyAfterBaseSleepTime()
+        {
+            var policy = new MockServiceBusRetryPolicy
+            {
+                ServerBusyBaseSleepTime = TimeSpan.FromMilliseconds(10)
+            };
+
+            Assert.ThrowsAsync<ServiceBusException>(async () =>
+            {
+                await policy.RunOperation((state, timeout, token) =>
+                    {
+                        throw new ServiceBusException("Busy", ServiceBusFailureReason.ServiceBusy);
+                    }, false, null,
+                    CancellationToken.None);
+            });
+
+            var serverNoLongerBusy = SpinWait.SpinUntil(() => policy.IsServerBusy == false, TimeSpan.FromSeconds(1));
+            Assert.That(serverNoLongerBusy, Is.True);
+        }
+
+        private class MockServiceBusRetryPolicy : ServiceBusRetryPolicy
+        {
+            public override TimeSpan CalculateTryTimeout(int attemptCount)
+            {
+                return TimeSpan.Zero;
+            }
+
+            public override TimeSpan? CalculateRetryDelay(Exception lastException, int attemptCount)
+            {
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
While trying to figure out what is going on with https://github.com/Azure/azure-sdk-for-net/issues/25275 I observed that the retry policy uses `volatile` and locking to achieve some sort of "consistent" state in the server busy case. I was wondering whether we are running into lock reentrancy problems and potential deadlocks there in edge cases. I tried to get rid of the lock as an attempt and figured I send in the PR to see what you think. 

In the best case, we have something valuable to proceed. In the worst case, I make a complete fool out of myself :smirk: but at least I tried :)

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
