### PR TITLE
[AzureMonitorExporter] improve `TelemetryItem` tests

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
 using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
@@ -20,9 +19,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
     /// </summary>
     public class LogsTests
     {
-        private const string activitySourceName = "MyCompany.MyProduct.MyLibrary";
-        private static readonly ActivitySource activitySource = new(activitySourceName);
-
         [Theory]
         [InlineData(LogLevel.Information, "Information")]
         [InlineData(LogLevel.Warning, "Warning")]
@@ -33,13 +29,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
         public void VerifyLog(LogLevel logLevel, string expectedSeverityLevel)
         {
             // SETUP
-            var logCategoryName = Guid.NewGuid().ToString();
+            var uniqueTestId = Guid.NewGuid();
+
+            var logCategoryName = $"logCategoryName{uniqueTestId}";
 
             ConcurrentBag<TelemetryItem> telemetryItems = null;
 
             var loggerFactory = LoggerFactory.Create(builder =>
             {
                 builder
+                    .AddFilter<OpenTelemetryLoggerProvider>("*", LogLevel.None)
                     .AddFilter<OpenTelemetryLoggerProvider>(logCategoryName, logLevel)
                     .AddOpenTelemetry(options =>
                     {
@@ -82,13 +81,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
         public void VerifyException(LogLevel logLevel, string expectedSeverityLevel)
         {
             // SETUP
-            var logCategoryName = Guid.NewGuid().ToString();
+            var uniqueTestId = Guid.NewGuid();
+
+            var logCategoryName = $"logCategoryName{uniqueTestId}";
 
             ConcurrentBag<TelemetryItem> telemetryItems = null;
 
             var loggerFactory = LoggerFactory.Create(builder =>
             {
                 builder
+                    .AddFilter<OpenTelemetryLoggerProvider>("*", LogLevel.None)
                     .AddFilter<OpenTelemetryLoggerProvider>(logCategoryName, logLevel)
                     .AddOpenTelemetry(options =>
                     {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
@@ -38,7 +38,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             var loggerFactory = LoggerFactory.Create(builder =>
             {
                 builder
-                    .AddFilter<OpenTelemetryLoggerProvider>("*", LogLevel.None)
                     .AddFilter<OpenTelemetryLoggerProvider>(logCategoryName, logLevel)
                     .AddOpenTelemetry(options =>
                     {
@@ -90,7 +89,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             var loggerFactory = LoggerFactory.Create(builder =>
             {
                 builder
-                    .AddFilter<OpenTelemetryLoggerProvider>("*", LogLevel.None)
                     .AddFilter<OpenTelemetryLoggerProvider>(logCategoryName, logLevel)
                     .AddOpenTelemetry(options =>
                     {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -22,9 +22,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
     /// </summary>
     public class TracesTests
     {
-        private const string activitySourceName = "MyCompany.MyProduct.MyLibrary";
-        private static readonly ActivitySource activitySource = new(activitySourceName);
-
         [Theory]
         [InlineData(ActivityKind.Client)]
         [InlineData(ActivityKind.Producer)]
@@ -32,6 +29,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
         public void VerifyTrace_CreatesDependency(ActivityKind activityKind)
         {
             // SETUP
+            var uniqueTestId = Guid.NewGuid();
+
+            var activitySourceName = $"activitySourceName{uniqueTestId}";
+            using var activitySource = new ActivitySource(activitySourceName);
+
             var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(activitySourceName)
                 .AddAzureMonitorTraceExporterForTest(out ConcurrentBag<TelemetryItem> telemetryItems)
@@ -69,6 +71,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
         public void VerifyTrace_CreatesRequest(ActivityKind activityKind)
         {
             // SETUP
+            var uniqueTestId = Guid.NewGuid();
+
+            var activitySourceName = $"activitySourceName{uniqueTestId}";
+            using var activitySource = new ActivitySource(activitySourceName);
+
             var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(activitySourceName)
                 .AddAzureMonitorTraceExporterForTest(out ConcurrentBag<TelemetryItem> telemetryItems)
@@ -111,7 +118,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
         public void VerifyLogWithinActivity(LogLevel logLevel, string expectedSeverityLevel)
         {
             // SETUP
-            var logCategoryName = Guid.NewGuid().ToString();
+            var uniqueTestId = Guid.NewGuid();
+
+            var activitySourceName = $"activitySourceName{uniqueTestId}";
+            using var activitySource = new ActivitySource(activitySourceName);
+
+            var logCategoryName = $"logCategoryName{uniqueTestId}"; ;
 
             ConcurrentBag<TelemetryItem> logTelemetryItems = null;
 


### PR DESCRIPTION
TelemetryItemValidation tests are having intermittent failures.
It appears that the tests are collecting extra TelemetryItems.
- https://dev.azure.com/azure-sdk/public/_build/results?buildId=1886074&view=results
- https://dev.azure.com/azure-sdk/public/_build/results?buildId=1886127&view=results
- https://dev.azure.com/azure-sdk/public/_build/results?buildId=1885771&view=results


### Changes
- remove `static` vars (`ActivitySource`, `Meter`).
- use a unique guid per test for every string name (ActivitySourceName, MeterName, LogCategory). 