### PR TITLE
[ServiceBus] Optimize body eager copying

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/MessageBody.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/MessageBody.cs
@@ -80,6 +80,11 @@ namespace Azure.Messaging.ServiceBus.Amqp
             private IList<ReadOnlyMemory<byte>> _segments;
             private IEnumerable<ReadOnlyMemory<byte>> _lazySegments;
 
+            internal CopyingOnConversionMessageBody(IEnumerable<ReadOnlyMemory<byte>> dataSegments)
+            {
+                _lazySegments = dataSegments;
+            }
+
             protected override ReadOnlyMemory<byte> WrittenMemory
             {
                 get
@@ -98,9 +103,9 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 }
             }
 
-            internal CopyingOnConversionMessageBody(IEnumerable<ReadOnlyMemory<byte>> dataSegments)
+            public override IEnumerator<ReadOnlyMemory<byte>> GetEnumerator()
             {
-                _lazySegments = dataSegments;
+                return _segments?.GetEnumerator() ?? _lazySegments.GetEnumerator();
             }
 
             private void Append(ReadOnlyMemory<byte> segment)
@@ -112,11 +117,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 segment.CopyTo(memory);
                 _writer.Advance(segment.Length);
                 _segments.Add(memory.Slice(0, segment.Length));
-            }
-
-            public override IEnumerator<ReadOnlyMemory<byte>> GetEnumerator()
-            {
-                return _segments?.GetEnumerator() ?? _lazySegments.GetEnumerator();
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/MessageBody.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/MessageBody.cs
@@ -141,7 +141,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     segments ??= dataSegments is IReadOnlyCollection<Data> readOnlyList
                         ? new List<ReadOnlyMemory<byte>>(readOnlyList.Count)
                         : new List<ReadOnlyMemory<byte>>();
-                    ReadOnlyMemory<byte> dataToAppend =  segment switch
+                    ReadOnlyMemory<byte> dataToAppend = segment switch
                     {
                         ReadOnlyMemory<byte> romSegment => romSegment,
                         Data data => data.Value switch

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/MessageBody.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/MessageBody.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/MessageBody.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/MessageBody.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -130,10 +131,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
             internal EagerCopyingMessageBody(IEnumerable<Data> dataSegments)
             {
-                foreach (var segment in dataSegments)
-                {
-                    Append(segment);
-                }
+                Append(dataSegments);
             }
 
             protected override ReadOnlyMemory<byte> WrittenMemory => _writer?.WrittenMemory ?? ReadOnlyMemory<byte>.Empty;
@@ -143,23 +141,44 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 return _segments.GetEnumerator();
             }
 
-            private void Append(Data segment)
+            private void Append(IEnumerable<Data> dataSegments)
             {
-                // fields are lazy initialized to not occupy unnecessary memory when there are no data segments
-                _writer ??= new ArrayBufferWriter<byte>();
-                _segments ??= new List<ReadOnlyMemory<byte>>();
-
-                ReadOnlyMemory<byte> dataToAppend = segment.Value switch
+                int length = 0;
+                int numberOfSegments = 0;
+                List<ReadOnlyMemory<byte>> segments = null;
+                foreach (var segment in dataSegments)
                 {
-                    byte[] byteArray => byteArray,
-                    ArraySegment<byte> arraySegment => arraySegment,
-                    _ => ReadOnlyMemory<byte>.Empty
-                };
+                    segments ??= dataSegments is IReadOnlyCollection<Data> readOnlyList
+                        ? new List<ReadOnlyMemory<byte>>(readOnlyList.Count)
+                        : new List<ReadOnlyMemory<byte>>();
+                    ReadOnlyMemory<byte> dataToAppend = segment.Value switch
+                    {
+                        byte[] byteArray => byteArray,
+                        ArraySegment<byte> arraySegment => arraySegment,
+                        _ => ReadOnlyMemory<byte>.Empty
+                    };
+                    length += dataToAppend.Length;
+                    numberOfSegments++;
+                    segments.Add(dataToAppend);
+                }
 
-                var memory = _writer.GetMemory(dataToAppend.Length);
-                dataToAppend.CopyTo(memory);
-                _writer.Advance(dataToAppend.Length);
-                _segments.Add(memory.Slice(0, dataToAppend.Length));
+                if (segments == null)
+                {
+                    return;
+                }
+
+                // fields are lazy initialized to not occupy unnecessary memory when there are no data segments
+                _writer = length > 0 ? new ArrayBufferWriter<byte>(length) : new ArrayBufferWriter<byte>();
+                _segments = segments;
+
+                for (var i = 0; i < numberOfSegments; i++)
+                {
+                    var dataToAppend = segments[i];
+                    var memory = _writer.GetMemory(dataToAppend.Length);
+                    dataToAppend.CopyTo(memory);
+                    _writer.Advance(dataToAppend.Length);
+                    segments[i] = memory.Slice(0, dataToAppend.Length);
+                }
             }
         }
     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/MessageBody.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/MessageBody.cs
@@ -91,11 +91,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 {
                     if (_lazySegments != null)
                     {
-                        foreach (var segment in _lazySegments)
-                        {
-                            Append(segment);
-                        }
-
+                        Append(_lazySegments);
                         _lazySegments = null;
                     }
 
@@ -108,15 +104,38 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 return _segments?.GetEnumerator() ?? _lazySegments.GetEnumerator();
             }
 
-            private void Append(ReadOnlyMemory<byte> segment)
+            private void Append(IEnumerable<ReadOnlyMemory<byte>> dataSegments)
             {
-                _writer ??= new ArrayBufferWriter<byte>();
-                _segments ??= new List<ReadOnlyMemory<byte>>();
+                int length = 0;
+                int numberOfSegments = 0;
+                List<ReadOnlyMemory<byte>> segments = null;
+                foreach (var segment in dataSegments)
+                {
+                    segments ??= dataSegments is IReadOnlyCollection<ReadOnlyMemory<byte>> readOnlyList
+                        ? new List<ReadOnlyMemory<byte>>(readOnlyList.Count)
+                        : new List<ReadOnlyMemory<byte>>();
+                    length += segment.Length;
+                    numberOfSegments++;
+                    segments.Add(segment);
+                }
 
-                var memory = _writer.GetMemory(segment.Length);
-                segment.CopyTo(memory);
-                _writer.Advance(segment.Length);
-                _segments.Add(memory.Slice(0, segment.Length));
+                if (segments == null)
+                {
+                    return;
+                }
+
+                // fields are lazy initialized to not occupy unnecessary memory when there are no data segments
+                _writer = length > 0 ? new ArrayBufferWriter<byte>(length) : new ArrayBufferWriter<byte>();
+                _segments = segments;
+
+                for (var i = 0; i < numberOfSegments; i++)
+                {
+                    var dataToAppend = segments[i];
+                    var memory = _writer.GetMemory(dataToAppend.Length);
+                    dataToAppend.CopyTo(memory);
+                    _writer.Advance(dataToAppend.Length);
+                    segments[i] = memory.Slice(0, dataToAppend.Length);
+                }
             }
         }
 


### PR DESCRIPTION
I was following up on a new idea to save allocations when receiving messages and had a fresh look at the eager copying code for the `ServiceBusReceivedMessage` body management and this is the result of it

![image](https://user-images.githubusercontent.com/174258/190913059-0bf0bb7b-7888-4abe-a1d1-a71f8cce4c91.png)

This benchmark used is

https://github.com/danielmarbach/MicroBenchmarks/commit/93d216e6d1489bfa5fde82fde8be6d317eedf3f4

The same tricks can be applied for EventHubs :tada: which I'm happy to do once the discussions and nits have settled here ;)

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
