### PR TITLE
[AzureMonitorExporter] refactor exporters

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -1,67 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Threading;
-
-using Azure.Core.Pipeline;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
-using Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage;
-using OpenTelemetry;
 using OpenTelemetry.Logs;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter
 {
-    internal class AzureMonitorLogExporter : BaseExporter<LogRecord>
+    internal class AzureMonitorLogExporter : BaseAzureMonitorExporter<LogRecord>
     {
-        private readonly ITransmitter _transmitter;
-        private readonly string _instrumentationKey;
-        private readonly ResourceParser _resourceParser;
-        private readonly AzureMonitorPersistentStorage _persistentStorage;
-
-        public AzureMonitorLogExporter(AzureMonitorExporterOptions options) : this(new AzureMonitorTransmitter(options))
-        {
-        }
+        public AzureMonitorLogExporter(AzureMonitorExporterOptions options)
+            : this(new AzureMonitorTransmitter(options))
+        { }
 
         internal AzureMonitorLogExporter(ITransmitter transmitter)
-        {
-            _transmitter = transmitter;
-            _instrumentationKey = transmitter.InstrumentationKey;
-            _resourceParser = new ResourceParser();
-
-            if (transmitter is AzureMonitorTransmitter azureMonitorTransmitter && azureMonitorTransmitter._fileBlobProvider != null)
-            {
-                _persistentStorage = new AzureMonitorPersistentStorage(transmitter);
-            }
-        }
-
-        /// <inheritdoc/>
-        public override ExportResult Export(in Batch<LogRecord> batch)
-        {
-            _persistentStorage?.StartExporterTimer();
-
-            // Prevent Azure Monitor's HTTP operations from being instrumented.
-            using var scope = SuppressInstrumentationScope.Begin();
-
-            try
-            {
-                if (_resourceParser.RoleName is null && _resourceParser.RoleInstance is null)
-                {
-                    var resource = ParentProvider.GetResource();
-                    _resourceParser.UpdateRoleNameAndInstance(resource);
-                }
-
-                var telemetryItems = LogsHelper.OtelToAzureMonitorLogs(batch, _resourceParser.RoleName, _resourceParser.RoleInstance, _instrumentationKey);
-                var exportResult = _transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
-                _persistentStorage?.StopExporterTimerAndTransmitFromStorage();
-
-                return exportResult;
-            }
-            catch (Exception ex)
-            {
-                AzureMonitorExporterEventSource.Log.WriteError("FailedToExport", ex);
-                return ExportResult.Failure;
-            }
-        }
+            : base(transmitter, LogsHelper.OtelToAzureMonitorLogs)
+        { }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
@@ -1,73 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Threading;
-
-using Azure.Core.Pipeline;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
-using Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage;
-using OpenTelemetry;
 using OpenTelemetry.Metrics;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter
 {
-    internal class AzureMonitorMetricExporter : BaseExporter<Metric>
+    internal class AzureMonitorMetricExporter : BaseAzureMonitorExporter<Metric>
     {
-        private readonly ITransmitter _transmitter;
-        private readonly string _instrumentationKey;
-        private readonly ResourceParser _resourceParser;
-        private readonly AzureMonitorPersistentStorage _persistentStorage;
-
-        public AzureMonitorMetricExporter(AzureMonitorExporterOptions options) : this(new AzureMonitorTransmitter(options))
-        {
-        }
+        public AzureMonitorMetricExporter(AzureMonitorExporterOptions options)
+            : this(new AzureMonitorTransmitter(options))
+        { }
 
         internal AzureMonitorMetricExporter(ITransmitter transmitter)
-        {
-            _transmitter = transmitter;
-            _instrumentationKey = transmitter.InstrumentationKey;
-            _resourceParser = new ResourceParser();
-
-            if (transmitter is AzureMonitorTransmitter azureMonitorTransmitter && azureMonitorTransmitter._fileBlobProvider != null)
-            {
-                _persistentStorage = new AzureMonitorPersistentStorage(transmitter);
-            }
-        }
-
-        /// <inheritdoc/>
-        public override ExportResult Export(in Batch<Metric> batch)
-        {
-            _persistentStorage?.StartExporterTimer();
-
-            // Prevent Azure Monitor's HTTP operations from being instrumented.
-            using var scope = SuppressInstrumentationScope.Begin();
-
-            try
-            {
-                var exportResult = ExportResult.Success;
-                // In case of metrics, export is called
-                // even if there are no items in batch
-                if (batch.Count > 0)
-                {
-                    if (_resourceParser.RoleName is null && _resourceParser.RoleInstance is null)
-                    {
-                        var resource = ParentProvider.GetResource();
-                        _resourceParser.UpdateRoleNameAndInstance(resource);
-                    }
-                    var telemetryItems = MetricHelper.OtelToAzureMonitorMetrics(batch, _resourceParser.RoleName, _resourceParser.RoleInstance, _instrumentationKey);
-                    exportResult = _transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
-                }
-
-                _persistentStorage?.StopExporterTimerAndTransmitFromStorage();
-
-                return exportResult;
-            }
-            catch (Exception ex)
-            {
-                AzureMonitorExporterEventSource.Log.WriteError("FailedToExport", ex);
-                return ExportResult.Failure;
-            }
-        }
+            : base(transmitter, MetricHelper.OtelToAzureMonitorMetrics)
+        { }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
@@ -1,67 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Diagnostics;
-using System.Threading;
-
-using Azure.Core.Pipeline;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
-using Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage;
-using OpenTelemetry;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter
 {
-    internal class AzureMonitorTraceExporter : BaseExporter<Activity>
+    internal class AzureMonitorTraceExporter : BaseAzureMonitorExporter<Activity>
     {
-        private readonly ITransmitter _transmitter;
-        private readonly string _instrumentationKey;
-        private readonly ResourceParser _resourceParser;
-        private readonly AzureMonitorPersistentStorage _persistentStorage;
-
-        public AzureMonitorTraceExporter(AzureMonitorExporterOptions options) : this(new AzureMonitorTransmitter(options))
-        {
-        }
+        public AzureMonitorTraceExporter(AzureMonitorExporterOptions options)
+            : this(new AzureMonitorTransmitter(options))
+        { }
 
         internal AzureMonitorTraceExporter(ITransmitter transmitter)
-        {
-            _transmitter = transmitter;
-            _instrumentationKey = transmitter.InstrumentationKey;
-            _resourceParser = new ResourceParser();
-
-            if (transmitter is AzureMonitorTransmitter azureMonitorTransmitter && azureMonitorTransmitter._fileBlobProvider != null)
-            {
-                _persistentStorage = new AzureMonitorPersistentStorage(transmitter);
-            }
-        }
-
-        /// <inheritdoc/>
-        public override ExportResult Export(in Batch<Activity> batch)
-        {
-            _persistentStorage?.StartExporterTimer();
-
-            // Prevent Azure Monitor's HTTP operations from being instrumented.
-            using var scope = SuppressInstrumentationScope.Begin();
-
-            try
-            {
-                if (_resourceParser.RoleName is null && _resourceParser.RoleInstance is null)
-                {
-                    var resource = ParentProvider.GetResource();
-                    _resourceParser.UpdateRoleNameAndInstance(resource);
-                }
-
-                var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, _resourceParser.RoleName, _resourceParser.RoleInstance, _instrumentationKey);
-                var exportResult = _transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
-                _persistentStorage?.StopExporterTimerAndTransmitFromStorage();
-
-                return exportResult;
-            }
-            catch (Exception ex)
-            {
-                AzureMonitorExporterEventSource.Log.WriteError("FailedToExport", ex);
-                return ExportResult.Failure;
-            }
-        }
+            : base(transmitter, TraceHelper.OtelToAzureMonitorTrace)
+        { }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/BaseAzureMonitorExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/BaseAzureMonitorExporter.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Azure.Core.Pipeline;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage;
+using Azure.Monitor.OpenTelemetry.Exporter.Models;
+using OpenTelemetry;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter
+{
+    internal abstract class BaseAzureMonitorExporter<T> : BaseExporter<T>
+        where T : class
+    {
+        private readonly ITransmitter _transmitter;
+        private readonly string _instrumentationKey;
+        private readonly ResourceParser _resourceParser;
+        private readonly AzureMonitorPersistentStorage _persistentStorage;
+        private readonly Func<Batch<T>, string, string, string, List<TelemetryItem>> _convertToTelemetryItemsFunc;
+
+        internal BaseAzureMonitorExporter(ITransmitter transmitter, Func<Batch<T>, string, string, string, List<TelemetryItem>> convertToTelemetryItemsFunc)
+        {
+            _transmitter = transmitter;
+            _instrumentationKey = transmitter.InstrumentationKey;
+            _resourceParser = new ResourceParser();
+            _convertToTelemetryItemsFunc = convertToTelemetryItemsFunc;
+
+            if (transmitter is AzureMonitorTransmitter azureMonitorTransmitter && azureMonitorTransmitter._fileBlobProvider != null)
+            {
+                _persistentStorage = new AzureMonitorPersistentStorage(transmitter);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override ExportResult Export(in Batch<T> batch)
+        {
+            _persistentStorage?.StartExporterTimer();
+
+            // Prevent Azure Monitor's HTTP operations from being instrumented.
+            using var scope = SuppressInstrumentationScope.Begin();
+
+            try
+            {
+                if (_resourceParser.RoleName is null && _resourceParser.RoleInstance is null)
+                {
+                    var resource = ParentProvider.GetResource();
+                    _resourceParser.UpdateRoleNameAndInstance(resource);
+                }
+
+                var telemetryItems = _convertToTelemetryItemsFunc(batch, _resourceParser.RoleName, _resourceParser.RoleInstance, _instrumentationKey);
+                var exportResult = _transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
+                _persistentStorage?.StopExporterTimerAndTransmitFromStorage();
+
+                return exportResult;
+            }
+            catch (Exception ex)
+            {
+                AzureMonitorExporterEventSource.Log.WriteError("FailedToExport", ex);
+                return ExportResult.Failure;
+            }
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorTraceExporterTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorTraceExporterTests.cs
@@ -66,11 +66,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // endpoint: AzureMonitorTraceExporter.AzureMonitorTransmitter.ServiceRestClient.endpoint
 
             ikey = typeof(AzureMonitorTraceExporter)
+                .BaseType
                 .GetField("_instrumentationKey", BindingFlags.Instance | BindingFlags.NonPublic)
                 .GetValue(exporter)
                 .ToString();
 
             var transmitter = typeof(AzureMonitorTraceExporter)
+                .BaseType
                 .GetField("_transmitter", BindingFlags.Instance | BindingFlags.NonPublic)
                 .GetValue(exporter);
 


### PR DESCRIPTION
Opening this to start having a conversation.
~I'm not expecting any action until after we release Beta4.~

As of today, the three exporters are almost identical.
Duplicate code was moved to `BaseAzureMonitorExporter`.

For further refactoring, the individual Exporters could be removed and the Base could be initialized from the Extensions (similar to InMemoryExporter).
At the moment, StatsBeat has a dependency on AzureMonitorMetricsrExporter.
