### PR TITLE
Check that mgmt libraries have a trigger path in resourcemanager ci.mgmt.yml file

### DIFF
--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -273,9 +273,9 @@
   </Target>
 
   <!-- Validates that all the mgmt libraries have a trigger path in the core resourcemanager pipeline -->
-  <Target Name="ValidateResourceManagerPipelineTriggers" AfterTargets="Build" Condition="'$(IsMgmtLibrary)' == 'true' and '$(IsShippingLibrary)' == 'true'" >
+  <Target Name="ValidateResourceManagerPipelineTriggers" AfterTargets="Build" Condition="'$(IsMgmtSubLibrary)' == 'true' and '$(IsShippingLibrary)' == 'true'" >
     <PropertyGroup>
-      <!-- makes sure that at the line ends in the project name which is why we need the newline chars at the end -->
+      <!-- makes sure that the line ends in the project name which is why we need the newline chars at the end -->
       <_ProjectTriggerPath>$(MSBuildProjectName)&#xD;&#xA;</_ProjectTriggerPath>
       <_ResourceManagerCIFile>$(RepoRoot)/sdk/resourcemanager/ci.mgmt.yml</_ResourceManagerCIFile>
       <_ResourceManagerCIFileContents>$([System.IO.File]::ReadAllText($(_ResourceManagerCIFile)))</_ResourceManagerCIFileContents>

--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -275,11 +275,9 @@
   <!-- Validates that all the mgmt libraries have a trigger path in the core resourcemanager pipeline -->
   <Target Name="ValidateResourceManagerPipelineTriggers" AfterTargets="Build" Condition="'$(IsMgmtSubLibrary)' == 'true' and '$(IsShippingLibrary)' == 'true'" >
     <PropertyGroup>
-      <!-- makes sure that the line ends in the project name which is why we need the newline chars at the end -->
-      <_ProjectTriggerPath>$(MSBuildProjectName)&#xD;&#xA;</_ProjectTriggerPath>
       <_ResourceManagerCIFile>$(RepoRoot)/sdk/resourcemanager/ci.mgmt.yml</_ResourceManagerCIFile>
       <_ResourceManagerCIFileContents>$([System.IO.File]::ReadAllText($(_ResourceManagerCIFile)))</_ResourceManagerCIFileContents>
-      <_ContainsTrigger>$(_ResourceManagerCIFileContents.Contains('$(_ProjectTriggerPath)'))</_ContainsTrigger>
+      <_ContainsTrigger>$([System.Text.RegularExpressions.Regex]::IsMatch($(_ResourceManagerCIFileContents), `- sdk/.*/$(MSBuildProjectName)\W+`))</_ContainsTrigger>
     </PropertyGroup>
 
     <Error Condition="'$(_ContainsTrigger)' != 'true'" Text="The core resourcemanager pipeline ['$(_ResourceManagerCIFile)'] does not contain a trigger path for your library please run 'eng/scripts/Update-Mgmt-CI.ps1' to add the correct trigger paths." />

--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -174,7 +174,7 @@
     <!-- Add ProjectReferences -->
     <ProjectReference Include="@(ProjectsToConvert -> '%(ProjectPath)')" />
   </ItemGroup>
-  
+
   <!--TODO: update build targets - ADO 5668-->
   <PropertyGroup>
     <MgmtCoreShared>$(MSBuildThisFileDirectory)/../sdk/resourcemanager/Azure.ResourceManager/src/Shared</MgmtCoreShared>
@@ -185,7 +185,7 @@
     <Compile Include="$(MgmtCoreShared)/**/*.cs"
                  LinkBase="Shared/Management" />
   </ItemGroup>
-  
+
   <!--TODO: end-->
 
   <!-- *********** Files needed for LRO ************* -->
@@ -210,13 +210,13 @@
     <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" LinkBase="Shared/Core" />
     <Compile Include="$(AzureCoreSharedSources)AppContextSwitchHelper.cs" LinkBase="Shared/Core" />
   </ItemGroup>
-    
+
     <!-- *********** Management Client Library Override section ************* -->
   <ItemGroup Condition="'$(IsMgmtLibrary)' == 'true' and '$(IsTestProject)' != 'true'">
 
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="System.Text.Json" />
-    
+
     <!-- TODO: Review these file references-->
     <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />
@@ -270,6 +270,19 @@
     </ItemGroup>
 
     <Error Condition="'@(PreviewPackageReferences)' != ''" Text="When the project has a release version it shouldn't reference any pre-release libraries. Found the following pre-release references: @(PreviewPackageReferences, ', ')" />
+  </Target>
+
+  <!-- Validates that all the mgmt libraries have a trigger path in the core resourcemanager pipeline -->
+  <Target Name="ValidateResourceManagerPipelineTriggers" AfterTargets="Build" Condition="'$(IsMgmtLibrary)' == 'true' and '$(IsShippingLibrary)' == 'true'" >
+    <PropertyGroup>
+      <!-- makes sure that at the line ends in the project name which is why we need the newline chars at the end -->
+      <_ProjectTriggerPath>$(MSBuildProjectName)&#xD;&#xA;</_ProjectTriggerPath>
+      <_ResourceManagerCIFile>$(RepoRoot)/sdk/resourcemanager/ci.mgmt.yml</_ResourceManagerCIFile>
+      <_ResourceManagerCIFileContents>$([System.IO.File]::ReadAllText($(_ResourceManagerCIFile)))</_ResourceManagerCIFileContents>
+      <_ContainsTrigger>$(_ResourceManagerCIFileContents.Contains('$(_ProjectTriggerPath)'))</_ContainsTrigger>
+    </PropertyGroup>
+
+    <Error Condition="'$(_ContainsTrigger)' != 'true'" Text="The core resourcemanager pipeline ['$(_ResourceManagerCIFile)'] does not contain a trigger path for your library please run 'eng/scripts/Update-Mgmt-CI.ps1' to add the correct trigger paths." />
   </Target>
 
   <!-- InheritDoc-->

--- a/eng/scripts/Update-Mgmt-CI.ps1
+++ b/eng/scripts/Update-Mgmt-CI.ps1
@@ -6,7 +6,7 @@ function Update-CIFile() {
     param(
         [string]$mgmtCiFile = ""
     )
-    
+
     $shouldRemove = $false
 
     $lines = Get-Content $mgmtCiFile
@@ -36,10 +36,10 @@ function Update-CIFile() {
             }
             $shouldRemove = $false
         }
-        
+
         $newLines.Add($line) | Out-Null
     }
-    
+
     Set-Content -Path $mgmtCiFile $newLines
 }
 
@@ -86,9 +86,9 @@ foreach($line in $armLines) {
     if($line.StartsWith("  paths:")) {
         $newLines.Add($line) | Out-Null
         $newLines.Add("    include:") | Out-Null
-        $newLines.Add("    - sdk/resourcemanager/") | Out-Null
-        $newLines.Add("    - common/ManagementTestShared/") | Out-Null
-        $newLines.Add("    - common/ManagementCoreShared/") | Out-Null
+        $newLines.Add("    - sdk/resourcemanager") | Out-Null
+        $newLines.Add("    - common/ManagementTestShared") | Out-Null
+        $newLines.Add("    - common/ManagementCoreShared") | Out-Null
         foreach($dir in $track2MgmtDirs) {
             $newLine = "    - $($dir.FullName.Substring($startIndex, $dir.FullName.Length - $startIndex).Replace('\', '/'))"
             $newLines.Add($newLine) | Out-Null

--- a/sdk/resourcemanager/ci.mgmt.yml
+++ b/sdk/resourcemanager/ci.mgmt.yml
@@ -8,9 +8,9 @@ trigger:
     - release/*
   paths:
     include:
-    - sdk/resourcemanager/
-    - common/ManagementTestShared/
-    - common/ManagementCoreShared/
+    - sdk/resourcemanager
+    - common/ManagementTestShared
+    - common/ManagementCoreShared
     - sdk/advisor/Azure.ResourceManager.Advisor
     - sdk/agrifood/Azure.ResourceManager.AgFoodPlatform
     - sdk/alertsmanagement/Azure.ResourceManager.AlertsManagement
@@ -143,9 +143,9 @@ pr:
     - release/*
   paths:
     include:
-    - sdk/resourcemanager/
-    - common/ManagementTestShared/
-    - common/ManagementCoreShared/
+    - sdk/resourcemanager
+    - common/ManagementTestShared
+    - common/ManagementCoreShared
     - sdk/advisor/Azure.ResourceManager.Advisor
     - sdk/agrifood/Azure.ResourceManager.AgFoodPlatform
     - sdk/alertsmanagement/Azure.ResourceManager.AlertsManagement


### PR DESCRIPTION
A better way to add the check from https://github.com/Azure/azure-sdk-for-net/pull/31021.

@JoshLove-msft FYI we should try to move more of the checks from CodeChecks into msbuild targets similar to this so that we can reduce some of the complexity inside there and prevent jumping in and out of PS and msbuild. 