### PR TITLE
Clean up XML doc comment for AddLogsIngestionClient extension method

### DIFF
--- a/sdk/monitor/Azure.Monitor.Ingestion/src/IngestionClientBuilderExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.Ingestion/src/IngestionClientBuilderExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Azure
     /// </summary>
     public static class IngestionClientBuilderExtensions
     {
-        /// <summary>Uri endpoint, TokenCredential credential, LogsIngestionClientOptions options
+        /// <summary>
         /// Registers a <see cref="LogsIngestionClient"/> instance with the provided <paramref name="endpoint"/>
         /// </summary>
         public static IAzureClientBuilder<LogsIngestionClient, LogsIngestionClientOptions> AddLogsIngestionClient<TBuilder>(this TBuilder builder, Uri endpoint)


### PR DESCRIPTION
Clean up the comment to make IntelliSense more readable for this method overload. Removes what's underlined in red in this screenshot:

![image](https://user-images.githubusercontent.com/10702007/195224161-84457b71-d5f5-47a5-8513-7acd53cdbf86.png)
