### PR TITLE
New swagger for Identity SDK with kind property support

### DIFF
--- a/sdk/communication/Azure.Communication.Identity/src/autorest.md
+++ b/sdk/communication/Azure.Communication.Identity/src/autorest.md
@@ -8,7 +8,7 @@ Run `dotnet msbuild /t:GenerateCode` to generate code.
 ``` yaml
 tag: package-2022-06
 require:
-    -  https://raw.githubusercontent.com/Azure/azure-rest-api-specs/5b0818f55339dbff370a967e3f068e180c6ad5a1/specification/communication/data-plane/Identity/readme.md
+    -  https://raw.githubusercontent.com/Azure/azure-rest-api-specs/f0343961168af6b19ea86dd3aa2429e2ca453db4/specification/communication/data-plane/Identity/readme.md
 payload-flattening-threshold: 3
 generation1-convenience-client: true
 ```


### PR DESCRIPTION
# Description

Updating swagger for Identity SDK to the version using kind property in polymorphic identifier model. Regenerated code has no differences as Identity SDK does not use `CommunicationUserIdentifierModel` directly.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
