### PR TITLE
Adding AZURE_CLIENT_CERTIFICATE_PASSWORD support to EnvironmentCredential

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -8,8 +8,8 @@
   - `AzurePowerShellCredential` and `AzurePowerShellCredentialOptions.PowerShellProcessTimeout`
   - `VisualStudioCredential` and `VisualStudioCredentialOptions.VisualStudioProcessTimeout`
   - `DefaultAzureCredential` and `DefaultAzureCredentialOptions.DeveloperCredentialTimeout`  Note: this option applies to all developer credentials above when using `DefaultAzureCredential`.
-  
 - Reintroduced `ManagedIdentityCredential` token caching support from 1.7.0-beta.1
+- `EnvironmentCredential` updated to support specifying a certificate password via the `AZURE_CLIENT_CERTIFICATE_PASSWORD` environment variable
 
 ### Breaking Changes
 

--- a/sdk/identity/Azure.Identity/README.md
+++ b/sdk/identity/Azure.Identity/README.md
@@ -194,7 +194,8 @@ The [Managed identity authentication](https://docs.microsoft.com/azure/active-di
 |-|-
 |`AZURE_CLIENT_ID`|id of an Azure Active Directory application
 |`AZURE_TENANT_ID`|id of the application's Azure Active Directory tenant
-|`AZURE_CLIENT_CERTIFICATE_PATH`|path to a PEM-encoded certificate file including private key (without password protection)
+|`AZURE_CLIENT_CERTIFICATE_PATH`|path to a PFX or PEM-encoded certificate file including private key
+|`AZURE_CLIENT_CERTIFICATE_PASSWORD`|(optional) the password protecting the certificate file (currently only supported for PFX (PKCS12) certificates)
 |`AZURE_CLIENT_SEND_CERTIFICATE_CHAIN`|(optional) send certificate chain in x5c header to support subject name / issuer based authentication
 
 #### Username and password

--- a/sdk/identity/Azure.Identity/TROUBLESHOOTING.md
+++ b/sdk/identity/Azure.Identity/TROUBLESHOOTING.md
@@ -108,6 +108,7 @@ DefaultAzureCredentialOptions options = new DefaultAzureCredentialOptions()
 | Error Message |Description| Mitigation |
 |---|---|---|
 |Environment variables aren't fully configured.|A valid combination of environment variables wasn't set.|Ensure the appropriate environment variables are set **prior to application startup** for the intended authentication method.</p><ul><li>To authenticate a service principal using a client secret, ensure the variables `AZURE_CLIENT_ID`, `AZURE_TENANT_ID` and `AZURE_CLIENT_SECRET` are properly set.</li><li>To authenticate a service principal using a certificate, ensure the variables `AZURE_CLIENT_ID`, `AZURE_TENANT_ID` and `AZURE_CLIENT_CERTIFICATE_PATH` are properly set.</li><li>To authenticate a user using a password, ensure the variables `AZURE_USERNAME` and `AZURE_PASSWORD` are properly set.</li><ul>|
+|Password protection for PEM encoded certificates is not supported.|`AZURE_CLIENT_CERTIFICATE_PASSWORD` was set when using a PEM encoded certificate.|Re-encode the client certificate to a password protected PFX (PKCS12) certificate, or a PEM certificate without password protection.|
 
 ## Troubleshoot `ClientSecretCredential` Authentication Issues
 `AuthenticationFailedException`

--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -101,9 +101,11 @@ namespace Azure.Identity
         protected ClientCertificateCredential() { }
         public ClientCertificateCredential(string tenantId, string clientId, System.Security.Cryptography.X509Certificates.X509Certificate2 clientCertificate) { }
         public ClientCertificateCredential(string tenantId, string clientId, System.Security.Cryptography.X509Certificates.X509Certificate2 clientCertificate, Azure.Identity.ClientCertificateCredentialOptions options) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public ClientCertificateCredential(string tenantId, string clientId, System.Security.Cryptography.X509Certificates.X509Certificate2 clientCertificate, Azure.Identity.TokenCredentialOptions options) { }
         public ClientCertificateCredential(string tenantId, string clientId, string clientCertificatePath) { }
         public ClientCertificateCredential(string tenantId, string clientId, string clientCertificatePath, Azure.Identity.ClientCertificateCredentialOptions options) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public ClientCertificateCredential(string tenantId, string clientId, string clientCertificatePath, Azure.Identity.TokenCredentialOptions options) { }
         public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/sdk/identity/Azure.Identity/src/Credentials/ClientCertificateCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ClientCertificateCredential.cs
@@ -5,6 +5,7 @@ using Azure.Core;
 using Azure.Core.Pipeline;
 using Microsoft.Identity.Client;
 using System;
+using System.ComponentModel;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -51,7 +52,7 @@ namespace Azure.Identity
         /// <param name="clientId">The client (application) ID of the service principal</param>
         /// <param name="clientCertificatePath">The path to a file which contains both the client certificate and private key.</param>
         public ClientCertificateCredential(string tenantId, string clientId, string clientCertificatePath)
-            : this(tenantId, clientId, clientCertificatePath, null, null, null)
+            : this(tenantId, clientId, clientCertificatePath, null, null, null, null)
         { }
 
         /// <summary>
@@ -61,8 +62,9 @@ namespace Azure.Identity
         /// <param name="clientId">The client (application) ID of the service principal</param>
         /// <param name="clientCertificatePath">The path to a file which contains both the client certificate and private key.</param>
         /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ClientCertificateCredential(string tenantId, string clientId, string clientCertificatePath, TokenCredentialOptions options)
-            : this(tenantId, clientId, clientCertificatePath, options, null, null)
+            : this(tenantId, clientId, clientCertificatePath, null, options, null, null)
         { }
 
         /// <summary>
@@ -73,7 +75,7 @@ namespace Azure.Identity
         /// <param name="clientCertificatePath">The path to a file which contains both the client certificate and private key.</param>
         /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
         public ClientCertificateCredential(string tenantId, string clientId, string clientCertificatePath, ClientCertificateCredentialOptions options)
-            : this(tenantId, clientId, clientCertificatePath, options, null, null)
+            : this(tenantId, clientId, clientCertificatePath, null, options, null, null)
         { }
 
         /// <summary>
@@ -93,6 +95,7 @@ namespace Azure.Identity
         /// <param name="clientId">The client (application) ID of the service principal</param>
         /// <param name="clientCertificate">The authentication X509 Certificate of the service principal</param>
         /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ClientCertificateCredential(string tenantId, string clientId, X509Certificate2 clientCertificate, TokenCredentialOptions options)
             : this(tenantId, clientId, clientCertificate, options, null, null)
         { }
@@ -112,13 +115,14 @@ namespace Azure.Identity
             string tenantId,
             string clientId,
             string certificatePath,
+            string certificatePassword,
             TokenCredentialOptions options,
             CredentialPipeline pipeline,
             MsalConfidentialClient client)
             : this(
                 tenantId,
                 clientId,
-                new X509Certificate2FromFileProvider(certificatePath ?? throw new ArgumentNullException(nameof(certificatePath))),
+                new X509Certificate2FromFileProvider(certificatePath ?? throw new ArgumentNullException(nameof(certificatePath)), certificatePassword),
                 options,
                 pipeline,
                 client)

--- a/sdk/identity/Azure.Identity/src/Credentials/EnvironmentCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/EnvironmentCredential.cs
@@ -63,6 +63,7 @@ namespace Azure.Identity
             string clientId = EnvironmentVariables.ClientId;
             string clientSecret = EnvironmentVariables.ClientSecret;
             string clientCertificatePath = EnvironmentVariables.ClientCertificatePath;
+            string clientCertificatePassword = EnvironmentVariables.ClientCertificatePassword;
             string clientSendCertificateChain = EnvironmentVariables.ClientSendCertificateChain;
             string username = EnvironmentVariables.Username;
             string password = EnvironmentVariables.Password;
@@ -99,7 +100,7 @@ namespace Azure.Identity
                         AdditionallyAllowedTenantsCore = new List<string>(_options.AdditionallyAllowedTenantsCore),
                         SendCertificateChain = sendCertificateChain
                     };
-                    Credential = new ClientCertificateCredential(tenantId, clientId, clientCertificatePath, clientCertificateCredentialOptions, _pipeline, null);
+                    Credential = new ClientCertificateCredential(tenantId, clientId, clientCertificatePath, clientCertificatePassword, clientCertificateCredentialOptions, _pipeline, null);
                 }
             }
         }

--- a/sdk/identity/Azure.Identity/src/EnvironmentVariables.cs
+++ b/sdk/identity/Azure.Identity/src/EnvironmentVariables.cs
@@ -17,6 +17,7 @@ namespace Azure.Identity
         public static string ClientId => Environment.GetEnvironmentVariable("AZURE_CLIENT_ID");
         public static string ClientSecret => Environment.GetEnvironmentVariable("AZURE_CLIENT_SECRET");
         public static string ClientCertificatePath => Environment.GetEnvironmentVariable("AZURE_CLIENT_CERTIFICATE_PATH");
+        public static string ClientCertificatePassword => Environment.GetEnvironmentVariable("AZURE_CLIENT_CERTIFICATE_PASSWORD");
         public static string ClientSendCertificateChain => Environment.GetEnvironmentVariable("AZURE_CLIENT_SEND_CERTIFICATE_CHAIN");
 
         public static string IdentityEndpoint => Environment.GetEnvironmentVariable("IDENTITY_ENDPOINT");

--- a/sdk/identity/Azure.Identity/src/X509Certificate2FromFileProvider.cs
+++ b/sdk/identity/Azure.Identity/src/X509Certificate2FromFileProvider.cs
@@ -45,7 +45,7 @@ namespace Azure.Identity
                 case ".pem":
                     if (CertificatePassword != null)
                     {
-                        throw new CredentialUnavailableException("Password protection for .pem files is not supported.");
+                        throw new CredentialUnavailableException("Password protection for PEM encoded certificates is not supported.");
                     }
                     return LoadCertificateFromPemFileAsync(async, CertificatePath, cancellationToken);
                 default:

--- a/sdk/identity/Azure.Identity/src/X509Certificate2FromFileProvider.cs
+++ b/sdk/identity/Azure.Identity/src/X509Certificate2FromFileProvider.cs
@@ -20,11 +20,13 @@ namespace Azure.Identity
         // Lazy initialized on the first call to GetCertificateAsync, based on CertificatePath.
         private X509Certificate2 Certificate { get; set; }
         internal string CertificatePath { get; }
+        internal string CertificatePassword { get; }
 
-        public X509Certificate2FromFileProvider(string clientCertificatePath)
+        public X509Certificate2FromFileProvider(string clientCertificatePath, string certificatePassword)
         {
             Argument.AssertNotNull(clientCertificatePath, nameof(clientCertificatePath));
             CertificatePath = clientCertificatePath ?? throw new ArgumentNullException(nameof(clientCertificatePath));
+            CertificatePassword = certificatePassword;
         }
 
         public ValueTask<X509Certificate2> GetCertificateAsync(bool async, CancellationToken cancellationToken)
@@ -39,15 +41,19 @@ namespace Azure.Identity
             switch (fileType.ToLowerInvariant())
             {
                 case ".pfx":
-                    return LoadCertificateFromPfxFileAsync(async, CertificatePath, cancellationToken);
+                    return LoadCertificateFromPfxFileAsync(async, CertificatePath, CertificatePassword, cancellationToken);
                 case ".pem":
+                    if (CertificatePassword != null)
+                    {
+                        throw new CredentialUnavailableException("Password protection for .pem files is not supported.");
+                    }
                     return LoadCertificateFromPemFileAsync(async, CertificatePath, cancellationToken);
                 default:
                     throw new CredentialUnavailableException("Only .pfx and .pem files are supported.");
             }
         }
 
-        private async ValueTask<X509Certificate2> LoadCertificateFromPfxFileAsync(bool async, string clientCertificatePath, CancellationToken cancellationToken)
+        private async ValueTask<X509Certificate2> LoadCertificateFromPfxFileAsync(bool async, string clientCertificatePath, string certificatePassword, CancellationToken cancellationToken)
         {
             const int BufferSize = 4 * 1024;
 
@@ -60,7 +66,7 @@ namespace Azure.Identity
             {
                 if (!async)
                 {
-                    Certificate = new X509Certificate2(clientCertificatePath);
+                    Certificate = new X509Certificate2(clientCertificatePath, certificatePassword);
                 }
                 else
                 {
@@ -84,7 +90,7 @@ namespace Azure.Identity
                         }
                     }
 
-                    Certificate = new X509Certificate2(certContents.ToArray());
+                    Certificate = new X509Certificate2(certContents.ToArray(), certificatePassword);
                 }
 
                 return Certificate;

--- a/sdk/identity/Azure.Identity/tests/ClientCertificateCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ClientCertificateCredentialTests.cs
@@ -155,7 +155,7 @@ namespace Azure.Identity.Tests
 
             ClientCertificateCredential credential = InstrumentClient(
                 usePemFile
-                    ? new ClientCertificateCredential(expectedTenantId, expectedClientId, certificatePathPem, default, default, mockMsalClient)
+                    ? new ClientCertificateCredential(expectedTenantId, expectedClientId, certificatePathPem, default, default, default, mockMsalClient)
                     : new ClientCertificateCredential(expectedTenantId, expectedClientId, mockCert, default, default, mockMsalClient)
             );
 
@@ -184,7 +184,7 @@ namespace Azure.Identity.Tests
 
             ClientCertificateCredential credential = InstrumentClient(
                 usePemFile
-                    ? new ClientCertificateCredential(TenantId, ClientId, certificatePathPem, options, default, mockConfidentialMsalClient)
+                    ? new ClientCertificateCredential(TenantId, ClientId, certificatePathPem, default, options, default, mockConfidentialMsalClient)
                     : new ClientCertificateCredential(TenantId, ClientId, mockCert, options, default, mockConfidentialMsalClient)
             );
 
@@ -234,7 +234,7 @@ namespace Azure.Identity.Tests
 
             ClientCertificateCredential credential = InstrumentClient(
                 usePemFile
-                    ? new ClientCertificateCredential(TenantId, ClientId, certificatePathPem, options,
+                    ? new ClientCertificateCredential(TenantId, ClientId, certificatePathPem, default, options,
                         new CredentialPipeline(new Uri("https://localhost"), _pipeline, new ClientDiagnostics(options)), null)
                     : new ClientCertificateCredential(TenantId, ClientId, mockCert, options,
                         new CredentialPipeline(new Uri("https://localhost"), _pipeline, new ClientDiagnostics(options)), null)

--- a/sdk/identity/Azure.Identity/tests/EnvironmentCredentialProviderTests.cs
+++ b/sdk/identity/Azure.Identity/tests/EnvironmentCredentialProviderTests.cs
@@ -56,11 +56,23 @@ namespace Azure.Identity.Tests
 
         [NonParallelizable]
         [Test]
-        public void CredentialConstructionClientCertificate()
+        public void CredentialConstructionClientCertificate([Values(null, "mockcertificatepassword")]string expPassword, [Values(null, "true", "false")]string includeX5C)
         {
             using (new TestEnvVar(new()
             {
-                { "AZURE_CLIENT_ID", "mockclientid" }, { "AZURE_TENANT_ID", "mocktenantid" }, { "AZURE_CLIENT_CERTIFICATE_PATH", "mockcertificatepath" }, { "AZURE_CLIENT_SEND_CERTIFICATE_CHAIN", null }, { "AZURE_PASSWORD", null }, { "AZURE_CLIENT_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IMDS_ENDPOINT", null }, { "IDENTITY_SERVER_THUMBPRINT", null }
+                { "AZURE_CLIENT_ID", "mockclientid" },
+                { "AZURE_TENANT_ID", "mocktenantid" },
+                { "AZURE_CLIENT_CERTIFICATE_PATH", "mockcertificatepath" },
+                { "AZURE_CLIENT_CERTIFICATE_PASSWORD", expPassword },
+                { "AZURE_CLIENT_SEND_CERTIFICATE_CHAIN", includeX5C },
+                { "AZURE_PASSWORD", null },
+                { "AZURE_CLIENT_SECRET", null },
+                { "IDENTITY_ENDPOINT", null },
+                { "IDENTITY_HEADER", null },
+                { "MSI_ENDPOINT", null },
+                { "MSI_SECRET", null },
+                { "IMDS_ENDPOINT", null },
+                { "IDENTITY_SERVER_THUMBPRINT", null }
             }))
             {
                 var provider = new EnvironmentCredential();
@@ -73,53 +85,8 @@ namespace Azure.Identity.Tests
 
                 Assert.NotNull(certProvider);
                 Assert.AreEqual("mockcertificatepath", certProvider.CertificatePath);
-                Assert.False(cred.Client._includeX5CClaimHeader);
-            }
-        }
-
-        [NonParallelizable]
-        [Test]
-        public void CredentialConstructionClientCertificateWithCertificateChain()
-        {
-            using (new TestEnvVar(new()
-            {
-                { "AZURE_CLIENT_ID", "mockclientid" }, { "AZURE_TENANT_ID", "mocktenantid" }, { "AZURE_CLIENT_CERTIFICATE_PATH", "mockcertificatepath" }, { "AZURE_CLIENT_SEND_CERTIFICATE_CHAIN", "true" }, { "AZURE_PASSWORD", null }, { "AZURE_CLIENT_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IMDS_ENDPOINT", null }, { "IDENTITY_SERVER_THUMBPRINT", null }
-            }))
-            {
-                var provider = new EnvironmentCredential();
-                var cred = provider.Credential as ClientCertificateCredential;
-                Assert.NotNull(cred);
-                Assert.AreEqual("mockclientid", cred.ClientId);
-                Assert.AreEqual("mocktenantid", cred.TenantId);
-
-                var certProvider = cred.ClientCertificateProvider as X509Certificate2FromFileProvider;
-
-                Assert.NotNull(certProvider);
-                Assert.AreEqual("mockcertificatepath", certProvider.CertificatePath);
-                Assert.True(cred.Client._includeX5CClaimHeader);
-            }
-        }
-
-        [NonParallelizable]
-        [Test]
-        public void CredentialConstructionClientCertificateWithoutCertificateChain()
-        {
-            using (new TestEnvVar(new()
-            {
-                { "AZURE_CLIENT_ID", "mockclientid" }, { "AZURE_TENANT_ID", "mocktenantid" }, { "AZURE_CLIENT_CERTIFICATE_PATH", "mockcertificatepath" }, { "AZURE_CLIENT_SEND_CERTIFICATE_CHAIN", "false" }, { "AZURE_PASSWORD", null }, { "AZURE_CLIENT_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IMDS_ENDPOINT", null }, { "IDENTITY_SERVER_THUMBPRINT", null }
-            }))
-            {
-                var provider = new EnvironmentCredential();
-                var cred = provider.Credential as ClientCertificateCredential;
-                Assert.NotNull(cred);
-                Assert.AreEqual("mockclientid", cred.ClientId);
-                Assert.AreEqual("mocktenantid", cred.TenantId);
-
-                var certProvider = cred.ClientCertificateProvider as X509Certificate2FromFileProvider;
-
-                Assert.NotNull(certProvider);
-                Assert.AreEqual("mockcertificatepath", certProvider.CertificatePath);
-                Assert.False(cred.Client._includeX5CClaimHeader);
+                Assert.AreEqual(expPassword, certProvider.CertificatePassword);
+                Assert.AreEqual(includeX5C == "true", cred.Client._includeX5CClaimHeader);
             }
         }
 
@@ -131,6 +98,7 @@ namespace Azure.Identity.Tests
                 {"AZURE_CLIENT_ID", null},
                 {"AZURE_TENANT_ID", null},
                 {"AZURE_CLIENT_CERTIFICATE_PATH", null},
+                {"AZURE_CLIENT_CERTIFICATE_PASSWORD", null},
                 {"AZURE_CLIENT_SEND_CERTIFICATE_CHAIN", null},
                 {"AZURE_CLIENT_SEND_X5C", null },
                 {"AZURE_PASSWORD", null},

--- a/sdk/identity/Azure.Identity/tests/X509Certificate2FromFileProviderTests.cs
+++ b/sdk/identity/Azure.Identity/tests/X509Certificate2FromFileProviderTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests
+{
+    public class X509Certificate2FromFileProviderTests
+    {
+        [Test]
+        public async Task ValidatePemCertificateLoad([Values]bool async)
+        {
+            var certificatePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pem");
+
+            var certProvider = new X509Certificate2FromFileProvider(certificatePath, null);
+
+            var cert = await certProvider.GetCertificateAsync(async, default);
+
+            Assert.NotNull(cert);
+        }
+
+        [Test]
+        public void ValidatePemCertificateLoadFailsWithPassword([Values]bool async)
+        {
+            var certificatePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pem");
+
+            var certProvider = new X509Certificate2FromFileProvider(certificatePath, "password");
+
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await certProvider.GetCertificateAsync(async, default));
+
+            StringAssert.Contains("Password protection for .pem files is not supported.", ex.Message);
+        }
+
+        [Test]
+        public async Task ValidatePfxCertificateLoad([Values] bool async, [Values(null, "password")]string password)
+        {
+            var certificatePath = password == null ? Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pfx") : Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert-password-protected.pfx");
+
+            var certProvider = new X509Certificate2FromFileProvider(certificatePath, password);
+
+            var cert = await certProvider.GetCertificateAsync(async, default);
+
+            Assert.NotNull(cert);
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/X509Certificate2FromFileProviderTests.cs
+++ b/sdk/identity/Azure.Identity/tests/X509Certificate2FromFileProviderTests.cs
@@ -30,7 +30,7 @@ namespace Azure.Identity.Tests
 
             var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await certProvider.GetCertificateAsync(async, default));
 
-            StringAssert.Contains("Password protection for .pem files is not supported.", ex.Message);
+            StringAssert.Contains("Password protection for PEM encoded certificates is not supported.", ex.Message);
         }
 
         [Test]


### PR DESCRIPTION

- Updates `EnvironmentCredential` to read certificate password from the  `AZURE_CLIENT_CERTIFICATE_PASSWORD` environment variable
- Password protection is currently only supported for PFX files

Fixes #29052