### PR TITLE
Exclude the failed package for .NET docs

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -423,8 +423,6 @@ function Update-dotnet-DocsMsPackages($DocsRepoLocation, $DocsMetadata) {
     Write-Host "  $excludedPackage - $($PackageExclusions[$excludedPackage])"
   }
 
-  # Also exclude 'spring' packages
-  # https://github.com/Azure/azure-sdk-for-java/issues/23087
   $FilteredMetadata = $DocsMetadata.Where({ !($PackageExclusions.ContainsKey($_.Package)) })
   UpdateDocsMsPackages `
     (Join-Path $DocsRepoLocation 'bundlepackages/azure-dotnet-preview.csv') `

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -413,16 +413,28 @@ function EnsureCustomSource($package) {
   return $package
 }
 
+$PackageExclusions = @{
+  "Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents" = "The package asks auth when use `Find-Package` for public feeds. Issue: https://github.com/Azure/azure-docs-sdk-dotnet/issues/2244";
+}
+
 function Update-dotnet-DocsMsPackages($DocsRepoLocation, $DocsMetadata) {
+  Write-Host "Excluded packages:"
+  foreach ($excludedPackage in $PackageExclusions.Keys) {
+    Write-Host "  $excludedPackage - $($PackageExclusions[$excludedPackage])"
+  }
+
+  # Also exclude 'spring' packages
+  # https://github.com/Azure/azure-sdk-for-java/issues/23087
+  $FilteredMetadata = $DocsMetadata.Where({ !($PackageExclusions.ContainsKey($_.Package)) })
   UpdateDocsMsPackages `
     (Join-Path $DocsRepoLocation 'bundlepackages/azure-dotnet-preview.csv') `
     'preview' `
-    $DocsMetadata 
+    $FilteredMetadata 
 
   UpdateDocsMsPackages `
     (Join-Path $DocsRepoLocation 'bundlepackages/azure-dotnet.csv') `
     'latest' `
-    $DocsMetadata
+    $FilteredMetadata
 }
 
 function UpdateDocsMsPackages($DocConfigFile, $Mode, $DocsMetadata) {


### PR DESCRIPTION
# Contributing to the Azure SDK
The package failed our script for a long time. Exclude the package for now and cut a ticket to devops for further investment.
Failed pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1903198&view=logs&s=96ac2280-8cb4-5df5-99de-dd2da759617d
Docindex pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1907107&view=results
Template pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1907110&view=results
Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
