### PR TITLE
[AzureMonitorExporter] update readme

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
@@ -78,7 +78,7 @@ Some key concepts for OpenTelemetry include:
   OpenTelemetry is a set of libraries used to collect and export telemetry data
   (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior.
 
-- [Instrumentation](instrumentation_library):
+- [Instrumentation](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/overview.md#instrumentation-libraries):
   The ability to call the OpenTelemetry API directly by any application is
   facilitated by instrumentation. A library that enables OpenTelemetry observability for another library is called an Instrumentation Library.
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
@@ -27,7 +27,7 @@ These are provided without support and are not intended for production workloads
 
 ### Add the Exporter
 
-The following examples demonstrate how to add the `AzureMonitorExporter` to either Traces, Metrics, or Logs.
+The following examples demonstrate how to add the `AzureMonitorExporter` to your OpenTelemetry configuration.
 
 - Traces
     ```csharp
@@ -36,12 +36,16 @@ The following examples demonstrate how to add the `AzureMonitorExporter` to eith
         .Build();
     ```
 
+  For a complete example see [TraceDemo.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/TraceDemo.cs).
+
 - Metrics
     ```csharp
     Sdk.CreateMeterProviderBuilder()
         .AddAzureMonitorMetricExporter(o => o.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000")
         .Build();
     ```
+
+  For a complete example see [MetricDemo.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Metrics/MetricDemo.cs).
 
 - Logs
     ```csharp
@@ -54,13 +58,43 @@ The following examples demonstrate how to add the `AzureMonitorExporter` to eith
     });
     ```
 
+  For a complete example see [LogDemo.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Logs/LogDemo.cs).
+
 ### Authenticate the client
 
 Exporter does not use authentication. 
 
 ## Key concepts
 
-This exporter sends traces to the configured Azure Monitor Resource using HTTPS. IP addresses used by the Azure Monitor is documented in [IP addresses used by Application Insights and Log Analytics](https://docs.microsoft.com/azure/azure-monitor/app/ip-addresses#outgoing-ports).
+Some key concepts for Azure Monitor include:
+
+- [IP Addresses used by Azure Monitor](https://docs.microsoft.com/azure/azure-monitor/app/ip-addresses#outgoing-ports):
+  This exporter sends traces to the configured Azure Monitor Resource using HTTPS.
+  You might need to know IP addresses if the app or infrastructure that you're monitoring is hosted behind a firewall.
+
+Some key concepts for OpenTelemetry include:
+
+- [OpenTelemetry](https://opentelemetry.io/):
+  OpenTelemetry is a set of libraries used to collect and export telemetry data
+  (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior.
+
+- [Instrumentation](instrumentation_library):
+  The ability to call the OpenTelemetry API directly by any application is
+  facilitated by instrumentation. A library that enables OpenTelemetry observability for another library is called an Instrumentation Library.
+
+- [Tracing Signal](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#tracing-signal): 
+  Trace refers to distributed tracing. It can be thought of as a directed acyclic graph (DAG) of Spans, where the edges between Spans are defined as parent/child relationship.
+
+- [Sampling](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#sampling): 
+  Sampling is a mechanism to control the noise and overhead introduced by OpenTelemetry by reducing the number of samples of traces collected and sent to the backend.
+
+- [Metric Signal](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#metric-signal):
+  OpenTelemetry allows to record raw measurements or metrics with predefined aggregation and a set of attributes (dimensions).
+
+- [Log Signal](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#log-signal):
+  A recording of an event. Typically the record includes a timestamp indicating when the event happened as well as other data that describes what happened, where it happened, etc.
+
+For more information on the OpenTelemetry project, please review the [OpenTelemetry Specifications](https://github.com/open-telemetry/opentelemetry-specification).
 
 ## Examples
 


### PR DESCRIPTION
Follow up to #31204 and #31180.

### Changes
- Update "Add the Exporter" with links to the new Demo classes.
- Expanded the Key Concepts section.
  Copied most of this from the [Java repo](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/monitor/azure-monitor-opentelemetry-exporter#key-concepts). 