### PR TITLE
Fix the PhoneNumber serialization bug

### DIFF
--- a/sdk/communication/Azure.Communication.Common/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.Common/CHANGELOG.md
@@ -1,13 +1,12 @@
 # Release History
 
-## 1.3.0-beta.1 (Unreleased)
+## 1.2.1 (Unreleased)
 
 ### Features Added
 
 ### Breaking Changes
 
 ### Bugs Fixed
-- Fixed the logic of `PhoneNumberIdentifier` to always maintain the original phone number string whether it included the leading `+` sign or not.
 
 ### Other Changes
 

--- a/sdk/communication/Azure.Communication.Common/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.Common/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed the logic of `PhoneNumberIdentifier` to always maintain the original phone number string whether it included the leading `+` sign or not.
 
 ### Other Changes
 

--- a/sdk/communication/Azure.Communication.Common/src/Azure.Communication.Common.csproj
+++ b/sdk/communication/Azure.Communication.Common/src/Azure.Communication.Common.csproj
@@ -5,7 +5,7 @@
       For this release, see notes - https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/communication/Azure.Communication.Common/README.md and https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/communication/Azure.Communication.Common/CHANGELOG.md.
     </Description>
     <AssemblyTitle>Azure Communication Services Common</AssemblyTitle>
-    <Version>1.3.0-beta.1</Version>
+    <Version>1.2.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.2.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Communication Service;Microsoft;Azure;Azure Communication Service;Communication;$(PackageCommonTags)</PackageTags>

--- a/sdk/communication/Azure.Communication.Common/src/CommunicationIdentifier.cs
+++ b/sdk/communication/Azure.Communication.Common/src/CommunicationIdentifier.cs
@@ -56,7 +56,7 @@ namespace Azure.Communication
 
             if (rawId.StartsWith("4:", StringComparison.OrdinalIgnoreCase))
             {
-                return new PhoneNumberIdentifier($"+{rawId.Substring("4:".Length)}");
+                return new PhoneNumberIdentifier(rawId.Substring("4:".Length));
             }
 
             var segments = rawId.Split(':');

--- a/sdk/communication/Azure.Communication.Common/src/PhoneNumberIdentifier.cs
+++ b/sdk/communication/Azure.Communication.Common/src/PhoneNumberIdentifier.cs
@@ -18,7 +18,7 @@ namespace Azure.Communication
         {
             get
             {
-                return _rawId ??= $"4:{PhoneNumber.TrimStart('+')}";
+                return _rawId ??= $"4:{PhoneNumber}";
             }
         }
 

--- a/sdk/communication/Azure.Communication.Common/tests/CommunicationIdentifierTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/CommunicationIdentifierTest.cs
@@ -24,8 +24,8 @@ namespace Azure.Communication
             Assert.AreEqual(new PhoneNumberIdentifier("+14255550123"), new PhoneNumberIdentifier("+14255550123"));
             Assert.AreNotEqual(new PhoneNumberIdentifier("+14255550123", "Raw Id"), new PhoneNumberIdentifier("+14255550123", "Another Raw Id"));
 
-            Assert.AreEqual(new PhoneNumberIdentifier("+override", "4:14255550123"), new PhoneNumberIdentifier("+14255550123"));
-            Assert.AreEqual(new PhoneNumberIdentifier("+14255550123"), new PhoneNumberIdentifier("+override", "4:14255550123"));
+            Assert.AreEqual(new PhoneNumberIdentifier("+override", "4:14255550123"), new PhoneNumberIdentifier("14255550123"));
+            Assert.AreEqual(new PhoneNumberIdentifier("14255550123"), new PhoneNumberIdentifier("+override", "4:14255550123"));
         }
 
         [Test]
@@ -47,10 +47,14 @@ namespace Azure.Communication
             AssertRawId(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: false), "8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130");
             AssertRawId(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true), "8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130");
             AssertRawId(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", rawId: "8:orgid:legacyFormat", isAnonymous: true), "8:orgid:legacyFormat");
-            AssertRawId(new PhoneNumberIdentifier("+112345556789"), "4:112345556789");
+            AssertRawId(new PhoneNumberIdentifier("+112345556789"), "4:+112345556789");
             AssertRawId(new PhoneNumberIdentifier("+112345556789", rawId: "4:otherFormat"), "4:otherFormat");
             AssertRawId(new UnknownIdentifier("28:45ab2481-1c1c-4005-be24-0ffb879b1130"), "28:45ab2481-1c1c-4005-be24-0ffb879b1130");
-            AssertRawId(new UnknownIdentifier("someFutureFormat"), "someFutureFormat");
+            AssertRawId(new PhoneNumberIdentifier("+112345556789"), "4:+112345556789");
+            AssertRawId(new PhoneNumberIdentifier("112345556789"), "4:112345556789");
+            AssertRawId(new PhoneNumberIdentifier("otherFormat", rawId: "4:207ffef6-9444-41fb-92ab-20eacaae2768"), "4:207ffef6-9444-41fb-92ab-20eacaae2768");
+            AssertRawId(new PhoneNumberIdentifier("otherFormat", rawId: "4:207ffef6-9444-41fb-92ab-20eacaae2768_207ffef6-9444-41fb-92ab-20eacaae2768"), "4:207ffef6-9444-41fb-92ab-20eacaae2768_207ffef6-9444-41fb-92ab-20eacaae2768");
+            AssertRawId(new PhoneNumberIdentifier("otherFormat", rawId: "4:+112345556789_207ffef6-9444-41fb-92ab-20eacaae2768"), "4:+112345556789_207ffef6-9444-41fb-92ab-20eacaae2768");
         }
 
         [Test]
@@ -74,8 +78,11 @@ namespace Azure.Communication
             AssertIdentifier("8:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", false, CommunicationCloudEnvironment.Gcch));
             AssertIdentifier("8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", true, CommunicationCloudEnvironment.Public));
             AssertIdentifier("8:orgid:legacyFormat", new MicrosoftTeamsUserIdentifier("legacyFormat", false, CommunicationCloudEnvironment.Public));
-            AssertIdentifier("4:112345556789", new PhoneNumberIdentifier("+112345556789"));
-            AssertIdentifier("4:otherFormat", new PhoneNumberIdentifier("+otherFormat"));
+            AssertIdentifier("4:+112345556789", new PhoneNumberIdentifier("+112345556789"));
+            AssertIdentifier("4:112345556789", new PhoneNumberIdentifier("112345556789"));
+            AssertIdentifier("4:207ffef6-9444-41fb-92ab-20eacaae2768", new PhoneNumberIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768"));
+            AssertIdentifier("4:207ffef6-9444-41fb-92ab-20eacaae2768_207ffef6-9444-41fb-92ab-20eacaae2768", new PhoneNumberIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768_207ffef6-9444-41fb-92ab-20eacaae2768"));
+            AssertIdentifier("4:+112345556789_207ffef6-9444-41fb-92ab-20eacaae2768", new PhoneNumberIdentifier("+112345556789_207ffef6-9444-41fb-92ab-20eacaae2768"));
             AssertIdentifier("28:45ab2481-1c1c-4005-be24-0ffb879b1130", new UnknownIdentifier("28:45ab2481-1c1c-4005-be24-0ffb879b1130"));
 
             Assert.Throws<ArgumentNullException>(() => CommunicationIdentifier.FromRawId(null));
@@ -97,7 +104,10 @@ namespace Azure.Communication
             AssertRoundtrip("8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130");
             AssertRoundtrip("8:orgid:legacyFormat");
             AssertRoundtrip("4:112345556789");
-            AssertRoundtrip("4:otherFormat");
+            AssertRoundtrip("4:+112345556789");
+            AssertRoundtrip("4:207ffef6-9444-41fb-92ab-20eacaae2768");
+            AssertRoundtrip("4:207ffef6-9444-41fb-92ab-20eacaae2768_207ffef6-9444-41fb-92ab-20eacaae2768");
+            AssertRoundtrip("4:+112345556789_207ffef6-9444-41fb-92ab-20eacaae2768");
             AssertRoundtrip("28:45ab2481-1c1c-4005-be24-0ffb879b1130");
         }
 

--- a/sdk/communication/Shared/src/CommunicationIdentifierSerializerTest.cs
+++ b/sdk/communication/Shared/src/CommunicationIdentifierSerializerTest.cs
@@ -11,7 +11,7 @@ namespace Azure.Communication
         private const string TestUserId = "User Id";
         private const string TestRawId = "Raw Id";
         private const string TestPhoneNumber = "+12223334444";
-        private const string TestPhoneNumberRawId = "4:12223334444";
+        private const string TestPhoneNumberRawId = "4:+12223334444";
         private const string TestTeamsUserId = "Microsoft Teams User Id";
         private const string TestTeamsCloud = "gcch";
 


### PR DESCRIPTION
# Contributing to the Azure SDK

Brief description: Fixed the logic of `PhoneNumberIdentifier` to always maintain the original phone number string whether it included the leading `+` sign or not.

More details: https://skype.visualstudio.com/SPOOL/_workitems/edit/2981911

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
