### PR TITLE
Update BlobNameValidationAttribute to allow $web

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/BlobNameValidationAttribute.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/BlobNameValidationAttribute.cs
@@ -90,6 +90,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
                 return true;
             }
 
+            if (containerName.Equals("$web", StringComparison.InvariantCulture))
+            {
+                return true;
+            }
+
             return Regex.IsMatch(containerName, @"^[a-z0-9](([a-z0-9\-[^\-])){1,61}[a-z0-9]$");
         }
 


### PR DESCRIPTION
Addresses issue: https://github.com/Azure/azure-functions-host/issues/3804. That's an old issue, but we've recently had customers running into this and asking us about the discrepancy in our discussion alias.

In the v4 version of the storage extension, a change was made in [this commit](https://github.com/Azure/azure-webjobs-sdk/commit/bc8e942279f84355c5ec50d414cd7d0266c1078e) to allow $web as a container name. That was done to support [Azure Static Web App](https://azure.microsoft.com/en-us/products/app-service/static/) scenarios, which stores site content in a container of this name. However, that commit wasn't carried forward to the v5 Track 2 extension it seems.

This blob container name validation is based on the storage naming documentation [here](http://msdn.microsoft.com/en-us/library/dd135715.aspx) which indicates that this name isn't valid, but it is. Longer term we might want to re-evaluate the validation we're doing and relax it further. But for now, I just want to unblock the scenario and bring these extension versions into parity.
