### PR TITLE
Revert "Exclude the failed package for .NET docs"

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -407,26 +407,16 @@ function EnsureCustomSource($package) {
   return $package
 }
 
-$PackageExclusions = @{
-  "Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents" = "The package asks auth when use `Find-Package` for public feeds. Issue: https://github.com/Azure/azure-docs-sdk-dotnet/issues/2244";
-}
-
 function Update-dotnet-DocsMsPackages($DocsRepoLocation, $DocsMetadata) {
-  Write-Host "Excluded packages:"
-  foreach ($excludedPackage in $PackageExclusions.Keys) {
-    Write-Host "  $excludedPackage - $($PackageExclusions[$excludedPackage])"
-  }
-
-  $FilteredMetadata = $DocsMetadata.Where({ !($PackageExclusions.ContainsKey($_.Package)) })
   UpdateDocsMsPackages `
     (Join-Path $DocsRepoLocation 'bundlepackages/azure-dotnet-preview.csv') `
     'preview' `
-    $FilteredMetadata 
+    $DocsMetadata 
 
   UpdateDocsMsPackages `
     (Join-Path $DocsRepoLocation 'bundlepackages/azure-dotnet.csv') `
     'latest' `
-    $FilteredMetadata
+    $DocsMetadata
 }
 
 function UpdateDocsMsPackages($DocConfigFile, $Mode, $DocsMetadata) {

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -456,7 +456,7 @@ function UpdateDocsMsPackages($DocConfigFile, $Mode, $DocsMetadata) {
     }
 
     if ($updatedVersion -ne $package.Versions[0]) {
-      Write-Host "Update tracked package: $($package.Name) to version $($updatedVersions)"
+      Write-Host "Update tracked package: $($package.Name) to version $updatedVersions"
       $package.Versions = @($updatedVersion)
       $package = EnsureCustomSource $package
     } else {

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -456,7 +456,7 @@ function UpdateDocsMsPackages($DocConfigFile, $Mode, $DocsMetadata) {
     }
 
     if ($updatedVersion -ne $package.Versions[0]) {
-      Write-Host "Update tracked package: $($package.Name) to version $updatedVersions"
+      Write-Host "Update tracked package: $($package.Name) to version $updatedVersion"
       $package.Versions = @($updatedVersion)
       $package = EnsureCustomSource $package
     } else {


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-net#31649 as the WebJob.Extension package problem has been resolved.

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1910244&view=logs&s=96ac2280-8cb4-5df5-99de-dd2da759617d