### PR TITLE
Dispose semaphores in ServiceBusProcessor

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -1029,6 +1029,9 @@ namespace Azure.Messaging.ServiceBus
         {
             await CloseAsync().ConfigureAwait(false);
             _handlerCts.Dispose();
+            _messageHandlerSemaphore.Dispose();
+            _maxConcurrentAcceptSessionsSemaphore.Dispose();
+            _processingStartStopSemaphore.Dispose();
             GC.SuppressFinalize(this);
         }
 


### PR DESCRIPTION
I wasn't certain if it was deliberate or an oversight, so I went ahead and disposed the semaphores owned by the processor. 

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
