### PR TITLE
Fix Key Vault live tests

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.KeyRotation.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.KeyRotation.cs
@@ -81,9 +81,6 @@ namespace Azure.Security.KeyVault.Keys.Tests
 
             Assert.AreEqual(policy.ExpiresIn, updatedPolicy.ExpiresIn);
 
-            // Notify policy is always present and can only be updated.
-            Assert.That(updatedPolicy.LifetimeActions, Has.One.Matches<KeyRotationLifetimeAction>(action => action.Action == KeyRotationPolicyAction.Notify));
-
             KeyRotationLifetimeAction rotateAction = updatedPolicy.LifetimeActions.Single(p => p.Action == KeyRotationPolicyAction.Rotate);
             Assert.AreEqual(policy.LifetimeActions[0].Action, rotateAction.Action);
             Assert.AreEqual(policy.LifetimeActions[0].TimeAfterCreate, rotateAction.TimeAfterCreate);


### PR DESCRIPTION
Recent regression in KV was causing a failure, but it was something I don't really need to be testing anyway (service behavior unrelated to the code under test). The service regression is also getting fixed.
