### PR TITLE
[AzureMonitorExporter] investigating test failure with Activity

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/AzureMonitorExporterTestExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/AzureMonitorExporterTestExtensions.cs
@@ -52,7 +52,23 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
         /// <summary>
         /// Extension methods to simplify registering of <see cref="AzureMonitorTraceExporter"/> with <see cref="MockTransmitter"/> for unit tests.
         /// </summary>
-        internal static TracerProviderBuilder AddAzureMonitorTraceExporterForTest(this TracerProviderBuilder builder, out ConcurrentBag<TelemetryItem> telemetryItems)
+        internal static TracerProviderBuilder AddAzureMonitorTraceExporterForTest(this TracerProviderBuilder builder, out SimpleActivityExportProcessor processor, out ConcurrentBag<TelemetryItem> telemetryItems)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            telemetryItems = new ConcurrentBag<TelemetryItem>();
+            processor = new SimpleActivityExportProcessor(new AzureMonitorTraceExporter(new MockTransmitter(telemetryItems)));
+
+            return builder.AddProcessor(processor);
+        }
+
+        /// <summary>
+        /// Extension methods to simplify registering of <see cref="AzureMonitorTraceExporter"/> with <see cref="MockTransmitter"/> for unit tests.
+        /// </summary>
+        internal static TracerProviderBuilder AddAzureMonitorTraceExporterForTest(this TracerProviderBuilder builder,  out ConcurrentBag<TelemetryItem> telemetryItems)
         {
             if (builder == null)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -393,7 +393,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             // ACT
             string spanId, traceId;
-            string activityName = $"TestActivity {nameof(this.LogWithinActivity_InMemoryExporterOnly)} {logLevel}";
+            string activityName = $"TestActivity {nameof(this.LogWithinActivity_ActivityListener)} {logLevel}";
 
             using (var activity = activitySource.StartActivity(name: activityName))
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
 using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
 using Microsoft.Extensions.Logging;
@@ -143,7 +144,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(activitySourceName)
-                .AddAzureMonitorTraceExporterForTest(out SimpleActivityExportProcessor activityProcessor, out ConcurrentBag<TelemetryItem> activityTelemetryItems)
+                .AddAzureMonitorTraceExporterForTest(out ConcurrentBag<TelemetryItem> activityTelemetryItems)
                 .Build();
 
             var loggerFactory = LoggerFactory.Create(builder =>
@@ -176,7 +177,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            activityProcessor.Shutdown();
+            Task.Delay(1000).Wait();
             tracerProvider.Dispose();
             loggerFactory.Dispose();
 
@@ -210,7 +211,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
         {
             // Running this test on a loop to try and force the failure.
 
-            for (int i = 0; i < 1000; i++)
+            for (int i = 0; i < 10000; i++)
             {
                 VerifyLogWithinActivity(LogLevel.Trace, "Verbose");
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -177,7 +177,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            Task.Delay(1000).Wait();
+            Task.Delay(500).Wait();
             tracerProvider.Dispose();
             loggerFactory.Dispose();
 
@@ -211,7 +211,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
         {
             // Running this test on a loop to try and force the failure.
 
-            for (int i = 0; i < 10000; i++)
+            for (int i = 0; i < 1000; i++)
             {
                 VerifyLogWithinActivity(LogLevel.Trace, "Verbose");
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -49,7 +49,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             var activitySourceName = $"activitySourceName{uniqueTestId}";
             using var activitySource = new ActivitySource(activitySourceName);
 
-            var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(activitySourceName)
                 .AddAzureMonitorTraceExporterForTest(out ConcurrentBag<TelemetryItem> telemetryItems)
                 .Build();
@@ -68,7 +68,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            tracerProvider.Dispose();
+            //tracerProvider.Dispose();
 
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
@@ -94,7 +94,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             var activitySourceName = $"activitySourceName{uniqueTestId}";
             using var activitySource = new ActivitySource(activitySourceName);
 
-            var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(activitySourceName)
                 .AddAzureMonitorTraceExporterForTest(out ConcurrentBag<TelemetryItem> telemetryItems)
                 .Build();
@@ -113,7 +113,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            tracerProvider.Dispose();
+            //tracerProvider.Dispose();
 
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
@@ -151,7 +151,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             ConcurrentBag<TelemetryItem> logTelemetryItems = null;
             List<Activity> inMemoryActivities = new List<Activity>();
 
-            var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(activitySourceName)
                 .AddAzureMonitorTraceExporterForTest(out ConcurrentBag<TelemetryItem> activityTelemetryItems)
                 .AddInMemoryExporter(inMemoryActivities)
@@ -187,7 +187,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            tracerProvider.Dispose();
+            //tracerProvider.Dispose();
             loggerFactory.Dispose();
 
             // ASSERT
@@ -276,7 +276,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             List<Activity> exportedActivities = new List<Activity>();
             List<LogRecord> exportedLogs = new List<LogRecord>();
 
-            var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(activitySourceName)
                 .AddInMemoryExporter(exportedActivities)
                 .Build();
@@ -311,7 +311,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            tracerProvider.Dispose();
+            //tracerProvider.Dispose();
             loggerFactory.Dispose();
 
             // ASSERT
@@ -375,7 +375,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             var activityLogs = new List<string>();
 
-            var listener = new ActivityListener
+            using var listener = new ActivityListener
             {
                 ActivityStarted = activity => activityLogs.Add($"ActivityStarted: {activity.OperationName}, {activity.Id}"),
                 ActivityStopped = activity => activityLogs.Add($"ActivityStopped: {activity.OperationName}, {activity.Id}"),
@@ -411,7 +411,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            listener.Dispose();
+            //listener.Dispose();
             loggerFactory.Dispose();
 
             // ASSERT

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -66,7 +66,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(telemetryItems);
-            var telemetryItem = telemetryItems.First(); // TODO: Change to Single(). Still investigating random duplicate export which only repros on build server.
+            var telemetryItem = telemetryItems.Single();
 
             TelemetryItemValidationHelper.AssertActivity_As_DependencyTelemetry(
                 telemetryItem: telemetryItem,
@@ -111,7 +111,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(telemetryItems);
-            var telemetryItem = telemetryItems.First(); // TODO: Change to Single(). Still investigating random duplicate export which only repros on build server.
+            var telemetryItem = telemetryItems.Single();
 
             TelemetryItemValidationHelper.AssertActivity_As_RequestTelemetry(
                 telemetryItem: telemetryItem,
@@ -182,7 +182,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             // ASSERT
             Assert.True(activityTelemetryItems.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(activityTelemetryItems);
-            var activityTelemetryItem = activityTelemetryItems.First(); // TODO: Change to Single(). Still investigating random duplicate export which only repros on build server.
+            var activityTelemetryItem = activityTelemetryItems.Single();
 
             TelemetryItemValidationHelper.AssertActivity_As_DependencyTelemetry(
                 telemetryItem: activityTelemetryItem,
@@ -202,6 +202,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedMeessageProperties: new Dictionary<string, string> { { "name", "World" } },
                 expectedSpanId: spanId,
                 expectedTraceId: traceId);
+        }
+
+        [Fact]
+        public void HopingToForceAFailure()
+        {
+            // Running this test on a loop to try and force the failure.
+
+            for (int i = 0; i < 1000; i++)
+            {
+                VerifyLogWithinActivity(LogLevel.Trace, "Verbose");
+            }
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -143,7 +143,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(activitySourceName)
-                .AddAzureMonitorTraceExporterForTest(out ConcurrentBag<TelemetryItem> activityTelemetryItems)
+                .AddAzureMonitorTraceExporterForTest(out SimpleActivityExportProcessor activityProcessor, out ConcurrentBag<TelemetryItem> activityTelemetryItems)
                 .Build();
 
             var loggerFactory = LoggerFactory.Create(builder =>
@@ -176,6 +176,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
+            activityProcessor.Shutdown();
             tracerProvider.Dispose();
             loggerFactory.Dispose();
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -190,28 +190,28 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 Assert.True(activityTelemetryItems.Count == 1, "Unexpected count of exported Activities.");
                 Assert.True(logTelemetryItems.Count == 1, "Unexpected count of exported Logs.");
 
-                //Assert.True(activityTelemetryItems.Any(), "Unit test failed to collect telemetry.");
+                Assert.True(activityTelemetryItems.Any(), "Unit test failed to collect telemetry.");
                 //this.telemetryOutput.Write(activityTelemetryItems);
-                //var activityTelemetryItem = activityTelemetryItems.Single();
+                var activityTelemetryItem = activityTelemetryItems.Single();
 
-                //TelemetryItemValidationHelper.AssertActivity_As_DependencyTelemetry(
-                //    telemetryItem: activityTelemetryItem,
-                //    expectedName: activityName,
-                //    expectedTraceId: traceId,
-                //    expectedSpanId: spanId,
-                //    expectedProperties: null);
+                TelemetryItemValidationHelper.AssertActivity_As_DependencyTelemetry(
+                    telemetryItem: activityTelemetryItem,
+                    expectedName: activityName,
+                    expectedTraceId: traceId,
+                    expectedSpanId: spanId,
+                    expectedProperties: null);
 
-                //Assert.True(logTelemetryItems.Any(), "Unit test failed to collect telemetry.");
+                Assert.True(logTelemetryItems.Any(), "Unit test failed to collect telemetry.");
                 //this.telemetryOutput.Write(logTelemetryItems);
-                //var logTelemetryItem = logTelemetryItems.Single();
+                var logTelemetryItem = logTelemetryItems.Single();
 
-                //TelemetryItemValidationHelper.AssertLog_As_MessageTelemetry(
-                //    telemetryItem: logTelemetryItem,
-                //    expectedSeverityLevel: expectedSeverityLevel,
-                //    expectedMessage: "Hello {name}.",
-                //    expectedMeessageProperties: new Dictionary<string, string> { { "name", "World" } },
-                //    expectedSpanId: spanId,
-                //    expectedTraceId: traceId);
+                TelemetryItemValidationHelper.AssertLog_As_MessageTelemetry(
+                    telemetryItem: logTelemetryItem,
+                    expectedSeverityLevel: expectedSeverityLevel,
+                    expectedMessage: "Hello {name}.",
+                    expectedMeessageProperties: new Dictionary<string, string> { { "name", "World" } },
+                    expectedSpanId: spanId,
+                    expectedTraceId: traceId);
             }
             catch (Exception)
             {
@@ -223,7 +223,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                     this._outputHelper.WriteLine("Exported Activity:");
                     this._outputHelper.WriteLine($"\tDisplayName: {activity.DisplayName}");
                     this._outputHelper.WriteLine($"\tId: {activity.Id}");
-                    this._outputHelper.WriteLine($"\tTraceid: {activity.TraceId.ToHexString()}");
+                    this._outputHelper.WriteLine($"\tTraceId: {activity.TraceId.ToHexString()}");
                     this._outputHelper.WriteLine($"\tSpanId: {activity.SpanId.ToHexString()}");
                 }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -375,14 +375,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             var activityLogs = new List<string>();
 
-            using var listener = new ActivityListener
+            var listener = new ActivityListener
             {
                 ActivityStarted = activity => activityLogs.Add($"ActivityStarted: {activity.OperationName}, {activity.Id}"),
                 ActivityStopped = activity => activityLogs.Add($"ActivityStopped: {activity.OperationName}, {activity.Id}"),
                 ShouldListenTo = activitySource => activitySource.Name.Equals(activitySourceName),
-                SampleUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivitySamplingResult.AllDataAndRecorded,
+                // SampleUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivitySamplingResult.AllDataAndRecorded,
                 Sample = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivitySamplingResult.AllDataAndRecorded,
-        };
+            };
 
             ActivitySource.AddActivityListener(listener);
             //Assert.True(activitySource.HasListeners());
@@ -411,6 +411,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
+            listener.Dispose();
             loggerFactory.Dispose();
 
             // ASSERT

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -190,28 +190,28 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 Assert.True(activityTelemetryItems.Count == 1, "Unexpected count of exported Activities.");
                 Assert.True(logTelemetryItems.Count == 1, "Unexpected count of exported Logs.");
 
-                Assert.True(activityTelemetryItems.Any(), "Unit test failed to collect telemetry.");
-                this.telemetryOutput.Write(activityTelemetryItems);
-                var activityTelemetryItem = activityTelemetryItems.Single();
+                //Assert.True(activityTelemetryItems.Any(), "Unit test failed to collect telemetry.");
+                //this.telemetryOutput.Write(activityTelemetryItems);
+                //var activityTelemetryItem = activityTelemetryItems.Single();
 
-                TelemetryItemValidationHelper.AssertActivity_As_DependencyTelemetry(
-                    telemetryItem: activityTelemetryItem,
-                    expectedName: activityName,
-                    expectedTraceId: traceId,
-                    expectedSpanId: spanId,
-                    expectedProperties: null);
+                //TelemetryItemValidationHelper.AssertActivity_As_DependencyTelemetry(
+                //    telemetryItem: activityTelemetryItem,
+                //    expectedName: activityName,
+                //    expectedTraceId: traceId,
+                //    expectedSpanId: spanId,
+                //    expectedProperties: null);
 
-                Assert.True(logTelemetryItems.Any(), "Unit test failed to collect telemetry.");
-                this.telemetryOutput.Write(logTelemetryItems);
-                var logTelemetryItem = logTelemetryItems.Single();
+                //Assert.True(logTelemetryItems.Any(), "Unit test failed to collect telemetry.");
+                //this.telemetryOutput.Write(logTelemetryItems);
+                //var logTelemetryItem = logTelemetryItems.Single();
 
-                TelemetryItemValidationHelper.AssertLog_As_MessageTelemetry(
-                    telemetryItem: logTelemetryItem,
-                    expectedSeverityLevel: expectedSeverityLevel,
-                    expectedMessage: "Hello {name}.",
-                    expectedMeessageProperties: new Dictionary<string, string> { { "name", "World" } },
-                    expectedSpanId: spanId,
-                    expectedTraceId: traceId);
+                //TelemetryItemValidationHelper.AssertLog_As_MessageTelemetry(
+                //    telemetryItem: logTelemetryItem,
+                //    expectedSeverityLevel: expectedSeverityLevel,
+                //    expectedMessage: "Hello {name}.",
+                //    expectedMeessageProperties: new Dictionary<string, string> { { "name", "World" } },
+                //    expectedSpanId: spanId,
+                //    expectedTraceId: traceId);
             }
             catch (Exception)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -369,7 +369,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             var activitySourceName = $"activitySourceName{uniqueTestId}";
             using var activitySource = new ActivitySource(activitySourceName);
-            Assert.False(activitySource.HasListeners());
+            //Assert.False(activitySource.HasListeners());
 
             var logCategoryName = $"logCategoryName{uniqueTestId}";
 
@@ -385,7 +385,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
         };
 
             ActivitySource.AddActivityListener(listener);
-            Assert.True(activitySource.HasListeners());
+            //Assert.True(activitySource.HasListeners());
 
             var loggerFactory = LoggerFactory.Create(builder =>
             {


### PR DESCRIPTION
Investigating test failure.

https://github.com/Azure/azure-sdk-for-net/blob/b744e571c4dfb5e0622f189a0efc9b3b41d80078/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs#L132


It appears that the same Activity has been exported twice: Name, TraceId, and SpanId are identical.

```
 Failed Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation.TracesTests.VerifyLogWithinActivity(logLevel: Trace, expectedSeverityLevel: "Verbose") [1 s]
  Error Message:
   System.InvalidOperationException : Sequence contains more than one element
  Stack Trace:
     at System.Linq.Enumerable.Single[TSource](IEnumerable`1 source)
   at Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation.TracesTests.VerifyLogWithinActivity(LogLevel logLevel, String expectedSeverityLevel) in D:\a\_work\1\s\sdk\monitor\Azure.Monitor.OpenTelemetry.Exporter\tests\Azure.Monitor.OpenTelemetry.Exporter.Tests\E2ETelemetryItemValidation\TracesTests.cs:line 185
  Standard Output Messages:
 --------------------------------
 Name: RemoteDependency
 Tags: 4
 	ai.operation.id: 13edd4f471789fa99d168090412fbf40
 	ai.cloud.role: unknown_service:testhost.net461
 	ai.cloud.roleInstance: f9ee0c6bc000019
 	ai.internal.sdkVersion: dotnet4.8.4515.0:otel1.3.1:ext1.0.0-alpha.20220930.7
 
BaseData: RemoteDependencyData
 Name: TestActivity VerifyLogWithinActivity Trace
 Id: 242d683d95b1297e
 Properties: 0
 --------------------------------
 Name: RemoteDependency
 Tags: 4
 	ai.operation.id: 13edd4f471789fa99d168090412fbf40
 	ai.cloud.role: unknown_service:testhost.net461
 	ai.cloud.roleInstance: f9ee0c6bc000019
 	ai.internal.sdkVersion: dotnet4.8.4515.0:otel1.3.1:ext1.0.0-alpha.20220930.7
 
BaseData: RemoteDependencyData
 Name: TestActivity VerifyLogWithinActivity Trace
 Id: 242d683d95b1297e
 Properties: 0
```

## Edit:
I added the `InMemoryExporter` to see if this is unique to the `AzureMonitorExporter`.
I can see that the InMemoryExporter is also capturing two Activities.
[LINK TO BUILD LOG](https://dev.azure.com/azure-sdk/public/_build/results?buildId=1900763&view=logs&j=4363848a-d9f0-50ba-ebe0-9dc15f106bd6&t=6f3acae8-997e-56b0-30fb-e974331059ef&l=274)
```
InMemoryExporter Activity Count: 2  AzureMonitorExporter ActivityTelemetry Count: 2  AzureMonitorExporter LogTelemetry Count:1
 Expected TraceId:23489a3a1402fd9f75c4051b6c1019dc  Expected SpanId:6aa5063d1d1d19eb
 
 Exported Activity:
 	DisplayName: TestActivity VerifyLogWithinActivity Trace
 	Id: 00-23489a3a1402fd9f75c4051b6c1019dc-6aa5063d1d1d19eb-01
 	TraceId: 23489a3a1402fd9f75c4051b6c1019dc
 	SpanId: 6aa5063d1d1d19eb
 Exported Activity:
 	DisplayName: TestActivity VerifyLogWithinActivity Trace
 	Id: 00-23489a3a1402fd9f75c4051b6c1019dc-6aa5063d1d1d19eb-01
 	TraceId: 23489a3a1402fd9f75c4051b6c1019dc
 	SpanId: 6aa5063d1d1d19eb

```

## Edit:
Verified that this occurs with only `InMemoryExporter`.
[LINK TO BUILD LOG](https://dev.azure.com/azure-sdk/public/_build/results?buildId=1900763&view=logs&j=df47e0b9-f7f0-5a6d-001b-395452402a29&t=4e7be197-90e0-54b4-32b4-fc5516b8477e&l=147)
```
Activities Count:2  Logs Count:1
 
 Expected TraceId:a920c147adc3f81fd0cbce1380195b23  Expected SpanId:98f0b3d85918c47a
 
 Exported Activity:
 	DisplayName: TestActivity LogWithinActivity Trace
 	Id: 00-a920c147adc3f81fd0cbce1380195b23-98f0b3d85918c47a-01
 	TraceId: a920c147adc3f81fd0cbce1380195b23
 	SpanId: 98f0b3d85918c47a
 Exported Activity:
 	DisplayName: TestActivity LogWithinActivity Trace
 	Id: 00-a920c147adc3f81fd0cbce1380195b23-98f0b3d85918c47a-01
 	TraceId: a920c147adc3f81fd0cbce1380195b23
 	SpanId: 98f0b3d85918c47a
```

## Edit:
I subscribed to OpenTelemetry's EventSource logs ([link](https://github.com/open-telemetry/opentelemetry-dotnet/blob/622583c6ffaea2e3d83d4fcb8935c6a8dbc6f81f/src/OpenTelemetry/Trace/TracerProviderSdk.cs#L143)) to monitor the Activity Listener.
I found that the Activity starts once, but stops twice.
```
 EVENT SOURCE LOGS:
 Activity started. OperationName = 'TestActivity LogWithinActivity_InMemoryExporterOnly Trace', Id = '00-0126e86bbff22cb04a354debdd05484a-9715aba14d39f7a3-01'.
 Activity stopped. OperationName = 'TestActivity LogWithinActivity_InMemoryExporterOnly Trace', Id = '00-0126e86bbff22cb04a354debdd05484a-9715aba14d39f7a3-01'.
 Activity stopped. OperationName = 'TestActivity LogWithinActivity_InMemoryExporterOnly Trace', Id = '00-0126e86bbff22cb04a354debdd05484a-9715aba14d39f7a3-01'.
 'TracerProvider' Disposed.
 'OpenTelemetryLoggerProvider' Disposed.

```

## Edit:
I created a test using only `ActivityListener` without any OpenTelemetry components.
My test was modeled off the official unit tests. ([link](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivitySourceTests.cs))
[LINK TO BUILD LOG](https://dev.azure.com/azure-sdk/public/_build/results?buildId=1902232&view=logs&j=e55623aa-2fbf-55e5-4c09-cf8db4d32009&t=4275b670-3b16-5f74-df27-48dcab0a8d51&l=262)
[LINK TO BUILD LOG 2](https://dev.azure.com/azure-sdk/public/_build/results?buildId=1902393&view=logs&j=e55623aa-2fbf-55e5-4c09-cf8db4d32009&t=4275b670-3b16-5f74-df27-48dcab0a8d51&l=261)

Note: there's a typo in the name of the activity, please disregard "_InMemoryExporterOnly". The test name is valid "_ActivityListener".
```
  Failed Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation.TracesTests.LogWithinActivity_ActivityListener(logLevel: Error) [190 ms]
  Error Message:
   Unexpected count of activity logs.
Expected: True
Actual:   False
  Stack Trace:
     at Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation.TracesTests.LogWithinActivity_ActivityListener(LogLevel logLevel) in /mnt/vss/_work/1/s/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs:line 419
  Standard Output Messages:
 Activities Logs:3
 
 Expected TraceId:92a7b68c9db1ac45c964b638b6014929  Expected SpanId:4009e925dcc179b0
 
 ActivityStarted: TestActivity LogWithinActivity_InMemoryExporterOnly Error, 00-92a7b68c9db1ac45c964b638b6014929-4009e925dcc179b0-01
 ActivityStarted: TestActivity LogWithinActivity_InMemoryExporterOnly Error, 00-92a7b68c9db1ac45c964b638b6014929-4009e925dcc179b0-01
 ActivityStopped: TestActivity LogWithinActivity_InMemoryExporterOnly Error, 00-92a7b68c9db1ac45c964b638b6014929-4009e925dcc179b0-01

```