### PR TITLE
Add InteractiveBrowserCredentialLoginHint to DefaultAzureCredentialOptions

### DIFF
--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -159,6 +159,7 @@ namespace Azure.Identity
         public bool ExcludeVisualStudioCodeCredential { get { throw null; } set { } }
         public bool ExcludeVisualStudioCredential { get { throw null; } set { } }
         public string InteractiveBrowserCredentialClientId { get { throw null; } set { } }
+        public string InteractiveBrowserCredentialLoginHint { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public string InteractiveBrowserTenantId { get { throw null; } set { } }
         public string ManagedIdentityClientId { get { throw null; } set { } }

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -181,6 +181,11 @@ namespace Azure.Identity
         public string SharedTokenCacheUsername { get; set; } = GetNonEmptyStringOrNull(EnvironmentVariables.Username);
 
         /// <summary>
+        /// Avoids the account prompt and pre-populates the username of the account to login for InteractiveBrowserCredential.
+        /// </summary>
+        public string InteractiveBrowserCredentialLoginHint { get; set; }
+
+        /// <summary>
         /// Specifies the client id of the selected credential
         /// </summary>
         public string InteractiveBrowserCredentialClientId { get; set; }
@@ -256,6 +261,7 @@ namespace Azure.Identity
                 _visualStudioTenantId = _visualStudioTenantId,
                 _visualStudioCodeTenantId = _visualStudioCodeTenantId,
                 SharedTokenCacheUsername = SharedTokenCacheUsername,
+                InteractiveBrowserCredentialLoginHint = InteractiveBrowserCredentialLoginHint,
                 InteractiveBrowserCredentialClientId = InteractiveBrowserCredentialClientId,
                 ManagedIdentityClientId = ManagedIdentityClientId,
                 ManagedIdentityResourceId = ManagedIdentityResourceId,

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -118,7 +118,8 @@ namespace Azure.Identity
             {
                 TokenCachePersistenceOptions = new TokenCachePersistenceOptions(),
                 AuthorityHost = Options.AuthorityHost,
-                TenantId = Options.InteractiveBrowserTenantId
+                TenantId = Options.InteractiveBrowserTenantId,
+                LoginHint = Options.InteractiveBrowserCredentialLoginHint,
             };
 
             foreach (var addlTenant in Options.AdditionallyAllowedTenants)

--- a/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialFactoryTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialFactoryTests.cs
@@ -264,7 +264,7 @@ namespace Azure.Identity.Tests
         }
 
         [Test]
-        public void ValidateInteractiveBrowserOptionsHonored([Values] bool setTenantId, [Values] bool setClientId, [Values] bool setInteractiveBrowserTenantId, [Values] bool setAdditionallyAllowedTenants)
+        public void ValidateInteractiveBrowserOptionsHonored([Values] bool setTenantId, [Values] bool setClientId, [Values] bool setInteractiveBrowserLoginHint, [Values] bool setInteractiveBrowserTenantId, [Values] bool setAdditionallyAllowedTenants)
         {
             // ignore when both setTenantId and setInteractiveBrowserTenantId are true since we cannot set both
             if (setTenantId && setInteractiveBrowserTenantId)
@@ -282,6 +282,7 @@ namespace Azure.Identity.Tests
             {
                 string expClientId = setClientId ? Guid.NewGuid().ToString() : Constants.DeveloperSignOnClientId;
                 string expTenantId = setTenantId ? Guid.NewGuid().ToString() : null;
+                string expInteractiveBrowserLoginHint = setInteractiveBrowserLoginHint ? Guid.NewGuid().ToString() : null;
                 string expInteractiveBrowserTenantId = setInteractiveBrowserTenantId ? Guid.NewGuid().ToString() : null;
                 string[] expAdditionallyAllowedTenants = setAdditionallyAllowedTenants ? new string[] { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() } : Array.Empty<string>();
 
@@ -295,6 +296,11 @@ namespace Azure.Identity.Tests
                 if (setClientId)
                 {
                     options.InteractiveBrowserCredentialClientId = expClientId;
+                }
+
+                if (setInteractiveBrowserLoginHint)
+                {
+                    options.InteractiveBrowserCredentialLoginHint = expInteractiveBrowserLoginHint;
                 }
 
                 if (setInteractiveBrowserTenantId)
@@ -311,6 +317,7 @@ namespace Azure.Identity.Tests
 
                 InteractiveBrowserCredential cred = (InteractiveBrowserCredential)factory.CreateInteractiveBrowserCredential();
 
+                Assert.AreEqual(expInteractiveBrowserLoginHint ?? expInteractiveBrowserLoginHint, cred.LoginHint);
                 Assert.AreEqual(expInteractiveBrowserTenantId ?? expTenantId, cred.TenantId);
                 Assert.AreEqual(expClientId, cred.ClientId);
                 CollectionAssert.AreEquivalent(expAdditionallyAllowedTenants, cred.AdditionallyAllowedTenantIds);

--- a/sdk/identity/Azure.Identity/tests/Mock/TestDefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/tests/Mock/TestDefaultAzureCredentialFactory.cs
@@ -31,7 +31,7 @@ namespace Azure.Identity.Tests.Mock
             => new SharedTokenCacheCredential(Options.SharedTokenCacheTenantId, Options.SharedTokenCacheUsername, Options, Pipeline);
 
         public override TokenCredential CreateInteractiveBrowserCredential()
-            => new InteractiveBrowserCredential(Options.InteractiveBrowserTenantId, Options.InteractiveBrowserCredentialClientId ?? Constants.DeveloperSignOnClientId, new InteractiveBrowserCredentialOptions() { AdditionallyAllowedTenantsCore = Options.AdditionallyAllowedTenantsCore, AuthorityHost = Options.AuthorityHost }, Pipeline);
+            => new InteractiveBrowserCredential(Options.InteractiveBrowserTenantId, Options.InteractiveBrowserCredentialClientId ?? Constants.DeveloperSignOnClientId, new InteractiveBrowserCredentialOptions() { AdditionallyAllowedTenantsCore = Options.AdditionallyAllowedTenantsCore, AuthorityHost = Options.AuthorityHost, LoginHint = Options.InteractiveBrowserCredentialLoginHint }, Pipeline);
 
         public override TokenCredential CreateAzureCliCredential()
         {


### PR DESCRIPTION
Allows you to specify the InteractiveBrowserCredentialLoginHint when
 creating a DefaultAzureCredential which will be passed onto the
 InteractiveBrowserCredentialOptions of the nested InteractiveBrowserCredential.

This avoids having to chain a InteractiveBrowserCredential with DefaultAzureCredential
 just in order to set this option.