### PR TITLE
Added namespaces to dotnet repo

### DIFF
--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -338,7 +338,7 @@
       <ServiceDirectory><![CDATA[$([System.Text.RegularExpressions.Regex]::Replace($(PackageRootDirectory), '^.*[\\/]+sdk[\\/]+([^\\/]+).*$', '$1'))]]></ServiceDirectory>
     </PropertyGroup>
 
-    <Message Condition="'$(IsShippingLibrary)' == 'true'" Text="'$(PackageRootDirectory)' '$(ServiceDirectory)' '$(PackageId)' '$(VersionForProperties)' '$(PackageSdkType)' '$(PackageIsNewSdk)'" Importance="High" />
+    <Message Condition="'$(IsShippingLibrary)' == 'true'" Text="'$(PackageRootDirectory)' '$(ServiceDirectory)' '$(PackageId)' '$(VersionForProperties)' '$(PackageSdkType)' '$(PackageIsNewSdk)' '$(BaseOutputPath)'" Importance="High" />
   </Target>
 
   <Target Name="_SetProjectDependsOnInnerTarget">

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -63,9 +63,11 @@ jobs:
           echo "##vso[build.addbuildtag]Scheduled"
         displayName: "Tag scheduled builds"
         condition: and(eq(variables['Build.SourceBranchName'],variables['DefaultBranch']),eq(variables['Build.Reason'],'Schedule'))
+      # Both 'Dump property properties' and 'Update package properties with dev version' serve the same purpose of generating package json.
+      # We decided to only run the later one (update properties) in all pipelines for the following reasons:
+      # 1. 'Update properties' happens after 'build', we will have more information at the 'update properties' step. 
+      # 2. We did not find any usage of package json before 'update properties' in .NET, so it is safe to skip the 'dump properties' for now.
       - template: /eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
-        parameters:
-          ServiceDirectory: ${{ parameters.ServiceDirectory }}
       - pwsh: |
           $skipDevBuildNumber = "false"
           # For .NET builds the only case we want to not have dev build numbers on our packages is when it is manually queued and
@@ -97,11 +99,10 @@ jobs:
           arguments: >
             -ServiceDirectory ${{parameters.ServiceDirectory}}
             -OutDirectory $(Build.ArtifactStagingDirectory)/PackageInfo
-            -AddDevVersion
+            -AddDevVersion:$$(SetDevVersion)
           pwsh: true
           workingDirectory: $(Pipeline.Workspace)
         displayName: Update package properties with dev version
-        condition: and(succeeded(),eq(variables['SetDevVersion'],'true'))
 
       - template: /eng/common/pipelines/templates/steps/create-apireview.yml
         parameters:

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -175,7 +175,7 @@ stages:
                               - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
                             WorkingDirectory: $(System.DefaultWorkingDirectory)
                             TargetDocRepoOwner: Azure
-                            TargetDocRepoName: ${{parameters.TargetDocRepoName}}
+                            TargetDocRepoName: azure-docs-sdk-dotnet
                             Language: 'dotnet'
                             SparseCheckoutPaths:
                               - /api/overview/azure/
@@ -301,7 +301,7 @@ stages:
                 - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
             WorkingDirectory: $(System.DefaultWorkingDirectory)
             TargetDocRepoOwner: Azure
-            TargetDocRepoName: ${{parameters.TargetDocRepoName}}
+            TargetDocRepoName: azure-docs-sdk-dotnet
             Language: 'dotnet'
             DailyDocsBuild: true
             SparseCheckoutPaths:

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -4,7 +4,8 @@ parameters:
   ArtifactName: 'not-specified'
   # Publish to https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-net
   DevOpsFeedId: '29ec6040-b234-4e31-b139-33dc4287b756/fa8c16a3-dbe0-4de2-a297-03065ec1ba3f'
-
+  TargetDocRepoOwner: 'not-specified'
+  TargetDocRepoName: 'not-specified'
 stages:
   - stage: Signing
     dependsOn: ${{parameters.DependsOn}}
@@ -174,12 +175,13 @@ stages:
                             PackageInfoLocations:
                               - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
                             WorkingDirectory: $(System.DefaultWorkingDirectory)
-                            TargetDocRepoOwner: Azure
-                            TargetDocRepoName: azure-docs-sdk-dotnet
+                            TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}
+                            TargetDocRepoName: ${{parameters.TargetDocRepoName}}
                             Language: 'dotnet'
                             SparseCheckoutPaths:
                               - /api/overview/azure/
                               - /metadata/
+
             - ${{if ne(artifact.skipPublishDocGithubIo, 'true')}}:
               - deployment: PublishDocs
                 displayName: Publish Docs to GitHub pages
@@ -300,8 +302,8 @@ stages:
               - ${{ each artifact in parameters.Artifacts }}:
                 - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
             WorkingDirectory: $(System.DefaultWorkingDirectory)
-            TargetDocRepoOwner: Azure
-            TargetDocRepoName: azure-docs-sdk-dotnet
+            TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}
+            TargetDocRepoName: ${{parameters.TargetDocRepoName}}
             Language: 'dotnet'
             DailyDocsBuild: true
             SparseCheckoutPaths:

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -174,13 +174,12 @@ stages:
                             PackageInfoLocations:
                               - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
                             WorkingDirectory: $(System.DefaultWorkingDirectory)
-                            TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}
+                            TargetDocRepoOwner: Azure
                             TargetDocRepoName: ${{parameters.TargetDocRepoName}}
                             Language: 'dotnet'
                             SparseCheckoutPaths:
                               - /api/overview/azure/
                               - /metadata/
-
             - ${{if ne(artifact.skipPublishDocGithubIo, 'true')}}:
               - deployment: PublishDocs
                 displayName: Publish Docs to GitHub pages
@@ -301,7 +300,7 @@ stages:
               - ${{ each artifact in parameters.Artifacts }}:
                 - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
             WorkingDirectory: $(System.DefaultWorkingDirectory)
-            TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}
+            TargetDocRepoOwner: Azure
             TargetDocRepoName: ${{parameters.TargetDocRepoName}}
             Language: 'dotnet'
             DailyDocsBuild: true

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -21,6 +21,12 @@ parameters:
 - name: ServiceDirectory
   type: string
   default: not-specified
+- name: TargetDocRepoOwner
+  type: string
+  default: Azure
+- name: TargetDocRepoName
+  type: string
+  default: azure-docs-sdk-dotnet
 - name: BuildSnippets
   type: boolean
   default: false
@@ -95,3 +101,5 @@ stages:
         ${{ if eq(parameters.ServiceDirectory, 'template') }}:
           TestPipeline: true
         ArtifactName: packages
+        TargetDocRepoOwner: ${{ parameters.TargetDocRepoOwner }}
+        TargetDocRepoName: ${{ parameters.TargetDocRepoName }}

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -21,12 +21,6 @@ parameters:
 - name: ServiceDirectory
   type: string
   default: not-specified
-- name: TargetDocRepoOwner
-  type: string
-  default: Azure
-- name: TargetDocRepoName
-  type: string
-  default: azure-docs-sdk-dotnet
 - name: BuildSnippets
   type: boolean
   default: false
@@ -101,5 +95,3 @@ stages:
         ${{ if eq(parameters.ServiceDirectory, 'template') }}:
           TestPipeline: true
         ArtifactName: packages
-        TargetDocRepoOwner: ${{ parameters.TargetDocRepoOwner }}
-        TargetDocRepoName: ${{ parameters.TargetDocRepoName }}

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -37,7 +37,7 @@ function Get-AllPackageInfoFromRepo($serviceDirectory)
     if (Test-Path "$dllFolder/Release/netstandard2.0/") {
       $defaultDll = Get-ChildItem "$dllFolder/Release/netstandard2.0/*" -Filter "$pkgName.dll" -Recurse
       if ($defaultDll -and (Test-Path $defaultDll)) {
-        Write-Host "Here is the dll file path: $($defaultDll.FullName)"
+        Write-Verbose "Here is the dll file path: $($defaultDll.FullName)"
         $namespaces = @(Get-NamepspacesFromDll $defaultDll.FullName)
       }
     }
@@ -47,7 +47,7 @@ function Get-AllPackageInfoFromRepo($serviceDirectory)
     $pkgProp.ArtifactName = $pkgName
     if ($namespaces) {
       $pkgProp = $pkgProp | Add-Member -MemberType NoteProperty -Name Namespaces -Value $namespaces -PassThru
-      Write-Host "Here are the namespaces: $($pkgProp.Namespaces)"
+      Write-Verbose "Here are the namespaces: $($pkgProp.Namespaces)"
     }
 
     $allPackageProps += $pkgProp

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -6,6 +6,8 @@ $packagePattern = "*.nupkg"
 $MetadataUri = "https://raw.githubusercontent.com/Azure/azure-sdk/main/_data/releases/latest/dotnet-packages.csv"
 $BlobStorageUrl = "https://azuresdkdocs.blob.core.windows.net/%24web?restype=container&comp=list&prefix=dotnet%2F&delimiter=%2F"
 
+. "$PSScriptRoot/docs/Docs-ToC.ps1"
+
 function Get-AllPackageInfoFromRepo($serviceDirectory)
 {
   $allPackageProps = @()
@@ -23,16 +25,30 @@ function Get-AllPackageInfoFromRepo($serviceDirectory)
   {
     if (!$projectOutput) { continue }
 
-    $pkgPath, $serviceDirectory, $pkgName, $pkgVersion, $sdkType, $isNewSdk = $projectOutput.Split(' ',[System.StringSplitOptions]::RemoveEmptyEntries).Trim("'")
-
+    $pkgPath, $serviceDirectory, $pkgName, $pkgVersion, $sdkType, $isNewSdk, $dllFolder = $projectOutput.Split(' ',[System.StringSplitOptions]::RemoveEmptyEntries).Trim("'")
     if(!(Test-Path $pkgPath)) {
       Write-Host "Parsed package path `$pkgPath` does not exist so skipping the package line '$projectOutput'."
       continue
+    }
+
+    # Add a step to extract namespaces
+    $namespaces = @()
+    # The namespaces currently only use for docs.ms toc, which is necessary for internal release.
+    if (Test-Path "$dllFolder/Release/netstandard2.0/") {
+      $defaultDll = Get-ChildItem "$dllFolder/Release/netstandard2.0/*" -Filter "$pkgName.dll" -Recurse
+      if ($defaultDll -and (Test-Path $defaultDll)) {
+        Write-Host "Here is the dll file path: $($defaultDll.FullName)"
+        $namespaces = @(Get-NamepspacesFromDll $defaultDll.FullName)
+      }
     }
     $pkgProp = [PackageProps]::new($pkgName, $pkgVersion, $pkgPath, $serviceDirectory)
     $pkgProp.SdkType = $sdkType
     $pkgProp.IsNewSdk = ($isNewSdk -eq 'true')
     $pkgProp.ArtifactName = $pkgName
+    if ($namespaces) {
+      $pkgProp = $pkgProp | Add-Member -MemberType NoteProperty -Name Namespaces -Value $namespaces -PassThru
+      Write-Host "Here are the namespaces: $($pkgProp.Namespaces)"
+    }
 
     $allPackageProps += $pkgProp
   }
@@ -112,7 +128,7 @@ function Get-dotnet-PackageInfoFromPackageFile ($pkg, $workingDirectory)
 # Return list of nupkg artifacts
 function Get-dotnet-Package-Artifacts ($Location)
 {
-  $pkgs = Get-ChildItem "${Location}" -Recurse | Where-Object -FilterScript {$_.Name.EndsWith(".nupkg") -and -not $_.Name.EndsWith(".symbols.nupkg")}
+  $pkgs = @(Get-ChildItem $Location -Recurse | Where-Object -FilterScript {$_.Name.EndsWith(".nupkg") -and -not $_.Name.EndsWith(".symbols.nupkg")})
   if (!$pkgs)
   {
     Write-Host "$($Location) does not have any package"

--- a/eng/scripts/docs/Docs-ToC.ps1
+++ b/eng/scripts/docs/Docs-ToC.ps1
@@ -1,0 +1,23 @@
+function Get-NamepspacesFromDll($dllPath) {
+    $file = [System.IO.File]::OpenRead($dllPath)
+    $namespaces = @()
+    try {
+        # Use to parse the namespaces out from the dll file.
+        $pe = [System.Reflection.PortableExecutable.PEReader]::new($file)
+        try {
+            $meta = [System.Reflection.Metadata.PEReaderExtensions]::GetMetadataReader($pe)
+            foreach ($typeHandle in $meta.TypeDefinitions) {
+                $type = $meta.GetTypeDefinition($typeHandle)
+                $attr = $type.Attributes
+                if ($attr -band 'Public' -and !$type.IsNested) {
+                    $namespaces += $meta.GetString($type.Namespace)
+                }
+            }
+        } finally {
+            $pe.Dispose()
+        }
+    } finally {
+        $file.Dispose()
+    }
+    return $namespaces | Sort-Object -Unique
+}


### PR DESCRIPTION
.NET has to fetch namespaces for toc generation automation. The change is a pre-requisite step of toc generation. 
We store the namespaces to package json to minimize the network call potentially used in toc generation step.

Here is the nightly built pipeline for storage:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1933949&view=results
Package json:
<img width="431" alt="image" src="https://user-images.githubusercontent.com/48036328/197056006-a565bca1-497a-4ff7-8511-6378531e01b3.png">
Package.json in docs repo: 
https://github.com/Azure/azure-docs-sdk-dotnet/blob/daily/2022-10-20/metadata/preview/Azure.Storage.Blobs.json

Template release pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1934026&view=results
Package.json in docs repo: https://github.com/Azure/azure-docs-sdk-dotnet/blob/main/metadata/preview/Azure.Template.json
PR pipeline(backward compability): https://dev.azure.com/azure-sdk/public/_build/results?buildId=1933942&view=results

