### PR TITLE
Re-enabling ignored test AnalyzeHealthcareEntitiesTestWithAssertions

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeHealthcareEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeHealthcareEntitiesTests.cs
@@ -134,7 +134,6 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/21796")]
         public async Task AnalyzeHealthcareEntitiesTestWithAssertions()
         {
             TextAnalyticsClient client = GetClient();

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeHealthcareEntitiesTests/AnalyzeHealthcareEntitiesTestWithAssertions.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeHealthcareEntitiesTests/AnalyzeHealthcareEntitiesTestWithAssertions.json
@@ -1,806 +1,860 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.1-preview.5/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-05-01",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Content-Length": "157",
+        "Accept": "application/json",
+        "Content-Length": "256",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1a849025a3a8e34d85926bee0331d4eb-6a4995d4fd968040-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20210514.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3ab5e70f5cb4da7730ff892b296e2123",
+        "traceparent": "00-c3f338a122e6032dc19400dfe6e0302b-97d1aa6da33d5bdf-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20220930.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "428d5bfa63b82fbf36fd830de20f7249",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "documents": [
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "0",
+              "text": "Baby not likely to have Meningitis. in case of fever in the mother, consider Penicillin for the baby too.",
+              "language": "en"
+            }
+          ]
+        },
+        "tasks": [
           {
-            "id": "0",
-            "text": "Baby not likely to have Meningitis. in case of fever in the mother, consider Penicillin for the baby too.",
-            "language": "en"
+            "parameters": {
+              "stringIndexType": "Utf16CodeUnit"
+            },
+            "kind": "Healthcare"
           }
         ]
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "aee3d609-05df-4194-a2a0-d362d6bed75a",
-        "Date": "Fri, 14 May 2021 17:28:29 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.1-preview.5/entities/health/jobs/1ed5e6ec-e304-44e7-87d6-294e25b64c64",
+        "apim-request-id": "39c248a2-b26a-4510-bd0b-d2a75aa55a75",
+        "Content-Length": "0",
+        "Date": "Fri, 30 Sep 2022 23:53:49 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/2ccd7761-e523-40c5-9758-a87cdc989535?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "103"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "117"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.1-preview.5/entities/health/jobs/1ed5e6ec-e304-44e7-87d6-294e25b64c64?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/2ccd7761-e523-40c5-9758-a87cdc989535?api-version=2022-05-01\u0026showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20210514.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9351c2a22c1c3ee6608aa58aee54a72a",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20220930.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "577fcbfb95c244ba43914ccf91ddc563",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d5ef3210-0e0f-4b7d-bbef-8ec4472f075a",
+        "apim-request-id": "9817a980-2c18-40d7-90ea-e77e0c70236a",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 14 May 2021 17:28:29 GMT",
+        "Date": "Fri, 30 Sep 2022 23:53:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "1ed5e6ec-e304-44e7-87d6-294e25b64c64",
-        "lastUpdateDateTime": "2021-05-14T17:28:29Z",
-        "createdDateTime": "2021-05-14T17:28:29Z",
-        "expirationDateTime": "2021-05-15T17:28:29Z",
+        "jobId": "2ccd7761-e523-40c5-9758-a87cdc989535",
+        "lastUpdatedDateTime": "2022-09-30T23:53:49Z",
+        "createdDateTime": "2022-09-30T23:53:49Z",
+        "expirationDateTime": "2022-10-01T23:53:49Z",
         "status": "notStarted",
-        "errors": []
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.1-preview.5/entities/health/jobs/1ed5e6ec-e304-44e7-87d6-294e25b64c64?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/2ccd7761-e523-40c5-9758-a87cdc989535?api-version=2022-05-01\u0026showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20210514.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e207b7364a4a32084d608e3c8dcf6c1e",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20220930.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d202a8a089ff1e5bc67a42005ae99025",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9dfaaff9-00d0-445d-a158-777c0d70a303",
+        "apim-request-id": "741f29d1-3280-4615-b6fb-0e660adfdb89",
+        "Content-Length": "7502",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 14 May 2021 17:28:30 GMT",
+        "Date": "Fri, 30 Sep 2022 23:53:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "33"
       },
       "ResponseBody": {
-        "jobId": "1ed5e6ec-e304-44e7-87d6-294e25b64c64",
-        "lastUpdateDateTime": "2021-05-14T17:28:30Z",
-        "createdDateTime": "2021-05-14T17:28:29Z",
-        "expirationDateTime": "2021-05-15T17:28:29Z",
+        "jobId": "2ccd7761-e523-40c5-9758-a87cdc989535",
+        "lastUpdatedDateTime": "2022-09-30T23:53:50Z",
+        "createdDateTime": "2022-09-30T23:53:49Z",
+        "expirationDateTime": "2022-10-01T23:53:49Z",
         "status": "succeeded",
         "errors": [],
-        "results": {
-          "documents": [
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 1,
+          "items": [
             {
-              "id": "0",
-              "entities": [
-                {
-                  "offset": 0,
-                  "length": 4,
-                  "text": "Baby",
-                  "category": "Age",
-                  "confidenceScore": 0.9,
-                  "name": "Infant",
-                  "links": [
-                    {
-                      "dataSource": "UMLS",
-                      "id": "C0021270"
-                    },
-                    {
-                      "dataSource": "AOD",
-                      "id": "0000005273"
-                    },
-                    {
-                      "dataSource": "CCPSS",
-                      "id": "0030805"
-                    },
-                    {
-                      "dataSource": "CHV",
-                      "id": "0000006675"
-                    },
-                    {
-                      "dataSource": "DXP",
-                      "id": "U002089"
-                    },
-                    {
-                      "dataSource": "LCH",
-                      "id": "U002421"
-                    },
-                    {
-                      "dataSource": "LCH_NW",
-                      "id": "sh85066022"
-                    },
-                    {
-                      "dataSource": "LNC",
-                      "id": "LA19747-7"
-                    },
-                    {
-                      "dataSource": "MDR",
-                      "id": "10021731"
-                    },
-                    {
-                      "dataSource": "MSH",
-                      "id": "D007223"
-                    },
-                    {
-                      "dataSource": "NCI",
-                      "id": "C27956"
-                    },
-                    {
-                      "dataSource": "NCI_FDA",
-                      "id": "C27956"
-                    },
-                    {
-                      "dataSource": "NCI_NICHD",
-                      "id": "C27956"
-                    },
-                    {
-                      "dataSource": "SNOMEDCT_US",
-                      "id": "133931009"
-                    }
-                  ]
-                },
-                {
-                  "offset": 24,
-                  "length": 10,
-                  "text": "Meningitis",
-                  "category": "Diagnosis",
-                  "confidenceScore": 0.9,
-                  "assertion": {
-                    "certainty": "negativePossible"
-                  },
-                  "name": "Meningitis",
-                  "links": [
-                    {
-                      "dataSource": "UMLS",
-                      "id": "C0025289"
-                    },
-                    {
-                      "dataSource": "AOD",
-                      "id": "0000006185"
-                    },
-                    {
-                      "dataSource": "BI",
-                      "id": "BI00546"
-                    },
-                    {
-                      "dataSource": "CCPSS",
-                      "id": "1018016"
-                    },
-                    {
-                      "dataSource": "CCSR_10",
-                      "id": "NVS001"
-                    },
-                    {
-                      "dataSource": "CHV",
-                      "id": "0000007932"
-                    },
-                    {
-                      "dataSource": "COSTAR",
-                      "id": "478"
-                    },
-                    {
-                      "dataSource": "CSP",
-                      "id": "2042-5301"
-                    },
-                    {
-                      "dataSource": "CST",
-                      "id": "MENINGITIS"
-                    },
-                    {
-                      "dataSource": "DXP",
-                      "id": "U002543"
-                    },
-                    {
-                      "dataSource": "HPO",
-                      "id": "HP:0001287"
-                    },
-                    {
-                      "dataSource": "ICD10",
-                      "id": "G03.9"
-                    },
-                    {
-                      "dataSource": "ICD10AM",
-                      "id": "G03.9"
-                    },
-                    {
-                      "dataSource": "ICD10CM",
-                      "id": "G03.9"
-                    },
-                    {
-                      "dataSource": "ICD9CM",
-                      "id": "322.9"
-                    },
-                    {
-                      "dataSource": "ICPC2ICD10ENG",
-                      "id": "MTHU048434"
-                    },
-                    {
-                      "dataSource": "ICPC2P",
-                      "id": "N71002"
-                    },
-                    {
-                      "dataSource": "LCH",
-                      "id": "U002901"
-                    },
-                    {
-                      "dataSource": "LCH_NW",
-                      "id": "sh85083562"
-                    },
-                    {
-                      "dataSource": "LNC",
-                      "id": "LP20756-0"
-                    },
-                    {
-                      "dataSource": "MDR",
-                      "id": "10027199"
-                    },
-                    {
-                      "dataSource": "MEDCIN",
-                      "id": "31192"
-                    },
-                    {
-                      "dataSource": "MEDLINEPLUS",
-                      "id": "324"
-                    },
-                    {
-                      "dataSource": "MSH",
-                      "id": "D008581"
-                    },
-                    {
-                      "dataSource": "NANDA-I",
-                      "id": "02899"
-                    },
-                    {
-                      "dataSource": "NCI",
-                      "id": "C26828"
-                    },
-                    {
-                      "dataSource": "NCI_CPTAC",
-                      "id": "C26828"
-                    },
-                    {
-                      "dataSource": "NCI_CTCAE",
-                      "id": "E11458"
-                    },
-                    {
-                      "dataSource": "NCI_FDA",
-                      "id": "2389"
-                    },
-                    {
-                      "dataSource": "NCI_NCI-GLOSS",
-                      "id": "CDR0000471780"
-                    },
-                    {
-                      "dataSource": "NCI_NICHD",
-                      "id": "C26828"
-                    },
-                    {
-                      "dataSource": "OMIM",
-                      "id": "MTHU005994"
-                    },
-                    {
-                      "dataSource": "PSY",
-                      "id": "30660"
-                    },
-                    {
-                      "dataSource": "RCD",
-                      "id": "X000H"
-                    },
-                    {
-                      "dataSource": "SNM",
-                      "id": "M-40000"
-                    },
-                    {
-                      "dataSource": "SNMI",
-                      "id": "DA-10010"
-                    },
-                    {
-                      "dataSource": "SNOMEDCT_US",
-                      "id": "7180009"
-                    },
-                    {
-                      "dataSource": "WHO",
-                      "id": "0955"
-                    }
-                  ]
-                },
-                {
-                  "offset": 47,
-                  "length": 5,
-                  "text": "fever",
-                  "category": "SymptomOrSign",
-                  "confidenceScore": 0.99,
-                  "name": "Fever",
-                  "links": [
-                    {
-                      "dataSource": "UMLS",
-                      "id": "C0015967"
-                    },
-                    {
-                      "dataSource": "AIR",
-                      "id": "FEVER"
-                    },
-                    {
-                      "dataSource": "AOD",
-                      "id": "0000004396"
-                    },
-                    {
-                      "dataSource": "BI",
-                      "id": "BI00751"
-                    },
-                    {
-                      "dataSource": "CCC",
-                      "id": "K25.2"
-                    },
-                    {
-                      "dataSource": "CCPSS",
-                      "id": "1017166"
-                    },
-                    {
-                      "dataSource": "CCSR_10",
-                      "id": "SYM002"
-                    },
-                    {
-                      "dataSource": "CHV",
-                      "id": "0000005010"
-                    },
-                    {
-                      "dataSource": "COSTAR",
-                      "id": "300"
-                    },
-                    {
-                      "dataSource": "CPM",
-                      "id": "65287"
-                    },
-                    {
-                      "dataSource": "CSP",
-                      "id": "2871-4310"
-                    },
-                    {
-                      "dataSource": "CST",
-                      "id": "FEVER"
-                    },
-                    {
-                      "dataSource": "DXP",
-                      "id": "U001483"
-                    },
-                    {
-                      "dataSource": "GO",
-                      "id": "GO:0001660"
-                    },
-                    {
-                      "dataSource": "HPO",
-                      "id": "HP:0001945"
-                    },
-                    {
-                      "dataSource": "ICD10",
-                      "id": "R50.9"
-                    },
-                    {
-                      "dataSource": "ICD10AM",
-                      "id": "R50.9"
-                    },
-                    {
-                      "dataSource": "ICD10CM",
-                      "id": "R50.9"
-                    },
-                    {
-                      "dataSource": "ICD9CM",
-                      "id": "780.60"
-                    },
-                    {
-                      "dataSource": "ICNP",
-                      "id": "10041539"
-                    },
-                    {
-                      "dataSource": "ICPC",
-                      "id": "A03"
-                    },
-                    {
-                      "dataSource": "ICPC2EENG",
-                      "id": "A03"
-                    },
-                    {
-                      "dataSource": "ICPC2ICD10ENG",
-                      "id": "MTHU041751"
-                    },
-                    {
-                      "dataSource": "ICPC2P",
-                      "id": "A03002"
-                    },
-                    {
-                      "dataSource": "LCH",
-                      "id": "U001776"
-                    },
-                    {
-                      "dataSource": "LCH_NW",
-                      "id": "sh85047994"
-                    },
-                    {
-                      "dataSource": "LNC",
-                      "id": "MTHU013518"
-                    },
-                    {
-                      "dataSource": "MDR",
-                      "id": "10005911"
-                    },
-                    {
-                      "dataSource": "MEDCIN",
-                      "id": "6005"
-                    },
-                    {
-                      "dataSource": "MEDLINEPLUS",
-                      "id": "511"
-                    },
-                    {
-                      "dataSource": "MSH",
-                      "id": "D005334"
-                    },
-                    {
-                      "dataSource": "MTHICD9",
-                      "id": "780.60"
-                    },
-                    {
-                      "dataSource": "NANDA-I",
-                      "id": "01128"
-                    },
-                    {
-                      "dataSource": "NCI",
-                      "id": "C3038"
-                    },
-                    {
-                      "dataSource": "NCI_CTCAE",
-                      "id": "E11102"
-                    },
-                    {
-                      "dataSource": "NCI_FDA",
-                      "id": "1858"
-                    },
-                    {
-                      "dataSource": "NCI_NCI-GLOSS",
-                      "id": "CDR0000450108"
-                    },
-                    {
-                      "dataSource": "NCI_NICHD",
-                      "id": "C3038"
-                    },
-                    {
-                      "dataSource": "NOC",
-                      "id": "070307"
-                    },
-                    {
-                      "dataSource": "OMIM",
-                      "id": "MTHU005439"
-                    },
-                    {
-                      "dataSource": "OMS",
-                      "id": "50.03"
-                    },
-                    {
-                      "dataSource": "PCDS",
-                      "id": "PRB_11020.02"
-                    },
-                    {
-                      "dataSource": "PDQ",
-                      "id": "CDR0000775882"
-                    },
-                    {
-                      "dataSource": "PSY",
-                      "id": "23840"
-                    },
-                    {
-                      "dataSource": "QMR",
-                      "id": "Q0200115"
-                    },
-                    {
-                      "dataSource": "RCD",
-                      "id": "X76EI"
-                    },
-                    {
-                      "dataSource": "SNM",
-                      "id": "F-03003"
-                    },
-                    {
-                      "dataSource": "SNMI",
-                      "id": "F-03003"
-                    },
-                    {
-                      "dataSource": "SNOMEDCT_US",
-                      "id": "386661006"
-                    },
-                    {
-                      "dataSource": "WHO",
-                      "id": "0725"
-                    }
-                  ]
-                },
-                {
-                  "offset": 60,
-                  "length": 6,
-                  "text": "mother",
-                  "category": "FamilyRelation",
-                  "confidenceScore": 0.99,
-                  "name": "Mother (person)",
-                  "links": [
-                    {
-                      "dataSource": "UMLS",
-                      "id": "C0026591"
-                    },
-                    {
-                      "dataSource": "AOD",
-                      "id": "0000027173"
-                    },
-                    {
-                      "dataSource": "CCPSS",
-                      "id": "U000286"
-                    },
-                    {
-                      "dataSource": "CHV",
-                      "id": "0000008266"
-                    },
-                    {
-                      "dataSource": "CSP",
-                      "id": "1124-5492"
-                    },
-                    {
-                      "dataSource": "HL7V3.0",
-                      "id": "MTH"
-                    },
-                    {
-                      "dataSource": "LCH",
-                      "id": "U003028"
-                    },
-                    {
-                      "dataSource": "LCH_NW",
-                      "id": "sh85087526"
-                    },
-                    {
-                      "dataSource": "LNC",
-                      "id": "LA10417-6"
-                    },
-                    {
-                      "dataSource": "MSH",
-                      "id": "D009035"
-                    },
-                    {
-                      "dataSource": "NCI",
-                      "id": "C25189"
-                    },
-                    {
-                      "dataSource": "NCI_CDISC",
-                      "id": "C25189"
-                    },
-                    {
-                      "dataSource": "NCI_GDC",
-                      "id": "C25189"
-                    },
-                    {
-                      "dataSource": "PSY",
-                      "id": "32140"
-                    },
-                    {
-                      "dataSource": "RCD",
-                      "id": "X78ym"
-                    },
-                    {
-                      "dataSource": "SNMI",
-                      "id": "S-10120"
-                    },
-                    {
-                      "dataSource": "SNOMEDCT_US",
-                      "id": "72705000"
-                    }
-                  ]
-                },
-                {
-                  "offset": 77,
-                  "length": 10,
-                  "text": "Penicillin",
-                  "category": "MedicationName",
-                  "confidenceScore": 0.95,
-                  "assertion": {
-                    "certainty": "neutralPossible"
-                  },
-                  "name": "penicillins",
-                  "links": [
-                    {
-                      "dataSource": "UMLS",
-                      "id": "C0030842"
-                    },
-                    {
-                      "dataSource": "AOD",
-                      "id": "0000019206"
-                    },
-                    {
-                      "dataSource": "ATC",
-                      "id": "J01C"
-                    },
-                    {
-                      "dataSource": "CCPSS",
-                      "id": "0014106"
-                    },
-                    {
-                      "dataSource": "CHV",
-                      "id": "0000009423"
-                    },
-                    {
-                      "dataSource": "CSP",
-                      "id": "0199-8025"
-                    },
-                    {
-                      "dataSource": "GS",
-                      "id": "4011"
-                    },
-                    {
-                      "dataSource": "LCH",
-                      "id": "U003521"
-                    },
-                    {
-                      "dataSource": "LCH_NW",
-                      "id": "sh85099402"
-                    },
-                    {
-                      "dataSource": "LNC",
-                      "id": "LP14319-5"
-                    },
-                    {
-                      "dataSource": "MEDCIN",
-                      "id": "40319"
-                    },
-                    {
-                      "dataSource": "MMSL",
-                      "id": "d00116"
-                    },
-                    {
-                      "dataSource": "MSH",
-                      "id": "D010406"
-                    },
-                    {
-                      "dataSource": "NCI",
-                      "id": "C1500"
-                    },
-                    {
-                      "dataSource": "NCI_DTP",
-                      "id": "NSC0402815"
-                    },
-                    {
-                      "dataSource": "NCI_NCI-GLOSS",
-                      "id": "CDR0000045296"
-                    },
-                    {
-                      "dataSource": "NDDF",
-                      "id": "016121"
-                    },
-                    {
-                      "dataSource": "PSY",
-                      "id": "37190"
-                    },
-                    {
-                      "dataSource": "RCD",
-                      "id": "x009C"
-                    },
-                    {
-                      "dataSource": "SNM",
-                      "id": "E-7260"
-                    },
-                    {
-                      "dataSource": "SNMI",
-                      "id": "C-54000"
-                    },
-                    {
-                      "dataSource": "SNOMEDCT_US",
-                      "id": "764146007"
-                    },
-                    {
-                      "dataSource": "VANDF",
-                      "id": "4019880"
-                    }
-                  ]
-                },
-                {
-                  "offset": 96,
-                  "length": 4,
-                  "text": "baby",
-                  "category": "Age",
-                  "confidenceScore": 0.96,
-                  "name": "Infant",
-                  "links": [
-                    {
-                      "dataSource": "UMLS",
-                      "id": "C0021270"
-                    },
-                    {
-                      "dataSource": "AOD",
-                      "id": "0000005273"
-                    },
-                    {
-                      "dataSource": "CCPSS",
-                      "id": "0030805"
-                    },
-                    {
-                      "dataSource": "CHV",
-                      "id": "0000006675"
-                    },
-                    {
-                      "dataSource": "DXP",
-                      "id": "U002089"
-                    },
-                    {
-                      "dataSource": "LCH",
-                      "id": "U002421"
-                    },
-                    {
-                      "dataSource": "LCH_NW",
-                      "id": "sh85066022"
-                    },
-                    {
-                      "dataSource": "LNC",
-                      "id": "LA19747-7"
-                    },
-                    {
-                      "dataSource": "MDR",
-                      "id": "10021731"
-                    },
-                    {
-                      "dataSource": "MSH",
-                      "id": "D007223"
-                    },
-                    {
-                      "dataSource": "NCI",
-                      "id": "C27956"
-                    },
-                    {
-                      "dataSource": "NCI_FDA",
-                      "id": "C27956"
-                    },
-                    {
-                      "dataSource": "NCI_NICHD",
-                      "id": "C27956"
-                    },
-                    {
-                      "dataSource": "SNOMEDCT_US",
-                      "id": "133931009"
-                    }
-                  ]
-                }
-              ],
-              "relations": [],
-              "warnings": []
+              "kind": "HealthcareLROResults",
+              "lastUpdateDateTime": "2022-09-30T23:53:50.0919478Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "offset": 0,
+                        "length": 4,
+                        "text": "Baby",
+                        "category": "Age",
+                        "confidenceScore": 0.94,
+                        "name": "Infant",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0021270"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000005273"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "0030805"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000006675"
+                          },
+                          {
+                            "dataSource": "DXP",
+                            "id": "U002089"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U002421"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85066022"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LA19747-7"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10021731"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D007223"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C27956"
+                          },
+                          {
+                            "dataSource": "NCI_FDA",
+                            "id": "C27956"
+                          },
+                          {
+                            "dataSource": "NCI_NICHD",
+                            "id": "C27956"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "133931009"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 24,
+                        "length": 10,
+                        "text": "Meningitis",
+                        "category": "Diagnosis",
+                        "confidenceScore": 1.0,
+                        "assertion": {
+                          "certainty": "negativePossible"
+                        },
+                        "name": "Meningitis",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0025289"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000006185"
+                          },
+                          {
+                            "dataSource": "BI",
+                            "id": "BI00546"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "1018016"
+                          },
+                          {
+                            "dataSource": "CCSR_10",
+                            "id": "NVS001"
+                          },
+                          {
+                            "dataSource": "CCSR_ICD10CM",
+                            "id": "NVS001"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000007932"
+                          },
+                          {
+                            "dataSource": "COSTAR",
+                            "id": "478"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "2042-5301"
+                          },
+                          {
+                            "dataSource": "CST",
+                            "id": "MENINGITIS"
+                          },
+                          {
+                            "dataSource": "DXP",
+                            "id": "U002543"
+                          },
+                          {
+                            "dataSource": "HPO",
+                            "id": "HP:0001287"
+                          },
+                          {
+                            "dataSource": "ICD10",
+                            "id": "G03.9"
+                          },
+                          {
+                            "dataSource": "ICD10AM",
+                            "id": "G03.9"
+                          },
+                          {
+                            "dataSource": "ICD10CM",
+                            "id": "G03.9"
+                          },
+                          {
+                            "dataSource": "ICD9CM",
+                            "id": "322.9"
+                          },
+                          {
+                            "dataSource": "ICPC2ICD10ENG",
+                            "id": "MTHU048434"
+                          },
+                          {
+                            "dataSource": "ICPC2P",
+                            "id": "N71002"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U002901"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85083562"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LP20756-0"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10027199"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "31192"
+                          },
+                          {
+                            "dataSource": "MEDLINEPLUS",
+                            "id": "324"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D008581"
+                          },
+                          {
+                            "dataSource": "NANDA-I",
+                            "id": "02899"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C26828"
+                          },
+                          {
+                            "dataSource": "NCI_CPTAC",
+                            "id": "C26828"
+                          },
+                          {
+                            "dataSource": "NCI_CTCAE",
+                            "id": "E11458"
+                          },
+                          {
+                            "dataSource": "NCI_FDA",
+                            "id": "2389"
+                          },
+                          {
+                            "dataSource": "NCI_NCI-GLOSS",
+                            "id": "CDR0000471780"
+                          },
+                          {
+                            "dataSource": "NCI_NICHD",
+                            "id": "C26828"
+                          },
+                          {
+                            "dataSource": "NCI_caDSR",
+                            "id": "C26828"
+                          },
+                          {
+                            "dataSource": "OMIM",
+                            "id": "MTHU005994"
+                          },
+                          {
+                            "dataSource": "PSY",
+                            "id": "30660"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "X000H"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "M-40000"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "DA-10010"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "7180009"
+                          },
+                          {
+                            "dataSource": "WHO",
+                            "id": "0955"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 47,
+                        "length": 5,
+                        "text": "fever",
+                        "category": "SymptomOrSign",
+                        "confidenceScore": 0.98,
+                        "name": "Fever",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0015967"
+                          },
+                          {
+                            "dataSource": "AIR",
+                            "id": "FEVER"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000004396"
+                          },
+                          {
+                            "dataSource": "BI",
+                            "id": "BI00751"
+                          },
+                          {
+                            "dataSource": "CCC",
+                            "id": "K25.2"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "1017166"
+                          },
+                          {
+                            "dataSource": "CCSR_10",
+                            "id": "SYM002"
+                          },
+                          {
+                            "dataSource": "CCSR_ICD10CM",
+                            "id": "SYM002"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000005010"
+                          },
+                          {
+                            "dataSource": "COSTAR",
+                            "id": "300"
+                          },
+                          {
+                            "dataSource": "CPM",
+                            "id": "65287"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "2871-4310"
+                          },
+                          {
+                            "dataSource": "CST",
+                            "id": "FEVER"
+                          },
+                          {
+                            "dataSource": "DXP",
+                            "id": "U001483"
+                          },
+                          {
+                            "dataSource": "GO",
+                            "id": "GO:0001660"
+                          },
+                          {
+                            "dataSource": "HPO",
+                            "id": "HP:0001945"
+                          },
+                          {
+                            "dataSource": "ICD10",
+                            "id": "R50.9"
+                          },
+                          {
+                            "dataSource": "ICD10AM",
+                            "id": "R50.9"
+                          },
+                          {
+                            "dataSource": "ICD10CM",
+                            "id": "R50.9"
+                          },
+                          {
+                            "dataSource": "ICD9CM",
+                            "id": "780.60"
+                          },
+                          {
+                            "dataSource": "ICNP",
+                            "id": "10041539"
+                          },
+                          {
+                            "dataSource": "ICPC",
+                            "id": "A03"
+                          },
+                          {
+                            "dataSource": "ICPC2EENG",
+                            "id": "A03"
+                          },
+                          {
+                            "dataSource": "ICPC2ICD10ENG",
+                            "id": "MTHU041751"
+                          },
+                          {
+                            "dataSource": "ICPC2P",
+                            "id": "A03002"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U001776"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85047994"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "MTHU013518"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10005911"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "6005"
+                          },
+                          {
+                            "dataSource": "MEDLINEPLUS",
+                            "id": "511"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D005334"
+                          },
+                          {
+                            "dataSource": "MTHICD9",
+                            "id": "780.60"
+                          },
+                          {
+                            "dataSource": "NANDA-I",
+                            "id": "01128"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C3038"
+                          },
+                          {
+                            "dataSource": "NCI_CTCAE",
+                            "id": "E11102"
+                          },
+                          {
+                            "dataSource": "NCI_FDA",
+                            "id": "1858"
+                          },
+                          {
+                            "dataSource": "NCI_GDC",
+                            "id": "C3038"
+                          },
+                          {
+                            "dataSource": "NCI_NCI-GLOSS",
+                            "id": "CDR0000450108"
+                          },
+                          {
+                            "dataSource": "NCI_NICHD",
+                            "id": "C3038"
+                          },
+                          {
+                            "dataSource": "NCI_caDSR",
+                            "id": "C3038"
+                          },
+                          {
+                            "dataSource": "NOC",
+                            "id": "070307"
+                          },
+                          {
+                            "dataSource": "OMIM",
+                            "id": "MTHU005439"
+                          },
+                          {
+                            "dataSource": "OMS",
+                            "id": "50.03"
+                          },
+                          {
+                            "dataSource": "PCDS",
+                            "id": "PRB_11020.02"
+                          },
+                          {
+                            "dataSource": "PDQ",
+                            "id": "CDR0000775882"
+                          },
+                          {
+                            "dataSource": "PSY",
+                            "id": "23840"
+                          },
+                          {
+                            "dataSource": "QMR",
+                            "id": "Q0200115"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "X76EI"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "F-03003"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "F-03003"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "386661006"
+                          },
+                          {
+                            "dataSource": "WHO",
+                            "id": "0725"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 60,
+                        "length": 6,
+                        "text": "mother",
+                        "category": "FamilyRelation",
+                        "confidenceScore": 0.99,
+                        "name": "Mother (person)",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0026591"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000027173"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "U000286"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000008266"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "1124-5492"
+                          },
+                          {
+                            "dataSource": "HL7V3.0",
+                            "id": "MTH"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U003028"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85087526"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LA10417-6"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D009035"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C25189"
+                          },
+                          {
+                            "dataSource": "NCI_CDISC",
+                            "id": "C25189"
+                          },
+                          {
+                            "dataSource": "NCI_GDC",
+                            "id": "C25189"
+                          },
+                          {
+                            "dataSource": "NCI_caDSR",
+                            "id": "C25189"
+                          },
+                          {
+                            "dataSource": "PSY",
+                            "id": "32140"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "X78ym"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "S-10120"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "72705000"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 77,
+                        "length": 10,
+                        "text": "Penicillin",
+                        "category": "MedicationName",
+                        "confidenceScore": 0.84,
+                        "assertion": {
+                          "certainty": "neutralPossible"
+                        },
+                        "name": "penicillins",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0030842"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000019206"
+                          },
+                          {
+                            "dataSource": "ATC",
+                            "id": "J01C"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "0014106"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000009423"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "0199-8025"
+                          },
+                          {
+                            "dataSource": "GS",
+                            "id": "4011"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U003521"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85099402"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LP14319-5"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "40319"
+                          },
+                          {
+                            "dataSource": "MMSL",
+                            "id": "d00116"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D010406"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C1500"
+                          },
+                          {
+                            "dataSource": "NCI_DTP",
+                            "id": "NSC0402815"
+                          },
+                          {
+                            "dataSource": "NCI_NCI-GLOSS",
+                            "id": "CDR0000045296"
+                          },
+                          {
+                            "dataSource": "NDDF",
+                            "id": "016121"
+                          },
+                          {
+                            "dataSource": "PSY",
+                            "id": "37190"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "x009C"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "E-7260"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "C-54000"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "764146007"
+                          },
+                          {
+                            "dataSource": "VANDF",
+                            "id": "4019880"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 96,
+                        "length": 4,
+                        "text": "baby",
+                        "category": "FamilyRelation",
+                        "confidenceScore": 1.0,
+                        "name": "Infant",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0021270"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000005273"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "0030805"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000006675"
+                          },
+                          {
+                            "dataSource": "DXP",
+                            "id": "U002089"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U002421"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85066022"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LA19747-7"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10021731"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D007223"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C27956"
+                          },
+                          {
+                            "dataSource": "NCI_FDA",
+                            "id": "C27956"
+                          },
+                          {
+                            "dataSource": "NCI_NICHD",
+                            "id": "C27956"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "133931009"
+                          }
+                        ]
+                      }
+                    ],
+                    "relations": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-03-01"
+              }
             }
-          ],
-          "errors": [],
-          "modelVersion": "2021-03-01"
+          ]
         }
       }
     }
   ],
   "Variables": {
-    "RandomSeed": "625362055",
+    "RandomSeed": "47745262",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeHealthcareEntitiesTests/AnalyzeHealthcareEntitiesTestWithAssertionsAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeHealthcareEntitiesTests/AnalyzeHealthcareEntitiesTestWithAssertionsAsync.json
@@ -1,806 +1,860 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.1-preview.5/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-05-01",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Content-Length": "157",
+        "Accept": "application/json",
+        "Content-Length": "256",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ff8a067f2873014b8135d8b5a76b6980-2c18419fda915743-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20210514.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "912de7ef7312f174815daaace9ee22e6",
+        "traceparent": "00-4d5204c5efb626510339090e1f749817-3aa9f080b0ee836d-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221003.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "02e080ac3cd43b432ce31b8f9b0ed80d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "documents": [
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "0",
+              "text": "Baby not likely to have Meningitis. in case of fever in the mother, consider Penicillin for the baby too.",
+              "language": "en"
+            }
+          ]
+        },
+        "tasks": [
           {
-            "id": "0",
-            "text": "Baby not likely to have Meningitis. in case of fever in the mother, consider Penicillin for the baby too.",
-            "language": "en"
+            "parameters": {
+              "stringIndexType": "Utf16CodeUnit"
+            },
+            "kind": "Healthcare"
           }
         ]
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "e9a35efc-b1ed-46dc-bfef-c466e485a726",
-        "Date": "Fri, 14 May 2021 17:28:51 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.1-preview.5/entities/health/jobs/41b14a1f-3514-414e-9c57-733f5a9dcf5f",
+        "apim-request-id": "cedcce27-cde8-4a1c-bb04-c6f77b152c25",
+        "Content-Length": "0",
+        "Date": "Mon, 03 Oct 2022 19:44:48 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/61405f3b-8353-47f3-a77d-d530bb18f420?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "92"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "108"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.1-preview.5/entities/health/jobs/41b14a1f-3514-414e-9c57-733f5a9dcf5f?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/61405f3b-8353-47f3-a77d-d530bb18f420?api-version=2022-05-01\u0026showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20210514.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "03ee5c28e71ec5ecf8fc2d0dce4ae244",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221003.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5735088ae0320a90cd371b9c17188f03",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cd3ce908-1eb8-46a3-ba49-3c4ec83560d6",
+        "apim-request-id": "a729b12f-872a-4729-a2c1-3bfd0918b74d",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 14 May 2021 17:28:51 GMT",
+        "Date": "Mon, 03 Oct 2022 19:44:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "13"
       },
       "ResponseBody": {
-        "jobId": "41b14a1f-3514-414e-9c57-733f5a9dcf5f",
-        "lastUpdateDateTime": "2021-05-14T17:28:51Z",
-        "createdDateTime": "2021-05-14T17:28:51Z",
-        "expirationDateTime": "2021-05-15T17:28:51Z",
+        "jobId": "61405f3b-8353-47f3-a77d-d530bb18f420",
+        "lastUpdatedDateTime": "2022-10-03T19:44:49Z",
+        "createdDateTime": "2022-10-03T19:44:48Z",
+        "expirationDateTime": "2022-10-04T19:44:48Z",
         "status": "notStarted",
-        "errors": []
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.1-preview.5/entities/health/jobs/41b14a1f-3514-414e-9c57-733f5a9dcf5f?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/61405f3b-8353-47f3-a77d-d530bb18f420?api-version=2022-05-01\u0026showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20210514.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3278ba1b878dc9118485304baf2db90f",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221003.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "271c12b47ce4c08451311d465492a494",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2f1a21d3-f5c5-4fcb-8696-70f5f04ca4d3",
+        "apim-request-id": "ffdbb27f-3491-4548-9342-974ba8055748",
+        "Content-Length": "7502",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 14 May 2021 17:28:52 GMT",
+        "Date": "Mon, 03 Oct 2022 19:44:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "36"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "28"
       },
       "ResponseBody": {
-        "jobId": "41b14a1f-3514-414e-9c57-733f5a9dcf5f",
-        "lastUpdateDateTime": "2021-05-14T17:28:52Z",
-        "createdDateTime": "2021-05-14T17:28:51Z",
-        "expirationDateTime": "2021-05-15T17:28:51Z",
+        "jobId": "61405f3b-8353-47f3-a77d-d530bb18f420",
+        "lastUpdatedDateTime": "2022-10-03T19:44:49Z",
+        "createdDateTime": "2022-10-03T19:44:48Z",
+        "expirationDateTime": "2022-10-04T19:44:48Z",
         "status": "succeeded",
         "errors": [],
-        "results": {
-          "documents": [
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 1,
+          "items": [
             {
-              "id": "0",
-              "entities": [
-                {
-                  "offset": 0,
-                  "length": 4,
-                  "text": "Baby",
-                  "category": "Age",
-                  "confidenceScore": 0.9,
-                  "name": "Infant",
-                  "links": [
-                    {
-                      "dataSource": "UMLS",
-                      "id": "C0021270"
-                    },
-                    {
-                      "dataSource": "AOD",
-                      "id": "0000005273"
-                    },
-                    {
-                      "dataSource": "CCPSS",
-                      "id": "0030805"
-                    },
-                    {
-                      "dataSource": "CHV",
-                      "id": "0000006675"
-                    },
-                    {
-                      "dataSource": "DXP",
-                      "id": "U002089"
-                    },
-                    {
-                      "dataSource": "LCH",
-                      "id": "U002421"
-                    },
-                    {
-                      "dataSource": "LCH_NW",
-                      "id": "sh85066022"
-                    },
-                    {
-                      "dataSource": "LNC",
-                      "id": "LA19747-7"
-                    },
-                    {
-                      "dataSource": "MDR",
-                      "id": "10021731"
-                    },
-                    {
-                      "dataSource": "MSH",
-                      "id": "D007223"
-                    },
-                    {
-                      "dataSource": "NCI",
-                      "id": "C27956"
-                    },
-                    {
-                      "dataSource": "NCI_FDA",
-                      "id": "C27956"
-                    },
-                    {
-                      "dataSource": "NCI_NICHD",
-                      "id": "C27956"
-                    },
-                    {
-                      "dataSource": "SNOMEDCT_US",
-                      "id": "133931009"
-                    }
-                  ]
-                },
-                {
-                  "offset": 24,
-                  "length": 10,
-                  "text": "Meningitis",
-                  "category": "Diagnosis",
-                  "confidenceScore": 0.9,
-                  "assertion": {
-                    "certainty": "negativePossible"
-                  },
-                  "name": "Meningitis",
-                  "links": [
-                    {
-                      "dataSource": "UMLS",
-                      "id": "C0025289"
-                    },
-                    {
-                      "dataSource": "AOD",
-                      "id": "0000006185"
-                    },
-                    {
-                      "dataSource": "BI",
-                      "id": "BI00546"
-                    },
-                    {
-                      "dataSource": "CCPSS",
-                      "id": "1018016"
-                    },
-                    {
-                      "dataSource": "CCSR_10",
-                      "id": "NVS001"
-                    },
-                    {
-                      "dataSource": "CHV",
-                      "id": "0000007932"
-                    },
-                    {
-                      "dataSource": "COSTAR",
-                      "id": "478"
-                    },
-                    {
-                      "dataSource": "CSP",
-                      "id": "2042-5301"
-                    },
-                    {
-                      "dataSource": "CST",
-                      "id": "MENINGITIS"
-                    },
-                    {
-                      "dataSource": "DXP",
-                      "id": "U002543"
-                    },
-                    {
-                      "dataSource": "HPO",
-                      "id": "HP:0001287"
-                    },
-                    {
-                      "dataSource": "ICD10",
-                      "id": "G03.9"
-                    },
-                    {
-                      "dataSource": "ICD10AM",
-                      "id": "G03.9"
-                    },
-                    {
-                      "dataSource": "ICD10CM",
-                      "id": "G03.9"
-                    },
-                    {
-                      "dataSource": "ICD9CM",
-                      "id": "322.9"
-                    },
-                    {
-                      "dataSource": "ICPC2ICD10ENG",
-                      "id": "MTHU048434"
-                    },
-                    {
-                      "dataSource": "ICPC2P",
-                      "id": "N71002"
-                    },
-                    {
-                      "dataSource": "LCH",
-                      "id": "U002901"
-                    },
-                    {
-                      "dataSource": "LCH_NW",
-                      "id": "sh85083562"
-                    },
-                    {
-                      "dataSource": "LNC",
-                      "id": "LP20756-0"
-                    },
-                    {
-                      "dataSource": "MDR",
-                      "id": "10027199"
-                    },
-                    {
-                      "dataSource": "MEDCIN",
-                      "id": "31192"
-                    },
-                    {
-                      "dataSource": "MEDLINEPLUS",
-                      "id": "324"
-                    },
-                    {
-                      "dataSource": "MSH",
-                      "id": "D008581"
-                    },
-                    {
-                      "dataSource": "NANDA-I",
-                      "id": "02899"
-                    },
-                    {
-                      "dataSource": "NCI",
-                      "id": "C26828"
-                    },
-                    {
-                      "dataSource": "NCI_CPTAC",
-                      "id": "C26828"
-                    },
-                    {
-                      "dataSource": "NCI_CTCAE",
-                      "id": "E11458"
-                    },
-                    {
-                      "dataSource": "NCI_FDA",
-                      "id": "2389"
-                    },
-                    {
-                      "dataSource": "NCI_NCI-GLOSS",
-                      "id": "CDR0000471780"
-                    },
-                    {
-                      "dataSource": "NCI_NICHD",
-                      "id": "C26828"
-                    },
-                    {
-                      "dataSource": "OMIM",
-                      "id": "MTHU005994"
-                    },
-                    {
-                      "dataSource": "PSY",
-                      "id": "30660"
-                    },
-                    {
-                      "dataSource": "RCD",
-                      "id": "X000H"
-                    },
-                    {
-                      "dataSource": "SNM",
-                      "id": "M-40000"
-                    },
-                    {
-                      "dataSource": "SNMI",
-                      "id": "DA-10010"
-                    },
-                    {
-                      "dataSource": "SNOMEDCT_US",
-                      "id": "7180009"
-                    },
-                    {
-                      "dataSource": "WHO",
-                      "id": "0955"
-                    }
-                  ]
-                },
-                {
-                  "offset": 47,
-                  "length": 5,
-                  "text": "fever",
-                  "category": "SymptomOrSign",
-                  "confidenceScore": 0.99,
-                  "name": "Fever",
-                  "links": [
-                    {
-                      "dataSource": "UMLS",
-                      "id": "C0015967"
-                    },
-                    {
-                      "dataSource": "AIR",
-                      "id": "FEVER"
-                    },
-                    {
-                      "dataSource": "AOD",
-                      "id": "0000004396"
-                    },
-                    {
-                      "dataSource": "BI",
-                      "id": "BI00751"
-                    },
-                    {
-                      "dataSource": "CCC",
-                      "id": "K25.2"
-                    },
-                    {
-                      "dataSource": "CCPSS",
-                      "id": "1017166"
-                    },
-                    {
-                      "dataSource": "CCSR_10",
-                      "id": "SYM002"
-                    },
-                    {
-                      "dataSource": "CHV",
-                      "id": "0000005010"
-                    },
-                    {
-                      "dataSource": "COSTAR",
-                      "id": "300"
-                    },
-                    {
-                      "dataSource": "CPM",
-                      "id": "65287"
-                    },
-                    {
-                      "dataSource": "CSP",
-                      "id": "2871-4310"
-                    },
-                    {
-                      "dataSource": "CST",
-                      "id": "FEVER"
-                    },
-                    {
-                      "dataSource": "DXP",
-                      "id": "U001483"
-                    },
-                    {
-                      "dataSource": "GO",
-                      "id": "GO:0001660"
-                    },
-                    {
-                      "dataSource": "HPO",
-                      "id": "HP:0001945"
-                    },
-                    {
-                      "dataSource": "ICD10",
-                      "id": "R50.9"
-                    },
-                    {
-                      "dataSource": "ICD10AM",
-                      "id": "R50.9"
-                    },
-                    {
-                      "dataSource": "ICD10CM",
-                      "id": "R50.9"
-                    },
-                    {
-                      "dataSource": "ICD9CM",
-                      "id": "780.60"
-                    },
-                    {
-                      "dataSource": "ICNP",
-                      "id": "10041539"
-                    },
-                    {
-                      "dataSource": "ICPC",
-                      "id": "A03"
-                    },
-                    {
-                      "dataSource": "ICPC2EENG",
-                      "id": "A03"
-                    },
-                    {
-                      "dataSource": "ICPC2ICD10ENG",
-                      "id": "MTHU041751"
-                    },
-                    {
-                      "dataSource": "ICPC2P",
-                      "id": "A03002"
-                    },
-                    {
-                      "dataSource": "LCH",
-                      "id": "U001776"
-                    },
-                    {
-                      "dataSource": "LCH_NW",
-                      "id": "sh85047994"
-                    },
-                    {
-                      "dataSource": "LNC",
-                      "id": "MTHU013518"
-                    },
-                    {
-                      "dataSource": "MDR",
-                      "id": "10005911"
-                    },
-                    {
-                      "dataSource": "MEDCIN",
-                      "id": "6005"
-                    },
-                    {
-                      "dataSource": "MEDLINEPLUS",
-                      "id": "511"
-                    },
-                    {
-                      "dataSource": "MSH",
-                      "id": "D005334"
-                    },
-                    {
-                      "dataSource": "MTHICD9",
-                      "id": "780.60"
-                    },
-                    {
-                      "dataSource": "NANDA-I",
-                      "id": "01128"
-                    },
-                    {
-                      "dataSource": "NCI",
-                      "id": "C3038"
-                    },
-                    {
-                      "dataSource": "NCI_CTCAE",
-                      "id": "E11102"
-                    },
-                    {
-                      "dataSource": "NCI_FDA",
-                      "id": "1858"
-                    },
-                    {
-                      "dataSource": "NCI_NCI-GLOSS",
-                      "id": "CDR0000450108"
-                    },
-                    {
-                      "dataSource": "NCI_NICHD",
-                      "id": "C3038"
-                    },
-                    {
-                      "dataSource": "NOC",
-                      "id": "070307"
-                    },
-                    {
-                      "dataSource": "OMIM",
-                      "id": "MTHU005439"
-                    },
-                    {
-                      "dataSource": "OMS",
-                      "id": "50.03"
-                    },
-                    {
-                      "dataSource": "PCDS",
-                      "id": "PRB_11020.02"
-                    },
-                    {
-                      "dataSource": "PDQ",
-                      "id": "CDR0000775882"
-                    },
-                    {
-                      "dataSource": "PSY",
-                      "id": "23840"
-                    },
-                    {
-                      "dataSource": "QMR",
-                      "id": "Q0200115"
-                    },
-                    {
-                      "dataSource": "RCD",
-                      "id": "X76EI"
-                    },
-                    {
-                      "dataSource": "SNM",
-                      "id": "F-03003"
-                    },
-                    {
-                      "dataSource": "SNMI",
-                      "id": "F-03003"
-                    },
-                    {
-                      "dataSource": "SNOMEDCT_US",
-                      "id": "386661006"
-                    },
-                    {
-                      "dataSource": "WHO",
-                      "id": "0725"
-                    }
-                  ]
-                },
-                {
-                  "offset": 60,
-                  "length": 6,
-                  "text": "mother",
-                  "category": "FamilyRelation",
-                  "confidenceScore": 0.99,
-                  "name": "Mother (person)",
-                  "links": [
-                    {
-                      "dataSource": "UMLS",
-                      "id": "C0026591"
-                    },
-                    {
-                      "dataSource": "AOD",
-                      "id": "0000027173"
-                    },
-                    {
-                      "dataSource": "CCPSS",
-                      "id": "U000286"
-                    },
-                    {
-                      "dataSource": "CHV",
-                      "id": "0000008266"
-                    },
-                    {
-                      "dataSource": "CSP",
-                      "id": "1124-5492"
-                    },
-                    {
-                      "dataSource": "HL7V3.0",
-                      "id": "MTH"
-                    },
-                    {
-                      "dataSource": "LCH",
-                      "id": "U003028"
-                    },
-                    {
-                      "dataSource": "LCH_NW",
-                      "id": "sh85087526"
-                    },
-                    {
-                      "dataSource": "LNC",
-                      "id": "LA10417-6"
-                    },
-                    {
-                      "dataSource": "MSH",
-                      "id": "D009035"
-                    },
-                    {
-                      "dataSource": "NCI",
-                      "id": "C25189"
-                    },
-                    {
-                      "dataSource": "NCI_CDISC",
-                      "id": "C25189"
-                    },
-                    {
-                      "dataSource": "NCI_GDC",
-                      "id": "C25189"
-                    },
-                    {
-                      "dataSource": "PSY",
-                      "id": "32140"
-                    },
-                    {
-                      "dataSource": "RCD",
-                      "id": "X78ym"
-                    },
-                    {
-                      "dataSource": "SNMI",
-                      "id": "S-10120"
-                    },
-                    {
-                      "dataSource": "SNOMEDCT_US",
-                      "id": "72705000"
-                    }
-                  ]
-                },
-                {
-                  "offset": 77,
-                  "length": 10,
-                  "text": "Penicillin",
-                  "category": "MedicationName",
-                  "confidenceScore": 0.95,
-                  "assertion": {
-                    "certainty": "neutralPossible"
-                  },
-                  "name": "penicillins",
-                  "links": [
-                    {
-                      "dataSource": "UMLS",
-                      "id": "C0030842"
-                    },
-                    {
-                      "dataSource": "AOD",
-                      "id": "0000019206"
-                    },
-                    {
-                      "dataSource": "ATC",
-                      "id": "J01C"
-                    },
-                    {
-                      "dataSource": "CCPSS",
-                      "id": "0014106"
-                    },
-                    {
-                      "dataSource": "CHV",
-                      "id": "0000009423"
-                    },
-                    {
-                      "dataSource": "CSP",
-                      "id": "0199-8025"
-                    },
-                    {
-                      "dataSource": "GS",
-                      "id": "4011"
-                    },
-                    {
-                      "dataSource": "LCH",
-                      "id": "U003521"
-                    },
-                    {
-                      "dataSource": "LCH_NW",
-                      "id": "sh85099402"
-                    },
-                    {
-                      "dataSource": "LNC",
-                      "id": "LP14319-5"
-                    },
-                    {
-                      "dataSource": "MEDCIN",
-                      "id": "40319"
-                    },
-                    {
-                      "dataSource": "MMSL",
-                      "id": "d00116"
-                    },
-                    {
-                      "dataSource": "MSH",
-                      "id": "D010406"
-                    },
-                    {
-                      "dataSource": "NCI",
-                      "id": "C1500"
-                    },
-                    {
-                      "dataSource": "NCI_DTP",
-                      "id": "NSC0402815"
-                    },
-                    {
-                      "dataSource": "NCI_NCI-GLOSS",
-                      "id": "CDR0000045296"
-                    },
-                    {
-                      "dataSource": "NDDF",
-                      "id": "016121"
-                    },
-                    {
-                      "dataSource": "PSY",
-                      "id": "37190"
-                    },
-                    {
-                      "dataSource": "RCD",
-                      "id": "x009C"
-                    },
-                    {
-                      "dataSource": "SNM",
-                      "id": "E-7260"
-                    },
-                    {
-                      "dataSource": "SNMI",
-                      "id": "C-54000"
-                    },
-                    {
-                      "dataSource": "SNOMEDCT_US",
-                      "id": "764146007"
-                    },
-                    {
-                      "dataSource": "VANDF",
-                      "id": "4019880"
-                    }
-                  ]
-                },
-                {
-                  "offset": 96,
-                  "length": 4,
-                  "text": "baby",
-                  "category": "Age",
-                  "confidenceScore": 0.96,
-                  "name": "Infant",
-                  "links": [
-                    {
-                      "dataSource": "UMLS",
-                      "id": "C0021270"
-                    },
-                    {
-                      "dataSource": "AOD",
-                      "id": "0000005273"
-                    },
-                    {
-                      "dataSource": "CCPSS",
-                      "id": "0030805"
-                    },
-                    {
-                      "dataSource": "CHV",
-                      "id": "0000006675"
-                    },
-                    {
-                      "dataSource": "DXP",
-                      "id": "U002089"
-                    },
-                    {
-                      "dataSource": "LCH",
-                      "id": "U002421"
-                    },
-                    {
-                      "dataSource": "LCH_NW",
-                      "id": "sh85066022"
-                    },
-                    {
-                      "dataSource": "LNC",
-                      "id": "LA19747-7"
-                    },
-                    {
-                      "dataSource": "MDR",
-                      "id": "10021731"
-                    },
-                    {
-                      "dataSource": "MSH",
-                      "id": "D007223"
-                    },
-                    {
-                      "dataSource": "NCI",
-                      "id": "C27956"
-                    },
-                    {
-                      "dataSource": "NCI_FDA",
-                      "id": "C27956"
-                    },
-                    {
-                      "dataSource": "NCI_NICHD",
-                      "id": "C27956"
-                    },
-                    {
-                      "dataSource": "SNOMEDCT_US",
-                      "id": "133931009"
-                    }
-                  ]
-                }
-              ],
-              "relations": [],
-              "warnings": []
+              "kind": "HealthcareLROResults",
+              "lastUpdateDateTime": "2022-10-03T19:44:49.5405632Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "offset": 0,
+                        "length": 4,
+                        "text": "Baby",
+                        "category": "Age",
+                        "confidenceScore": 0.94,
+                        "name": "Infant",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0021270"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000005273"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "0030805"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000006675"
+                          },
+                          {
+                            "dataSource": "DXP",
+                            "id": "U002089"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U002421"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85066022"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LA19747-7"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10021731"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D007223"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C27956"
+                          },
+                          {
+                            "dataSource": "NCI_FDA",
+                            "id": "C27956"
+                          },
+                          {
+                            "dataSource": "NCI_NICHD",
+                            "id": "C27956"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "133931009"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 24,
+                        "length": 10,
+                        "text": "Meningitis",
+                        "category": "Diagnosis",
+                        "confidenceScore": 1.0,
+                        "assertion": {
+                          "certainty": "negativePossible"
+                        },
+                        "name": "Meningitis",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0025289"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000006185"
+                          },
+                          {
+                            "dataSource": "BI",
+                            "id": "BI00546"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "1018016"
+                          },
+                          {
+                            "dataSource": "CCSR_10",
+                            "id": "NVS001"
+                          },
+                          {
+                            "dataSource": "CCSR_ICD10CM",
+                            "id": "NVS001"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000007932"
+                          },
+                          {
+                            "dataSource": "COSTAR",
+                            "id": "478"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "2042-5301"
+                          },
+                          {
+                            "dataSource": "CST",
+                            "id": "MENINGITIS"
+                          },
+                          {
+                            "dataSource": "DXP",
+                            "id": "U002543"
+                          },
+                          {
+                            "dataSource": "HPO",
+                            "id": "HP:0001287"
+                          },
+                          {
+                            "dataSource": "ICD10",
+                            "id": "G03.9"
+                          },
+                          {
+                            "dataSource": "ICD10AM",
+                            "id": "G03.9"
+                          },
+                          {
+                            "dataSource": "ICD10CM",
+                            "id": "G03.9"
+                          },
+                          {
+                            "dataSource": "ICD9CM",
+                            "id": "322.9"
+                          },
+                          {
+                            "dataSource": "ICPC2ICD10ENG",
+                            "id": "MTHU048434"
+                          },
+                          {
+                            "dataSource": "ICPC2P",
+                            "id": "N71002"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U002901"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85083562"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LP20756-0"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10027199"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "31192"
+                          },
+                          {
+                            "dataSource": "MEDLINEPLUS",
+                            "id": "324"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D008581"
+                          },
+                          {
+                            "dataSource": "NANDA-I",
+                            "id": "02899"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C26828"
+                          },
+                          {
+                            "dataSource": "NCI_CPTAC",
+                            "id": "C26828"
+                          },
+                          {
+                            "dataSource": "NCI_CTCAE",
+                            "id": "E11458"
+                          },
+                          {
+                            "dataSource": "NCI_FDA",
+                            "id": "2389"
+                          },
+                          {
+                            "dataSource": "NCI_NCI-GLOSS",
+                            "id": "CDR0000471780"
+                          },
+                          {
+                            "dataSource": "NCI_NICHD",
+                            "id": "C26828"
+                          },
+                          {
+                            "dataSource": "NCI_caDSR",
+                            "id": "C26828"
+                          },
+                          {
+                            "dataSource": "OMIM",
+                            "id": "MTHU005994"
+                          },
+                          {
+                            "dataSource": "PSY",
+                            "id": "30660"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "X000H"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "M-40000"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "DA-10010"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "7180009"
+                          },
+                          {
+                            "dataSource": "WHO",
+                            "id": "0955"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 47,
+                        "length": 5,
+                        "text": "fever",
+                        "category": "SymptomOrSign",
+                        "confidenceScore": 0.98,
+                        "name": "Fever",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0015967"
+                          },
+                          {
+                            "dataSource": "AIR",
+                            "id": "FEVER"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000004396"
+                          },
+                          {
+                            "dataSource": "BI",
+                            "id": "BI00751"
+                          },
+                          {
+                            "dataSource": "CCC",
+                            "id": "K25.2"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "1017166"
+                          },
+                          {
+                            "dataSource": "CCSR_10",
+                            "id": "SYM002"
+                          },
+                          {
+                            "dataSource": "CCSR_ICD10CM",
+                            "id": "SYM002"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000005010"
+                          },
+                          {
+                            "dataSource": "COSTAR",
+                            "id": "300"
+                          },
+                          {
+                            "dataSource": "CPM",
+                            "id": "65287"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "2871-4310"
+                          },
+                          {
+                            "dataSource": "CST",
+                            "id": "FEVER"
+                          },
+                          {
+                            "dataSource": "DXP",
+                            "id": "U001483"
+                          },
+                          {
+                            "dataSource": "GO",
+                            "id": "GO:0001660"
+                          },
+                          {
+                            "dataSource": "HPO",
+                            "id": "HP:0001945"
+                          },
+                          {
+                            "dataSource": "ICD10",
+                            "id": "R50.9"
+                          },
+                          {
+                            "dataSource": "ICD10AM",
+                            "id": "R50.9"
+                          },
+                          {
+                            "dataSource": "ICD10CM",
+                            "id": "R50.9"
+                          },
+                          {
+                            "dataSource": "ICD9CM",
+                            "id": "780.60"
+                          },
+                          {
+                            "dataSource": "ICNP",
+                            "id": "10041539"
+                          },
+                          {
+                            "dataSource": "ICPC",
+                            "id": "A03"
+                          },
+                          {
+                            "dataSource": "ICPC2EENG",
+                            "id": "A03"
+                          },
+                          {
+                            "dataSource": "ICPC2ICD10ENG",
+                            "id": "MTHU041751"
+                          },
+                          {
+                            "dataSource": "ICPC2P",
+                            "id": "A03002"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U001776"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85047994"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "MTHU013518"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10005911"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "6005"
+                          },
+                          {
+                            "dataSource": "MEDLINEPLUS",
+                            "id": "511"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D005334"
+                          },
+                          {
+                            "dataSource": "MTHICD9",
+                            "id": "780.60"
+                          },
+                          {
+                            "dataSource": "NANDA-I",
+                            "id": "01128"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C3038"
+                          },
+                          {
+                            "dataSource": "NCI_CTCAE",
+                            "id": "E11102"
+                          },
+                          {
+                            "dataSource": "NCI_FDA",
+                            "id": "1858"
+                          },
+                          {
+                            "dataSource": "NCI_GDC",
+                            "id": "C3038"
+                          },
+                          {
+                            "dataSource": "NCI_NCI-GLOSS",
+                            "id": "CDR0000450108"
+                          },
+                          {
+                            "dataSource": "NCI_NICHD",
+                            "id": "C3038"
+                          },
+                          {
+                            "dataSource": "NCI_caDSR",
+                            "id": "C3038"
+                          },
+                          {
+                            "dataSource": "NOC",
+                            "id": "070307"
+                          },
+                          {
+                            "dataSource": "OMIM",
+                            "id": "MTHU005439"
+                          },
+                          {
+                            "dataSource": "OMS",
+                            "id": "50.03"
+                          },
+                          {
+                            "dataSource": "PCDS",
+                            "id": "PRB_11020.02"
+                          },
+                          {
+                            "dataSource": "PDQ",
+                            "id": "CDR0000775882"
+                          },
+                          {
+                            "dataSource": "PSY",
+                            "id": "23840"
+                          },
+                          {
+                            "dataSource": "QMR",
+                            "id": "Q0200115"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "X76EI"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "F-03003"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "F-03003"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "386661006"
+                          },
+                          {
+                            "dataSource": "WHO",
+                            "id": "0725"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 60,
+                        "length": 6,
+                        "text": "mother",
+                        "category": "FamilyRelation",
+                        "confidenceScore": 0.99,
+                        "name": "Mother (person)",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0026591"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000027173"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "U000286"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000008266"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "1124-5492"
+                          },
+                          {
+                            "dataSource": "HL7V3.0",
+                            "id": "MTH"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U003028"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85087526"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LA10417-6"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D009035"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C25189"
+                          },
+                          {
+                            "dataSource": "NCI_CDISC",
+                            "id": "C25189"
+                          },
+                          {
+                            "dataSource": "NCI_GDC",
+                            "id": "C25189"
+                          },
+                          {
+                            "dataSource": "NCI_caDSR",
+                            "id": "C25189"
+                          },
+                          {
+                            "dataSource": "PSY",
+                            "id": "32140"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "X78ym"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "S-10120"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "72705000"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 77,
+                        "length": 10,
+                        "text": "Penicillin",
+                        "category": "MedicationName",
+                        "confidenceScore": 0.84,
+                        "assertion": {
+                          "certainty": "neutralPossible"
+                        },
+                        "name": "penicillins",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0030842"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000019206"
+                          },
+                          {
+                            "dataSource": "ATC",
+                            "id": "J01C"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "0014106"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000009423"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "0199-8025"
+                          },
+                          {
+                            "dataSource": "GS",
+                            "id": "4011"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U003521"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85099402"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LP14319-5"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "40319"
+                          },
+                          {
+                            "dataSource": "MMSL",
+                            "id": "d00116"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D010406"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C1500"
+                          },
+                          {
+                            "dataSource": "NCI_DTP",
+                            "id": "NSC0402815"
+                          },
+                          {
+                            "dataSource": "NCI_NCI-GLOSS",
+                            "id": "CDR0000045296"
+                          },
+                          {
+                            "dataSource": "NDDF",
+                            "id": "016121"
+                          },
+                          {
+                            "dataSource": "PSY",
+                            "id": "37190"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "x009C"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "E-7260"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "C-54000"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "764146007"
+                          },
+                          {
+                            "dataSource": "VANDF",
+                            "id": "4019880"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 96,
+                        "length": 4,
+                        "text": "baby",
+                        "category": "FamilyRelation",
+                        "confidenceScore": 1.0,
+                        "name": "Infant",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0021270"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000005273"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "0030805"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000006675"
+                          },
+                          {
+                            "dataSource": "DXP",
+                            "id": "U002089"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U002421"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85066022"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LA19747-7"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10021731"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D007223"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C27956"
+                          },
+                          {
+                            "dataSource": "NCI_FDA",
+                            "id": "C27956"
+                          },
+                          {
+                            "dataSource": "NCI_NICHD",
+                            "id": "C27956"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "133931009"
+                          }
+                        ]
+                      }
+                    ],
+                    "relations": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-03-01"
+              }
             }
-          ],
-          "errors": [],
-          "modelVersion": "2021-03-01"
+          ]
         }
       }
     }
   ],
   "Variables": {
-    "RandomSeed": "1480713916",
+    "RandomSeed": "694155766",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }
 }


### PR DESCRIPTION
Resolves #21796.

The service team has changed the values in the swagger spec to PascalCase, thus aligning with what is returned by the server:
https://github.com/Azure/azure-rest-api-specs/blob/338ccc7bfc79689760959765543387e58b0e4855/specification/cognitiveservices/data-plane/TextAnalytics/stable/v3.1/TextAnalytics.json#L1884