### PR TITLE
[Communication] Fix BCC Null Check

### DIFF
--- a/sdk/communication/Azure.Communication.Email/src/Models/EmailRecipients.cs
+++ b/sdk/communication/Azure.Communication.Email/src/Models/EmailRecipients.cs
@@ -32,7 +32,7 @@ namespace Azure.Communication.Email.Models
                 CC = new ChangeTrackingList<EmailAddress>(new Optional<IList<EmailAddress>>(cc.ToList()));
             }
 
-            if (cc != null)
+            if (bcc != null)
             {
                 BCC = new ChangeTrackingList<EmailAddress>(new Optional<IList<EmailAddress>>(bcc.ToList()));
             }

--- a/sdk/communication/Azure.Communication.Email/tests/EmailRecipientsTests.cs
+++ b/sdk/communication/Azure.Communication.Email/tests/EmailRecipientsTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Azure.Communication.Email.Models;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.Communication.Email.Tests
+{
+    public class EmailRecipientsTests : ClientTestBase
+    {
+        public EmailRecipientsTests(bool isAsync) : base(isAsync)
+        {
+        }
+
+        [Test]
+        [SyncOnly]
+        [TestCase(0, 0)]
+        [TestCase(1, 0)]
+        [TestCase(0, 1)]
+        [TestCase(1, 1)]
+        public void MultipleRecipients(int ccCount, int bccCount)
+        {
+            var recipients = new EmailRecipients(DefaultRecipients(), DefaultRecipients(ccCount), DefaultRecipients(bccCount));
+
+            Assert.AreEqual(recipients.CC.Count, ccCount);
+            Assert.AreEqual(recipients.BCC.Count, bccCount);
+        }
+
+        private static List<EmailAddress> DefaultRecipients(int count = 1)
+        {
+            return count == 0 ? null : Enumerable.Repeat(new EmailAddress("customer@Contoso.com", "Customer Name"), count).ToList();
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes a typo in a null check in the `Azure.Communication.Email` that was brought up in [this issue](https://github.com/Azure/azure-sdk-for-net/issues/31054).

resolves #31054