### PR TITLE
[Event Hubs] October Processor Release Prep

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -88,7 +88,7 @@
     <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.21" />
     <PackageReference Update="Azure.Data.SchemaRegistry" Version="1.2.0" />
     <PackageReference Update="Azure.Data.Tables" Version="12.5.0" />
-    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.7.2" />
+    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.7.3" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.10.0" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.10.0" />
     <PackageReference Update="Azure.Messaging.WebPubSub" Version="1.0.0" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Release History
 
-## 5.8.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 5.7.3 (2022-10-11)
 
 ### Other Changes
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This library extends its Event Processor with durable storage for checkpoint information using Azure Blob storage.  For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.8.0-beta.1</Version>
+    <Version>5.7.3</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>5.7.2</ApiCompatVersion>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;Event Processor;EventProcessor;$(PackageCommonTags)</PackageTags>


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare the Event Hubs Processor package for the October release.

**Note:** This will not be merged until the October release has been performed for the Event Hubs core package and the new version is available on NuGet.