### PR TITLE
Add default .assets directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ developer/
 launch.json
 launchSettings.json
 
+# Default Assets restore directory
+.assets
+
 # Build results
 binaries/
 [Dd]ebug*/


### PR DESCRIPTION
The default assets restore is a `.assets` directory in the repository root. This directory needs to be ignored by each individual langue.