### PR TITLE
[AppConfig] Avoid throwing NullReferenceException 

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/SecretReferenceConfigurationSetting.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/SecretReferenceConfigurationSetting.cs
@@ -63,7 +63,7 @@ namespace Azure.Data.AppConfiguration
 
         internal override string GetValue()
         {
-            return _originalValue ??= FormatValue();
+             return _isValidValue ? FormatValue() : _originalValue;
         }
 
         private string FormatValue()


### PR DESCRIPTION

If the value of a `SecretReferenceConfigurationSetting` is null, accessing this value throws `NullReferenceException`. Seems like an oversight in this line of code.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
