### PR TITLE
Change severity of link creation exceptions as these are already logged in the higher level methods

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -1254,7 +1254,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             }
         }
 
-        [Event(CreateSendLinkExceptionEvent, Level = EventLevel.Error, Message = "An exception occurred while creating send link for Identifier: {0}. Error Message: '{1}'")]
+        [Event(CreateSendLinkExceptionEvent, Level = EventLevel.Verbose, Message = "An exception occurred while creating send link for Identifier: {0}. Error Message: '{1}'")]
         public virtual void CreateSendLinkException(
             string identifier,
             string exception)
@@ -1312,7 +1312,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             }
         }
 
-        [Event(CreateReceiveLinkExceptionEvent, Level = EventLevel.Error, Message = "An exception occurred while creating receive link for Identifier: {0}. Error Message: '{1}'")]
+        [Event(CreateReceiveLinkExceptionEvent, Level = EventLevel.Verbose, Message = "An exception occurred while creating receive link for Identifier: {0}. Error Message: '{1}'")]
         public virtual void CreateReceiveLinkException(string identifier, string exception)
         {
             if (IsEnabled())
@@ -1339,7 +1339,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             }
         }
 
-        [Event(CreateManagementLinkExceptionEvent, Level = EventLevel.Error, Message = "An exception occurred while creating management link for Identifier: {0}. Error Message: '{1}'")]
+        [Event(CreateManagementLinkExceptionEvent, Level = EventLevel.Verbose, Message = "An exception occurred while creating management link for Identifier: {0}. Error Message: '{1}'")]
         public virtual void CreateManagementLinkException(string identifier, string exception)
         {
             if (IsEnabled())


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/30745
If retries are exhausted these errors will be logged as errors in the relevant higher level methods.