### PR TITLE
Create workspace based application insights resource for live testing

### DIFF
--- a/sdk/monitor/test-resources.bicep
+++ b/sdk/monitor/test-resources.bicep
@@ -13,6 +13,7 @@ resource baseName_resource 'Microsoft.Insights/components@2020-02-02-preview' = 
   location: location
   properties: {
     Application_Type: 'other'
+    WorkspaceResourceId: primaryWorkspace.id
   }
 }
 


### PR DESCRIPTION
This is in preparation for https://github.com/Azure/azure-sdk-for-net/issues/25462. As stated [here](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.Query/MigrationGuideApplicationInsights.md#resource-mode-support) the new package `Azure.Monitor.Query` does not support resources in classic mode.