### PR TITLE
[ServiceBus] Buffer receive bodies

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
@@ -100,7 +100,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             Argument.AssertNotNull(credential, nameof(credential));
             Argument.AssertNotNull(options, nameof(options));
 
-            _messageConverter = AmqpMessageConverter.Default;
+            _messageConverter = AmqpMessageConverter.NonTrackingDefault;
 
             ServiceEndpoint = new UriBuilder
             {
@@ -196,7 +196,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 sessionId,
                 isSessionReceiver,
                 isProcessor,
-                _messageConverter,
+                new AmqpMessageConverter(true),
                 cancellationToken
             );
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpMessageBatchTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpMessageBatchTests.cs
@@ -523,6 +523,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             public Func<ServiceBusMessage, AmqpMessage> BuildAmqpMessageFromSBMessageHandler = (_s) => Mock.Of<AmqpMessage>();
             public Func<IEnumerable<ServiceBusMessage>, bool, AmqpMessage> BuildBatchFromSBMessagesHandler = (_s, _f) => Mock.Of<AmqpMessage>();
             public Func<IEnumerable<AmqpMessage>, AmqpMessage> BuildBatchFromAmqpMessagesHandler = (_s) => Mock.Of<AmqpMessage>();
+
+            public InjectableMockConverter(bool trackBodies = false) : base(trackBodies)
+            {
+            }
+
             public override AmqpMessage SBMessageToAmqpMessage(ServiceBusMessage source) => BuildAmqpMessageFromSBMessageHandler(source);
             public override AmqpMessage BuildAmqpBatchFromMessages(IReadOnlyCollection<AmqpMessage> source, bool forceBatch) => BuildBatchFromAmqpMessagesHandler(source);
             public override AmqpMessage BatchSBMessagesAsAmqpMessage(IReadOnlyCollection<ServiceBusMessage> source, bool forceBatch) => BuildBatchFromSBMessagesHandler(source, forceBatch);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/MessageBodyTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/MessageBodyTests.cs
@@ -89,5 +89,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             Assert.AreEqual(new byte[] { 1, 2, 3, 4, 5, 6 }, fromReadOnlyMemorySegments.ToArray());
             Assert.IsTrue(fromReadOnlyMemorySegments.Equals(convertedASecondTime));
         }
+
+        // TBD add sensible test
     }
 }


### PR DESCRIPTION
Builds on top of #31214 

This brings back an approach discussed in https://github.com/Azure/azure-sdk-for-net/pull/20320 but with a twist to address the scenario that it is possible to hold on to `ServiceBusReceivedMessage` for longer than the lifetime of the processor callbacks. This is a hack to demonstrate the idea. Like discussed previously this could also be an opt-in feature exposed over the options. 

This should also address the fact that Annotated Messages are mutable and the body can be exchanged. Once the body is replaced, it will get GCed and then the buffer is released by the finalizer. 

Not immediately returning buffers should not be an issue according to the ArrayPool documentation. Alternatively, it would also be possible to expose an array pool over the options so that a different one can be used for the received messages. 

> Failure to return a rented buffer is not a fatal error. However, it may lead to decreased application performance, as the pool may need to create a new buffer to replace the lost one.

https://learn.microsoft.com/en-us/dotnet/api/system.buffers.arraypool-1.rent?view=net-6.0#System_Buffers_ArrayPool_1_Rent_System_Int32_

Let's discuss and shoot it down ;)

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
