### PR TITLE
[AzureMonitorExporter] refactor how `MockTransmitter` is used in tests

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/Azure.Monitor.OpenTelemetry.Exporter.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/Azure.Monitor.OpenTelemetry.Exporter.Tests.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Integration.Tests\TestFramework\MockTransmitter.cs" Link="MockTransmitter.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/AzureMonitorExporterTestExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/AzureMonitorExporterTestExtensions.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using Azure.Monitor.OpenTelemetry.Exporter.Models;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
+{
+    /// <summary>
+    /// Extension methods to simplify registering of Azure Monitor Exporter for unit tests.
+    /// </summary>
+    public static class AzureMonitorExporterTestExtensions
+    {
+        /// <summary>
+        /// Extension methods to simplify registering of <see cref="AzureMonitorLogExporter"/> with <see cref="MockTransmitter"/> for unit tests.
+        /// </summary>
+        internal static OpenTelemetryLoggerOptions AddAzureMonitorLogExporterForTest(this OpenTelemetryLoggerOptions loggerOptions, out ConcurrentBag<TelemetryItem> telemetryItems)
+        {
+            if (loggerOptions == null)
+            {
+                throw new ArgumentNullException(nameof(loggerOptions));
+            }
+
+            telemetryItems = new ConcurrentBag<TelemetryItem>();
+
+            return loggerOptions.AddProcessor(new BatchLogRecordExportProcessor(new AzureMonitorLogExporter(new MockTransmitter(telemetryItems))));
+        }
+
+        /// <summary>
+        /// Extension methods to simplify registering of <see cref="AzureMonitorMetricExporter"/> with <see cref="MockTransmitter"/> for unit tests.
+        /// </summary>
+        internal static MeterProviderBuilder AddAzureMonitorMetricExporterForTest(this MeterProviderBuilder builder, out ConcurrentBag<TelemetryItem> telemetryItems)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            telemetryItems = new ConcurrentBag<TelemetryItem>();
+
+            return builder.AddReader(new PeriodicExportingMetricReader(new AzureMonitorMetricExporter(new MockTransmitter(telemetryItems)))
+            {
+                TemporalityPreference = MetricReaderTemporalityPreference.Delta
+            });
+        }
+
+        /// <summary>
+        /// Extension methods to simplify registering of <see cref="AzureMonitorTraceExporter"/> with <see cref="MockTransmitter"/> for unit tests.
+        /// </summary>
+        internal static TracerProviderBuilder AddAzureMonitorTraceExporterForTest(this TracerProviderBuilder builder, out ConcurrentBag<TelemetryItem> telemetryItems)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            telemetryItems = new ConcurrentBag<TelemetryItem>();
+
+            return builder.AddProcessor(new SimpleActivityExportProcessor(new AzureMonitorTraceExporter(new MockTransmitter(telemetryItems))));
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockTransmitter.cs
@@ -12,13 +12,18 @@ using Azure.Monitor.OpenTelemetry.Exporter.Models;
 
 using OpenTelemetry;
 
-namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.TestFramework
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
 {
     internal class MockTransmitter : ITransmitter
     {
-        public ConcurrentBag<TelemetryItem> TelemetryItems = new ConcurrentBag<TelemetryItem>();
+        public readonly ConcurrentBag<TelemetryItem> TelemetryItems;
 
         public string InstrumentationKey => "00000000-0000-0000-0000-000000000000";
+
+        public MockTransmitter(ConcurrentBag<TelemetryItem> telemetryItems)
+        {
+            this.TelemetryItems = telemetryItems;
+        }
 
         public ValueTask<ExportResult> TrackAsync(IEnumerable<TelemetryItem> telemetryItems, bool async, CancellationToken cancellationToken)
         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
@@ -40,4 +40,8 @@
     <ProjectReference Include="..\Integration.Tests.AspNetCoreWebApp\Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.AspNetCoreWebApp.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Azure.Monitor.OpenTelemetry.Exporter.Tests\CommonTestFramework\**" Link="CommonTestFramework\%(Filename)%(Extension)" />
+  </ItemGroup>
+  
 </Project>


### PR DESCRIPTION
I'm working on some new tests. 
This PR will simplify the steps to setup our Exporter with the `MockTransmitter`.

### Changes
- changes to csproj
  - Move `MockTransmitter` from project `Exporter.Integration.Tests` to `Exporter.Tests`.
  - Project `Exporter.Integration.Tests` now references the directory `CommonTestFramework`
- new `AzureMonitorExporterTestExtensions`. 
  This encapsulates creating the Processor/Reader and configuring the `MockTransmitter`.
  This will simplify setting up tests.
- updated unit tests to use the new Extensions