### PR TITLE
[EventHubs] Fix broken tests

### DIFF
--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventHubNamespaceTests/AddSetRemoveTag(False).json
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventHubNamespaceTests/AddSetRemoveTag(False).json
@@ -1,43 +1,52 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e?api-version=2021-01-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c?api-version=2021-01-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-6f041a362f834441bde2a16865a6acee-d8f09fecb52ee048-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "be498aa4cf2196a0b0c21bde29c91222",
+        "traceparent": "00-bb46930056ebae43bba322fbbdc876f1-6c355348ff1c9f4c-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b7257113c33beff6b68fcccb239e61be",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "460",
+        "Content-Length": "747",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:10:31 GMT",
+        "Date": "Wed, 12 Oct 2022 07:07:07 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "3f6031c2-2037-418c-8dde-9f8c2b63ec3f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11964",
-        "x-ms-request-id": "3f6031c2-2037-418c-8dde-9f8c2b63ec3f",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161032Z:3f6031c2-2037-418c-8dde-9f8c2b63ec3f"
+        "x-ms-correlation-request-id": "fae85538-1424-4dce-a60f-d57e9bfe9a7e",
+        "x-ms-ratelimit-remaining-subscription-reads": "11999",
+        "x-ms-request-id": "fae85538-1424-4dce-a60f-d57e9bfe9a7e",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070707Z:fae85538-1424-4dce-a60f-d57e9bfe9a7e"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "authorizationSource": "RoleBased",
-        "managedByTenants": [
-          {
-            "tenantId": "2f4a9838-26b7-47ee-be60-ccc1fdec5953"
-          }
-        ],
-        "subscriptionId": "326100e2-f69d-4268-8503-075374f62b6e",
+        "managedByTenants": [],
+        "tags": {
+          "TagKey-9823": "TagValue-566",
+          "TagKey-3481": "TagValue-320",
+          "TagKey-4926": "TagValue-1187",
+          "TagKey-751": "TagValue-3921",
+          "TagKey-1866": "TagValue-8559",
+          "TagKey-3094": "TagValue-9190",
+          "TagKey-2449": "TagValue-9",
+          "TagKey-8379": "TagValue-164",
+          "TagKey-7470": "TagValue-2205",
+          "TagKey-4236": "TagValue-3698",
+          "TagKey-5316": "TagValue-2725"
+        },
+        "subscriptionId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-        "displayName": "Azure Messaging PM Playground",
+        "displayName": ".NET Mgmt SDK Test with TTL = 1 Day",
         "state": "Enabled",
         "subscriptionPolicies": {
           "locationPlacementId": "Internal_2014-09-01",
@@ -47,16 +56,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourcegroups/testeventhubRG-2210?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourcegroups/testeventhubRG-4591?api-version=2021-04-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "44",
         "Content-Type": "application/json",
-        "traceparent": "00-6a7d575ca24bfb4b8362904b2e16fd01-fddc78ff83d43849-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "4a21fa6f172faa3585150c357291cdb1",
+        "traceparent": "00-bb5911e95e388a429a2c7bb9e761b417-c46e0a301b133d47-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "7a18d63c884a58c28b08eb44a2378d2b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -70,19 +79,19 @@
         "Cache-Control": "no-cache",
         "Content-Length": "258",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:10:33 GMT",
+        "Date": "Wed, 12 Oct 2022 07:07:10 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "b05d69d8-f9d1-4473-be98-8f7e8ccd214c",
-        "x-ms-ratelimit-remaining-subscription-writes": "1191",
-        "x-ms-request-id": "b05d69d8-f9d1-4473-be98-8f7e8ccd214c",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161033Z:b05d69d8-f9d1-4473-be98-8f7e8ccd214c"
+        "x-ms-correlation-request-id": "d54215e2-61b2-4a67-981a-94ef220625e1",
+        "x-ms-ratelimit-remaining-subscription-writes": "1199",
+        "x-ms-request-id": "d54215e2-61b2-4a67-981a-94ef220625e1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070711Z:d54215e2-61b2-4a67-981a-94ef220625e1"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210",
-        "name": "testeventhubRG-2210",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591",
+        "name": "testeventhubRG-4591",
         "type": "Microsoft.Resources/resourceGroups",
         "location": "eastus2",
         "tags": {
@@ -94,27 +103,27 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/providers/Microsoft.EventHub/checkNameAvailability?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.EventHub/checkNameAvailability?api-version=2021-11-01",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "32",
         "Content-Type": "application/json",
-        "traceparent": "00-716971ca70e17f47bdc58b2e61788423-17c40c8ce8f60646-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "27aa07bb49a2cf40e0bc0fc82fd63886",
+        "traceparent": "00-a46b1647bf723a4d9ebb1cd979a14d9e-112272504bd98b43-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6bf6d3f1d92537690284a3e32c421907",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "testnamespacemgmt3622"
+        "name": "testnamespacemgmt7362"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "53",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:10:34 GMT",
+        "Date": "Wed, 12 Oct 2022 07:07:12 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -124,11 +133,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "27aa07bb49a2cf40e0bc0fc82fd63886",
-        "x-ms-correlation-request-id": "a11aad7f-c423-4858-aeba-f331b7a04b56",
-        "x-ms-ratelimit-remaining-subscription-writes": "1197",
-        "x-ms-request-id": "5908b130-b0d7-4b40-a3df-53bc69d5c66e_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161034Z:a11aad7f-c423-4858-aeba-f331b7a04b56"
+        "x-ms-client-request-id": "6bf6d3f1d92537690284a3e32c421907",
+        "x-ms-correlation-request-id": "dda84bd3-7f98-4040-a8da-95b06a14f30c",
+        "x-ms-ratelimit-remaining-subscription-writes": "1199",
+        "x-ms-request-id": "e5f30187-8a98-4097-9dfa-76aa0fd2ab2e_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070713Z:dda84bd3-7f98-4040-a8da-95b06a14f30c"
       },
       "ResponseBody": {
         "nameAvailable": true,
@@ -137,16 +146,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362?api-version=2021-11-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "48",
         "Content-Type": "application/json",
-        "traceparent": "00-2eca2d9e9aeaaa45bf950df08a2f1ba3-a9e2fbb5b8c25d48-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "4169cd4874351372149cb994613d304d",
+        "traceparent": "00-36c134ed494b4e43b5d99a681a9a3053-be67ed8fbf7a7748-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "edd9770dc84e62e95fb0bb0bab13573e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -159,7 +168,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:10:40 GMT",
+        "Date": "Wed, 12 Oct 2022 07:07:22 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -169,11 +178,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "4169cd4874351372149cb994613d304d",
-        "x-ms-correlation-request-id": "88b79b07-6b95-4afc-a270-77d0f7a936d4",
-        "x-ms-ratelimit-remaining-subscription-resource-requests": "47",
-        "x-ms-request-id": "0ed13429-336e-4357-b973-2bf10850d47c_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161040Z:88b79b07-6b95-4afc-a270-77d0f7a936d4"
+        "x-ms-client-request-id": "edd9770dc84e62e95fb0bb0bab13573e",
+        "x-ms-correlation-request-id": "7f12f0da-a0a1-435e-af26-466d7761b9fb",
+        "x-ms-ratelimit-remaining-subscription-resource-requests": "49",
+        "x-ms-request-id": "a0018dd6-be0c-456f-978f-2b13af3caed8_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070722Z:7f12f0da-a0a1-435e-af26-466d7761b9fb"
       },
       "ResponseBody": {
         "sku": {
@@ -181,8 +190,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622",
-        "name": "testnamespacemgmt3622",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362",
+        "name": "testnamespacemgmt7362",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -193,22 +202,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt3622",
-          "createdAt": "2022-10-11T16:10:38.203Z",
-          "updatedAt": "2022-10-11T16:10:38.203Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3622.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7362",
+          "createdAt": "2022-10-12T07:07:20.703Z",
+          "updatedAt": "2022-10-12T07:07:20.703Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7362.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-2eca2d9e9aeaaa45bf950df08a2f1ba3-c45bef0695e37347-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "c329aed3706446709596130690ab6ea2",
+        "traceparent": "00-36c134ed494b4e43b5d99a681a9a3053-7df36912f9a3b847-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c0953cd13eb42852ea930c741e5e8bee",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -217,7 +226,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:10:40 GMT",
+        "Date": "Wed, 12 Oct 2022 07:07:23 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -227,11 +236,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c329aed3706446709596130690ab6ea2",
-        "x-ms-correlation-request-id": "50d91fc1-24ae-4034-a203-ec33ed10c962",
-        "x-ms-ratelimit-remaining-subscription-reads": "11963",
-        "x-ms-request-id": "dcef9889-1186-478b-b168-0a3dbf987482_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161041Z:50d91fc1-24ae-4034-a203-ec33ed10c962"
+        "x-ms-client-request-id": "c0953cd13eb42852ea930c741e5e8bee",
+        "x-ms-correlation-request-id": "76c140f4-7bbb-4509-aa24-336972124dad",
+        "x-ms-ratelimit-remaining-subscription-reads": "11998",
+        "x-ms-request-id": "bb353aa5-c790-47e7-a7e4-248ea5c401dd_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070723Z:76c140f4-7bbb-4509-aa24-336972124dad"
       },
       "ResponseBody": {
         "sku": {
@@ -239,8 +248,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622",
-        "name": "testnamespacemgmt3622",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362",
+        "name": "testnamespacemgmt7362",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -251,22 +260,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt3622",
-          "createdAt": "2022-10-11T16:10:38.203Z",
-          "updatedAt": "2022-10-11T16:10:38.203Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3622.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7362",
+          "createdAt": "2022-10-12T07:07:20.703Z",
+          "updatedAt": "2022-10-12T07:07:20.703Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7362.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-2eca2d9e9aeaaa45bf950df08a2f1ba3-8428603f89fe4646-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "ab9bc28b2dc9cf0e00b85fb92517ed32",
+        "traceparent": "00-36c134ed494b4e43b5d99a681a9a3053-a6820d67d07eab4f-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a943652c8b954b3f60dc3e0b80e443ea",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -275,7 +284,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:10:42 GMT",
+        "Date": "Wed, 12 Oct 2022 07:07:25 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -285,11 +294,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "ab9bc28b2dc9cf0e00b85fb92517ed32",
-        "x-ms-correlation-request-id": "f282bc35-5307-48ac-ac14-bfebbcebd34e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11962",
-        "x-ms-request-id": "65a1e1cf-5bda-46cb-8ed3-bce2a9749cf3_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161042Z:f282bc35-5307-48ac-ac14-bfebbcebd34e"
+        "x-ms-client-request-id": "a943652c8b954b3f60dc3e0b80e443ea",
+        "x-ms-correlation-request-id": "4b9f5336-e1e6-498f-a010-b0d550be0236",
+        "x-ms-ratelimit-remaining-subscription-reads": "11997",
+        "x-ms-request-id": "af40f561-85a6-4c8b-8d8c-6fb8483b4f59_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070725Z:4b9f5336-e1e6-498f-a010-b0d550be0236"
       },
       "ResponseBody": {
         "sku": {
@@ -297,8 +306,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622",
-        "name": "testnamespacemgmt3622",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362",
+        "name": "testnamespacemgmt7362",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -309,22 +318,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt3622",
-          "createdAt": "2022-10-11T16:10:38.203Z",
-          "updatedAt": "2022-10-11T16:10:38.203Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3622.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7362",
+          "createdAt": "2022-10-12T07:07:20.703Z",
+          "updatedAt": "2022-10-12T07:07:20.703Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7362.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-2eca2d9e9aeaaa45bf950df08a2f1ba3-bb4e8021e7afbc44-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "b2c079466d13bce913c675e165c62035",
+        "traceparent": "00-36c134ed494b4e43b5d99a681a9a3053-06bb79a87eacfc4d-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6f39f652967e62893084a335b5a2de50",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -333,7 +342,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:10:44 GMT",
+        "Date": "Wed, 12 Oct 2022 07:07:26 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -343,11 +352,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "b2c079466d13bce913c675e165c62035",
-        "x-ms-correlation-request-id": "ccb126ce-605d-493b-a955-925a72779629",
-        "x-ms-ratelimit-remaining-subscription-reads": "11961",
-        "x-ms-request-id": "138a9b07-3304-4816-9ba8-a4fdb4094214_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161044Z:ccb126ce-605d-493b-a955-925a72779629"
+        "x-ms-client-request-id": "6f39f652967e62893084a335b5a2de50",
+        "x-ms-correlation-request-id": "ec4fa47c-d5be-4d5e-a4c4-b9ceaa79f515",
+        "x-ms-ratelimit-remaining-subscription-reads": "11996",
+        "x-ms-request-id": "14969e77-c234-4bbe-8958-13f96047a9dc_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070727Z:ec4fa47c-d5be-4d5e-a4c4-b9ceaa79f515"
       },
       "ResponseBody": {
         "sku": {
@@ -355,8 +364,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622",
-        "name": "testnamespacemgmt3622",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362",
+        "name": "testnamespacemgmt7362",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -367,22 +376,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt3622",
-          "createdAt": "2022-10-11T16:10:38.203Z",
-          "updatedAt": "2022-10-11T16:10:38.203Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3622.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7362",
+          "createdAt": "2022-10-12T07:07:20.703Z",
+          "updatedAt": "2022-10-12T07:07:20.703Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7362.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-2eca2d9e9aeaaa45bf950df08a2f1ba3-365096bb2cb6c048-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "64d0ac0daa46a5769f5ac2ab10b6217e",
+        "traceparent": "00-36c134ed494b4e43b5d99a681a9a3053-ee5de7694bc1ac4a-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b9d759b6b532462ffc4a60d8ff47a705",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -391,7 +400,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:10:45 GMT",
+        "Date": "Wed, 12 Oct 2022 07:07:28 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -401,11 +410,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "64d0ac0daa46a5769f5ac2ab10b6217e",
-        "x-ms-correlation-request-id": "86fde132-6640-438c-811e-7409213794f2",
-        "x-ms-ratelimit-remaining-subscription-reads": "11960",
-        "x-ms-request-id": "bd9b7f61-e185-4d8c-94a9-0fb56c48bff4_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161046Z:86fde132-6640-438c-811e-7409213794f2"
+        "x-ms-client-request-id": "b9d759b6b532462ffc4a60d8ff47a705",
+        "x-ms-correlation-request-id": "c44c3bc7-e0ee-4423-b54b-d484e58fa26f",
+        "x-ms-ratelimit-remaining-subscription-reads": "11995",
+        "x-ms-request-id": "7b5c9282-f2bc-4a4e-9cfc-0c0c020fe1a7_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070729Z:c44c3bc7-e0ee-4423-b54b-d484e58fa26f"
       },
       "ResponseBody": {
         "sku": {
@@ -413,8 +422,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622",
-        "name": "testnamespacemgmt3622",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362",
+        "name": "testnamespacemgmt7362",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -425,22 +434,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt3622",
-          "createdAt": "2022-10-11T16:10:38.203Z",
-          "updatedAt": "2022-10-11T16:10:38.203Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3622.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7362",
+          "createdAt": "2022-10-12T07:07:20.703Z",
+          "updatedAt": "2022-10-12T07:07:20.703Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7362.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-2eca2d9e9aeaaa45bf950df08a2f1ba3-008c03a6dceb5740-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "16c0e0a8bbeb1d8ed8de9702b82d693a",
+        "traceparent": "00-36c134ed494b4e43b5d99a681a9a3053-4a16e5a65ca37640-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "282222501c24966fdce07911e70a95bd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -449,7 +458,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:10:48 GMT",
+        "Date": "Wed, 12 Oct 2022 07:07:31 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -459,11 +468,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "16c0e0a8bbeb1d8ed8de9702b82d693a",
-        "x-ms-correlation-request-id": "8c69d161-652e-4550-8677-5d115bac16b2",
-        "x-ms-ratelimit-remaining-subscription-reads": "11959",
-        "x-ms-request-id": "59f5b3d6-e9bc-4bd5-b15c-d38b0a7f53d4_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161048Z:8c69d161-652e-4550-8677-5d115bac16b2"
+        "x-ms-client-request-id": "282222501c24966fdce07911e70a95bd",
+        "x-ms-correlation-request-id": "6143acf9-4bf5-4a38-bd31-f5f5909b8d73",
+        "x-ms-ratelimit-remaining-subscription-reads": "11994",
+        "x-ms-request-id": "b1df95eb-e85d-4df9-9d58-2da15e764f94_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070731Z:6143acf9-4bf5-4a38-bd31-f5f5909b8d73"
       },
       "ResponseBody": {
         "sku": {
@@ -471,8 +480,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622",
-        "name": "testnamespacemgmt3622",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362",
+        "name": "testnamespacemgmt7362",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -483,22 +492,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt3622",
-          "createdAt": "2022-10-11T16:10:38.203Z",
-          "updatedAt": "2022-10-11T16:10:38.203Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3622.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7362",
+          "createdAt": "2022-10-12T07:07:20.703Z",
+          "updatedAt": "2022-10-12T07:07:20.703Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7362.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-2eca2d9e9aeaaa45bf950df08a2f1ba3-00e87002c4359347-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "78ac2a9889469ceb031b12b9aa3eac5d",
+        "traceparent": "00-36c134ed494b4e43b5d99a681a9a3053-cf7996a3ed364047-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "2754edfd8a0d9cb8c6f3723436b062e8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -507,7 +516,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:10:53 GMT",
+        "Date": "Wed, 12 Oct 2022 07:07:35 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -517,246 +526,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "78ac2a9889469ceb031b12b9aa3eac5d",
-        "x-ms-correlation-request-id": "03d87ce1-6c60-40a6-9d0e-c85b500fd08a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11958",
-        "x-ms-request-id": "aed51dcb-3583-4913-9bd2-b8b4420a7a49_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161054Z:03d87ce1-6c60-40a6-9d0e-c85b500fd08a"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622",
-        "name": "testnamespacemgmt3622",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt3622",
-          "createdAt": "2022-10-11T16:10:38.203Z",
-          "updatedAt": "2022-10-11T16:10:38.203Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3622.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-2eca2d9e9aeaaa45bf950df08a2f1ba3-1912d53b511faf49-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "8538f7a40a06514a1db28b671273ec72",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:11:03 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8538f7a40a06514a1db28b671273ec72",
-        "x-ms-correlation-request-id": "d3047671-3b0a-4aec-a5c5-315b7a19f495",
-        "x-ms-ratelimit-remaining-subscription-reads": "11957",
-        "x-ms-request-id": "060030d5-1610-4cb6-8b9f-d89b442307cb_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161103Z:d3047671-3b0a-4aec-a5c5-315b7a19f495"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622",
-        "name": "testnamespacemgmt3622",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt3622",
-          "createdAt": "2022-10-11T16:10:38.203Z",
-          "updatedAt": "2022-10-11T16:10:38.203Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3622.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-2eca2d9e9aeaaa45bf950df08a2f1ba3-e29ebd636b11dd46-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "e61388f0a9091e37f42412cfa9d5739a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:11:20 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "e61388f0a9091e37f42412cfa9d5739a",
-        "x-ms-correlation-request-id": "0c33ace7-32da-49af-89f2-f4756373129e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11956",
-        "x-ms-request-id": "b17df559-3f5c-4669-ac8b-9dda6f4359ca_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161121Z:0c33ace7-32da-49af-89f2-f4756373129e"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622",
-        "name": "testnamespacemgmt3622",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt3622",
-          "createdAt": "2022-10-11T16:10:38.203Z",
-          "updatedAt": "2022-10-11T16:10:38.203Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3622.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "Connection": "close",
-        "traceparent": "00-2eca2d9e9aeaaa45bf950df08a2f1ba3-1376270099d38247-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "c15e3a32e4f48d34df5a5a94fe848990",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Connection": "close",
-        "Content-Length": "735",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:11:54 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c15e3a32e4f48d34df5a5a94fe848990",
-        "x-ms-correlation-request-id": "f701dee3-182a-409d-a1a3-d7e555e4ee5b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11955",
-        "x-ms-request-id": "3dd069c1-6e85-4d3a-9f38-2319b6d37073_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161154Z:f701dee3-182a-409d-a1a3-d7e555e4ee5b"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622",
-        "name": "testnamespacemgmt3622",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt3622",
-          "createdAt": "2022-10-11T16:10:38.203Z",
-          "updatedAt": "2022-10-11T16:11:31.25Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3622.servicebus.windows.net:443/",
-          "status": "Active"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-8abce88befa77a4ea2d1d56e4e37234a-37e13ebf53a26a41-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "22c9a02ec52afb53c01990e1f77aa848",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "735",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:11:54 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "22c9a02ec52afb53c01990e1f77aa848",
-        "x-ms-correlation-request-id": "05c6abb3-a252-4ad9-86cf-a7aca0dc16bf",
+        "x-ms-client-request-id": "2754edfd8a0d9cb8c6f3723436b062e8",
+        "x-ms-correlation-request-id": "4909f1d4-0e4b-4d2c-af78-fe436b4f56a8",
         "x-ms-ratelimit-remaining-subscription-reads": "11993",
-        "x-ms-request-id": "f37dc815-4a9c-439b-b4c5-b9daf653a7ab_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161155Z:05c6abb3-a252-4ad9-86cf-a7aca0dc16bf"
+        "x-ms-request-id": "bf0609ab-0ec1-4542-a43c-743f3db9854f_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070736Z:4909f1d4-0e4b-4d2c-af78-fe436b4f56a8"
       },
       "ResponseBody": {
         "sku": {
@@ -764,8 +538,182 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622",
-        "name": "testnamespacemgmt3622",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362",
+        "name": "testnamespacemgmt7362",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7362",
+          "createdAt": "2022-10-12T07:07:20.703Z",
+          "updatedAt": "2022-10-12T07:07:20.703Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7362.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-36c134ed494b4e43b5d99a681a9a3053-7663f1d0ea299449-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "93e49dddb6809a2ce941dd513c1e5ef2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "738",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:07:44 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "93e49dddb6809a2ce941dd513c1e5ef2",
+        "x-ms-correlation-request-id": "7e6b84ef-837a-46eb-b05e-cc0a32643489",
+        "x-ms-ratelimit-remaining-subscription-reads": "11992",
+        "x-ms-request-id": "8a0eaecf-b8bb-4285-bcbb-dbbc8deffa58_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070744Z:7e6b84ef-837a-46eb-b05e-cc0a32643489"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362",
+        "name": "testnamespacemgmt7362",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7362",
+          "createdAt": "2022-10-12T07:07:20.703Z",
+          "updatedAt": "2022-10-12T07:07:20.703Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7362.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-36c134ed494b4e43b5d99a681a9a3053-fc73fafba373584c-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "12dba2b480f2c5f86a856130a93b602b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "738",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:08:00 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "12dba2b480f2c5f86a856130a93b602b",
+        "x-ms-correlation-request-id": "faddc3fa-eb5f-453e-9bc7-73736712fa2b",
+        "x-ms-ratelimit-remaining-subscription-reads": "11991",
+        "x-ms-request-id": "841b3fda-c966-465a-8ffd-03d8f2b52b75_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070801Z:faddc3fa-eb5f-453e-9bc7-73736712fa2b"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362",
+        "name": "testnamespacemgmt7362",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7362",
+          "createdAt": "2022-10-12T07:07:20.703Z",
+          "updatedAt": "2022-10-12T07:07:20.703Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7362.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-36c134ed494b4e43b5d99a681a9a3053-92868fb1709a6a48-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "4933907e0125463dc1ba3dccad6760a7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "735",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:08:33 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "4933907e0125463dc1ba3dccad6760a7",
+        "x-ms-correlation-request-id": "020f4ee8-a13d-4906-aab0-051350a175a8",
+        "x-ms-ratelimit-remaining-subscription-reads": "11990",
+        "x-ms-request-id": "ba2898bb-285f-47c0-96d9-ccf479c9080b_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070833Z:020f4ee8-a13d-4906-aab0-051350a175a8"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362",
+        "name": "testnamespacemgmt7362",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -776,101 +724,32 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt3622",
-          "createdAt": "2022-10-11T16:10:38.203Z",
-          "updatedAt": "2022-10-11T16:11:31.25Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3622.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7362",
+          "createdAt": "2022-10-12T07:07:20.703Z",
+          "updatedAt": "2022-10-12T07:08:13.18Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7362.servicebus.windows.net:443/",
           "status": "Active"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622?api-version=2021-11-01",
-      "RequestMethod": "PATCH",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "65",
-        "Content-Type": "application/json",
-        "traceparent": "00-8abce88befa77a4ea2d1d56e4e37234a-ed53644cb5821741-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "d735f13f2b150b7d548507ae4ea22070",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "tags": {
-          "key": "Sanitized"
-        },
-        "location": "eastus2",
-        "properties": {}
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "756",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:11:59 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d735f13f2b150b7d548507ae4ea22070",
-        "x-ms-correlation-request-id": "4fa85cc0-b4b1-41ee-86cb-5d8d69c8613f",
-        "x-ms-ratelimit-remaining-subscription-resource-requests": "49",
-        "x-ms-request-id": "fcb3cd04-d0d1-4bf7-909b-286ce5946c22_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161200Z:4fa85cc0-b4b1-41ee-86cb-5d8d69c8613f"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622",
-        "name": "testnamespacemgmt3622",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {
-          "key": "Sanitized"
-        },
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Updating",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt3622",
-          "createdAt": "2022-10-11T16:10:38.203Z",
-          "updatedAt": "2022-10-11T16:11:57.027Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3622.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-e4e5dbbb0ef98345bd19042385a858e7-8820b07425223941-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "08a1829a510b6d6fe66201db54529665",
+        "traceparent": "00-d333d8cc6a6caa439cc1ed6de68bfa99-c12c11119746dc49-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "937f7f9550d55cf6a51f29fa55fbf0ad",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "753",
+        "Content-Length": "735",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:12:00 GMT",
+        "Date": "Wed, 12 Oct 2022 07:08:33 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -880,11 +759,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "08a1829a510b6d6fe66201db54529665",
-        "x-ms-correlation-request-id": "9ff4b269-2c99-4500-9fb0-7e4722d064b8",
-        "x-ms-ratelimit-remaining-subscription-reads": "11992",
-        "x-ms-request-id": "965d91f4-3b25-4425-8612-9a4b860ec1f7_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161201Z:9ff4b269-2c99-4500-9fb0-7e4722d064b8"
+        "x-ms-client-request-id": "937f7f9550d55cf6a51f29fa55fbf0ad",
+        "x-ms-correlation-request-id": "7a182476-b152-47b4-baf2-df573d4ed6ea",
+        "x-ms-ratelimit-remaining-subscription-reads": "11989",
+        "x-ms-request-id": "0757e5b2-28f3-4292-80d9-c8a9779218a6_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070834Z:7a182476-b152-47b4-baf2-df573d4ed6ea"
       },
       "ResponseBody": {
         "sku": {
@@ -892,13 +771,11 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622",
-        "name": "testnamespacemgmt3622",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362",
+        "name": "testnamespacemgmt7362",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
-        "tags": {
-          "key": "Sanitized"
-        },
+        "tags": {},
         "properties": {
           "disableLocalAuth": false,
           "zoneRedundant": false,
@@ -906,30 +783,29 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt3622",
-          "createdAt": "2022-10-11T16:10:38.203Z",
-          "updatedAt": "2022-10-11T16:11:59.173Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3622.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7362",
+          "createdAt": "2022-10-12T07:07:20.703Z",
+          "updatedAt": "2022-10-12T07:08:13.18Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7362.servicebus.windows.net:443/",
           "status": "Active"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362?api-version=2021-11-01",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "81",
+        "Content-Length": "63",
         "Content-Type": "application/json",
-        "traceparent": "00-e4e5dbbb0ef98345bd19042385a858e7-05a1b4f03a599a4e-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "0c5511b2b24f027a23becea5bea4ac1d",
+        "traceparent": "00-d333d8cc6a6caa439cc1ed6de68bfa99-f997184e101a4149-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "abd2b1e014eab3cd65945138422b1803",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "tags": {
-          "key": "Sanitized",
           "key1": "value1"
         },
         "location": "eastus2",
@@ -938,9 +814,9 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "771",
+        "Content-Length": "753",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:12:04 GMT",
+        "Date": "Wed, 12 Oct 2022 07:08:37 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -950,11 +826,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "0c5511b2b24f027a23becea5bea4ac1d",
-        "x-ms-correlation-request-id": "2c5a7ce7-a673-4833-9b11-d3c1602da1df",
+        "x-ms-client-request-id": "abd2b1e014eab3cd65945138422b1803",
+        "x-ms-correlation-request-id": "eb1b80db-966c-4d8e-a788-5618b0d2c6bd",
         "x-ms-ratelimit-remaining-subscription-resource-requests": "48",
-        "x-ms-request-id": "2ea806d3-8803-443e-95f3-704ae4dd5335_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161204Z:2c5a7ce7-a673-4833-9b11-d3c1602da1df"
+        "x-ms-request-id": "ce1a5f21-5fd5-443f-88f4-3a85a9e6d84b_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070837Z:eb1b80db-966c-4d8e-a788-5618b0d2c6bd"
       },
       "ResponseBody": {
         "sku": {
@@ -962,12 +838,11 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622",
-        "name": "testnamespacemgmt3622",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362",
+        "name": "testnamespacemgmt7362",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {
-          "key": "Sanitized",
           "key1": "value1"
         },
         "properties": {
@@ -977,167 +852,46 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Updating",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt3622",
-          "createdAt": "2022-10-11T16:10:38.203Z",
-          "updatedAt": "2022-10-11T16:12:03.24Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3622.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7362",
+          "createdAt": "2022-10-12T07:07:20.703Z",
+          "updatedAt": "2022-10-12T07:08:34.93Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7362.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-b3b0936e92e17845bf5b1d49f9429513-21a87846667f3043-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "74471ff89fd8ee3d81c7f1b22aa2b701",
+        "traceparent": "00-2c5023d2cb9ef847b43a8678bb2609ea-16d1043d9b27704c-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "2a9bb925cdbc2e559ad7a406d842f1c5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "771",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:12:05 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "74471ff89fd8ee3d81c7f1b22aa2b701",
-        "x-ms-correlation-request-id": "85a995c0-f336-4e9d-9065-dde962a7fa6a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11991",
-        "x-ms-request-id": "245fc153-dc23-44ff-9302-49128f5bd2c1_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161205Z:85a995c0-f336-4e9d-9065-dde962a7fa6a"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622",
-        "name": "testnamespacemgmt3622",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {
-          "key": "Sanitized",
-          "key1": "value1"
-        },
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Updating",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt3622",
-          "createdAt": "2022-10-11T16:10:38.203Z",
-          "updatedAt": "2022-10-11T16:12:03.24Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3622.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622?api-version=2021-11-01",
-      "RequestMethod": "PATCH",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "63",
-        "Content-Type": "application/json",
-        "traceparent": "00-b3b0936e92e17845bf5b1d49f9429513-0d203f37df4b864f-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "3cfca1ee144de821079fe54d83caae41",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "tags": {
-          "key1": "value1"
-        },
-        "location": "eastus2",
-        "properties": {}
-      },
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Connection": "close",
-        "Content-Length": "192",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:12:06 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Retry-After": "182",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "3cfca1ee144de821079fe54d83caae41",
-        "x-ms-correlation-request-id": "090b7056-8374-4d48-ad5d-dd164caa81af",
-        "x-ms-ratelimit-remaining-subscription-resource-requests": "47",
-        "x-ms-request-id": "b6f57757-1aa4-4eeb-8783-27eeb952bb6d_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161206Z:090b7056-8374-4d48-ad5d-dd164caa81af"
-      },
-      "ResponseBody": {
-        "error": {
-          "message": "Namespace provisioning in transition. For more information visit https://aka.ms/eventhubsarmexceptions. CorrelationId: 090b7056-8374-4d48-ad5d-dd164caa81af",
-          "code": "429"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622?api-version=2021-11-01",
-      "RequestMethod": "PATCH",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Content-Length": "63",
-        "Content-Type": "application/json",
-        "traceparent": "00-b3b0936e92e17845bf5b1d49f9429513-0d203f37df4b864f-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "3cfca1ee144de821079fe54d83caae41",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "tags": {
-          "key1": "value1"
-        },
-        "location": "eastus2",
-        "properties": {}
-      },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "753",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:15:20 GMT",
+        "Date": "Wed, 12 Oct 2022 07:08:37 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "3cfca1ee144de821079fe54d83caae41",
-        "x-ms-correlation-request-id": "6ae96a84-e115-4025-9069-0545a6bee957",
-        "x-ms-ratelimit-remaining-subscription-resource-requests": "49",
-        "x-ms-request-id": "022f9706-98ba-4e42-80ea-841ed5fb5c8f_M10SN1_M10SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161520Z:6ae96a84-e115-4025-9069-0545a6bee957"
+        "x-ms-client-request-id": "2a9bb925cdbc2e559ad7a406d842f1c5",
+        "x-ms-correlation-request-id": "5efabd50-8041-4307-afcd-60ce65ca522b",
+        "x-ms-ratelimit-remaining-subscription-reads": "11988",
+        "x-ms-request-id": "401aad76-0d8f-44e7-8ca3-0138e169fe9f_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070838Z:5efabd50-8041-4307-afcd-60ce65ca522b"
       },
       "ResponseBody": {
         "sku": {
@@ -1145,8 +899,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622",
-        "name": "testnamespacemgmt3622",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362",
+        "name": "testnamespacemgmt7362",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {
@@ -1159,46 +913,55 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Updating",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt3622",
-          "createdAt": "2022-10-11T16:10:38.203Z",
-          "updatedAt": "2022-10-11T16:15:16.06Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3622.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7362",
+          "createdAt": "2022-10-12T07:07:20.703Z",
+          "updatedAt": "2022-10-12T07:08:34.93Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7362.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622?api-version=2021-11-01",
-      "RequestMethod": "GET",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362?api-version=2021-11-01",
+      "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-65b41f49f63a1b4daf7970d88c95e2e9-dcb96675bda0564c-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "34e2e3b6220b128cd4678b87c0c8d781",
+        "Content-Length": "79",
+        "Content-Type": "application/json",
+        "traceparent": "00-2c5023d2cb9ef847b43a8678bb2609ea-1f5b0c9183b1ba41-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "fbeb8fc9b49481bdb2cc2d41febd1979",
         "x-ms-return-client-request-id": "true"
       },
-      "RequestBody": null,
+      "RequestBody": {
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        },
+        "location": "eastus2",
+        "properties": {}
+      },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "750",
+        "Content-Length": "770",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:15:31 GMT",
+        "Date": "Wed, 12 Oct 2022 07:08:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "34e2e3b6220b128cd4678b87c0c8d781",
-        "x-ms-correlation-request-id": "058168ad-c295-4161-b7c5-47dc4923018b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11999",
-        "x-ms-request-id": "411a0113-578a-40d9-8b34-7c876dce0463_M10SN1_M10SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161531Z:058168ad-c295-4161-b7c5-47dc4923018b"
+        "x-ms-client-request-id": "fbeb8fc9b49481bdb2cc2d41febd1979",
+        "x-ms-correlation-request-id": "3b628af2-0fe0-4e83-b1ed-fbc7e51334b9",
+        "x-ms-ratelimit-remaining-subscription-resource-requests": "47",
+        "x-ms-request-id": "73ea4a4c-be40-4fa4-8779-5546b577cc8b_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070841Z:3b628af2-0fe0-4e83-b1ed-fbc7e51334b9"
       },
       "ResponseBody": {
         "sku": {
@@ -1206,12 +969,205 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2210/providers/Microsoft.EventHub/namespaces/testnamespacemgmt3622",
-        "name": "testnamespacemgmt3622",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362",
+        "name": "testnamespacemgmt7362",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {
-          "key1": "value1"
+          "key1": "value1",
+          "key2": "value2"
+        },
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Updating",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7362",
+          "createdAt": "2022-10-12T07:07:20.703Z",
+          "updatedAt": "2022-10-12T07:08:39.297Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7362.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-57ec48569d74574faade09d496a6350b-e6213ee29e3fb843-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "9bd52606c66013f15ca411136fc7da23",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "770",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:08:41 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "9bd52606c66013f15ca411136fc7da23",
+        "x-ms-correlation-request-id": "c1ee4945-1155-44c7-b0f6-26642b83893e",
+        "x-ms-ratelimit-remaining-subscription-reads": "11987",
+        "x-ms-request-id": "6f8309f7-bc70-4d4d-ba54-de265d028339_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070842Z:c1ee4945-1155-44c7-b0f6-26642b83893e"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362",
+        "name": "testnamespacemgmt7362",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        },
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Updating",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7362",
+          "createdAt": "2022-10-12T07:07:20.703Z",
+          "updatedAt": "2022-10-12T07:08:39.297Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7362.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362?api-version=2021-11-01",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "63",
+        "Content-Type": "application/json",
+        "traceparent": "00-57ec48569d74574faade09d496a6350b-a8e70aef3225504a-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b36f8ba21c40706efc1977f09f142fdc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "tags": {
+          "key2": "value2"
+        },
+        "location": "eastus2",
+        "properties": {}
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "754",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:08:45 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b36f8ba21c40706efc1977f09f142fdc",
+        "x-ms-correlation-request-id": "d2484762-4ddb-49e1-849d-87a66372dadb",
+        "x-ms-ratelimit-remaining-subscription-resource-requests": "46",
+        "x-ms-request-id": "23089d1e-410e-474f-8afc-a54f26bb19da_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070845Z:d2484762-4ddb-49e1-849d-87a66372dadb"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362",
+        "name": "testnamespacemgmt7362",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {
+          "key2": "value2"
+        },
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Updating",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7362",
+          "createdAt": "2022-10-12T07:07:20.703Z",
+          "updatedAt": "2022-10-12T07:08:43.823Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7362.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8eb21f84d6beee44bae54d9fdbfe19bf-e1ac1ac388156245-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b2ff2abd566c02649dd79ff0a2a911ea",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "751",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:08:55 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b2ff2abd566c02649dd79ff0a2a911ea",
+        "x-ms-correlation-request-id": "e2a3e89a-b143-4e87-aa0d-830f518d3695",
+        "x-ms-ratelimit-remaining-subscription-reads": "11986",
+        "x-ms-request-id": "5261dd68-6edd-48ab-8537-1cdba89dcf7f_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070855Z:e2a3e89a-b143-4e87-aa0d-830f518d3695"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4591/providers/Microsoft.EventHub/namespaces/testnamespacemgmt7362",
+        "name": "testnamespacemgmt7362",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {
+          "key2": "value2"
         },
         "properties": {
           "disableLocalAuth": false,
@@ -1220,10 +1176,10 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt3622",
-          "createdAt": "2022-10-11T16:10:38.203Z",
-          "updatedAt": "2022-10-11T16:15:19.47Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt3622.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt7362",
+          "createdAt": "2022-10-12T07:07:20.703Z",
+          "updatedAt": "2022-10-12T07:08:47.383Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt7362.servicebus.windows.net:443/",
           "status": "Active"
         }
       }
@@ -1231,8 +1187,8 @@
   ],
   "Variables": {
     "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "1677035450",
+    "RandomSeed": "1589052691",
     "RESOURCE_MANAGER_URL": null,
-    "SUBSCRIPTION_ID": "326100e2-f69d-4268-8503-075374f62b6e"
+    "SUBSCRIPTION_ID": "db1ab6f0-4769-4b27-930e-01e2ef9c123c"
   }
 }

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventHubNamespaceTests/AddSetRemoveTag(False)Async.json
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventHubNamespaceTests/AddSetRemoveTag(False)Async.json
@@ -1,43 +1,52 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e?api-version=2021-01-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c?api-version=2021-01-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-e37ce1541004ae428137eb3b5185186b-a189664f041a0d4a-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "c7684ab451a3946f62a165257cbdb36e",
+        "traceparent": "00-878f14877206ab40a25367cb2ab43438-f6b10792b3b74d4f-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "45394b84adbc5c026052e91a6b984277",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "460",
+        "Content-Length": "747",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:19:46 GMT",
+        "Date": "Wed, 12 Oct 2022 07:09:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "139c1716-3717-4cb2-ba36-89c8009bb81c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11995",
-        "x-ms-request-id": "139c1716-3717-4cb2-ba36-89c8009bb81c",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161947Z:139c1716-3717-4cb2-ba36-89c8009bb81c"
+        "x-ms-correlation-request-id": "fb155c72-1ba6-4a6e-83b5-6b56275c66b2",
+        "x-ms-ratelimit-remaining-subscription-reads": "11985",
+        "x-ms-request-id": "fb155c72-1ba6-4a6e-83b5-6b56275c66b2",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070904Z:fb155c72-1ba6-4a6e-83b5-6b56275c66b2"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "authorizationSource": "RoleBased",
-        "managedByTenants": [
-          {
-            "tenantId": "2f4a9838-26b7-47ee-be60-ccc1fdec5953"
-          }
-        ],
-        "subscriptionId": "326100e2-f69d-4268-8503-075374f62b6e",
+        "managedByTenants": [],
+        "tags": {
+          "TagKey-9823": "TagValue-566",
+          "TagKey-3481": "TagValue-320",
+          "TagKey-4926": "TagValue-1187",
+          "TagKey-751": "TagValue-3921",
+          "TagKey-1866": "TagValue-8559",
+          "TagKey-3094": "TagValue-9190",
+          "TagKey-2449": "TagValue-9",
+          "TagKey-8379": "TagValue-164",
+          "TagKey-7470": "TagValue-2205",
+          "TagKey-4236": "TagValue-3698",
+          "TagKey-5316": "TagValue-2725"
+        },
+        "subscriptionId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-        "displayName": "Azure Messaging PM Playground",
+        "displayName": ".NET Mgmt SDK Test with TTL = 1 Day",
         "state": "Enabled",
         "subscriptionPolicies": {
           "locationPlacementId": "Internal_2014-09-01",
@@ -47,16 +56,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourcegroups/testeventhubRG-2102?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourcegroups/testeventhubRG-4955?api-version=2021-04-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "44",
         "Content-Type": "application/json",
-        "traceparent": "00-c5b374521e5ac44289d1f71ed4ff1c2e-b1925d0191048141-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "f163e684a3ee6df48ba5458c503bb53e",
+        "traceparent": "00-f58db835bfc8d846b9e2540fa7b7227f-bd67c81fcbfe224a-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a5e3ffdcdc893595b3f531438aa5caa0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -70,19 +79,19 @@
         "Cache-Control": "no-cache",
         "Content-Length": "258",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:19:49 GMT",
+        "Date": "Wed, 12 Oct 2022 07:09:07 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "b5158e36-043c-47ff-a7b9-bd5972ad2d76",
+        "x-ms-correlation-request-id": "9193cd55-4f2b-40a0-8943-296d36be03a0",
         "x-ms-ratelimit-remaining-subscription-writes": "1198",
-        "x-ms-request-id": "b5158e36-043c-47ff-a7b9-bd5972ad2d76",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161950Z:b5158e36-043c-47ff-a7b9-bd5972ad2d76"
+        "x-ms-request-id": "9193cd55-4f2b-40a0-8943-296d36be03a0",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070907Z:9193cd55-4f2b-40a0-8943-296d36be03a0"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102",
-        "name": "testeventhubRG-2102",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955",
+        "name": "testeventhubRG-4955",
         "type": "Microsoft.Resources/resourceGroups",
         "location": "eastus2",
         "tags": {
@@ -94,915 +103,27 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/providers/Microsoft.EventHub/checkNameAvailability?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.EventHub/checkNameAvailability?api-version=2021-11-01",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "32",
         "Content-Type": "application/json",
-        "traceparent": "00-1bf02ae87e8d80459fa8dd82c4b23629-7591abbcc68b5f49-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "c44cddc5fece857c09acf7d02f6e81ee",
+        "traceparent": "00-d2b7e8bd0459e24d8eaa3b889d680449-5c958bdb8580fe42-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "eb4f2fb0528a2a637cb7263a12f8b156",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "testnamespacemgmt8252"
+        "name": "testnamespacemgmt4619"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "53",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:19:50 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c44cddc5fece857c09acf7d02f6e81ee",
-        "x-ms-correlation-request-id": "2c5a9ca0-8551-40e9-acc9-d85b117546a6",
-        "x-ms-ratelimit-remaining-subscription-writes": "1199",
-        "x-ms-request-id": "8c106421-991d-40f6-8b7a-982a1183830b_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161950Z:2c5a9ca0-8551-40e9-acc9-d85b117546a6"
-      },
-      "ResponseBody": {
-        "nameAvailable": true,
-        "reason": "None",
-        "message": null
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252?api-version=2021-11-01",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "48",
-        "Content-Type": "application/json",
-        "traceparent": "00-f7680dea0357484083dc5ac9e1c80445-a7baaf08e84caa40-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "98043745c68973a65918ab2a081266b0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "tags": {},
-        "location": "eastus2",
-        "properties": {}
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:19:56 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "98043745c68973a65918ab2a081266b0",
-        "x-ms-correlation-request-id": "23831715-0bb4-48d3-a967-3392e7fe95ac",
-        "x-ms-ratelimit-remaining-subscription-resource-requests": "46",
-        "x-ms-request-id": "f0f789a2-629d-487d-9e24-050b0a3f0820_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161956Z:23831715-0bb4-48d3-a967-3392e7fe95ac"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252",
-        "name": "testnamespacemgmt8252",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt8252",
-          "createdAt": "2022-10-11T16:19:53.757Z",
-          "updatedAt": "2022-10-11T16:19:53.757Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8252.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f7680dea0357484083dc5ac9e1c80445-b2ab831148e6094a-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "040a9dc4a5b0ffac36d96bb553527cf7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:19:56 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "040a9dc4a5b0ffac36d96bb553527cf7",
-        "x-ms-correlation-request-id": "4a7c2a32-e153-4f73-bad4-f7992f434495",
-        "x-ms-ratelimit-remaining-subscription-reads": "11994",
-        "x-ms-request-id": "ff26b56d-8ec7-4c85-bcd2-837748e807f3_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161956Z:4a7c2a32-e153-4f73-bad4-f7992f434495"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252",
-        "name": "testnamespacemgmt8252",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt8252",
-          "createdAt": "2022-10-11T16:19:53.757Z",
-          "updatedAt": "2022-10-11T16:19:53.757Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8252.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f7680dea0357484083dc5ac9e1c80445-4f8b437860f90742-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "e8e84645ab7684cc801cb21de2af75bc",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:19:58 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "e8e84645ab7684cc801cb21de2af75bc",
-        "x-ms-correlation-request-id": "750492de-884a-4f57-9974-7489d481e5b8",
-        "x-ms-ratelimit-remaining-subscription-reads": "11993",
-        "x-ms-request-id": "7e9aa712-8589-4d89-9933-76d66361dd2f_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161958Z:750492de-884a-4f57-9974-7489d481e5b8"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252",
-        "name": "testnamespacemgmt8252",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt8252",
-          "createdAt": "2022-10-11T16:19:53.757Z",
-          "updatedAt": "2022-10-11T16:19:53.757Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8252.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f7680dea0357484083dc5ac9e1c80445-99eb4f447923c746-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "6a6674bb620742ff99f89f4855009494",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:20:00 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "6a6674bb620742ff99f89f4855009494",
-        "x-ms-correlation-request-id": "7a22f98d-8b62-470e-b8d0-3458b36676ea",
-        "x-ms-ratelimit-remaining-subscription-reads": "11992",
-        "x-ms-request-id": "b7adf63b-029d-45cd-bbc8-7585afbe70b1_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T162000Z:7a22f98d-8b62-470e-b8d0-3458b36676ea"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252",
-        "name": "testnamespacemgmt8252",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt8252",
-          "createdAt": "2022-10-11T16:19:53.757Z",
-          "updatedAt": "2022-10-11T16:19:53.757Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8252.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f7680dea0357484083dc5ac9e1c80445-14e62b83b5461644-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "b6b2edef73b419c0d1868394f38f1d87",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:20:02 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "b6b2edef73b419c0d1868394f38f1d87",
-        "x-ms-correlation-request-id": "4bcc822c-cc98-45d1-a66f-70abd7ed149b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11991",
-        "x-ms-request-id": "9b11e4d5-1a15-4b31-b6c1-253a626fea77_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T162002Z:4bcc822c-cc98-45d1-a66f-70abd7ed149b"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252",
-        "name": "testnamespacemgmt8252",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt8252",
-          "createdAt": "2022-10-11T16:19:53.757Z",
-          "updatedAt": "2022-10-11T16:19:53.757Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8252.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f7680dea0357484083dc5ac9e1c80445-0ab4119b6dff8d41-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "dffaaf6311ebe2f047a64f7e0b832e80",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:20:04 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "dffaaf6311ebe2f047a64f7e0b832e80",
-        "x-ms-correlation-request-id": "5c952c0e-0476-4cc5-b5a1-18201b791c36",
-        "x-ms-ratelimit-remaining-subscription-reads": "11990",
-        "x-ms-request-id": "d73718b8-ae0f-46ce-a1ca-6596aff414a2_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T162005Z:5c952c0e-0476-4cc5-b5a1-18201b791c36"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252",
-        "name": "testnamespacemgmt8252",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt8252",
-          "createdAt": "2022-10-11T16:19:53.757Z",
-          "updatedAt": "2022-10-11T16:19:53.757Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8252.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f7680dea0357484083dc5ac9e1c80445-51ea761b093ca34d-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "f52d1d88bffd4707b44d9880df6b4f0a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:20:09 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f52d1d88bffd4707b44d9880df6b4f0a",
-        "x-ms-correlation-request-id": "7e297331-53fd-482e-88d8-9688769ac909",
-        "x-ms-ratelimit-remaining-subscription-reads": "11989",
-        "x-ms-request-id": "d7fd4b57-44dc-4e26-a3fa-15a867ab7559_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T162010Z:7e297331-53fd-482e-88d8-9688769ac909"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252",
-        "name": "testnamespacemgmt8252",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt8252",
-          "createdAt": "2022-10-11T16:19:53.757Z",
-          "updatedAt": "2022-10-11T16:19:53.757Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8252.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f7680dea0357484083dc5ac9e1c80445-cc5ec43d7307c548-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "a6e417dbb406dda8fccf6f0e24420d4e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:20:19 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a6e417dbb406dda8fccf6f0e24420d4e",
-        "x-ms-correlation-request-id": "ab7e34ea-ae25-4288-b3ad-67893615f68c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11988",
-        "x-ms-request-id": "1ef93118-9a62-47ae-a341-1ee8586e8722_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T162019Z:ab7e34ea-ae25-4288-b3ad-67893615f68c"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252",
-        "name": "testnamespacemgmt8252",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt8252",
-          "createdAt": "2022-10-11T16:19:53.757Z",
-          "updatedAt": "2022-10-11T16:19:53.757Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8252.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f7680dea0357484083dc5ac9e1c80445-02992ac86c34f446-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "d50b02582861a48aa7b22b9e786f03dc",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:20:36 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d50b02582861a48aa7b22b9e786f03dc",
-        "x-ms-correlation-request-id": "9e8a2226-8b04-4302-baf6-38e4ed697a8b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11987",
-        "x-ms-request-id": "3d689c96-0093-438c-b24c-acc5f5382611_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T162036Z:9e8a2226-8b04-4302-baf6-38e4ed697a8b"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252",
-        "name": "testnamespacemgmt8252",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt8252",
-          "createdAt": "2022-10-11T16:19:53.757Z",
-          "updatedAt": "2022-10-11T16:19:53.757Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8252.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f7680dea0357484083dc5ac9e1c80445-0b0360cb581cff41-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "f3a24457879fd37a744ff82d4ff92371",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "735",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:21:10 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f3a24457879fd37a744ff82d4ff92371",
-        "x-ms-correlation-request-id": "58c9d287-de80-40e3-ab50-7f81e4626c46",
-        "x-ms-ratelimit-remaining-subscription-reads": "11986",
-        "x-ms-request-id": "6f51830b-9fe6-4e4a-b614-4fa1dc942428_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T162110Z:58c9d287-de80-40e3-ab50-7f81e4626c46"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252",
-        "name": "testnamespacemgmt8252",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt8252",
-          "createdAt": "2022-10-11T16:19:53.757Z",
-          "updatedAt": "2022-10-11T16:20:45.58Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8252.servicebus.windows.net:443/",
-          "status": "Active"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-86b06f4cb8b6884c962be42caf201d17-e078c3e9fae33d45-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "dd284a3f795fb3a88d3ffe538909648d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "735",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:21:11 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "dd284a3f795fb3a88d3ffe538909648d",
-        "x-ms-correlation-request-id": "eb143f3b-7292-484e-9893-24ce175ffa3a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11985",
-        "x-ms-request-id": "634d91c5-ca40-431c-91df-5559ae37259f_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T162111Z:eb143f3b-7292-484e-9893-24ce175ffa3a"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252",
-        "name": "testnamespacemgmt8252",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt8252",
-          "createdAt": "2022-10-11T16:19:53.757Z",
-          "updatedAt": "2022-10-11T16:20:45.58Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8252.servicebus.windows.net:443/",
-          "status": "Active"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252?api-version=2021-11-01",
-      "RequestMethod": "PATCH",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "65",
-        "Content-Type": "application/json",
-        "traceparent": "00-86b06f4cb8b6884c962be42caf201d17-cb354ce041bfb24a-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "dfb693cb199fd0af88386011305c55ae",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "tags": {
-          "key": "Sanitized"
-        },
-        "location": "eastus2",
-        "properties": {}
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "756",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:21:15 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "dfb693cb199fd0af88386011305c55ae",
-        "x-ms-correlation-request-id": "3323a47a-7161-4d87-b8ed-b7b75a89ac5b",
-        "x-ms-ratelimit-remaining-subscription-resource-requests": "45",
-        "x-ms-request-id": "eba85d7b-83a3-4670-9d62-5882e2a7e777_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T162116Z:3323a47a-7161-4d87-b8ed-b7b75a89ac5b"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252",
-        "name": "testnamespacemgmt8252",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {
-          "key": "Sanitized"
-        },
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Updating",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt8252",
-          "createdAt": "2022-10-11T16:19:53.757Z",
-          "updatedAt": "2022-10-11T16:21:12.897Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8252.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-e7c51f7637624648b78b71ac32e61807-5ad13e8e9ab26a49-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "2e5fb98f2646dd7c9cee665f8926496b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "753",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:21:16 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2e5fb98f2646dd7c9cee665f8926496b",
-        "x-ms-correlation-request-id": "aa77d4da-b568-4d61-923f-91a36540417e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11984",
-        "x-ms-request-id": "5d376dd7-973f-42b3-865f-2ca408794292_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T162116Z:aa77d4da-b568-4d61-923f-91a36540417e"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252",
-        "name": "testnamespacemgmt8252",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {
-          "key": "Sanitized"
-        },
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt8252",
-          "createdAt": "2022-10-11T16:19:53.757Z",
-          "updatedAt": "2022-10-11T16:21:14.197Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8252.servicebus.windows.net:443/",
-          "status": "Active"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252?api-version=2021-11-01",
-      "RequestMethod": "PATCH",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "81",
-        "Content-Type": "application/json",
-        "traceparent": "00-e7c51f7637624648b78b71ac32e61807-75b5d209d795ab44-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "bc626aeb434226d29b58542719968330",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "tags": {
-          "key": "Sanitized",
-          "key1": "value1"
-        },
-        "location": "eastus2",
-        "properties": {}
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "772",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:21:20 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "bc626aeb434226d29b58542719968330",
-        "x-ms-correlation-request-id": "ef5abec7-b087-4a09-8da5-80e02359393e",
-        "x-ms-ratelimit-remaining-subscription-resource-requests": "44",
-        "x-ms-request-id": "cbc2169e-b1a0-40c0-83e6-36758d9bee4d_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T162120Z:ef5abec7-b087-4a09-8da5-80e02359393e"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252",
-        "name": "testnamespacemgmt8252",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {
-          "key": "Sanitized",
-          "key1": "value1"
-        },
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Updating",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt8252",
-          "createdAt": "2022-10-11T16:19:53.757Z",
-          "updatedAt": "2022-10-11T16:21:18.847Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8252.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Connection": "close",
-        "traceparent": "00-d88189f32329e341bb266c68c4da4620-718516a811f6cc4f-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "d0c450ea36aaa54616d943b1b24f4661",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Connection": "close",
-        "Content-Length": "769",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:31:20 GMT",
+        "Date": "Wed, 12 Oct 2022 07:09:08 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1012,11 +133,56 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d0c450ea36aaa54616d943b1b24f4661",
-        "x-ms-correlation-request-id": "aadecdf3-f143-4e4e-b02c-12545fd09fe9",
-        "x-ms-ratelimit-remaining-subscription-reads": "11996",
-        "x-ms-request-id": "17a82cb4-c526-4736-83c6-4d1f8037d5f6_M2CH3_M2CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T163120Z:aadecdf3-f143-4e4e-b02c-12545fd09fe9"
+        "x-ms-client-request-id": "eb4f2fb0528a2a637cb7263a12f8b156",
+        "x-ms-correlation-request-id": "a07eed2a-aabd-40a9-bb50-9c8ff21fa7fe",
+        "x-ms-ratelimit-remaining-subscription-writes": "1198",
+        "x-ms-request-id": "742f33de-5cab-44b6-b516-a4ad0297c4e4_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070908Z:a07eed2a-aabd-40a9-bb50-9c8ff21fa7fe"
+      },
+      "ResponseBody": {
+        "nameAvailable": true,
+        "reason": "None",
+        "message": null
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619?api-version=2021-11-01",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "48",
+        "Content-Type": "application/json",
+        "traceparent": "00-909dfe9d12773d489294cc4a19d41661-74ee01236eb8274b-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "8d53fc99fbc3a36f1009b7d118d5ac1e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "tags": {},
+        "location": "eastus2",
+        "properties": {}
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "738",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:09:14 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "8d53fc99fbc3a36f1009b7d118d5ac1e",
+        "x-ms-correlation-request-id": "c5f79031-1577-4cc5-9d36-5cdaabd671e0",
+        "x-ms-ratelimit-remaining-subscription-resource-requests": "45",
+        "x-ms-request-id": "2bfca666-8d94-41e3-ab06-2fcfe1dea1ea_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070914Z:c5f79031-1577-4cc5-9d36-5cdaabd671e0"
       },
       "ResponseBody": {
         "sku": {
@@ -1024,14 +190,533 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252",
-        "name": "testnamespacemgmt8252",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619",
+        "name": "testnamespacemgmt4619",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
-        "tags": {
-          "key": "Sanitized",
-          "key1": "value1"
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4619",
+          "createdAt": "2022-10-12T07:09:12.843Z",
+          "updatedAt": "2022-10-12T07:09:12.843Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4619.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-909dfe9d12773d489294cc4a19d41661-44ae7115d427694e-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a8f0ed801276b4b7c0abdb809a9211a6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "738",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:09:14 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a8f0ed801276b4b7c0abdb809a9211a6",
+        "x-ms-correlation-request-id": "587ddc59-649d-4ee9-93af-0ed49b4d55c3",
+        "x-ms-ratelimit-remaining-subscription-reads": "11984",
+        "x-ms-request-id": "f5e5771a-0e9d-4eab-bfc8-965f010fa84d_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070914Z:587ddc59-649d-4ee9-93af-0ed49b4d55c3"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
         },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619",
+        "name": "testnamespacemgmt4619",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4619",
+          "createdAt": "2022-10-12T07:09:12.843Z",
+          "updatedAt": "2022-10-12T07:09:12.843Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4619.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-909dfe9d12773d489294cc4a19d41661-f625a6d41c3f6946-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "20bf080a9d0fd72faaa70d47ee493515",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "738",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:09:16 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "20bf080a9d0fd72faaa70d47ee493515",
+        "x-ms-correlation-request-id": "f693e0db-bdde-47f6-82c9-aaae750e560b",
+        "x-ms-ratelimit-remaining-subscription-reads": "11983",
+        "x-ms-request-id": "40778207-ff0e-4874-835f-5fcf74158746_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070916Z:f693e0db-bdde-47f6-82c9-aaae750e560b"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619",
+        "name": "testnamespacemgmt4619",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4619",
+          "createdAt": "2022-10-12T07:09:12.843Z",
+          "updatedAt": "2022-10-12T07:09:12.843Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4619.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-909dfe9d12773d489294cc4a19d41661-12d443f91e677242-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "2b50b96803e568a83933527ce7d111ed",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "738",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:09:17 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2b50b96803e568a83933527ce7d111ed",
+        "x-ms-correlation-request-id": "c59a8a31-e34a-4842-9658-13adcff78e0b",
+        "x-ms-ratelimit-remaining-subscription-reads": "11982",
+        "x-ms-request-id": "44967ed0-560b-4623-bb8a-bc2f91d1e600_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070917Z:c59a8a31-e34a-4842-9658-13adcff78e0b"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619",
+        "name": "testnamespacemgmt4619",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4619",
+          "createdAt": "2022-10-12T07:09:12.843Z",
+          "updatedAt": "2022-10-12T07:09:12.843Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4619.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-909dfe9d12773d489294cc4a19d41661-3b7f84b24b4d5841-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "661a6669803be2eebe19fecf046fc676",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "738",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:09:19 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "661a6669803be2eebe19fecf046fc676",
+        "x-ms-correlation-request-id": "79ea2f71-a4f1-46cd-8deb-139e37b64867",
+        "x-ms-ratelimit-remaining-subscription-reads": "11981",
+        "x-ms-request-id": "df436098-d120-46b3-81c5-ef688e153f1d_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070919Z:79ea2f71-a4f1-46cd-8deb-139e37b64867"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619",
+        "name": "testnamespacemgmt4619",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4619",
+          "createdAt": "2022-10-12T07:09:12.843Z",
+          "updatedAt": "2022-10-12T07:09:12.843Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4619.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-909dfe9d12773d489294cc4a19d41661-383494800fe9fb44-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "e118c576e64106c15f57e7dc4bb2f0d9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "738",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:09:21 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e118c576e64106c15f57e7dc4bb2f0d9",
+        "x-ms-correlation-request-id": "ce1dae22-88a9-4e11-973c-6702e68e7ce4",
+        "x-ms-ratelimit-remaining-subscription-reads": "11980",
+        "x-ms-request-id": "ea4a57c6-28ea-4aac-9556-d65937004b9f_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070922Z:ce1dae22-88a9-4e11-973c-6702e68e7ce4"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619",
+        "name": "testnamespacemgmt4619",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4619",
+          "createdAt": "2022-10-12T07:09:12.843Z",
+          "updatedAt": "2022-10-12T07:09:12.843Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4619.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-909dfe9d12773d489294cc4a19d41661-5c62a69a3399e645-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "88dd2095ce2fe8dacb6e6ccc05d963c9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "738",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:09:25 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "88dd2095ce2fe8dacb6e6ccc05d963c9",
+        "x-ms-correlation-request-id": "ce2d5587-54b6-43e7-bec2-1ebe8a7611cb",
+        "x-ms-ratelimit-remaining-subscription-reads": "11979",
+        "x-ms-request-id": "b5f5a7c6-6229-4fc2-84d0-b895f4868864_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070926Z:ce2d5587-54b6-43e7-bec2-1ebe8a7611cb"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619",
+        "name": "testnamespacemgmt4619",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4619",
+          "createdAt": "2022-10-12T07:09:12.843Z",
+          "updatedAt": "2022-10-12T07:09:12.843Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4619.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-909dfe9d12773d489294cc4a19d41661-482d1503ff58cb46-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "2105dc6d30b982aca41406e39811970b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "738",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:09:34 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2105dc6d30b982aca41406e39811970b",
+        "x-ms-correlation-request-id": "61e70a54-0768-4c4a-a749-8da315c45dba",
+        "x-ms-ratelimit-remaining-subscription-reads": "11978",
+        "x-ms-request-id": "e90cc71b-116e-4703-ae05-152f859da11d_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070935Z:61e70a54-0768-4c4a-a749-8da315c45dba"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619",
+        "name": "testnamespacemgmt4619",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4619",
+          "createdAt": "2022-10-12T07:09:12.843Z",
+          "updatedAt": "2022-10-12T07:09:12.843Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4619.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-909dfe9d12773d489294cc4a19d41661-d1bb6f3a75b44f45-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "e43925283e92a747eb3015d379f50186",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "738",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:09:52 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e43925283e92a747eb3015d379f50186",
+        "x-ms-correlation-request-id": "dee3260c-1b2d-4db4-a72f-faf656d6ea08",
+        "x-ms-ratelimit-remaining-subscription-reads": "11977",
+        "x-ms-request-id": "31538ff1-22ab-4836-a391-62a5ead181f3_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T070952Z:dee3260c-1b2d-4db4-a72f-faf656d6ea08"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619",
+        "name": "testnamespacemgmt4619",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4619",
+          "createdAt": "2022-10-12T07:09:12.843Z",
+          "updatedAt": "2022-10-12T07:09:12.843Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4619.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-909dfe9d12773d489294cc4a19d41661-61f6d306cbca1849-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6f6f1df4ceac6420735ae31ac7f64fb9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "735",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:10:24 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "6f6f1df4ceac6420735ae31ac7f64fb9",
+        "x-ms-correlation-request-id": "3780a639-4ed3-4dde-ac79-bd70982c1427",
+        "x-ms-ratelimit-remaining-subscription-reads": "11976",
+        "x-ms-request-id": "8238c2b8-1d9e-43f8-8378-7921ece3dd19_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T071025Z:3780a639-4ed3-4dde-ac79-bd70982c1427"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619",
+        "name": "testnamespacemgmt4619",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
         "properties": {
           "disableLocalAuth": false,
           "zoneRedundant": false,
@@ -1039,25 +724,84 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt8252",
-          "createdAt": "2022-10-11T16:19:53.757Z",
-          "updatedAt": "2022-10-11T16:21:20.597Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8252.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4619",
+          "createdAt": "2022-10-12T07:09:12.843Z",
+          "updatedAt": "2022-10-12T07:10:01.35Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4619.servicebus.windows.net:443/",
           "status": "Active"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-57fa551da1f9034c9b73bf1d9b27837b-c577fb31ee43ba43-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "dfa361d77e9f2e37945e36881bd909af",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "735",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:10:27 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "dfa361d77e9f2e37945e36881bd909af",
+        "x-ms-correlation-request-id": "abba13f2-acab-4290-bd72-b7ed12538acd",
+        "x-ms-ratelimit-remaining-subscription-reads": "11975",
+        "x-ms-request-id": "4788067b-72e6-4e14-9609-4d1e53d2b25c_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T071027Z:abba13f2-acab-4290-bd72-b7ed12538acd"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619",
+        "name": "testnamespacemgmt4619",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Succeeded",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4619",
+          "createdAt": "2022-10-12T07:09:12.843Z",
+          "updatedAt": "2022-10-12T07:10:01.35Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4619.servicebus.windows.net:443/",
+          "status": "Active"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619?api-version=2021-11-01",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "63",
         "Content-Type": "application/json",
-        "traceparent": "00-d88189f32329e341bb266c68c4da4620-d714539b34d6bb4d-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "c526f5ee98fa4c6ce63892eed154c405",
+        "traceparent": "00-57fa551da1f9034c9b73bf1d9b27837b-3760f767f4ae0e47-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "7bef7f1328a25a5e05d570375a2ce0f4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -1072,7 +816,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "754",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:31:26 GMT",
+        "Date": "Wed, 12 Oct 2022 07:10:31 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1082,11 +826,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "c526f5ee98fa4c6ce63892eed154c405",
-        "x-ms-correlation-request-id": "d5f283f0-549d-4d81-b87e-50b05598ae59",
-        "x-ms-ratelimit-remaining-subscription-resource-requests": "49",
-        "x-ms-request-id": "f7eb3f8d-2c0e-4822-ba43-19c732445e15_M11CH3_M11CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T163126Z:d5f283f0-549d-4d81-b87e-50b05598ae59"
+        "x-ms-client-request-id": "7bef7f1328a25a5e05d570375a2ce0f4",
+        "x-ms-correlation-request-id": "45a31896-258f-439a-a339-6eec9306679f",
+        "x-ms-ratelimit-remaining-subscription-resource-requests": "44",
+        "x-ms-request-id": "8669d88a-1bea-4248-8c4b-ff0989df186b_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T071031Z:45a31896-258f-439a-a339-6eec9306679f"
       },
       "ResponseBody": {
         "sku": {
@@ -1094,8 +838,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252",
-        "name": "testnamespacemgmt8252",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619",
+        "name": "testnamespacemgmt4619",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {
@@ -1108,32 +852,32 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Updating",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt8252",
-          "createdAt": "2022-10-11T16:19:53.757Z",
-          "updatedAt": "2022-10-11T16:31:23.077Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8252.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4619",
+          "createdAt": "2022-10-12T07:09:12.843Z",
+          "updatedAt": "2022-10-12T07:10:28.183Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4619.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-51784a528a72a84eb638375a013eea53-b0b15b1bc07efb40-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "3975356b7962b4c023bca668ff21734b",
+        "traceparent": "00-b702d9e28627aa468943ed6f5ed8caf3-5fd9f49f7d89c34c-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "18fc5be0215175e7e640da4e9897489a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "750",
+        "Content-Length": "754",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:31:36 GMT",
+        "Date": "Wed, 12 Oct 2022 07:10:31 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1143,11 +887,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "3975356b7962b4c023bca668ff21734b",
-        "x-ms-correlation-request-id": "9903148a-2433-46ea-9baa-c7bd07a7b086",
-        "x-ms-ratelimit-remaining-subscription-reads": "11999",
-        "x-ms-request-id": "38873e04-2a0f-4801-bf2d-9cbafd40f6f6_M11CH3_M11CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T163137Z:9903148a-2433-46ea-9baa-c7bd07a7b086"
+        "x-ms-client-request-id": "18fc5be0215175e7e640da4e9897489a",
+        "x-ms-correlation-request-id": "331f459d-8992-4142-b1ff-ca6786a643bb",
+        "x-ms-ratelimit-remaining-subscription-reads": "11974",
+        "x-ms-request-id": "2b39b065-8d57-4e45-9c4c-ef22cfe7dd37_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T071032Z:331f459d-8992-4142-b1ff-ca6786a643bb"
       },
       "ResponseBody": {
         "sku": {
@@ -1155,8 +899,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-2102/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8252",
-        "name": "testnamespacemgmt8252",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619",
+        "name": "testnamespacemgmt4619",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {
@@ -1168,11 +912,325 @@
           "isAutoInflateEnabled": false,
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
+          "provisioningState": "Updating",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4619",
+          "createdAt": "2022-10-12T07:09:12.843Z",
+          "updatedAt": "2022-10-12T07:10:28.183Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4619.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619?api-version=2021-11-01",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "79",
+        "Content-Type": "application/json",
+        "traceparent": "00-b702d9e28627aa468943ed6f5ed8caf3-1f92f23fca7a2d44-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "47073351d307ae170249dac90effd467",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        },
+        "location": "eastus2",
+        "properties": {}
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "770",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:10:36 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "47073351d307ae170249dac90effd467",
+        "x-ms-correlation-request-id": "660ea321-60e5-40a5-b915-2107b8e23014",
+        "x-ms-ratelimit-remaining-subscription-resource-requests": "43",
+        "x-ms-request-id": "9e460ab5-bc55-4c0b-9e2c-95767de11cff_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T071036Z:660ea321-60e5-40a5-b915-2107b8e23014"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619",
+        "name": "testnamespacemgmt4619",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        },
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Updating",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4619",
+          "createdAt": "2022-10-12T07:09:12.843Z",
+          "updatedAt": "2022-10-12T07:10:34.887Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4619.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c43fcc529b5f3647938241fa7d2cdfee-198de56303bdd240-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c0a8427df0ddf15d987a95624d10c26e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "770",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:10:36 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "c0a8427df0ddf15d987a95624d10c26e",
+        "x-ms-correlation-request-id": "a0629664-241d-4530-be96-dfa46eb1c87c",
+        "x-ms-ratelimit-remaining-subscription-reads": "11973",
+        "x-ms-request-id": "f325c5a1-cc55-46ac-ab76-77b4323b6dd0_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T071037Z:a0629664-241d-4530-be96-dfa46eb1c87c"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619",
+        "name": "testnamespacemgmt4619",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        },
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Updating",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4619",
+          "createdAt": "2022-10-12T07:09:12.843Z",
+          "updatedAt": "2022-10-12T07:10:34.887Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4619.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619?api-version=2021-11-01",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "63",
+        "Content-Type": "application/json",
+        "traceparent": "00-c43fcc529b5f3647938241fa7d2cdfee-57c0e1ff0a24ca44-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "27e6d68c98250cec444d1508461e66e6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "tags": {
+          "key2": "value2"
+        },
+        "location": "eastus2",
+        "properties": {}
+      },
+      "StatusCode": 429,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Connection": "close",
+        "Content-Length": "192",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:10:37 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Retry-After": "200",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "27e6d68c98250cec444d1508461e66e6",
+        "x-ms-correlation-request-id": "e5682d88-a838-4a32-9e81-2cbae29fa782",
+        "x-ms-ratelimit-remaining-subscription-resource-requests": "42",
+        "x-ms-request-id": "ae95bf13-4930-4bbe-99a5-e68b0b5b3fe6_M1CH3_M1CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T071037Z:e5682d88-a838-4a32-9e81-2cbae29fa782"
+      },
+      "ResponseBody": {
+        "error": {
+          "message": "Namespace provisioning in transition. For more information visit https://aka.ms/eventhubsarmexceptions. CorrelationId: e5682d88-a838-4a32-9e81-2cbae29fa782",
+          "code": "429"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619?api-version=2021-11-01",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Content-Length": "63",
+        "Content-Type": "application/json",
+        "traceparent": "00-c43fcc529b5f3647938241fa7d2cdfee-57c0e1ff0a24ca44-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "27e6d68c98250cec444d1508461e66e6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "tags": {
+          "key2": "value2"
+        },
+        "location": "eastus2",
+        "properties": {}
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "754",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:14:02 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "27e6d68c98250cec444d1508461e66e6",
+        "x-ms-correlation-request-id": "583c173c-f11a-4443-8728-c458a2db277c",
+        "x-ms-ratelimit-remaining-subscription-resource-requests": "49",
+        "x-ms-request-id": "b9db85e6-b418-4753-8c4f-8ed5c358eca5_M9CH3_M9CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T071403Z:583c173c-f11a-4443-8728-c458a2db277c"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619",
+        "name": "testnamespacemgmt4619",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {
+          "key2": "value2"
+        },
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Updating",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4619",
+          "createdAt": "2022-10-12T07:09:12.843Z",
+          "updatedAt": "2022-10-12T07:14:00.333Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4619.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fa7725ac1af99a43a571a72a138c2daf-b6af496a98bb8145-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "56d0736c88ef61bdd615af8d3eb461f2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "751",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:14:14 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "56d0736c88ef61bdd615af8d3eb461f2",
+        "x-ms-correlation-request-id": "d33b6001-5c5f-4285-9716-54ea2dea9284",
+        "x-ms-ratelimit-remaining-subscription-reads": "11999",
+        "x-ms-request-id": "4d60c817-9b44-4709-91db-50c891a5f09b_M2CH3_M2CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T071415Z:d33b6001-5c5f-4285-9716-54ea2dea9284"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4955/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4619",
+        "name": "testnamespacemgmt4619",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {
+          "key2": "value2"
+        },
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
           "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt8252",
-          "createdAt": "2022-10-11T16:19:53.757Z",
-          "updatedAt": "2022-10-11T16:31:25.88Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt8252.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt4619",
+          "createdAt": "2022-10-12T07:09:12.843Z",
+          "updatedAt": "2022-10-12T07:14:03.763Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt4619.servicebus.windows.net:443/",
           "status": "Active"
         }
       }
@@ -1180,8 +1238,8 @@
   ],
   "Variables": {
     "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "361499140",
+    "RandomSeed": "75192365",
     "RESOURCE_MANAGER_URL": null,
-    "SUBSCRIPTION_ID": "326100e2-f69d-4268-8503-075374f62b6e"
+    "SUBSCRIPTION_ID": "db1ab6f0-4769-4b27-930e-01e2ef9c123c"
   }
 }

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventHubNamespaceTests/AddSetRemoveTag(True).json
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventHubNamespaceTests/AddSetRemoveTag(True).json
@@ -1,43 +1,53 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e?api-version=2021-01-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c?api-version=2021-01-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-80f6fc22dd3ae645a99b83e219ff68b0-5cd7877ff7128843-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "3976b51e99a0b06ce122ddb7310bc7c7",
+        "Connection": "keep-alive",
+        "traceparent": "00-12c0800c6d2b0b4ea5bff2cb0692ca65-ce1c670f24c6944e-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "75e9b3e5d75bbdc5b9d850a174e3fb6b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "460",
+        "Content-Length": "747",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:37 GMT",
+        "Date": "Wed, 12 Oct 2022 07:51:38 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "00107623-76f3-42a3-8b8e-1f754ba4ae9d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11981",
-        "x-ms-request-id": "00107623-76f3-42a3-8b8e-1f754ba4ae9d",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160838Z:00107623-76f3-42a3-8b8e-1f754ba4ae9d"
+        "x-ms-correlation-request-id": "836189a9-ec19-43f9-8233-2b813b8decf0",
+        "x-ms-ratelimit-remaining-subscription-reads": "11998",
+        "x-ms-request-id": "836189a9-ec19-43f9-8233-2b813b8decf0",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075138Z:836189a9-ec19-43f9-8233-2b813b8decf0"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "authorizationSource": "RoleBased",
-        "managedByTenants": [
-          {
-            "tenantId": "2f4a9838-26b7-47ee-be60-ccc1fdec5953"
-          }
-        ],
-        "subscriptionId": "326100e2-f69d-4268-8503-075374f62b6e",
+        "managedByTenants": [],
+        "tags": {
+          "TagKey-9823": "TagValue-566",
+          "TagKey-3481": "TagValue-320",
+          "TagKey-4926": "TagValue-1187",
+          "TagKey-751": "TagValue-3921",
+          "TagKey-1866": "TagValue-8559",
+          "TagKey-3094": "TagValue-9190",
+          "TagKey-2449": "TagValue-9",
+          "TagKey-8379": "TagValue-164",
+          "TagKey-7470": "TagValue-2205",
+          "TagKey-4236": "TagValue-3698",
+          "TagKey-5316": "TagValue-2725"
+        },
+        "subscriptionId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-        "displayName": "Azure Messaging PM Playground",
+        "displayName": ".NET Mgmt SDK Test with TTL = 1 Day",
         "state": "Enabled",
         "subscriptionPolicies": {
           "locationPlacementId": "Internal_2014-09-01",
@@ -47,16 +57,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourcegroups/testeventhubRG-707?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourcegroups/testeventhubRG-6684?api-version=2021-04-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "44",
         "Content-Type": "application/json",
-        "traceparent": "00-c7524919532b5f4dbb1088c39a328cca-fa9f6bb4fc6f9f48-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "67eef26bc2c581b0a28f8750d032c82f",
+        "traceparent": "00-73f9ab76907b6f4194b1f5e1ef5d005f-f4f25848913ea444-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c47f217b6c646a731d3217a882adf344",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -68,21 +78,21 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "256",
+        "Content-Length": "258",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:39 GMT",
+        "Date": "Wed, 12 Oct 2022 07:51:42 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "10224473-98bf-4062-a768-975510480f69",
-        "x-ms-ratelimit-remaining-subscription-writes": "1195",
-        "x-ms-request-id": "10224473-98bf-4062-a768-975510480f69",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160839Z:10224473-98bf-4062-a768-975510480f69"
+        "x-ms-correlation-request-id": "02070323-f091-447c-ba5a-17285b8b7a14",
+        "x-ms-ratelimit-remaining-subscription-writes": "1199",
+        "x-ms-request-id": "02070323-f091-447c-ba5a-17285b8b7a14",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075142Z:02070323-f091-447c-ba5a-17285b8b7a14"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707",
-        "name": "testeventhubRG-707",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684",
+        "name": "testeventhubRG-6684",
         "type": "Microsoft.Resources/resourceGroups",
         "location": "eastus2",
         "tags": {
@@ -94,27 +104,27 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/providers/Microsoft.EventHub/checkNameAvailability?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.EventHub/checkNameAvailability?api-version=2021-11-01",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "32",
         "Content-Type": "application/json",
-        "traceparent": "00-48e514496206fa4db3a051a16e18ecdc-d6092c5a08892443-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "ce1885a9b468d27f16dd1780bf013575",
+        "traceparent": "00-6330b7e6f6c5054593e49ae81b3dbb11-8c5963cbd544794c-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "705d11a33f9e8e865c311cc8b665ce47",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "testnamespacemgmt1985"
+        "name": "testnamespacemgmt8243"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "53",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:39 GMT",
+        "Date": "Wed, 12 Oct 2022 07:51:43 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -124,11 +134,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "ce1885a9b468d27f16dd1780bf013575",
-        "x-ms-correlation-request-id": "bcb38b37-74db-4426-8d9d-99e78ca9a441",
-        "x-ms-ratelimit-remaining-subscription-writes": "1198",
-        "x-ms-request-id": "2a2f24ae-d408-46c8-a2a9-84e1eaa0ef02_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160840Z:bcb38b37-74db-4426-8d9d-99e78ca9a441"
+        "x-ms-client-request-id": "705d11a33f9e8e865c311cc8b665ce47",
+        "x-ms-correlation-request-id": "8bfaaeac-08f2-47a8-b751-7aad83e26359",
+        "x-ms-ratelimit-remaining-subscription-writes": "1199",
+        "x-ms-request-id": "4603cd47-0d6e-46f3-a490-72db73f80860_M7CH3_M7CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075143Z:8bfaaeac-08f2-47a8-b751-7aad83e26359"
       },
       "ResponseBody": {
         "nameAvailable": true,
@@ -137,16 +147,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243?api-version=2021-11-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "48",
         "Content-Type": "application/json",
-        "traceparent": "00-557fc767d953ab4c8c4b4cf76dd409d3-1738ba5d32ad0b47-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "0d1aa9515995c6f3b8fe0ae45f11f014",
+        "traceparent": "00-213d00f4c39f24469317ed781bce31d6-47703c858fca4a45-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c0242534813d75470b3da5ad15362a5c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -157,9 +167,9 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "737",
+        "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:44 GMT",
+        "Date": "Wed, 12 Oct 2022 07:51:50 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -169,11 +179,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "0d1aa9515995c6f3b8fe0ae45f11f014",
-        "x-ms-correlation-request-id": "38ffa5e3-3dca-4448-95f2-03262f7536b6",
-        "x-ms-ratelimit-remaining-subscription-resource-requests": "48",
-        "x-ms-request-id": "f160f8df-5816-4c00-a7cd-dc9fc1a15778_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160845Z:38ffa5e3-3dca-4448-95f2-03262f7536b6"
+        "x-ms-client-request-id": "c0242534813d75470b3da5ad15362a5c",
+        "x-ms-correlation-request-id": "7c8942d0-75f0-4b0a-a0aa-afbd14f192ca",
+        "x-ms-ratelimit-remaining-subscription-resource-requests": "49",
+        "x-ms-request-id": "2bb3ebdf-999d-4dec-93b3-fc33cbc11c37_M7CH3_M7CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075151Z:7c8942d0-75f0-4b0a-a0aa-afbd14f192ca"
       },
       "ResponseBody": {
         "sku": {
@@ -181,8 +191,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985",
-        "name": "testnamespacemgmt1985",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243",
+        "name": "testnamespacemgmt8243",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -193,31 +203,31 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1985",
-          "createdAt": "2022-10-11T16:08:43.307Z",
-          "updatedAt": "2022-10-11T16:08:43.307Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1985.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8243",
+          "createdAt": "2022-10-12T07:51:49.297Z",
+          "updatedAt": "2022-10-12T07:51:49.297Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8243.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-557fc767d953ab4c8c4b4cf76dd409d3-fce2dd3688895c48-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "887fda5222ae50379252166aa99b7205",
+        "traceparent": "00-213d00f4c39f24469317ed781bce31d6-fc7b025acb90284e-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "884e614983ce22c4cae864609ad87926",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "737",
+        "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:45 GMT",
+        "Date": "Wed, 12 Oct 2022 07:51:50 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -227,11 +237,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "887fda5222ae50379252166aa99b7205",
-        "x-ms-correlation-request-id": "87bdf6b8-e77e-4d92-bed5-0f1d5dfb6262",
-        "x-ms-ratelimit-remaining-subscription-reads": "11980",
-        "x-ms-request-id": "fa6ce788-a94a-4f24-9c58-998a152e7b22_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160846Z:87bdf6b8-e77e-4d92-bed5-0f1d5dfb6262"
+        "x-ms-client-request-id": "884e614983ce22c4cae864609ad87926",
+        "x-ms-correlation-request-id": "35056699-f34e-417d-8b1a-619b8608bc29",
+        "x-ms-ratelimit-remaining-subscription-reads": "11997",
+        "x-ms-request-id": "ecf1f9a1-6ff9-49a1-929a-dcc0faeb1bc3_M7CH3_M7CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075151Z:35056699-f34e-417d-8b1a-619b8608bc29"
       },
       "ResponseBody": {
         "sku": {
@@ -239,8 +249,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985",
-        "name": "testnamespacemgmt1985",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243",
+        "name": "testnamespacemgmt8243",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -251,31 +261,31 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1985",
-          "createdAt": "2022-10-11T16:08:43.307Z",
-          "updatedAt": "2022-10-11T16:08:43.307Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1985.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8243",
+          "createdAt": "2022-10-12T07:51:49.297Z",
+          "updatedAt": "2022-10-12T07:51:49.297Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8243.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-557fc767d953ab4c8c4b4cf76dd409d3-2c6df4ca2c85fa49-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "5bf803ecf39fc8c6a7dc9e00aa0e2db7",
+        "traceparent": "00-213d00f4c39f24469317ed781bce31d6-43259fbbdada7247-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "436bbf06e4253f394742c706790b1f69",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "737",
+        "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:47 GMT",
+        "Date": "Wed, 12 Oct 2022 07:51:52 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -285,11 +295,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5bf803ecf39fc8c6a7dc9e00aa0e2db7",
-        "x-ms-correlation-request-id": "7905ce34-4994-44a2-af77-a41a39896aab",
-        "x-ms-ratelimit-remaining-subscription-reads": "11979",
-        "x-ms-request-id": "239551f5-e82d-42a5-b89c-9855d8f5fa96_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160848Z:7905ce34-4994-44a2-af77-a41a39896aab"
+        "x-ms-client-request-id": "436bbf06e4253f394742c706790b1f69",
+        "x-ms-correlation-request-id": "6dc5a390-5c80-41d0-a125-17dd67779a87",
+        "x-ms-ratelimit-remaining-subscription-reads": "11996",
+        "x-ms-request-id": "eb629077-a93b-40f1-8fc4-a502c7c79831_M7CH3_M7CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075153Z:6dc5a390-5c80-41d0-a125-17dd67779a87"
       },
       "ResponseBody": {
         "sku": {
@@ -297,8 +307,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985",
-        "name": "testnamespacemgmt1985",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243",
+        "name": "testnamespacemgmt8243",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -309,31 +319,31 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1985",
-          "createdAt": "2022-10-11T16:08:43.307Z",
-          "updatedAt": "2022-10-11T16:08:43.307Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1985.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8243",
+          "createdAt": "2022-10-12T07:51:49.297Z",
+          "updatedAt": "2022-10-12T07:51:49.297Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8243.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-557fc767d953ab4c8c4b4cf76dd409d3-200a02f2cedac84c-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "85917c1b679265662c10ae5c729894d3",
+        "traceparent": "00-213d00f4c39f24469317ed781bce31d6-e8d17b173877dd42-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b364d8d6a2e7d98ead1d2025907d4720",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "737",
+        "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:49 GMT",
+        "Date": "Wed, 12 Oct 2022 07:51:53 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -343,11 +353,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "85917c1b679265662c10ae5c729894d3",
-        "x-ms-correlation-request-id": "46211bc8-30da-4090-8f22-dffb6aa3ad4b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11978",
-        "x-ms-request-id": "80fe1841-ea15-42ee-93a8-3424c950c1ca_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160850Z:46211bc8-30da-4090-8f22-dffb6aa3ad4b"
+        "x-ms-client-request-id": "b364d8d6a2e7d98ead1d2025907d4720",
+        "x-ms-correlation-request-id": "79d14116-cf08-41aa-b1c1-f6620a5d5a71",
+        "x-ms-ratelimit-remaining-subscription-reads": "11995",
+        "x-ms-request-id": "3c16ac86-06ac-4cae-b307-950e9d9b89c3_M7CH3_M7CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075154Z:79d14116-cf08-41aa-b1c1-f6620a5d5a71"
       },
       "ResponseBody": {
         "sku": {
@@ -355,8 +365,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985",
-        "name": "testnamespacemgmt1985",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243",
+        "name": "testnamespacemgmt8243",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -367,31 +377,31 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1985",
-          "createdAt": "2022-10-11T16:08:43.307Z",
-          "updatedAt": "2022-10-11T16:08:43.307Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1985.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8243",
+          "createdAt": "2022-10-12T07:51:49.297Z",
+          "updatedAt": "2022-10-12T07:51:49.297Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8243.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-557fc767d953ab4c8c4b4cf76dd409d3-aaffc966c0b78c4d-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "95f7a92286085fee14b6e1d28337a684",
+        "traceparent": "00-213d00f4c39f24469317ed781bce31d6-5002acf450317f41-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "9634e1bd233665a7270f408bbbbda9be",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "737",
+        "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:51 GMT",
+        "Date": "Wed, 12 Oct 2022 07:51:56 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -401,11 +411,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "95f7a92286085fee14b6e1d28337a684",
-        "x-ms-correlation-request-id": "780651dd-5b7d-4954-af2f-9d782f5c24b2",
-        "x-ms-ratelimit-remaining-subscription-reads": "11977",
-        "x-ms-request-id": "578873ec-db4c-4ecf-89cb-31904619df94_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160851Z:780651dd-5b7d-4954-af2f-9d782f5c24b2"
+        "x-ms-client-request-id": "9634e1bd233665a7270f408bbbbda9be",
+        "x-ms-correlation-request-id": "fd4ce959-afd8-4866-a4a4-627b68ca5f83",
+        "x-ms-ratelimit-remaining-subscription-reads": "11994",
+        "x-ms-request-id": "78326624-1c3c-4aca-b2c1-7210c6b7c3ee_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075157Z:fd4ce959-afd8-4866-a4a4-627b68ca5f83"
       },
       "ResponseBody": {
         "sku": {
@@ -413,8 +423,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985",
-        "name": "testnamespacemgmt1985",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243",
+        "name": "testnamespacemgmt8243",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -425,31 +435,31 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1985",
-          "createdAt": "2022-10-11T16:08:43.307Z",
-          "updatedAt": "2022-10-11T16:08:43.307Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1985.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8243",
+          "createdAt": "2022-10-12T07:51:49.297Z",
+          "updatedAt": "2022-10-12T07:51:49.297Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8243.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-557fc767d953ab4c8c4b4cf76dd409d3-0989d68b514bdc46-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "2d4e5e24ed0985739c922f8f4469550e",
+        "traceparent": "00-213d00f4c39f24469317ed781bce31d6-b0ef1a6108677e42-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c28afbc8c574633e31929608c313aeca",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "737",
+        "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:54 GMT",
+        "Date": "Wed, 12 Oct 2022 07:51:59 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -459,11 +469,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "2d4e5e24ed0985739c922f8f4469550e",
-        "x-ms-correlation-request-id": "7e303206-cca1-478a-aff9-fced669c1ddd",
-        "x-ms-ratelimit-remaining-subscription-reads": "11976",
-        "x-ms-request-id": "a21456c5-df28-4f06-b848-be01fe9d2d9d_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160854Z:7e303206-cca1-478a-aff9-fced669c1ddd"
+        "x-ms-client-request-id": "c28afbc8c574633e31929608c313aeca",
+        "x-ms-correlation-request-id": "a5fcf43e-e80f-422a-9b1e-834035ed8c2f",
+        "x-ms-ratelimit-remaining-subscription-reads": "11993",
+        "x-ms-request-id": "1382ad1d-7d0a-4e5c-8fc5-3e084112a730_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075159Z:a5fcf43e-e80f-422a-9b1e-834035ed8c2f"
       },
       "ResponseBody": {
         "sku": {
@@ -471,8 +481,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985",
-        "name": "testnamespacemgmt1985",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243",
+        "name": "testnamespacemgmt8243",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -483,31 +493,31 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1985",
-          "createdAt": "2022-10-11T16:08:43.307Z",
-          "updatedAt": "2022-10-11T16:08:43.307Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1985.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8243",
+          "createdAt": "2022-10-12T07:51:49.297Z",
+          "updatedAt": "2022-10-12T07:51:49.297Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8243.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-557fc767d953ab4c8c4b4cf76dd409d3-759e515415e42444-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "00ddcb47971695af8e3270db8694e2f5",
+        "traceparent": "00-213d00f4c39f24469317ed781bce31d6-af61ee9614c2c945-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "9749a7fb88d6b23331ff8bd862021def",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "737",
+        "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:58 GMT",
+        "Date": "Wed, 12 Oct 2022 07:52:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -517,11 +527,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "00ddcb47971695af8e3270db8694e2f5",
-        "x-ms-correlation-request-id": "fb013dcb-3c9e-454d-a8da-fafc47c672d0",
-        "x-ms-ratelimit-remaining-subscription-reads": "11975",
-        "x-ms-request-id": "ee9ee776-67a3-4486-b1b5-00b2830d1a1c_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160859Z:fb013dcb-3c9e-454d-a8da-fafc47c672d0"
+        "x-ms-client-request-id": "9749a7fb88d6b23331ff8bd862021def",
+        "x-ms-correlation-request-id": "a1da3389-8681-45a0-a98f-8ec0634b55a4",
+        "x-ms-ratelimit-remaining-subscription-reads": "11992",
+        "x-ms-request-id": "9ea76711-b2a5-48ac-8ba3-0645872bd19d_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075204Z:a1da3389-8681-45a0-a98f-8ec0634b55a4"
       },
       "ResponseBody": {
         "sku": {
@@ -529,8 +539,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985",
-        "name": "testnamespacemgmt1985",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243",
+        "name": "testnamespacemgmt8243",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -541,31 +551,31 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1985",
-          "createdAt": "2022-10-11T16:08:43.307Z",
-          "updatedAt": "2022-10-11T16:08:43.307Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1985.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8243",
+          "createdAt": "2022-10-12T07:51:49.297Z",
+          "updatedAt": "2022-10-12T07:51:49.297Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8243.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-557fc767d953ab4c8c4b4cf76dd409d3-88fa453edb6b2c4e-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "14372a69664935c93672f975575e1aab",
+        "traceparent": "00-213d00f4c39f24469317ed781bce31d6-26552fc987d98341-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "955d617384f2f7aba3d064a48d9ea114",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "737",
+        "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:09:07 GMT",
+        "Date": "Wed, 12 Oct 2022 07:52:12 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -575,11 +585,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "14372a69664935c93672f975575e1aab",
-        "x-ms-correlation-request-id": "ffba7d4a-de7f-46c7-8e51-ac5c7d7e1295",
-        "x-ms-ratelimit-remaining-subscription-reads": "11974",
-        "x-ms-request-id": "263d8600-5613-4d7b-a35c-60efa8c67f88_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160908Z:ffba7d4a-de7f-46c7-8e51-ac5c7d7e1295"
+        "x-ms-client-request-id": "955d617384f2f7aba3d064a48d9ea114",
+        "x-ms-correlation-request-id": "72cad4ef-a8d2-48b1-b1d3-51b84fd537a2",
+        "x-ms-ratelimit-remaining-subscription-reads": "11991",
+        "x-ms-request-id": "0bca7423-47b6-4c56-b824-7c607b4f33ee_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075212Z:72cad4ef-a8d2-48b1-b1d3-51b84fd537a2"
       },
       "ResponseBody": {
         "sku": {
@@ -587,8 +597,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985",
-        "name": "testnamespacemgmt1985",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243",
+        "name": "testnamespacemgmt8243",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -599,31 +609,31 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1985",
-          "createdAt": "2022-10-11T16:08:43.307Z",
-          "updatedAt": "2022-10-11T16:08:43.307Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1985.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8243",
+          "createdAt": "2022-10-12T07:51:49.297Z",
+          "updatedAt": "2022-10-12T07:51:49.297Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8243.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-557fc767d953ab4c8c4b4cf76dd409d3-5649cb3099ade44b-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "b78ad261a6598d6dafb99fd67c98fe08",
+        "traceparent": "00-213d00f4c39f24469317ed781bce31d6-0ecc2bc37b9dfc43-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "138f756012733fe7c8d791753966012f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "737",
+        "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:09:23 GMT",
+        "Date": "Wed, 12 Oct 2022 07:52:29 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -633,11 +643,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "b78ad261a6598d6dafb99fd67c98fe08",
-        "x-ms-correlation-request-id": "d0701544-6fbe-470e-9751-bce7735eb8b5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11973",
-        "x-ms-request-id": "b2a0cca5-6533-42e7-92a5-763492df0a00_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160924Z:d0701544-6fbe-470e-9751-bce7735eb8b5"
+        "x-ms-client-request-id": "138f756012733fe7c8d791753966012f",
+        "x-ms-correlation-request-id": "bbf29b1a-584a-4be0-9d7c-1944f291a76d",
+        "x-ms-ratelimit-remaining-subscription-reads": "11990",
+        "x-ms-request-id": "085f9c80-06b8-4e5a-ac1e-3f95d72c0dba_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075230Z:bbf29b1a-584a-4be0-9d7c-1944f291a76d"
       },
       "ResponseBody": {
         "sku": {
@@ -645,8 +655,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985",
-        "name": "testnamespacemgmt1985",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243",
+        "name": "testnamespacemgmt8243",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -657,22 +667,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1985",
-          "createdAt": "2022-10-11T16:08:43.307Z",
-          "updatedAt": "2022-10-11T16:08:43.307Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1985.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8243",
+          "createdAt": "2022-10-12T07:51:49.297Z",
+          "updatedAt": "2022-10-12T07:51:49.297Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8243.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-557fc767d953ab4c8c4b4cf76dd409d3-7b1330d5a1094041-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "19253ab04131e0c401a7caa39e3a3d2f",
+        "traceparent": "00-213d00f4c39f24469317ed781bce31d6-48e60f2729b0b141-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6295a67419b677d7fb52f306238e2492",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -681,7 +691,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "735",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:09:56 GMT",
+        "Date": "Wed, 12 Oct 2022 07:53:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -691,11 +701,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "19253ab04131e0c401a7caa39e3a3d2f",
-        "x-ms-correlation-request-id": "929e5b17-ab88-4410-86ee-566ce2b5830d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11972",
-        "x-ms-request-id": "45f20f48-4a26-405a-9c00-525376993cfe_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160957Z:929e5b17-ab88-4410-86ee-566ce2b5830d"
+        "x-ms-client-request-id": "6295a67419b677d7fb52f306238e2492",
+        "x-ms-correlation-request-id": "51e849a9-1be3-4929-88d7-ac939c5c472a",
+        "x-ms-ratelimit-remaining-subscription-reads": "11989",
+        "x-ms-request-id": "e941e859-20bd-4d49-b7a0-66e8a1d6de14_M2CH3_M2CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075304Z:51e849a9-1be3-4929-88d7-ac939c5c472a"
       },
       "ResponseBody": {
         "sku": {
@@ -703,8 +713,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985",
-        "name": "testnamespacemgmt1985",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243",
+        "name": "testnamespacemgmt8243",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -715,43 +725,43 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1985",
-          "createdAt": "2022-10-11T16:08:43.307Z",
-          "updatedAt": "2022-10-11T16:09:32.487Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1985.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8243",
+          "createdAt": "2022-10-12T07:51:49.297Z",
+          "updatedAt": "2022-10-12T07:52:43.51Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8243.servicebus.windows.net:443/",
           "status": "Active"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-95c015b0894b3044b892cf64881569be-9de1585e5e4c4149-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "b37ac4182a09c39bbcaa6490c7f3b89e",
+        "traceparent": "00-93f7bc4340e1b745810cf926ca392cf0-89d407ee7b111344-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ec77775d0972607c791dcc1bf336be3d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "275",
+        "Content-Length": "276",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:09:56 GMT",
+        "Date": "Wed, 12 Oct 2022 07:53:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "e9a59b14-bed8-415e-8dc1-a40ba6f8678a",
-        "x-ms-ratelimit-remaining-subscription-reads": "11971",
-        "x-ms-request-id": "e9a59b14-bed8-415e-8dc1-a40ba6f8678a",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160957Z:e9a59b14-bed8-415e-8dc1-a40ba6f8678a"
+        "x-ms-correlation-request-id": "3c28c918-4bc0-4ced-9130-2882c836ec75",
+        "x-ms-ratelimit-remaining-subscription-reads": "11988",
+        "x-ms-request-id": "3c28c918-4bc0-4ced-9130-2882c836ec75",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075304Z:3c28c918-4bc0-4ced-9130-2882c836ec75"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985/providers/Microsoft.Resources/tags/default",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243/providers/Microsoft.Resources/tags/default",
         "name": "default",
         "type": "Microsoft.Resources/tags",
         "properties": {
@@ -760,69 +770,69 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "43",
+        "Content-Length": "41",
         "Content-Type": "application/json",
-        "traceparent": "00-95c015b0894b3044b892cf64881569be-5b252b06412e7544-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "1dc4f07300381f7a0daab6b2dcc9ee75",
+        "traceparent": "00-93f7bc4340e1b745810cf926ca392cf0-6b7fea398dcfeb45-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "e73035cf3e09475e9e1818211fe11c39",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "properties": {
           "tags": {
-            "key": "Sanitized"
+            "key1": "value1"
           }
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "292",
+        "Content-Length": "291",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:10:00 GMT",
+        "Date": "Wed, 12 Oct 2022 07:53:08 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "743932da-dc14-462c-9838-8970a62a7249",
-        "x-ms-ratelimit-remaining-subscription-writes": "1194",
-        "x-ms-request-id": "743932da-dc14-462c-9838-8970a62a7249",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161000Z:743932da-dc14-462c-9838-8970a62a7249"
+        "x-ms-correlation-request-id": "08549f00-20ca-4c7a-a459-5403b72ac21a",
+        "x-ms-ratelimit-remaining-subscription-writes": "1198",
+        "x-ms-request-id": "08549f00-20ca-4c7a-a459-5403b72ac21a",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075308Z:08549f00-20ca-4c7a-a459-5403b72ac21a"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985/providers/Microsoft.Resources/tags/default",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243/providers/Microsoft.Resources/tags/default",
         "name": "default",
         "type": "Microsoft.Resources/tags",
         "properties": {
           "tags": {
-            "key": "Sanitized"
+            "key1": "value1"
           }
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-95c015b0894b3044b892cf64881569be-9f7f4d8bf7f5b74b-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "b8be6f7b4b1d85ff9e625d86dc34180e",
+        "traceparent": "00-93f7bc4340e1b745810cf926ca392cf0-39b78244e1559346-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c117feb314ee6abc2934e9984cbc83c4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "754",
+        "Content-Length": "751",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:10:01 GMT",
+        "Date": "Wed, 12 Oct 2022 07:53:10 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -832,11 +842,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "b8be6f7b4b1d85ff9e625d86dc34180e",
-        "x-ms-correlation-request-id": "240bd6bf-27b8-4314-8bd0-8e7a93ecc8a3",
-        "x-ms-ratelimit-remaining-subscription-reads": "11970",
-        "x-ms-request-id": "c88a5aea-f59f-4932-9b58-c953630278ff_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161001Z:240bd6bf-27b8-4314-8bd0-8e7a93ecc8a3"
+        "x-ms-client-request-id": "c117feb314ee6abc2934e9984cbc83c4",
+        "x-ms-correlation-request-id": "235d20e1-df1f-4709-8e46-5c4bb5a11495",
+        "x-ms-ratelimit-remaining-subscription-reads": "11987",
+        "x-ms-request-id": "d555e5c0-70f9-45a9-9f38-a380ba3b3767_M10CH3_M10CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075310Z:235d20e1-df1f-4709-8e46-5c4bb5a11495"
       },
       "ResponseBody": {
         "sku": {
@@ -844,12 +854,12 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985",
-        "name": "testnamespacemgmt1985",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243",
+        "name": "testnamespacemgmt8243",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {
-          "key": "Sanitized"
+          "key1": "value1"
         },
         "properties": {
           "disableLocalAuth": false,
@@ -857,24 +867,24 @@
           "isAutoInflateEnabled": false,
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
-          "provisioningState": "Updating",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1985",
-          "createdAt": "2022-10-11T16:08:43.307Z",
-          "updatedAt": "2022-10-11T16:09:58.71Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1985.servicebus.windows.net:443/",
-          "status": "Activating"
+          "provisioningState": "Succeeded",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8243",
+          "createdAt": "2022-10-12T07:51:49.297Z",
+          "updatedAt": "2022-10-12T07:53:08.277Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8243.servicebus.windows.net:443/",
+          "status": "Active"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f42768a59663fa44b45f623d6ed8b3ce-9e10efc814522c4f-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "ae302bee207517f74a5aa55e74e9e6f3",
+        "traceparent": "00-18e2aa7d0c5ec146928e4df6d6942ba2-99c55f0ec272364e-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ed37b6933c5e1f89192f4e5af15a4198",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -882,47 +892,47 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Tue, 11 Oct 2022 16:10:03 GMT",
+        "Date": "Wed, 12 Oct 2022 07:53:13 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "b2ad74ee-a2ff-4763-924e-613b03d0a400",
-        "x-ms-ratelimit-remaining-subscription-deletes": "14998",
-        "x-ms-request-id": "b2ad74ee-a2ff-4763-924e-613b03d0a400",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161003Z:b2ad74ee-a2ff-4763-924e-613b03d0a400"
+        "x-ms-correlation-request-id": "8f7fa350-a1a5-4b90-ac53-55df182ae43b",
+        "x-ms-ratelimit-remaining-subscription-deletes": "14999",
+        "x-ms-request-id": "8f7fa350-a1a5-4b90-ac53-55df182ae43b",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075313Z:8f7fa350-a1a5-4b90-ac53-55df182ae43b"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f42768a59663fa44b45f623d6ed8b3ce-5de2939081725640-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "5815efbb00342880f03e7ed5a3f342d9",
+        "traceparent": "00-18e2aa7d0c5ec146928e4df6d6942ba2-47ce3e63b68e7d4c-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f4679301fc1fba4e79c5bdd455c5fbe1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "275",
+        "Content-Length": "276",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:10:04 GMT",
+        "Date": "Wed, 12 Oct 2022 07:53:13 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "039057e2-160a-4511-b70e-fcf0313816a3",
-        "x-ms-ratelimit-remaining-subscription-reads": "11969",
-        "x-ms-request-id": "039057e2-160a-4511-b70e-fcf0313816a3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161004Z:039057e2-160a-4511-b70e-fcf0313816a3"
+        "x-ms-correlation-request-id": "628c9193-44b5-4914-aece-c8ec250ed9eb",
+        "x-ms-ratelimit-remaining-subscription-reads": "11986",
+        "x-ms-request-id": "628c9193-44b5-4914-aece-c8ec250ed9eb",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075313Z:628c9193-44b5-4914-aece-c8ec250ed9eb"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985/providers/Microsoft.Resources/tags/default",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243/providers/Microsoft.Resources/tags/default",
         "name": "default",
         "type": "Microsoft.Resources/tags",
         "properties": {
@@ -931,62 +941,62 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "59",
+        "Content-Length": "57",
         "Content-Type": "application/json",
-        "traceparent": "00-f42768a59663fa44b45f623d6ed8b3ce-cd27c9d3821e7f41-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "b0c3a79140995aff78a66dc2a5a011b5",
+        "traceparent": "00-18e2aa7d0c5ec146928e4df6d6942ba2-b41ec59e26c93b41-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "688e53942eaa76da75f7a8bec56178cf",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "properties": {
           "tags": {
-            "key": "Sanitized",
-            "key1": "value1"
+            "key1": "value1",
+            "key2": "value2"
           }
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "308",
+        "Content-Length": "307",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:10:07 GMT",
+        "Date": "Wed, 12 Oct 2022 07:53:17 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "215d9d3a-51e2-483a-974c-a7e1295310a0",
-        "x-ms-ratelimit-remaining-subscription-writes": "1193",
-        "x-ms-request-id": "215d9d3a-51e2-483a-974c-a7e1295310a0",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161007Z:215d9d3a-51e2-483a-974c-a7e1295310a0"
+        "x-ms-correlation-request-id": "f278af10-438c-48fc-99ec-bbbbd0b69909",
+        "x-ms-ratelimit-remaining-subscription-writes": "1197",
+        "x-ms-request-id": "f278af10-438c-48fc-99ec-bbbbd0b69909",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075317Z:f278af10-438c-48fc-99ec-bbbbd0b69909"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985/providers/Microsoft.Resources/tags/default",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243/providers/Microsoft.Resources/tags/default",
         "name": "default",
         "type": "Microsoft.Resources/tags",
         "properties": {
           "tags": {
-            "key": "Sanitized",
-            "key1": "value1"
+            "key1": "value1",
+            "key2": "value2"
           }
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f42768a59663fa44b45f623d6ed8b3ce-fc94cfc4b4883441-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "edcb6a7bc01eeed9ab07bd36a2217356",
+        "traceparent": "00-18e2aa7d0c5ec146928e4df6d6942ba2-21e5c6e38168f144-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b89750f28f5497a4687c74997fb4c953",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -995,7 +1005,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "768",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:10:08 GMT",
+        "Date": "Wed, 12 Oct 2022 07:53:17 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -1005,11 +1015,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "edcb6a7bc01eeed9ab07bd36a2217356",
-        "x-ms-correlation-request-id": "766a613d-07bd-49a3-9e66-eedb0aafdda8",
-        "x-ms-ratelimit-remaining-subscription-reads": "11968",
-        "x-ms-request-id": "6f31ff54-91a2-4838-9328-b81795e6aace_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161008Z:766a613d-07bd-49a3-9e66-eedb0aafdda8"
+        "x-ms-client-request-id": "b89750f28f5497a4687c74997fb4c953",
+        "x-ms-correlation-request-id": "5c19f451-0a59-49ae-a603-853e4f043ec2",
+        "x-ms-ratelimit-remaining-subscription-reads": "11985",
+        "x-ms-request-id": "825af509-8643-4cc6-ab3a-646b8bd0bad3_M2CH3_M2CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075318Z:5c19f451-0a59-49ae-a603-853e4f043ec2"
       },
       "ResponseBody": {
         "sku": {
@@ -1017,159 +1027,13 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985",
-        "name": "testnamespacemgmt1985",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243",
+        "name": "testnamespacemgmt8243",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {
-          "key": "Sanitized",
-          "key1": "value1"
-        },
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1985",
-          "createdAt": "2022-10-11T16:08:43.307Z",
-          "updatedAt": "2022-10-11T16:10:07.707Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1985.servicebus.windows.net:443/",
-          "status": "Active"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-f161163f5706d1449070faeb8b73685b-e1e2873e5dfebf43-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "cccdcc1836267a59efbbe08d92bd8250",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "308",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:10:09 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "c620542b-abfe-459c-b89b-ff3ba1460e91",
-        "x-ms-ratelimit-remaining-subscription-reads": "11967",
-        "x-ms-request-id": "c620542b-abfe-459c-b89b-ff3ba1460e91",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161009Z:c620542b-abfe-459c-b89b-ff3ba1460e91"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985/providers/Microsoft.Resources/tags/default",
-        "name": "default",
-        "type": "Microsoft.Resources/tags",
-        "properties": {
-          "tags": {
-            "key": "Sanitized",
-            "key1": "value1"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "41",
-        "Content-Type": "application/json",
-        "traceparent": "00-f161163f5706d1449070faeb8b73685b-7d109a370d18de40-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "395ac92d5528d0baced4049183c9b856",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "properties": {
-          "tags": {
-            "key1": "value1"
-          }
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "290",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:10:12 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "455d496e-c365-4faf-90f4-a622bdad3975",
-        "x-ms-ratelimit-remaining-subscription-writes": "1192",
-        "x-ms-request-id": "455d496e-c365-4faf-90f4-a622bdad3975",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161012Z:455d496e-c365-4faf-90f4-a622bdad3975"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985/providers/Microsoft.Resources/tags/default",
-        "name": "default",
-        "type": "Microsoft.Resources/tags",
-        "properties": {
-          "tags": {
-            "key1": "value1"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-f161163f5706d1449070faeb8b73685b-bcf216455dc90747-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "d9aa173344d3458e1050fd63e04b5bed",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "752",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:10:13 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d9aa173344d3458e1050fd63e04b5bed",
-        "x-ms-correlation-request-id": "8686deee-9de7-4af9-81dd-1a141e5ef890",
-        "x-ms-ratelimit-remaining-subscription-reads": "11966",
-        "x-ms-request-id": "5a552ade-3f2a-4f8a-80cf-6a6cb307d453_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161013Z:8686deee-9de7-4af9-81dd-1a141e5ef890"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985",
-        "name": "testnamespacemgmt1985",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {
-          "key1": "value1"
+          "key1": "value1",
+          "key2": "value2"
         },
         "properties": {
           "disableLocalAuth": false,
@@ -1178,46 +1042,174 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Updating",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1985",
-          "createdAt": "2022-10-11T16:08:43.307Z",
-          "updatedAt": "2022-10-11T16:10:10.95Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1985.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8243",
+          "createdAt": "2022-10-12T07:51:49.297Z",
+          "updatedAt": "2022-10-12T07:53:15.8Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8243.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-8a77ec88ec3fd34995f995644d632ce0-e3eebb58a30f4b4c-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "d9086d853ac7c32d11fcfe5131c7f726",
+        "traceparent": "00-7b83095c7bd6a04c9ad835fd24bb0100-bab3ef8996bed840-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "9ec56d34d9ccd2edb8f17e28538ff417",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "749",
+        "Content-Length": "307",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:10:24 GMT",
+        "Date": "Wed, 12 Oct 2022 07:53:18 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "b53808d0-81ba-4e4b-9964-330bf6f44ab0",
+        "x-ms-ratelimit-remaining-subscription-reads": "11984",
+        "x-ms-request-id": "b53808d0-81ba-4e4b-9964-330bf6f44ab0",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075318Z:b53808d0-81ba-4e4b-9964-330bf6f44ab0"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243/providers/Microsoft.Resources/tags/default",
+        "name": "default",
+        "type": "Microsoft.Resources/tags",
+        "properties": {
+          "tags": {
+            "key1": "value1",
+            "key2": "value2"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "41",
+        "Content-Type": "application/json",
+        "traceparent": "00-7b83095c7bd6a04c9ad835fd24bb0100-4203f74d5f8dad42-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "04e2ed4d422d058caef7002dba41f7c1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "properties": {
+          "tags": {
+            "key2": "value2"
+          }
+        }
+      },
+      "StatusCode": 429,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Connection": "close",
+        "Content-Length": "249",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:53:19 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "25a0b478-a6d6-4bef-8b11-1376ef2185df",
+        "x-ms-failure-cause": "",
+        "x-ms-request-id": "25a0b478-a6d6-4bef-8b11-1376ef2185df",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075319Z:25a0b478-a6d6-4bef-8b11-1376ef2185df"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "ProviderError",
+          "message": "{\u0022error\u0022:{\u0022message\u0022:\u0022Namespace provisioning in transition. For more information visit https://aka.ms/eventhubsarmexceptions. CorrelationId: 25a0b478-a6d6-4bef-8b11-1376ef2185df\u0022,\u0022code\u0022:\u0022429\u0022}}"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "41",
+        "Content-Type": "application/json",
+        "traceparent": "00-7b83095c7bd6a04c9ad835fd24bb0100-4203f74d5f8dad42-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "04e2ed4d422d058caef7002dba41f7c1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "properties": {
+          "tags": {
+            "key2": "value2"
+          }
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "291",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:53:24 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "363cee31-d023-4871-ba02-4332a1cc01a7",
+        "x-ms-ratelimit-remaining-subscription-writes": "1199",
+        "x-ms-request-id": "363cee31-d023-4871-ba02-4332a1cc01a7",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075325Z:363cee31-d023-4871-ba02-4332a1cc01a7"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243/providers/Microsoft.Resources/tags/default",
+        "name": "default",
+        "type": "Microsoft.Resources/tags",
+        "properties": {
+          "tags": {
+            "key2": "value2"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7b83095c7bd6a04c9ad835fd24bb0100-2d43ce4ba7cac44c-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "588a552dda9c190363c50063107c43d8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "751",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:53:25 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d9086d853ac7c32d11fcfe5131c7f726",
-        "x-ms-correlation-request-id": "0dc20fdc-3674-4add-bcf3-c78ac58a8c8c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11965",
-        "x-ms-request-id": "37ba519c-4758-4c53-8423-429ebf14585b_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161024Z:0dc20fdc-3674-4add-bcf3-c78ac58a8c8c"
+        "x-ms-client-request-id": "588a552dda9c190363c50063107c43d8",
+        "x-ms-correlation-request-id": "fcd7f80a-b3a7-496a-913d-7a995295891e",
+        "x-ms-ratelimit-remaining-subscription-reads": "11996",
+        "x-ms-request-id": "79be5008-a0ac-4ec6-b354-d00f4b8cf74d_M0SN1_M0SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075326Z:fcd7f80a-b3a7-496a-913d-7a995295891e"
       },
       "ResponseBody": {
         "sku": {
@@ -1225,12 +1217,12 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-707/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1985",
-        "name": "testnamespacemgmt1985",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6684/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8243",
+        "name": "testnamespacemgmt8243",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {
-          "key1": "value1"
+          "key2": "value2"
         },
         "properties": {
           "disableLocalAuth": false,
@@ -1239,10 +1231,10 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1985",
-          "createdAt": "2022-10-11T16:08:43.307Z",
-          "updatedAt": "2022-10-11T16:10:14.13Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1985.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8243",
+          "createdAt": "2022-10-12T07:51:49.297Z",
+          "updatedAt": "2022-10-12T07:53:24.617Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8243.servicebus.windows.net:443/",
           "status": "Active"
         }
       }
@@ -1250,8 +1242,8 @@
   ],
   "Variables": {
     "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "633750182",
+    "RandomSeed": "1881860131",
     "RESOURCE_MANAGER_URL": null,
-    "SUBSCRIPTION_ID": "326100e2-f69d-4268-8503-075374f62b6e"
+    "SUBSCRIPTION_ID": "db1ab6f0-4769-4b27-930e-01e2ef9c123c"
   }
 }

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventHubNamespaceTests/AddSetRemoveTag(True)Async.json
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventHubNamespaceTests/AddSetRemoveTag(True)Async.json
@@ -1,43 +1,53 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e?api-version=2021-01-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c?api-version=2021-01-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-110363a229dd2849bcf379944cddea20-4e3408a5a6485c46-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "3819d1ee64ee4948266c74d6ac3ffff2",
+        "Connection": "keep-alive",
+        "traceparent": "00-5306c2e9fc480646936eced34e2bc951-e31bd4bf755c104f-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "740bf3391f42535b69fedf7fabf507fa",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "460",
+        "Content-Length": "747",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:44 GMT",
+        "Date": "Wed, 12 Oct 2022 08:00:48 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "bd836e4b-10ca-4fbe-b894-ea4b11df24ee",
-        "x-ms-ratelimit-remaining-subscription-reads": "11995",
-        "x-ms-request-id": "bd836e4b-10ca-4fbe-b894-ea4b11df24ee",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161745Z:bd836e4b-10ca-4fbe-b894-ea4b11df24ee"
+        "x-ms-correlation-request-id": "781dad83-7168-4f6f-b9be-38a001403558",
+        "x-ms-ratelimit-remaining-subscription-reads": "11999",
+        "x-ms-request-id": "781dad83-7168-4f6f-b9be-38a001403558",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080049Z:781dad83-7168-4f6f-b9be-38a001403558"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "authorizationSource": "RoleBased",
-        "managedByTenants": [
-          {
-            "tenantId": "2f4a9838-26b7-47ee-be60-ccc1fdec5953"
-          }
-        ],
-        "subscriptionId": "326100e2-f69d-4268-8503-075374f62b6e",
+        "managedByTenants": [],
+        "tags": {
+          "TagKey-9823": "TagValue-566",
+          "TagKey-3481": "TagValue-320",
+          "TagKey-4926": "TagValue-1187",
+          "TagKey-751": "TagValue-3921",
+          "TagKey-1866": "TagValue-8559",
+          "TagKey-3094": "TagValue-9190",
+          "TagKey-2449": "TagValue-9",
+          "TagKey-8379": "TagValue-164",
+          "TagKey-7470": "TagValue-2205",
+          "TagKey-4236": "TagValue-3698",
+          "TagKey-5316": "TagValue-2725"
+        },
+        "subscriptionId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-        "displayName": "Azure Messaging PM Playground",
+        "displayName": ".NET Mgmt SDK Test with TTL = 1 Day",
         "state": "Enabled",
         "subscriptionPolicies": {
           "locationPlacementId": "Internal_2014-09-01",
@@ -47,16 +57,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourcegroups/testeventhubRG-6972?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourcegroups/testeventhubRG-2750?api-version=2021-04-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "44",
         "Content-Type": "application/json",
-        "traceparent": "00-c2996d481cb22340b22362551d38ba3e-daf3952411035040-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "f26a15cfc52b6bb381e0c472763b92e0",
+        "traceparent": "00-cfba29007967e846946b0dfc5d8193d9-d07a572baaeee54d-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "8411794cfbd804333bb71816a22dcd34",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -70,19 +80,19 @@
         "Cache-Control": "no-cache",
         "Content-Length": "258",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:49 GMT",
+        "Date": "Wed, 12 Oct 2022 08:00:52 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "f51068db-8296-4364-bfa0-fdacf046c9c0",
-        "x-ms-ratelimit-remaining-subscription-writes": "1197",
-        "x-ms-request-id": "f51068db-8296-4364-bfa0-fdacf046c9c0",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161750Z:f51068db-8296-4364-bfa0-fdacf046c9c0"
+        "x-ms-correlation-request-id": "9c84b381-bca2-4661-a63f-1c3cb637187b",
+        "x-ms-ratelimit-remaining-subscription-writes": "1199",
+        "x-ms-request-id": "9c84b381-bca2-4661-a63f-1c3cb637187b",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080052Z:9c84b381-bca2-4661-a63f-1c3cb637187b"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972",
-        "name": "testeventhubRG-6972",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750",
+        "name": "testeventhubRG-2750",
         "type": "Microsoft.Resources/resourceGroups",
         "location": "eastus2",
         "tags": {
@@ -94,27 +104,27 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/providers/Microsoft.EventHub/checkNameAvailability?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.EventHub/checkNameAvailability?api-version=2021-11-01",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "32",
         "Content-Type": "application/json",
-        "traceparent": "00-add8cfa23a5bf3439c6b204bf6c40935-54a7eb4da2305443-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "fd0e96ef66871006098a084afcf0ad55",
+        "traceparent": "00-297508938b2a4c428a7ddc9c71e6e053-c38421a9f20de446-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "75bebc08892c91ab02b855fc9b103a2a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "testnamespacemgmt1511"
+        "name": "testnamespacemgmt8928"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "53",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:50 GMT",
+        "Date": "Wed, 12 Oct 2022 08:00:53 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -124,11 +134,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "fd0e96ef66871006098a084afcf0ad55",
-        "x-ms-correlation-request-id": "c59376ae-d303-48d7-8aed-dce89b11cb64",
+        "x-ms-client-request-id": "75bebc08892c91ab02b855fc9b103a2a",
+        "x-ms-correlation-request-id": "510f7a81-6e7e-4471-ab23-f6a61b522594",
         "x-ms-ratelimit-remaining-subscription-writes": "1199",
-        "x-ms-request-id": "694b4294-8eec-4ad4-9c10-a2a89f764f86_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161751Z:c59376ae-d303-48d7-8aed-dce89b11cb64"
+        "x-ms-request-id": "6c3a4f20-d855-4708-b791-9568f10eefbe_M10SN1_M10SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080053Z:510f7a81-6e7e-4471-ab23-f6a61b522594"
       },
       "ResponseBody": {
         "nameAvailable": true,
@@ -137,16 +147,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928?api-version=2021-11-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "48",
         "Content-Type": "application/json",
-        "traceparent": "00-0dd226e5e24baf4c94b2d7622327babe-63684325547f234b-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "7b1a891bc351650ccd6d8384d6b031e2",
+        "traceparent": "00-2d82d82f23976044a7065d496aa01d3f-163512d3c694d640-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "28f4ec5d60f0d8f8700668433dc7d111",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -159,7 +169,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:55 GMT",
+        "Date": "Wed, 12 Oct 2022 08:00:59 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
@@ -169,11 +179,11 @@
         "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "7b1a891bc351650ccd6d8384d6b031e2",
-        "x-ms-correlation-request-id": "56ec14dd-12c9-4a6e-a8c4-7ad746bfd470",
+        "x-ms-client-request-id": "28f4ec5d60f0d8f8700668433dc7d111",
+        "x-ms-correlation-request-id": "1910a399-19e4-48da-832e-5277c03e3454",
         "x-ms-ratelimit-remaining-subscription-resource-requests": "49",
-        "x-ms-request-id": "66ca1577-e551-4022-8419-ad506f49acd1_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161756Z:56ec14dd-12c9-4a6e-a8c4-7ad746bfd470"
+        "x-ms-request-id": "f32c0493-11e0-46ea-831b-fb564caccdea_M10SN1_M10SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080100Z:1910a399-19e4-48da-832e-5277c03e3454"
       },
       "ResponseBody": {
         "sku": {
@@ -181,8 +191,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511",
-        "name": "testnamespacemgmt1511",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928",
+        "name": "testnamespacemgmt8928",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -193,22 +203,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1511",
-          "createdAt": "2022-10-11T16:17:54.523Z",
-          "updatedAt": "2022-10-11T16:17:54.523Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1511.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8928",
+          "createdAt": "2022-10-12T08:00:58.863Z",
+          "updatedAt": "2022-10-12T08:00:58.863Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8928.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-0dd226e5e24baf4c94b2d7622327babe-69bcfe3ef701c043-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "b25a1d1664772cec8aa83019e2813959",
+        "traceparent": "00-2d82d82f23976044a7065d496aa01d3f-9b46c7b1e7bd754a-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "4144ecdd0bd8a73cc4e605252068543b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -217,21 +227,253 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:55 GMT",
+        "Date": "Wed, 12 Oct 2022 08:01:02 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "b25a1d1664772cec8aa83019e2813959",
-        "x-ms-correlation-request-id": "0e8135eb-b5da-43ed-861b-b411bcdda598",
+        "x-ms-client-request-id": "4144ecdd0bd8a73cc4e605252068543b",
+        "x-ms-correlation-request-id": "1cdaf319-67ad-4302-958f-e6d8db9a81e7",
+        "x-ms-ratelimit-remaining-subscription-reads": "11998",
+        "x-ms-request-id": "4c7d2998-2230-441a-9b3c-cab6c18356ed_M2CH3_M2CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080103Z:1cdaf319-67ad-4302-958f-e6d8db9a81e7"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928",
+        "name": "testnamespacemgmt8928",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8928",
+          "createdAt": "2022-10-12T08:00:58.863Z",
+          "updatedAt": "2022-10-12T08:00:58.863Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8928.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-2d82d82f23976044a7065d496aa01d3f-95f972865426e14d-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "1cb144e7ef22e5eecc03c3fe8bb4fa68",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "738",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 08:01:04 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "1cb144e7ef22e5eecc03c3fe8bb4fa68",
+        "x-ms-correlation-request-id": "9f0e31ef-f28c-4925-8c62-cb8f99d57611",
+        "x-ms-ratelimit-remaining-subscription-reads": "11997",
+        "x-ms-request-id": "57daf7eb-7db8-4dd8-82e1-52f7baf3bdbf_M9CH3_M9CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080105Z:9f0e31ef-f28c-4925-8c62-cb8f99d57611"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928",
+        "name": "testnamespacemgmt8928",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8928",
+          "createdAt": "2022-10-12T08:00:58.863Z",
+          "updatedAt": "2022-10-12T08:00:58.863Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8928.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-2d82d82f23976044a7065d496aa01d3f-8cf629d5acb6fd42-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "5165c16690823f384246865572f9cffc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "738",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 08:01:06 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "5165c16690823f384246865572f9cffc",
+        "x-ms-correlation-request-id": "2a954888-fd5c-4413-98ff-c76c4c9b0d7b",
+        "x-ms-ratelimit-remaining-subscription-reads": "11996",
+        "x-ms-request-id": "76d71a9e-2762-42c2-89d8-53e491971014_M2CH3_M2CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080106Z:2a954888-fd5c-4413-98ff-c76c4c9b0d7b"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928",
+        "name": "testnamespacemgmt8928",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8928",
+          "createdAt": "2022-10-12T08:00:58.863Z",
+          "updatedAt": "2022-10-12T08:00:58.863Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8928.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-2d82d82f23976044a7065d496aa01d3f-93e3c2e00da27745-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "985b9a9e8356ed84fe5f74d5483d1b0f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "738",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 08:01:08 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "985b9a9e8356ed84fe5f74d5483d1b0f",
+        "x-ms-correlation-request-id": "42311cf6-1071-4463-ae51-61d8f9b4d111",
+        "x-ms-ratelimit-remaining-subscription-reads": "11995",
+        "x-ms-request-id": "4bb41c75-7942-41e9-bf1a-02abe83a99fe_M9CH3_M9CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080108Z:42311cf6-1071-4463-ae51-61d8f9b4d111"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928",
+        "name": "testnamespacemgmt8928",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8928",
+          "createdAt": "2022-10-12T08:00:58.863Z",
+          "updatedAt": "2022-10-12T08:00:58.863Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8928.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-2d82d82f23976044a7065d496aa01d3f-84b785e874048548-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "5fbf9deb020357b90c72d9dc689872d2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "738",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 08:01:11 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "5fbf9deb020357b90c72d9dc689872d2",
+        "x-ms-correlation-request-id": "1283335d-d067-4f71-92e5-755559a6bf03",
         "x-ms-ratelimit-remaining-subscription-reads": "11994",
-        "x-ms-request-id": "a9fe5987-3bbf-4e9d-ab88-d91394e882e1_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161756Z:0e8135eb-b5da-43ed-861b-b411bcdda598"
+        "x-ms-request-id": "60156ec5-5609-43c9-9aef-5eeeeff9f0e6_M2CH3_M2CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080111Z:1283335d-d067-4f71-92e5-755559a6bf03"
       },
       "ResponseBody": {
         "sku": {
@@ -239,8 +481,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511",
-        "name": "testnamespacemgmt1511",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928",
+        "name": "testnamespacemgmt8928",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -251,22 +493,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1511",
-          "createdAt": "2022-10-11T16:17:54.523Z",
-          "updatedAt": "2022-10-11T16:17:54.523Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1511.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8928",
+          "createdAt": "2022-10-12T08:00:58.863Z",
+          "updatedAt": "2022-10-12T08:00:58.863Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8928.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-0dd226e5e24baf4c94b2d7622327babe-9072b85ed7936d46-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "8e54255944a12971406b176fa1d2baab",
+        "traceparent": "00-2d82d82f23976044a7065d496aa01d3f-d1f148f2dd230644-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f15fc6336259e3113d7753231b63f705",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -275,21 +517,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:57 GMT",
+        "Date": "Wed, 12 Oct 2022 08:01:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8e54255944a12971406b176fa1d2baab",
-        "x-ms-correlation-request-id": "3ef31b6d-4320-4b30-8e53-fa3611d0ab3a",
+        "x-ms-client-request-id": "f15fc6336259e3113d7753231b63f705",
+        "x-ms-correlation-request-id": "57e62ab1-32a8-4c1f-b26d-d3e69d0ef219",
         "x-ms-ratelimit-remaining-subscription-reads": "11993",
-        "x-ms-request-id": "520d970e-f5e6-4abc-8c0d-701ffe0e8d23_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161758Z:3ef31b6d-4320-4b30-8e53-fa3611d0ab3a"
+        "x-ms-request-id": "15e26854-3fc4-40e3-bd0c-d9c5060c5435_M9CH3_M9CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080116Z:57e62ab1-32a8-4c1f-b26d-d3e69d0ef219"
       },
       "ResponseBody": {
         "sku": {
@@ -297,8 +539,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511",
-        "name": "testnamespacemgmt1511",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928",
+        "name": "testnamespacemgmt8928",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -309,22 +551,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1511",
-          "createdAt": "2022-10-11T16:17:54.523Z",
-          "updatedAt": "2022-10-11T16:17:54.523Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1511.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8928",
+          "createdAt": "2022-10-12T08:00:58.863Z",
+          "updatedAt": "2022-10-12T08:00:58.863Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8928.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-0dd226e5e24baf4c94b2d7622327babe-c730647dedc44446-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "b96d93e87f55916a8122de3bc02ecce2",
+        "traceparent": "00-2d82d82f23976044a7065d496aa01d3f-08b6bce6bd38ec49-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "d56a772a703a9bf9e0048ce4a9a78465",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -333,21 +575,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:59 GMT",
+        "Date": "Wed, 12 Oct 2022 08:01:24 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "b96d93e87f55916a8122de3bc02ecce2",
-        "x-ms-correlation-request-id": "3140bebd-53d4-4b6d-9324-c04ad41c0dbc",
+        "x-ms-client-request-id": "d56a772a703a9bf9e0048ce4a9a78465",
+        "x-ms-correlation-request-id": "c1c54063-a2e1-4d81-97da-43492f362532",
         "x-ms-ratelimit-remaining-subscription-reads": "11992",
-        "x-ms-request-id": "47386256-bc06-44b9-b34a-b5ec8bc0eac3_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161800Z:3140bebd-53d4-4b6d-9324-c04ad41c0dbc"
+        "x-ms-request-id": "8af898f2-f039-4fcf-b026-e6f6de139c74_M9CH3_M9CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080125Z:c1c54063-a2e1-4d81-97da-43492f362532"
       },
       "ResponseBody": {
         "sku": {
@@ -355,8 +597,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511",
-        "name": "testnamespacemgmt1511",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928",
+        "name": "testnamespacemgmt8928",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -367,22 +609,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1511",
-          "createdAt": "2022-10-11T16:17:54.523Z",
-          "updatedAt": "2022-10-11T16:17:54.523Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1511.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8928",
+          "createdAt": "2022-10-12T08:00:58.863Z",
+          "updatedAt": "2022-10-12T08:00:58.863Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8928.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-0dd226e5e24baf4c94b2d7622327babe-8ecffddd83065b43-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "86e0c8a8f6ccd24eab31710c4d7c8ab7",
+        "traceparent": "00-2d82d82f23976044a7065d496aa01d3f-50b7bca4b7ffbe4d-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "81a1a2ec2ade88b68cdb228baf953ca8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -391,21 +633,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:18:01 GMT",
+        "Date": "Wed, 12 Oct 2022 08:01:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "86e0c8a8f6ccd24eab31710c4d7c8ab7",
-        "x-ms-correlation-request-id": "26758747-526a-419e-815b-966b948029a1",
+        "x-ms-client-request-id": "81a1a2ec2ade88b68cdb228baf953ca8",
+        "x-ms-correlation-request-id": "d07da315-1663-4668-aed9-acdcb3253433",
         "x-ms-ratelimit-remaining-subscription-reads": "11991",
-        "x-ms-request-id": "6cb0f096-2fba-4182-884c-6a933c11ca15_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161802Z:26758747-526a-419e-815b-966b948029a1"
+        "x-ms-request-id": "cf112cd5-db36-4152-8fc6-ea4cc37e0c47_M9CH3_M9CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080142Z:d07da315-1663-4668-aed9-acdcb3253433"
       },
       "ResponseBody": {
         "sku": {
@@ -413,8 +655,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511",
-        "name": "testnamespacemgmt1511",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928",
+        "name": "testnamespacemgmt8928",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -425,45 +667,45 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1511",
-          "createdAt": "2022-10-11T16:17:54.523Z",
-          "updatedAt": "2022-10-11T16:17:54.523Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1511.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8928",
+          "createdAt": "2022-10-12T08:00:58.863Z",
+          "updatedAt": "2022-10-12T08:00:58.863Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8928.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-0dd226e5e24baf4c94b2d7622327babe-1559bde27a4a0e49-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "4e3184ee8013d903bac30c7e65356811",
+        "traceparent": "00-2d82d82f23976044a7065d496aa01d3f-d3434f55fd5ed641-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f1b2d47b9d2dc397cdc31054d52d3995",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "738",
+        "Content-Length": "734",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:18:04 GMT",
+        "Date": "Wed, 12 Oct 2022 08:02:14 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "4e3184ee8013d903bac30c7e65356811",
-        "x-ms-correlation-request-id": "38823b89-be25-462c-81b2-2c50e79ef751",
+        "x-ms-client-request-id": "f1b2d47b9d2dc397cdc31054d52d3995",
+        "x-ms-correlation-request-id": "581ea61b-e1ac-47fc-84a0-d929f2f0a3e5",
         "x-ms-ratelimit-remaining-subscription-reads": "11990",
-        "x-ms-request-id": "91dcad9f-807b-4783-919e-fc0f9aa9d3ca_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161805Z:38823b89-be25-462c-81b2-2c50e79ef751"
+        "x-ms-request-id": "81c2a5dd-7733-4326-ac36-154d87d73b69_M9CH3_M9CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080215Z:581ea61b-e1ac-47fc-84a0-d929f2f0a3e5"
       },
       "ResponseBody": {
         "sku": {
@@ -471,240 +713,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511",
-        "name": "testnamespacemgmt1511",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1511",
-          "createdAt": "2022-10-11T16:17:54.523Z",
-          "updatedAt": "2022-10-11T16:17:54.523Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1511.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-0dd226e5e24baf4c94b2d7622327babe-01389d7b68fab844-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "d9c7349e33f1f2df449b0d240d5e4305",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:18:08 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d9c7349e33f1f2df449b0d240d5e4305",
-        "x-ms-correlation-request-id": "01ecb58b-2b66-4acc-bc1b-eee199caa473",
-        "x-ms-ratelimit-remaining-subscription-reads": "11989",
-        "x-ms-request-id": "abebdcdc-d0b9-4018-a78e-1537bd5ab5db_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161809Z:01ecb58b-2b66-4acc-bc1b-eee199caa473"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511",
-        "name": "testnamespacemgmt1511",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1511",
-          "createdAt": "2022-10-11T16:17:54.523Z",
-          "updatedAt": "2022-10-11T16:17:54.523Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1511.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-0dd226e5e24baf4c94b2d7622327babe-e2984fcb6fd40743-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "3b4d27977dfd27cec407cb09e9d06c76",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:18:18 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "3b4d27977dfd27cec407cb09e9d06c76",
-        "x-ms-correlation-request-id": "eaaedda8-521d-45c2-a904-60a9ad061358",
-        "x-ms-ratelimit-remaining-subscription-reads": "11988",
-        "x-ms-request-id": "67402e9a-bef2-4090-95ff-2c8be49341a7_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161818Z:eaaedda8-521d-45c2-a904-60a9ad061358"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511",
-        "name": "testnamespacemgmt1511",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1511",
-          "createdAt": "2022-10-11T16:17:54.523Z",
-          "updatedAt": "2022-10-11T16:17:54.523Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1511.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-0dd226e5e24baf4c94b2d7622327babe-0dec00b93e9ee54b-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "186d60c8b1b4bac5a53e097872dfcb5c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:18:36 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "186d60c8b1b4bac5a53e097872dfcb5c",
-        "x-ms-correlation-request-id": "94aba669-637d-4733-a0cd-b596a7d82c39",
-        "x-ms-ratelimit-remaining-subscription-reads": "11987",
-        "x-ms-request-id": "a5eda5a9-14f0-49e5-b0bb-6d792a370328_M3CH3_M3CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161836Z:94aba669-637d-4733-a0cd-b596a7d82c39"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511",
-        "name": "testnamespacemgmt1511",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1511",
-          "createdAt": "2022-10-11T16:17:54.523Z",
-          "updatedAt": "2022-10-11T16:17:54.523Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1511.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-0dd226e5e24baf4c94b2d7622327babe-1db326b5ea9cae4b-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "3ee6077f2de72014669f14ea68d50974",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "735",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:19:08 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "3ee6077f2de72014669f14ea68d50974",
-        "x-ms-correlation-request-id": "279bff68-bb98-4009-a1d8-1a3556dbe29f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11986",
-        "x-ms-request-id": "00e2c012-0ad7-450d-88fc-e726c36ba09f_M3CH3_M3CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161909Z:279bff68-bb98-4009-a1d8-1a3556dbe29f"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511",
-        "name": "testnamespacemgmt1511",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928",
+        "name": "testnamespacemgmt8928",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -715,23 +725,23 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1511",
-          "createdAt": "2022-10-11T16:17:54.523Z",
-          "updatedAt": "2022-10-11T16:18:46.39Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1511.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8928",
+          "createdAt": "2022-10-12T08:00:58.863Z",
+          "updatedAt": "2022-10-12T08:01:50.8Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8928.servicebus.windows.net:443/",
           "status": "Active"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-c2a600cc26f17c4989206116c817867f-32ae4faaf2886a4d-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "ad5b972e2bf0e650619396be7356b5e4",
+        "traceparent": "00-6b7f4e0368d5474684a59864cc73204d-9b42a1a45213fb4b-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "7836edf276c2ff26c0e1495e4d6eec4a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -740,18 +750,18 @@
         "Cache-Control": "no-cache",
         "Content-Length": "276",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:19:09 GMT",
+        "Date": "Wed, 12 Oct 2022 08:02:15 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "b15a03de-e667-47b3-a452-a29379eb9b11",
-        "x-ms-ratelimit-remaining-subscription-reads": "11985",
-        "x-ms-request-id": "b15a03de-e667-47b3-a452-a29379eb9b11",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161910Z:b15a03de-e667-47b3-a452-a29379eb9b11"
+        "x-ms-correlation-request-id": "f0b7727f-c979-445c-aaa5-baecca5b25a5",
+        "x-ms-ratelimit-remaining-subscription-reads": "11989",
+        "x-ms-request-id": "f0b7727f-c979-445c-aaa5-baecca5b25a5",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080215Z:f0b7727f-c979-445c-aaa5-baecca5b25a5"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511/providers/Microsoft.Resources/tags/default",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928/providers/Microsoft.Resources/tags/default",
         "name": "default",
         "type": "Microsoft.Resources/tags",
         "properties": {
@@ -760,414 +770,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "43",
-        "Content-Type": "application/json",
-        "traceparent": "00-c2a600cc26f17c4989206116c817867f-16f0d72cb301574c-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "e28a6f3b2de99b8e4b4cb2149cdb52d0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "properties": {
-          "tags": {
-            "key": "Sanitized"
-          }
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "293",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:19:13 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "df82295f-e79f-4cd0-851c-9c9eede0c9a0",
-        "x-ms-ratelimit-remaining-subscription-writes": "1196",
-        "x-ms-request-id": "df82295f-e79f-4cd0-851c-9c9eede0c9a0",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161914Z:df82295f-e79f-4cd0-851c-9c9eede0c9a0"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511/providers/Microsoft.Resources/tags/default",
-        "name": "default",
-        "type": "Microsoft.Resources/tags",
-        "properties": {
-          "tags": {
-            "key": "Sanitized"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-c2a600cc26f17c4989206116c817867f-b2180d2d0e970749-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "db4995351e83536bb600dd549655ad0f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "756",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:19:16 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "db4995351e83536bb600dd549655ad0f",
-        "x-ms-correlation-request-id": "cb3be888-2eeb-4713-80f7-8c8155fc2d6c",
-        "x-ms-ratelimit-remaining-subscription-reads": "11984",
-        "x-ms-request-id": "0c43b182-15a1-44c8-8871-79cb5bf279a5_M3CH3_M3CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161916Z:cb3be888-2eeb-4713-80f7-8c8155fc2d6c"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511",
-        "name": "testnamespacemgmt1511",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {
-          "key": "Sanitized"
-        },
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Updating",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1511",
-          "createdAt": "2022-10-11T16:17:54.523Z",
-          "updatedAt": "2022-10-11T16:19:11.277Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1511.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-329e6fcca32706409f60d1f4f1a763ef-78d934c77f306a42-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "f8af2fea264b008b08c061a4793b4a86",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Connection": "close",
-        "Content-Length": "249",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:19:17 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "ae57648c-0ae8-4fe9-aadc-019601ab50ae",
-        "x-ms-failure-cause": "",
-        "x-ms-request-id": "ae57648c-0ae8-4fe9-aadc-019601ab50ae",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161917Z:ae57648c-0ae8-4fe9-aadc-019601ab50ae"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "ProviderError",
-          "message": "{\u0022error\u0022:{\u0022message\u0022:\u0022Namespace provisioning in transition. For more information visit https://aka.ms/eventhubsarmexceptions. CorrelationId: ae57648c-0ae8-4fe9-aadc-019601ab50ae\u0022,\u0022code\u0022:\u0022429\u0022}}"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-329e6fcca32706409f60d1f4f1a763ef-78d934c77f306a42-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "f8af2fea264b008b08c061a4793b4a86",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Date": "Tue, 11 Oct 2022 16:19:26 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "188ae68c-37fd-499a-b25a-a693eababf67",
-        "x-ms-ratelimit-remaining-subscription-deletes": "14999",
-        "x-ms-request-id": "188ae68c-37fd-499a-b25a-a693eababf67",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161926Z:188ae68c-37fd-499a-b25a-a693eababf67"
-      },
-      "ResponseBody": null
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-329e6fcca32706409f60d1f4f1a763ef-265aaeda6f7e2d4e-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "de89c540da0c1c6104362be8503904f6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "276",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:19:26 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "ed487d3a-7753-4bc1-80fe-c5828c6c4ae1",
-        "x-ms-ratelimit-remaining-subscription-reads": "11979",
-        "x-ms-request-id": "ed487d3a-7753-4bc1-80fe-c5828c6c4ae1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161926Z:ed487d3a-7753-4bc1-80fe-c5828c6c4ae1"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511/providers/Microsoft.Resources/tags/default",
-        "name": "default",
-        "type": "Microsoft.Resources/tags",
-        "properties": {
-          "tags": {}
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "59",
-        "Content-Type": "application/json",
-        "traceparent": "00-329e6fcca32706409f60d1f4f1a763ef-fcbdf23d15e2a14e-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "6c2aa29f592b0e850948d2c3bcc7d97a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "properties": {
-          "tags": {
-            "key": "Sanitized",
-            "key1": "value1"
-          }
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "309",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:19:29 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "7df0f550-5e24-41c6-8a86-7a320be6c48b",
-        "x-ms-ratelimit-remaining-subscription-writes": "1193",
-        "x-ms-request-id": "7df0f550-5e24-41c6-8a86-7a320be6c48b",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161929Z:7df0f550-5e24-41c6-8a86-7a320be6c48b"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511/providers/Microsoft.Resources/tags/default",
-        "name": "default",
-        "type": "Microsoft.Resources/tags",
-        "properties": {
-          "tags": {
-            "key": "Sanitized",
-            "key1": "value1"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-329e6fcca32706409f60d1f4f1a763ef-19fc3b1311002042-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "d01357b6cecc1003ce92f414fba2b0cf",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "772",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:19:30 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d01357b6cecc1003ce92f414fba2b0cf",
-        "x-ms-correlation-request-id": "b34e60ca-2133-4d62-b058-bb08471bfc34",
-        "x-ms-ratelimit-remaining-subscription-reads": "11978",
-        "x-ms-request-id": "685843ed-96b4-4633-b0f7-170402f43610_M1SN1_M1SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161931Z:b34e60ca-2133-4d62-b058-bb08471bfc34"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511",
-        "name": "testnamespacemgmt1511",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {
-          "key": "Sanitized",
-          "key1": "value1"
-        },
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Updating",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1511",
-          "createdAt": "2022-10-11T16:17:54.523Z",
-          "updatedAt": "2022-10-11T16:19:27.983Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1511.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-e4aae1ff1a503149b26570dc99dfd197-d7d24f24476f584c-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "d7046bbcdd11e75a407ad5c3089e603d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "309",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:19:31 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "8b4f83c1-d0cb-4668-ab6a-d732a6726530",
-        "x-ms-ratelimit-remaining-subscription-reads": "11977",
-        "x-ms-request-id": "8b4f83c1-d0cb-4668-ab6a-d732a6726530",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161931Z:8b4f83c1-d0cb-4668-ab6a-d732a6726530"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511/providers/Microsoft.Resources/tags/default",
-        "name": "default",
-        "type": "Microsoft.Resources/tags",
-        "properties": {
-          "tags": {
-            "key": "Sanitized",
-            "key1": "value1"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "41",
         "Content-Type": "application/json",
-        "traceparent": "00-e4aae1ff1a503149b26570dc99dfd197-4f714579b04e4f4d-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "f932b15d3326d12a9e199d9864701367",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "properties": {
-          "tags": {
-            "key1": "value1"
-          }
-        }
-      },
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Connection": "close",
-        "Content-Length": "249",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:19:32 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "986ac69a-7825-445f-8f55-fe26b303599b",
-        "x-ms-failure-cause": "",
-        "x-ms-request-id": "986ac69a-7825-445f-8f55-fe26b303599b",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161933Z:986ac69a-7825-445f-8f55-fe26b303599b"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "ProviderError",
-          "message": "{\u0022error\u0022:{\u0022message\u0022:\u0022Namespace provisioning in transition. For more information visit https://aka.ms/eventhubsarmexceptions. CorrelationId: 986ac69a-7825-445f-8f55-fe26b303599b\u0022,\u0022code\u0022:\u0022429\u0022}}"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "41",
-        "Content-Type": "application/json",
-        "traceparent": "00-e4aae1ff1a503149b26570dc99dfd197-4f714579b04e4f4d-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "f932b15d3326d12a9e199d9864701367",
+        "traceparent": "00-6b7f4e0368d5474684a59864cc73204d-10fdccf4eb067b46-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "d469e3c893f54f380bddb31a1a61b35e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -1182,18 +794,18 @@
         "Cache-Control": "no-cache",
         "Content-Length": "291",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:19:39 GMT",
+        "Date": "Wed, 12 Oct 2022 08:02:20 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "da428209-287d-42c4-b0c9-ad499f73dbd4",
-        "x-ms-ratelimit-remaining-subscription-writes": "1199",
-        "x-ms-request-id": "da428209-287d-42c4-b0c9-ad499f73dbd4",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161940Z:da428209-287d-42c4-b0c9-ad499f73dbd4"
+        "x-ms-correlation-request-id": "39331138-e453-4c39-b131-9efaae5dd2ea",
+        "x-ms-ratelimit-remaining-subscription-writes": "1198",
+        "x-ms-request-id": "39331138-e453-4c39-b131-9efaae5dd2ea",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080221Z:39331138-e453-4c39-b131-9efaae5dd2ea"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511/providers/Microsoft.Resources/tags/default",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928/providers/Microsoft.Resources/tags/default",
         "name": "default",
         "type": "Microsoft.Resources/tags",
         "properties": {
@@ -1204,37 +816,37 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-e4aae1ff1a503149b26570dc99dfd197-56e6465a9466b843-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "5106029802c2d868fc2c9052f93f0830",
+        "traceparent": "00-6b7f4e0368d5474684a59864cc73204d-e25f7ca66f1e9c42-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c2988ca2c35f05e6aeb2314b5338755f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "751",
+        "Content-Length": "750",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:19:42 GMT",
+        "Date": "Wed, 12 Oct 2022 08:02:21 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5106029802c2d868fc2c9052f93f0830",
-        "x-ms-correlation-request-id": "3de1a494-63cc-404a-971a-3396c0a3c13f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11996",
-        "x-ms-request-id": "3da4ff61-2a60-4af6-a701-a80cc54702a0_M3SN1_M3SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161942Z:3de1a494-63cc-404a-971a-3396c0a3c13f"
+        "x-ms-client-request-id": "c2988ca2c35f05e6aeb2314b5338755f",
+        "x-ms-correlation-request-id": "625fe015-9fca-49da-a301-49cbfc15fcb5",
+        "x-ms-ratelimit-remaining-subscription-reads": "11988",
+        "x-ms-request-id": "a1e3bbcc-67b0-42d7-877f-b293b270aad1_M9CH3_M9CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080221Z:625fe015-9fca-49da-a301-49cbfc15fcb5"
       },
       "ResponseBody": {
         "sku": {
@@ -1242,8 +854,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-6972/providers/Microsoft.EventHub/namespaces/testnamespacemgmt1511",
-        "name": "testnamespacemgmt1511",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928",
+        "name": "testnamespacemgmt8928",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {
@@ -1256,10 +868,391 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt1511",
-          "createdAt": "2022-10-11T16:17:54.523Z",
-          "updatedAt": "2022-10-11T16:19:40.257Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt1511.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8928",
+          "createdAt": "2022-10-12T08:00:58.863Z",
+          "updatedAt": "2022-10-12T08:02:19.97Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8928.servicebus.windows.net:443/",
+          "status": "Active"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a3a2d8caac7b9646b7129a6adf284f1c-9f849be758e5e44f-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f18cc5d764c45fa0b5e76de4c20be55e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Wed, 12 Oct 2022 08:02:24 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "d2a899de-9041-4bd7-b453-1ec9985b89d2",
+        "x-ms-ratelimit-remaining-subscription-deletes": "14999",
+        "x-ms-request-id": "d2a899de-9041-4bd7-b453-1ec9985b89d2",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080225Z:d2a899de-9041-4bd7-b453-1ec9985b89d2"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a3a2d8caac7b9646b7129a6adf284f1c-a110a75f2f07614f-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c0bcea2e29d504ebfd63264262ecfbd2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "276",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 08:02:25 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "68a616fe-4ce6-486f-b955-0c766dcb90aa",
+        "x-ms-ratelimit-remaining-subscription-reads": "11987",
+        "x-ms-request-id": "68a616fe-4ce6-486f-b955-0c766dcb90aa",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080225Z:68a616fe-4ce6-486f-b955-0c766dcb90aa"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928/providers/Microsoft.Resources/tags/default",
+        "name": "default",
+        "type": "Microsoft.Resources/tags",
+        "properties": {
+          "tags": {}
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "57",
+        "Content-Type": "application/json",
+        "traceparent": "00-a3a2d8caac7b9646b7129a6adf284f1c-43baf54188d1a340-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "54425468c1d53d9aec390d77560242a2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "properties": {
+          "tags": {
+            "key1": "value1",
+            "key2": "value2"
+          }
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "307",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 08:02:28 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "f49e51c9-af7e-481f-a514-ea3b2fa1e3b8",
+        "x-ms-ratelimit-remaining-subscription-writes": "1197",
+        "x-ms-request-id": "f49e51c9-af7e-481f-a514-ea3b2fa1e3b8",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080228Z:f49e51c9-af7e-481f-a514-ea3b2fa1e3b8"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928/providers/Microsoft.Resources/tags/default",
+        "name": "default",
+        "type": "Microsoft.Resources/tags",
+        "properties": {
+          "tags": {
+            "key1": "value1",
+            "key2": "value2"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a3a2d8caac7b9646b7129a6adf284f1c-39042e2a33d87743-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "691dd2cdb47bae89d987f4603e5dfdc8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "770",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 08:02:28 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "691dd2cdb47bae89d987f4603e5dfdc8",
+        "x-ms-correlation-request-id": "b5cb7945-e0fa-4497-af4e-6aeaf627c81c",
+        "x-ms-ratelimit-remaining-subscription-reads": "11986",
+        "x-ms-request-id": "055c97c7-73c7-4fbd-b1e3-1069bcf06937_M9CH3_M9CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080229Z:b5cb7945-e0fa-4497-af4e-6aeaf627c81c"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928",
+        "name": "testnamespacemgmt8928",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        },
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Updating",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8928",
+          "createdAt": "2022-10-12T08:00:58.863Z",
+          "updatedAt": "2022-10-12T08:02:27.143Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8928.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2ff41ffa1b229141b6198c3a533a935c-ee7ac6062c0ebc40-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6d7c9aeb90c96c894f7fd49c1c73aefa",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "307",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 08:02:29 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "41b60b4a-df89-4611-b845-784d8f335efc",
+        "x-ms-ratelimit-remaining-subscription-reads": "11985",
+        "x-ms-request-id": "41b60b4a-df89-4611-b845-784d8f335efc",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080229Z:41b60b4a-df89-4611-b845-784d8f335efc"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928/providers/Microsoft.Resources/tags/default",
+        "name": "default",
+        "type": "Microsoft.Resources/tags",
+        "properties": {
+          "tags": {
+            "key1": "value1",
+            "key2": "value2"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "41",
+        "Content-Type": "application/json",
+        "traceparent": "00-2ff41ffa1b229141b6198c3a533a935c-975b81587541674a-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "8f75842191ceb356ca947b4ecd3afe8e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "properties": {
+          "tags": {
+            "key2": "value2"
+          }
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "291",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 08:02:32 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "e6e7e91d-176c-4d45-9098-e7d5cbd7b244",
+        "x-ms-ratelimit-remaining-subscription-writes": "1196",
+        "x-ms-request-id": "e6e7e91d-176c-4d45-9098-e7d5cbd7b244",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080232Z:e6e7e91d-176c-4d45-9098-e7d5cbd7b244"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928/providers/Microsoft.Resources/tags/default",
+        "name": "default",
+        "type": "Microsoft.Resources/tags",
+        "properties": {
+          "tags": {
+            "key2": "value2"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2ff41ffa1b229141b6198c3a533a935c-344bf9170b030e47-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "bb8c443bd4863cd949b119fce0ed9265",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "753",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 08:02:32 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "bb8c443bd4863cd949b119fce0ed9265",
+        "x-ms-correlation-request-id": "84153203-babd-48bb-81c8-e52a9e46c12c",
+        "x-ms-ratelimit-remaining-subscription-reads": "11984",
+        "x-ms-request-id": "5ad2fbfb-0192-45ee-82f9-8386e939ce93_M9CH3_M9CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080233Z:84153203-babd-48bb-81c8-e52a9e46c12c"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928",
+        "name": "testnamespacemgmt8928",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {
+          "key2": "value2"
+        },
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Updating",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8928",
+          "createdAt": "2022-10-12T08:00:58.863Z",
+          "updatedAt": "2022-10-12T08:02:31.19Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8928.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-95d75bb6254627419fdb0a181200ab14-d6c090af9ddd2a41-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b93ef9d86de859fa44c8a334153a9e15",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "751",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 08:02:43 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b93ef9d86de859fa44c8a334153a9e15",
+        "x-ms-correlation-request-id": "17456ec5-bfd1-49c7-bd65-08866790115f",
+        "x-ms-ratelimit-remaining-subscription-reads": "11983",
+        "x-ms-request-id": "50efbb5c-a899-4d8a-a905-06a5dcabbe5f_M9CH3_M9CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T080244Z:17456ec5-bfd1-49c7-bd65-08866790115f"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-2750/providers/Microsoft.EventHub/namespaces/testnamespacemgmt8928",
+        "name": "testnamespacemgmt8928",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {
+          "key2": "value2"
+        },
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Succeeded",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt8928",
+          "createdAt": "2022-10-12T08:00:58.863Z",
+          "updatedAt": "2022-10-12T08:02:32.757Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt8928.servicebus.windows.net:443/",
           "status": "Active"
         }
       }
@@ -1267,8 +1260,8 @@
   ],
   "Variables": {
     "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "212580958",
+    "RandomSeed": "2060363991",
     "RESOURCE_MANAGER_URL": null,
-    "SUBSCRIPTION_ID": "326100e2-f69d-4268-8503-075374f62b6e"
+    "SUBSCRIPTION_ID": "db1ab6f0-4769-4b27-930e-01e2ef9c123c"
   }
 }

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventHubNamespaceTests/AddSetRemoveTag(null).json
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventHubNamespaceTests/AddSetRemoveTag(null).json
@@ -1,44 +1,52 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e?api-version=2021-01-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c?api-version=2021-01-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "traceparent": "00-626eea5863b28a42bbe6f8fb290526d1-8bb168f8c37ee446-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "0fd1107b415469e0916fa5d82d78018f",
+        "traceparent": "00-bacbb2df3de36d47856b3c7bd905b471-2e1f0aa7c12ce743-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "becff637093edba9ef995d748d0ee3d7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "460",
+        "Content-Length": "747",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:06:32 GMT",
+        "Date": "Wed, 12 Oct 2022 07:45:38 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "6e34e7ec-b105-4dba-b07e-81e47bc7f2e1",
-        "x-ms-ratelimit-remaining-subscription-reads": "11999",
-        "x-ms-request-id": "6e34e7ec-b105-4dba-b07e-81e47bc7f2e1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160633Z:6e34e7ec-b105-4dba-b07e-81e47bc7f2e1"
+        "x-ms-correlation-request-id": "4c08d931-fa93-490d-ab27-4eb0e90c41ed",
+        "x-ms-ratelimit-remaining-subscription-reads": "11992",
+        "x-ms-request-id": "4c08d931-fa93-490d-ab27-4eb0e90c41ed",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074538Z:4c08d931-fa93-490d-ab27-4eb0e90c41ed"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "authorizationSource": "RoleBased",
-        "managedByTenants": [
-          {
-            "tenantId": "2f4a9838-26b7-47ee-be60-ccc1fdec5953"
-          }
-        ],
-        "subscriptionId": "326100e2-f69d-4268-8503-075374f62b6e",
+        "managedByTenants": [],
+        "tags": {
+          "TagKey-9823": "TagValue-566",
+          "TagKey-3481": "TagValue-320",
+          "TagKey-4926": "TagValue-1187",
+          "TagKey-751": "TagValue-3921",
+          "TagKey-1866": "TagValue-8559",
+          "TagKey-3094": "TagValue-9190",
+          "TagKey-2449": "TagValue-9",
+          "TagKey-8379": "TagValue-164",
+          "TagKey-7470": "TagValue-2205",
+          "TagKey-4236": "TagValue-3698",
+          "TagKey-5316": "TagValue-2725"
+        },
+        "subscriptionId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-        "displayName": "Azure Messaging PM Playground",
+        "displayName": ".NET Mgmt SDK Test with TTL = 1 Day",
         "state": "Enabled",
         "subscriptionPolicies": {
           "locationPlacementId": "Internal_2014-09-01",
@@ -48,16 +56,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourcegroups/testeventhubRG-3927?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourcegroups/testeventhubRG-4752?api-version=2021-04-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "44",
         "Content-Type": "application/json",
-        "traceparent": "00-40ff3f2fdef6f24e8890af257caa3408-ca9b606dec0cf347-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "281144ff0bb9917e081d230a5cffed65",
+        "traceparent": "00-f2f2c6a1cfdda749beee69e7c1639fa3-94446eb760e19d4f-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "82aa676aba3e6f82694cd2f164603399",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -71,19 +79,19 @@
         "Cache-Control": "no-cache",
         "Content-Length": "258",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:06:38 GMT",
+        "Date": "Wed, 12 Oct 2022 07:45:41 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "1ecd1d69-4c47-4eb9-a063-54b63b663e6b",
+        "x-ms-correlation-request-id": "9a31cecd-8914-477f-a6ba-a9901196ec59",
         "x-ms-ratelimit-remaining-subscription-writes": "1199",
-        "x-ms-request-id": "1ecd1d69-4c47-4eb9-a063-54b63b663e6b",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160639Z:1ecd1d69-4c47-4eb9-a063-54b63b663e6b"
+        "x-ms-request-id": "9a31cecd-8914-477f-a6ba-a9901196ec59",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074542Z:9a31cecd-8914-477f-a6ba-a9901196ec59"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927",
-        "name": "testeventhubRG-3927",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752",
+        "name": "testeventhubRG-4752",
         "type": "Microsoft.Resources/resourceGroups",
         "location": "eastus2",
         "tags": {
@@ -95,41 +103,41 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/providers/Microsoft.EventHub/checkNameAvailability?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.EventHub/checkNameAvailability?api-version=2021-11-01",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "32",
         "Content-Type": "application/json",
-        "traceparent": "00-921756a9a6408748814b425e71c2b07e-45d65da9155cc24f-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "f40563c840cb0e2a99e23f492da6ff55",
+        "traceparent": "00-1dcc96ca509bca4ab5b96f538111932e-2f909cd7a8598c42-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f9458a7cf83b0dbf02b4323af75cb895",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "testnamespacemgmt2380"
+        "name": "testnamespacemgmt6135"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "53",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:06:39 GMT",
+        "Date": "Wed, 12 Oct 2022 07:45:42 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f40563c840cb0e2a99e23f492da6ff55",
-        "x-ms-correlation-request-id": "27127bc4-8756-42b1-8863-f0e03ee5d919",
+        "x-ms-client-request-id": "f9458a7cf83b0dbf02b4323af75cb895",
+        "x-ms-correlation-request-id": "d3dea195-3f24-4cb8-b2ef-326a5ac25c1b",
         "x-ms-ratelimit-remaining-subscription-writes": "1199",
-        "x-ms-request-id": "0e0bdda9-6e2a-46a1-be7b-6d8b055b8778_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160640Z:27127bc4-8756-42b1-8863-f0e03ee5d919"
+        "x-ms-request-id": "cd9dfd1e-5412-4011-b7d5-8f55dece7f2a_M1SN1_M1SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074543Z:d3dea195-3f24-4cb8-b2ef-326a5ac25c1b"
       },
       "ResponseBody": {
         "nameAvailable": true,
@@ -138,16 +146,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135?api-version=2021-11-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "48",
         "Content-Type": "application/json",
-        "traceparent": "00-f7a38dcdf01661418a9b9902de9e9213-d64250d2e3368740-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "91a71dfdc11652057e4b23bd5e3470b8",
+        "traceparent": "00-24cc27d23b8686468209f5c9f479daba-64a7d3553493b849-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ed6c942ef95e4d3c4fd4bdd6e98b3929",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -158,23 +166,23 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "738",
+        "Content-Length": "736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:06:47 GMT",
+        "Date": "Wed, 12 Oct 2022 07:45:49 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "91a71dfdc11652057e4b23bd5e3470b8",
-        "x-ms-correlation-request-id": "f8213705-2faf-432b-910b-75fd6f03eb4a",
+        "x-ms-client-request-id": "ed6c942ef95e4d3c4fd4bdd6e98b3929",
+        "x-ms-correlation-request-id": "5e3e0cff-2fed-491e-b185-caf6e2e694b7",
         "x-ms-ratelimit-remaining-subscription-resource-requests": "49",
-        "x-ms-request-id": "ea396127-752d-4696-8f2e-b59cb66b01bb_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160647Z:f8213705-2faf-432b-910b-75fd6f03eb4a"
+        "x-ms-request-id": "8a55d315-eb2e-457f-ab73-4769243c4eb2_M1SN1_M1SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074549Z:5e3e0cff-2fed-491e-b185-caf6e2e694b7"
       },
       "ResponseBody": {
         "sku": {
@@ -182,8 +190,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380",
-        "name": "testnamespacemgmt2380",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135",
+        "name": "testnamespacemgmt6135",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -194,486 +202,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt2380",
-          "createdAt": "2022-10-11T16:06:46.253Z",
-          "updatedAt": "2022-10-11T16:06:46.253Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2380.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6135",
+          "createdAt": "2022-10-12T07:45:48.31Z",
+          "updatedAt": "2022-10-12T07:45:48.31Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6135.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-f7a38dcdf01661418a9b9902de9e9213-4a49502019cc804c-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "e15eb523d44507775eb276801d6daf64",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:06:49 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "e15eb523d44507775eb276801d6daf64",
-        "x-ms-correlation-request-id": "acdb1406-1a87-476c-995d-dd3a71f1907d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11998",
-        "x-ms-request-id": "8d3de384-972e-418a-b7f6-bfe74b0a3cf9_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160649Z:acdb1406-1a87-476c-995d-dd3a71f1907d"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380",
-        "name": "testnamespacemgmt2380",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt2380",
-          "createdAt": "2022-10-11T16:06:46.253Z",
-          "updatedAt": "2022-10-11T16:06:46.253Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2380.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f7a38dcdf01661418a9b9902de9e9213-67a8b34be0b21c49-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "8ed7877262f6eacbe9a4abfca0dc1436",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:06:50 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8ed7877262f6eacbe9a4abfca0dc1436",
-        "x-ms-correlation-request-id": "f2264130-b28e-43af-9077-9e14ea2ecddb",
-        "x-ms-ratelimit-remaining-subscription-reads": "11997",
-        "x-ms-request-id": "9865d96b-2f7d-43f4-84d1-b5f5783ab297_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160650Z:f2264130-b28e-43af-9077-9e14ea2ecddb"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380",
-        "name": "testnamespacemgmt2380",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt2380",
-          "createdAt": "2022-10-11T16:06:46.253Z",
-          "updatedAt": "2022-10-11T16:06:46.253Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2380.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f7a38dcdf01661418a9b9902de9e9213-78e7db1e79796e43-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "a999ac708ed69e7227a83fd79cb3e679",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:06:52 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a999ac708ed69e7227a83fd79cb3e679",
-        "x-ms-correlation-request-id": "4f4660df-6498-4233-8e2a-3c50724e1495",
-        "x-ms-ratelimit-remaining-subscription-reads": "11996",
-        "x-ms-request-id": "9909f76d-02d0-42b7-8fd8-4db5d3ffe5d2_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160652Z:4f4660df-6498-4233-8e2a-3c50724e1495"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380",
-        "name": "testnamespacemgmt2380",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt2380",
-          "createdAt": "2022-10-11T16:06:46.253Z",
-          "updatedAt": "2022-10-11T16:06:46.253Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2380.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f7a38dcdf01661418a9b9902de9e9213-f63a4648fa21ac4c-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "b6b6bc6a4c70c080ea73f7a1297a6681",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:06:54 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "b6b6bc6a4c70c080ea73f7a1297a6681",
-        "x-ms-correlation-request-id": "aaf561af-9430-4427-93ac-1c962b50930d",
-        "x-ms-ratelimit-remaining-subscription-reads": "11995",
-        "x-ms-request-id": "1a3b58e0-448f-4a48-aee3-c07afe2b07be_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160654Z:aaf561af-9430-4427-93ac-1c962b50930d"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380",
-        "name": "testnamespacemgmt2380",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt2380",
-          "createdAt": "2022-10-11T16:06:46.253Z",
-          "updatedAt": "2022-10-11T16:06:46.253Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2380.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f7a38dcdf01661418a9b9902de9e9213-5de07cd5aabdbd4a-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "700f3f9e06d3e38d1538674e23f34e35",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:06:56 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "700f3f9e06d3e38d1538674e23f34e35",
-        "x-ms-correlation-request-id": "6e3a5ceb-2d9c-4d8b-99a6-41758cbfce42",
-        "x-ms-ratelimit-remaining-subscription-reads": "11994",
-        "x-ms-request-id": "1e1dc897-d7fb-44c7-8ca9-94981de871d4_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160657Z:6e3a5ceb-2d9c-4d8b-99a6-41758cbfce42"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380",
-        "name": "testnamespacemgmt2380",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt2380",
-          "createdAt": "2022-10-11T16:06:46.253Z",
-          "updatedAt": "2022-10-11T16:06:46.253Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2380.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f7a38dcdf01661418a9b9902de9e9213-fbcb0f25e43b2b4f-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "e49231be5d2623c62cd8bf6296d075ac",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:07:01 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "e49231be5d2623c62cd8bf6296d075ac",
-        "x-ms-correlation-request-id": "f6330933-8698-4572-a8ec-21e8553cfcc2",
-        "x-ms-ratelimit-remaining-subscription-reads": "11993",
-        "x-ms-request-id": "1f7e7ba7-6dd1-40a1-be17-d5aa96366612_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160701Z:f6330933-8698-4572-a8ec-21e8553cfcc2"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380",
-        "name": "testnamespacemgmt2380",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt2380",
-          "createdAt": "2022-10-11T16:06:46.253Z",
-          "updatedAt": "2022-10-11T16:06:46.253Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2380.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f7a38dcdf01661418a9b9902de9e9213-d016ea885f334c4f-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "5d39be4175a464a52ed2a137e5319df6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:07:10 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5d39be4175a464a52ed2a137e5319df6",
-        "x-ms-correlation-request-id": "2875bb26-05c4-40b0-9d43-4ffdd58a20cd",
-        "x-ms-ratelimit-remaining-subscription-reads": "11992",
-        "x-ms-request-id": "94acfc32-b997-4274-b0f3-e850124cb3ce_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160710Z:2875bb26-05c4-40b0-9d43-4ffdd58a20cd"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380",
-        "name": "testnamespacemgmt2380",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt2380",
-          "createdAt": "2022-10-11T16:06:46.253Z",
-          "updatedAt": "2022-10-11T16:06:46.253Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2380.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f7a38dcdf01661418a9b9902de9e9213-1d91764a9249874d-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "f7e3c22582e8405a78eb44fb462a4c45",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:07:27 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "f7e3c22582e8405a78eb44fb462a4c45",
-        "x-ms-correlation-request-id": "897c36b2-154d-4c9e-8e84-541e43f8a597",
-        "x-ms-ratelimit-remaining-subscription-reads": "11991",
-        "x-ms-request-id": "7b6285c5-b019-4025-b3d0-2eeb424aa5bb_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160727Z:897c36b2-154d-4c9e-8e84-541e43f8a597"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380",
-        "name": "testnamespacemgmt2380",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt2380",
-          "createdAt": "2022-10-11T16:06:46.253Z",
-          "updatedAt": "2022-10-11T16:06:46.253Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2380.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f7a38dcdf01661418a9b9902de9e9213-932d5a659a77ee4b-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "650cbac3f1ba48918c2db553bc8e3efa",
+        "traceparent": "00-24cc27d23b8686468209f5c9f479daba-9cf329bf45a7fc45-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "cc355c1aacc683ab4ef8a9663ae92377",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -682,21 +226,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:07:59 GMT",
+        "Date": "Wed, 12 Oct 2022 07:45:50 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "650cbac3f1ba48918c2db553bc8e3efa",
-        "x-ms-correlation-request-id": "74102aad-fbe5-4610-82a2-8559e85a9200",
-        "x-ms-ratelimit-remaining-subscription-reads": "11990",
-        "x-ms-request-id": "3291ed36-666f-4dba-bcd6-b6deab940a8b_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160800Z:74102aad-fbe5-4610-82a2-8559e85a9200"
+        "x-ms-client-request-id": "cc355c1aacc683ab4ef8a9663ae92377",
+        "x-ms-correlation-request-id": "f5f2ba12-3dcd-45f5-a421-0b56fb21a7dd",
+        "x-ms-ratelimit-remaining-subscription-reads": "11991",
+        "x-ms-request-id": "b6096bcc-0e0e-4803-8df3-c5bc86670549_M1SN1_M1SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074550Z:f5f2ba12-3dcd-45f5-a421-0b56fb21a7dd"
       },
       "ResponseBody": {
         "sku": {
@@ -704,8 +248,472 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380",
-        "name": "testnamespacemgmt2380",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135",
+        "name": "testnamespacemgmt6135",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6135",
+          "createdAt": "2022-10-12T07:45:48.31Z",
+          "updatedAt": "2022-10-12T07:45:48.31Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6135.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-24cc27d23b8686468209f5c9f479daba-c57106808b081246-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "7460087b60caf70365fe03e9bd36fd1b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "736",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:45:52 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/SN1",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7460087b60caf70365fe03e9bd36fd1b",
+        "x-ms-correlation-request-id": "36743c85-22a9-40ec-8a07-881ed82c04e3",
+        "x-ms-ratelimit-remaining-subscription-reads": "11990",
+        "x-ms-request-id": "08aa36ab-ba82-4764-915c-8c1b27bddb3c_M1SN1_M1SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074552Z:36743c85-22a9-40ec-8a07-881ed82c04e3"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135",
+        "name": "testnamespacemgmt6135",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6135",
+          "createdAt": "2022-10-12T07:45:48.31Z",
+          "updatedAt": "2022-10-12T07:45:48.31Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6135.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-24cc27d23b8686468209f5c9f479daba-2500263616f0794a-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "8dbbce626c552e62d80e09998ec83301",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "736",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:45:53 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/SN1",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "8dbbce626c552e62d80e09998ec83301",
+        "x-ms-correlation-request-id": "50d3e372-e3f6-4c15-94a8-bd411aa923e2",
+        "x-ms-ratelimit-remaining-subscription-reads": "11989",
+        "x-ms-request-id": "72597959-04b2-453a-81c9-d27f9c32b95e_M1SN1_M1SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074554Z:50d3e372-e3f6-4c15-94a8-bd411aa923e2"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135",
+        "name": "testnamespacemgmt6135",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6135",
+          "createdAt": "2022-10-12T07:45:48.31Z",
+          "updatedAt": "2022-10-12T07:45:48.31Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6135.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-24cc27d23b8686468209f5c9f479daba-03c25f9e49342c4d-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "478ac451fdd3ba24593d67c8a9c1c618",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "736",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:45:55 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/SN1",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "478ac451fdd3ba24593d67c8a9c1c618",
+        "x-ms-correlation-request-id": "7075954b-ba97-42e6-b49d-109905f0e2fd",
+        "x-ms-ratelimit-remaining-subscription-reads": "11988",
+        "x-ms-request-id": "c522a9f4-fe8a-47d3-b106-212447bf7ba7_M1SN1_M1SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074555Z:7075954b-ba97-42e6-b49d-109905f0e2fd"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135",
+        "name": "testnamespacemgmt6135",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6135",
+          "createdAt": "2022-10-12T07:45:48.31Z",
+          "updatedAt": "2022-10-12T07:45:48.31Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6135.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-24cc27d23b8686468209f5c9f479daba-3f55550e2653624b-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6c048dfb962d0e21a5329cbc5669689d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "736",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:45:58 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/SN1",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "6c048dfb962d0e21a5329cbc5669689d",
+        "x-ms-correlation-request-id": "c77b0cbd-9683-4202-acb6-987d1e70dca0",
+        "x-ms-ratelimit-remaining-subscription-reads": "11987",
+        "x-ms-request-id": "c39ecbe5-07f8-419c-a480-46f15610db81_M1SN1_M1SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074558Z:c77b0cbd-9683-4202-acb6-987d1e70dca0"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135",
+        "name": "testnamespacemgmt6135",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6135",
+          "createdAt": "2022-10-12T07:45:48.31Z",
+          "updatedAt": "2022-10-12T07:45:48.31Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6135.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-24cc27d23b8686468209f5c9f479daba-52bbdd7f4ad1e347-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f89802cab5ab6448a9013417059a8516",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "736",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:46:02 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/SN1",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "f89802cab5ab6448a9013417059a8516",
+        "x-ms-correlation-request-id": "c93bc6db-b9a2-4da3-a436-5d82fa15a12a",
+        "x-ms-ratelimit-remaining-subscription-reads": "11986",
+        "x-ms-request-id": "b1bce2d1-64be-4cc7-b6f6-5a610fa59cc6_M1SN1_M1SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074603Z:c93bc6db-b9a2-4da3-a436-5d82fa15a12a"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135",
+        "name": "testnamespacemgmt6135",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6135",
+          "createdAt": "2022-10-12T07:45:48.31Z",
+          "updatedAt": "2022-10-12T07:45:48.31Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6135.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-24cc27d23b8686468209f5c9f479daba-8f82105d83d61a42-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "019ef047c7c3bad3a37ba1a1616763ef",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "736",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:46:11 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/SN1",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "019ef047c7c3bad3a37ba1a1616763ef",
+        "x-ms-correlation-request-id": "35c1041e-72db-4366-b58f-9371e308df62",
+        "x-ms-ratelimit-remaining-subscription-reads": "11985",
+        "x-ms-request-id": "1a63be4e-f332-4603-aceb-33977b5f6794_M11SN1_M11SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074611Z:35c1041e-72db-4366-b58f-9371e308df62"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135",
+        "name": "testnamespacemgmt6135",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6135",
+          "createdAt": "2022-10-12T07:45:48.31Z",
+          "updatedAt": "2022-10-12T07:45:48.31Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6135.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-24cc27d23b8686468209f5c9f479daba-dee24537fec3834d-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a7fecad4cd29456c459fc22c6209090b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "736",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:46:29 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/SN1",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a7fecad4cd29456c459fc22c6209090b",
+        "x-ms-correlation-request-id": "1a7124d5-17c8-4bbc-a90f-c76144735d80",
+        "x-ms-ratelimit-remaining-subscription-reads": "11984",
+        "x-ms-request-id": "203f1069-7223-4819-8125-c6eb9c650613_M4SN1_M4SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074630Z:1a7124d5-17c8-4bbc-a90f-c76144735d80"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135",
+        "name": "testnamespacemgmt6135",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6135",
+          "createdAt": "2022-10-12T07:45:48.31Z",
+          "updatedAt": "2022-10-12T07:45:48.31Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6135.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-24cc27d23b8686468209f5c9f479daba-52e58d48e6db1e42-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "667485ac67cb02d92edd552f13a60341",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "735",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:47:02 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/SN1",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "667485ac67cb02d92edd552f13a60341",
+        "x-ms-correlation-request-id": "fd214c8a-3c0d-4164-8a02-52f1631fa55b",
+        "x-ms-ratelimit-remaining-subscription-reads": "11983",
+        "x-ms-request-id": "0f50e616-28bd-4669-ab55-9fc0644a874c_M2SN1_M2SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074703Z:fd214c8a-3c0d-4164-8a02-52f1631fa55b"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135",
+        "name": "testnamespacemgmt6135",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -716,43 +724,43 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt2380",
-          "createdAt": "2022-10-11T16:06:46.253Z",
-          "updatedAt": "2022-10-11T16:07:33.743Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2380.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6135",
+          "createdAt": "2022-10-12T07:45:48.31Z",
+          "updatedAt": "2022-10-12T07:46:35.927Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6135.servicebus.windows.net:443/",
           "status": "Active"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-af22b89af4664144a749ce0ade8fdcdc-25a2d0681c399940-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "d43dc83a7eecbfc463f8e4b831aa1d03",
+        "traceparent": "00-ea0910fe8486bc4194dc69c2415a1b89-2bcdde7f2b69cc4e-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "3b42449ddd9b7aed8358bb2404a75899",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "17937",
+        "Content-Length": "17580",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:00 GMT",
+        "Date": "Wed, 12 Oct 2022 07:47:03 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "7e01c32d-be15-45ef-a93c-f0150098ef34",
-        "x-ms-ratelimit-remaining-subscription-reads": "11989",
-        "x-ms-request-id": "7e01c32d-be15-45ef-a93c-f0150098ef34",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160801Z:7e01c32d-be15-45ef-a93c-f0150098ef34"
+        "x-ms-correlation-request-id": "4b389557-7fe5-4f6a-9a04-6c4e0d782e15",
+        "x-ms-ratelimit-remaining-subscription-reads": "11982",
+        "x-ms-request-id": "4b389557-7fe5-4f6a-9a04-6c4e0d782e15",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074704Z:4b389557-7fe5-4f6a-9a04-6c4e0d782e15"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/providers/Microsoft.Resources",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources",
         "namespace": "Microsoft.Resources",
         "authorizations": [
           {
@@ -1286,11 +1294,7 @@
               "Jio India West",
               "West US 3",
               "Qatar Central",
-              "Sweden Central",
-              "UAE Central",
-              "Norway West",
-              "East US 2 EUAP",
-              "Central US EUAP"
+              "Sweden Central"
             ],
             "apiVersions": [
               "2019-05-01",
@@ -1367,11 +1371,7 @@
               "Jio India West",
               "West US 3",
               "Qatar Central",
-              "Sweden Central",
-              "UAE Central",
-              "Norway West",
-              "East US 2 EUAP",
-              "Central US EUAP"
+              "Sweden Central"
             ],
             "apiVersions": [
               "2019-05-01",
@@ -1779,9 +1779,7 @@
               "West US",
               "South Central US",
               "West US 3",
-              "South Africa North",
-              "Central US EUAP",
-              "East US 2 EUAP"
+              "South Africa North"
             ],
             "apiVersions": [
               "2020-10-01",
@@ -1824,9 +1822,7 @@
               "West US",
               "South Central US",
               "West US 3",
-              "South Africa North",
-              "Central US EUAP",
-              "East US 2 EUAP"
+              "South Africa North"
             ],
             "apiVersions": [
               "2020-10-01",
@@ -1869,9 +1865,7 @@
               "West US",
               "South Central US",
               "West US 3",
-              "South Africa North",
-              "Central US EUAP",
-              "East US 2 EUAP"
+              "South Africa North"
             ],
             "apiVersions": [
               "2020-10-01",
@@ -1918,11 +1912,7 @@
               "West US",
               "West US 3",
               "South Central US",
-              "South Africa North",
-              "Central US EUAP",
-              "East US 2 EUAP",
-              "Norway West",
-              "UAE Central"
+              "South Africa North"
             ],
             "apiVersions": [
               "2022-02-01",
@@ -1971,11 +1961,7 @@
               "West US",
               "West US 3",
               "South Central US",
-              "South Africa North",
-              "Central US EUAP",
-              "East US 2 EUAP",
-              "Norway West",
-              "UAE Central"
+              "South Africa North"
             ],
             "apiVersions": [
               "2022-02-01",
@@ -2016,14 +2002,14 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-af22b89af4664144a749ce0ade8fdcdc-bc36eeb5b7441d41-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "2a745b863825343c309a6abacd0784ea",
+        "traceparent": "00-ea0910fe8486bc4194dc69c2415a1b89-2edb61cd2f152346-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "dbf49672fdf26d24f0fc784c773d329e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -2032,18 +2018,18 @@
         "Cache-Control": "no-cache",
         "Content-Length": "276",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:01 GMT",
+        "Date": "Wed, 12 Oct 2022 07:47:04 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "0c5dc72c-b3a8-42f4-92cf-e76160e0bb9b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11988",
-        "x-ms-request-id": "0c5dc72c-b3a8-42f4-92cf-e76160e0bb9b",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160802Z:0c5dc72c-b3a8-42f4-92cf-e76160e0bb9b"
+        "x-ms-correlation-request-id": "7b416e6f-06fe-4a0f-b0f2-dc13043e807e",
+        "x-ms-ratelimit-remaining-subscription-reads": "11981",
+        "x-ms-request-id": "7b416e6f-06fe-4a0f-b0f2-dc13043e807e",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074704Z:7b416e6f-06fe-4a0f-b0f2-dc13043e807e"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380/providers/Microsoft.Resources/tags/default",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135/providers/Microsoft.Resources/tags/default",
         "name": "default",
         "type": "Microsoft.Resources/tags",
         "properties": {
@@ -2052,336 +2038,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "43",
-        "Content-Type": "application/json",
-        "traceparent": "00-af22b89af4664144a749ce0ade8fdcdc-adba323cfe4b9848-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "7dc049ad78ed4558f64c01c10dd817e1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "properties": {
-          "tags": {
-            "key": "Sanitized"
-          }
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "293",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:06 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "3635b312-3bd4-402d-9b6f-5e79ae6df443",
-        "x-ms-ratelimit-remaining-subscription-writes": "1198",
-        "x-ms-request-id": "3635b312-3bd4-402d-9b6f-5e79ae6df443",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160806Z:3635b312-3bd4-402d-9b6f-5e79ae6df443"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380/providers/Microsoft.Resources/tags/default",
-        "name": "default",
-        "type": "Microsoft.Resources/tags",
-        "properties": {
-          "tags": {
-            "key": "Sanitized"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-af22b89af4664144a749ce0ade8fdcdc-d45424a89935794e-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "60cdb10f131a02d48c08a3511309f25c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "753",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:06 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "60cdb10f131a02d48c08a3511309f25c",
-        "x-ms-correlation-request-id": "ee17a549-7f8a-4e07-bd84-103cb218e639",
-        "x-ms-ratelimit-remaining-subscription-reads": "11987",
-        "x-ms-request-id": "65a14b54-36de-4b62-b4b1-abaaa237d7d6_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160806Z:ee17a549-7f8a-4e07-bd84-103cb218e639"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380",
-        "name": "testnamespacemgmt2380",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {
-          "key": "Sanitized"
-        },
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt2380",
-          "createdAt": "2022-10-11T16:06:46.253Z",
-          "updatedAt": "2022-10-11T16:08:05.163Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2380.servicebus.windows.net:443/",
-          "status": "Active"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-5ca21c7db5e9394c8528a94c9101cd05-1f69fd629a8d0e44-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "e70bf974a0ea0d16032f34d8367a2757",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Date": "Tue, 11 Oct 2022 16:08:09 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "e05d5e5f-681d-4df5-9f3f-62fe10f36f73",
-        "x-ms-ratelimit-remaining-subscription-deletes": "14999",
-        "x-ms-request-id": "e05d5e5f-681d-4df5-9f3f-62fe10f36f73",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160809Z:e05d5e5f-681d-4df5-9f3f-62fe10f36f73"
-      },
-      "ResponseBody": null
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-5ca21c7db5e9394c8528a94c9101cd05-d32763c3276ac242-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "1baa8983233999d074bdf0e4d40631ed",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "276",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:09 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "acb86f3f-f00f-45a6-adeb-b5a13194d50b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11986",
-        "x-ms-request-id": "acb86f3f-f00f-45a6-adeb-b5a13194d50b",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160809Z:acb86f3f-f00f-45a6-adeb-b5a13194d50b"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380/providers/Microsoft.Resources/tags/default",
-        "name": "default",
-        "type": "Microsoft.Resources/tags",
-        "properties": {
-          "tags": {}
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "59",
-        "Content-Type": "application/json",
-        "traceparent": "00-5ca21c7db5e9394c8528a94c9101cd05-1b1cf8ebe63f034b-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "134da55a2fcd6ff79bbf5deadffccb12",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "properties": {
-          "tags": {
-            "key": "Sanitized",
-            "key1": "value1"
-          }
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "309",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:12 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "80dc5b84-bc5b-484c-a58a-f57918c0aea8",
-        "x-ms-ratelimit-remaining-subscription-writes": "1197",
-        "x-ms-request-id": "80dc5b84-bc5b-484c-a58a-f57918c0aea8",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160812Z:80dc5b84-bc5b-484c-a58a-f57918c0aea8"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380/providers/Microsoft.Resources/tags/default",
-        "name": "default",
-        "type": "Microsoft.Resources/tags",
-        "properties": {
-          "tags": {
-            "key": "Sanitized",
-            "key1": "value1"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-5ca21c7db5e9394c8528a94c9101cd05-0bd5ba2157d37549-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "8ace4be1d65e50222972732caf3139fc",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "772",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:13 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/CH3",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8ace4be1d65e50222972732caf3139fc",
-        "x-ms-correlation-request-id": "e3442456-90ef-4994-80b1-6a8985df987b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11985",
-        "x-ms-request-id": "d5a6c6f6-2e13-4600-ba56-abe5be7cd105_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160813Z:e3442456-90ef-4994-80b1-6a8985df987b"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380",
-        "name": "testnamespacemgmt2380",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {
-          "key": "Sanitized",
-          "key1": "value1"
-        },
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Updating",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt2380",
-          "createdAt": "2022-10-11T16:06:46.253Z",
-          "updatedAt": "2022-10-11T16:08:10.823Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2380.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-1729eb8ac6edfa49a965b78a924b737e-ea07f92970f10343-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "917d47fd142d548a913b807ac6e5ba78",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "309",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:13 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "01065a3d-fa62-4056-8d14-f0c5db2e9ad8",
-        "x-ms-ratelimit-remaining-subscription-reads": "11984",
-        "x-ms-request-id": "01065a3d-fa62-4056-8d14-f0c5db2e9ad8",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160813Z:01065a3d-fa62-4056-8d14-f0c5db2e9ad8"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380/providers/Microsoft.Resources/tags/default",
-        "name": "default",
-        "type": "Microsoft.Resources/tags",
-        "properties": {
-          "tags": {
-            "key": "Sanitized",
-            "key1": "value1"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "41",
         "Content-Type": "application/json",
-        "traceparent": "00-1729eb8ac6edfa49a965b78a924b737e-0a55a86a033e0041-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "8802def2a738838f82fce95bbccac069",
+        "traceparent": "00-ea0910fe8486bc4194dc69c2415a1b89-bae7791533bbb84f-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "1d8e819bcdc6cf7098fae272abb4fd86",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -2396,18 +2062,18 @@
         "Cache-Control": "no-cache",
         "Content-Length": "291",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:15 GMT",
+        "Date": "Wed, 12 Oct 2022 07:47:08 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "c2019375-963d-49b8-ae5f-20a7a965fffe",
-        "x-ms-ratelimit-remaining-subscription-writes": "1196",
-        "x-ms-request-id": "c2019375-963d-49b8-ae5f-20a7a965fffe",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160815Z:c2019375-963d-49b8-ae5f-20a7a965fffe"
+        "x-ms-correlation-request-id": "1a5edd9e-d3f8-44a3-b2c4-42c3924cf6bc",
+        "x-ms-ratelimit-remaining-subscription-writes": "1198",
+        "x-ms-request-id": "1a5edd9e-d3f8-44a3-b2c4-42c3924cf6bc",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074709Z:1a5edd9e-d3f8-44a3-b2c4-42c3924cf6bc"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380/providers/Microsoft.Resources/tags/default",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135/providers/Microsoft.Resources/tags/default",
         "name": "default",
         "type": "Microsoft.Resources/tags",
         "properties": {
@@ -2418,37 +2084,37 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-1729eb8ac6edfa49a965b78a924b737e-76f7a37ac69fed4c-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "97ed6086397ecde4c179f82356a88944",
+        "traceparent": "00-ea0910fe8486bc4194dc69c2415a1b89-578d646c71383840-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "7dbdbc8427b19f4e20d54a9f64a10246",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "754",
+        "Content-Length": "751",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:17 GMT",
+        "Date": "Wed, 12 Oct 2022 07:47:09 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "97ed6086397ecde4c179f82356a88944",
-        "x-ms-correlation-request-id": "d1711e9d-5b1a-4932-9bd0-993587902c8b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11983",
-        "x-ms-request-id": "1098fbd2-6f73-4280-b3e0-bc5ddf327176_M4CH3_M4CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160817Z:d1711e9d-5b1a-4932-9bd0-993587902c8b"
+        "x-ms-client-request-id": "7dbdbc8427b19f4e20d54a9f64a10246",
+        "x-ms-correlation-request-id": "eb179317-1f3e-4b97-a96d-bbb62598481f",
+        "x-ms-ratelimit-remaining-subscription-reads": "11980",
+        "x-ms-request-id": "23601a3f-8e8b-46b2-8d4b-64e48a07c257_M10SN1_M10SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074709Z:eb179317-1f3e-4b97-a96d-bbb62598481f"
       },
       "ResponseBody": {
         "sku": {
@@ -2456,8 +2122,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380",
-        "name": "testnamespacemgmt2380",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135",
+        "name": "testnamespacemgmt6135",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {
@@ -2470,46 +2136,193 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Updating",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt2380",
-          "createdAt": "2022-10-11T16:06:46.253Z",
-          "updatedAt": "2022-10-11T16:08:14.643Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2380.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6135",
+          "createdAt": "2022-10-12T07:45:48.31Z",
+          "updatedAt": "2022-10-12T07:47:07.3Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6135.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380?api-version=2021-11-01",
-      "RequestMethod": "GET",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-22687f71c11f724c9941df05f7f4498e-518de1bdc2bf874b-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "d03afab7b02e55c3b8fa0e302a2f97c7",
+        "traceparent": "00-ee378a8709a0284bb981c6d7017d6eba-18eb6be58daefb43-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "83891d263b18a5d2262543f81bb1c13c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 429,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Connection": "close",
+        "Content-Length": "249",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:47:10 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "74c90432-fe53-44d9-b907-cdc38121c356",
+        "x-ms-failure-cause": "",
+        "x-ms-request-id": "74c90432-fe53-44d9-b907-cdc38121c356",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074711Z:74c90432-fe53-44d9-b907-cdc38121c356"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "ProviderError",
+          "message": "{\u0022error\u0022:{\u0022message\u0022:\u0022Namespace provisioning in transition. For more information visit https://aka.ms/eventhubsarmexceptions. CorrelationId: 74c90432-fe53-44d9-b907-cdc38121c356\u0022,\u0022code\u0022:\u0022429\u0022}}"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ee378a8709a0284bb981c6d7017d6eba-18eb6be58daefb43-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "83891d263b18a5d2262543f81bb1c13c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "751",
+        "Content-Length": "0",
+        "Date": "Wed, 12 Oct 2022 07:47:15 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "9777c0db-8502-440a-b076-cd9ff376eb20",
+        "x-ms-ratelimit-remaining-subscription-deletes": "14999",
+        "x-ms-request-id": "9777c0db-8502-440a-b076-cd9ff376eb20",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074716Z:9777c0db-8502-440a-b076-cd9ff376eb20"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ee378a8709a0284bb981c6d7017d6eba-4b5ad0804b91e04e-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "bbc7f1feb48073ed32effdf182d06af7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "276",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:08:29 GMT",
+        "Date": "Wed, 12 Oct 2022 07:47:16 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "b2a6a838-8581-4fb0-b04d-1c3a46a21d70",
+        "x-ms-ratelimit-remaining-subscription-reads": "11996",
+        "x-ms-request-id": "b2a6a838-8581-4fb0-b04d-1c3a46a21d70",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074717Z:b2a6a838-8581-4fb0-b04d-1c3a46a21d70"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135/providers/Microsoft.Resources/tags/default",
+        "name": "default",
+        "type": "Microsoft.Resources/tags",
+        "properties": {
+          "tags": {}
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "57",
+        "Content-Type": "application/json",
+        "traceparent": "00-ee378a8709a0284bb981c6d7017d6eba-ac10caadad4c5b4b-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "8e4c9cf77a2b496ee918578be456846f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "properties": {
+          "tags": {
+            "key1": "value1",
+            "key2": "value2"
+          }
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "307",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:47:19 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "914c38c5-1b75-4cac-9722-723e11b08c00",
+        "x-ms-ratelimit-remaining-subscription-writes": "1199",
+        "x-ms-request-id": "914c38c5-1b75-4cac-9722-723e11b08c00",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074720Z:914c38c5-1b75-4cac-9722-723e11b08c00"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135/providers/Microsoft.Resources/tags/default",
+        "name": "default",
+        "type": "Microsoft.Resources/tags",
+        "properties": {
+          "tags": {
+            "key1": "value1",
+            "key2": "value2"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ee378a8709a0284bb981c6d7017d6eba-89a6d7d98bab6d4c-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "73a10e1447d971c62f1550293de12255",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "769",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:47:20 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/CH3",
+          "Service-Bus-Resource-Provider/SN1",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d03afab7b02e55c3b8fa0e302a2f97c7",
-        "x-ms-correlation-request-id": "7de28382-f3ed-495e-9df6-6e84d9d5b3f4",
-        "x-ms-ratelimit-remaining-subscription-reads": "11982",
-        "x-ms-request-id": "26382874-1004-473b-8a81-9c15e6ef09c0_M6CH3_M6CH3",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T160829Z:7de28382-f3ed-495e-9df6-6e84d9d5b3f4"
+        "x-ms-client-request-id": "73a10e1447d971c62f1550293de12255",
+        "x-ms-correlation-request-id": "6ece11e4-9c8c-4ad3-bbcd-7eebb15214ff",
+        "x-ms-ratelimit-remaining-subscription-reads": "11995",
+        "x-ms-request-id": "d63db39c-765e-444c-b5ce-d4d651300236_M3SN1_M3SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074721Z:6ece11e4-9c8c-4ad3-bbcd-7eebb15214ff"
       },
       "ResponseBody": {
         "sku": {
@@ -2517,12 +2330,159 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-3927/providers/Microsoft.EventHub/namespaces/testnamespacemgmt2380",
-        "name": "testnamespacemgmt2380",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135",
+        "name": "testnamespacemgmt6135",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {
-          "key1": "value1"
+          "key1": "value1",
+          "key2": "value2"
+        },
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Updating",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6135",
+          "createdAt": "2022-10-12T07:45:48.31Z",
+          "updatedAt": "2022-10-12T07:47:18.173Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6135.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9251b2eb977ecc4586d38c19be8b41c1-226cc7bd617b5145-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "7e004bbb32658310837dd1685d618fdc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "307",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:47:20 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "5cfd812f-c8bd-4862-95f7-6b4e2931e34b",
+        "x-ms-ratelimit-remaining-subscription-reads": "11994",
+        "x-ms-request-id": "5cfd812f-c8bd-4862-95f7-6b4e2931e34b",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074721Z:5cfd812f-c8bd-4862-95f7-6b4e2931e34b"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135/providers/Microsoft.Resources/tags/default",
+        "name": "default",
+        "type": "Microsoft.Resources/tags",
+        "properties": {
+          "tags": {
+            "key1": "value1",
+            "key2": "value2"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "41",
+        "Content-Type": "application/json",
+        "traceparent": "00-9251b2eb977ecc4586d38c19be8b41c1-2d395951c78dc640-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "74dc8e6af72fb01dd5da5f1629440b08",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "properties": {
+          "tags": {
+            "key2": "value2"
+          }
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "291",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:47:22 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "c8fa00f7-16a3-4005-80ca-a3b25cf92e7c",
+        "x-ms-ratelimit-remaining-subscription-writes": "1198",
+        "x-ms-request-id": "c8fa00f7-16a3-4005-80ca-a3b25cf92e7c",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074723Z:c8fa00f7-16a3-4005-80ca-a3b25cf92e7c"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135/providers/Microsoft.Resources/tags/default",
+        "name": "default",
+        "type": "Microsoft.Resources/tags",
+        "properties": {
+          "tags": {
+            "key2": "value2"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9251b2eb977ecc4586d38c19be8b41c1-31de4733346f0e4a-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "98d001f50555e10afd1def5c765e13cd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "750",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:47:23 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/SN1",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "98d001f50555e10afd1def5c765e13cd",
+        "x-ms-correlation-request-id": "bdd38b87-dade-4a31-9065-6bac565d974c",
+        "x-ms-ratelimit-remaining-subscription-reads": "11993",
+        "x-ms-request-id": "40de7b6e-93df-4f97-82f7-070dd8618136_M3SN1_M3SN1",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T074724Z:bdd38b87-dade-4a31-9065-6bac565d974c"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-4752/providers/Microsoft.EventHub/namespaces/testnamespacemgmt6135",
+        "name": "testnamespacemgmt6135",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {
+          "key2": "value2"
         },
         "properties": {
           "disableLocalAuth": false,
@@ -2531,10 +2491,10 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt2380",
-          "createdAt": "2022-10-11T16:06:46.253Z",
-          "updatedAt": "2022-10-11T16:08:18.317Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt2380.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt6135",
+          "createdAt": "2022-10-12T07:45:48.31Z",
+          "updatedAt": "2022-10-12T07:47:23.497Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt6135.servicebus.windows.net:443/",
           "status": "Active"
         }
       }
@@ -2542,8 +2502,8 @@
   ],
   "Variables": {
     "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "1559548020",
+    "RandomSeed": "374403318",
     "RESOURCE_MANAGER_URL": null,
-    "SUBSCRIPTION_ID": "326100e2-f69d-4268-8503-075374f62b6e"
+    "SUBSCRIPTION_ID": "db1ab6f0-4769-4b27-930e-01e2ef9c123c"
   }
 }

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventHubNamespaceTests/AddSetRemoveTag(null)Async.json
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventHubNamespaceTests/AddSetRemoveTag(null)Async.json
@@ -1,43 +1,53 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e?api-version=2021-01-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c?api-version=2021-01-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-7c1996dabd3587419b72c0cc3452f3fd-7bace5642194fe47-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "fe578dfd2470ee39634066e482cc882a",
+        "Connection": "keep-alive",
+        "traceparent": "00-9e6e55ab1552454f87b8c7f3acb7127b-d7bbe06e33ea6249-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "5bf3ceca713450c66d2c2c1baecd826c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "460",
+        "Content-Length": "747",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:15:38 GMT",
+        "Date": "Wed, 12 Oct 2022 07:53:43 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "05027738-1ae5-4e9b-ba25-3b9d25796e6b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11998",
-        "x-ms-request-id": "05027738-1ae5-4e9b-ba25-3b9d25796e6b",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161538Z:05027738-1ae5-4e9b-ba25-3b9d25796e6b"
+        "x-ms-correlation-request-id": "c5b4c487-9b8b-41f3-8be6-eda5eacfd18b",
+        "x-ms-ratelimit-remaining-subscription-reads": "11995",
+        "x-ms-request-id": "c5b4c487-9b8b-41f3-8be6-eda5eacfd18b",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075343Z:c5b4c487-9b8b-41f3-8be6-eda5eacfd18b"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "authorizationSource": "RoleBased",
-        "managedByTenants": [
-          {
-            "tenantId": "2f4a9838-26b7-47ee-be60-ccc1fdec5953"
-          }
-        ],
-        "subscriptionId": "326100e2-f69d-4268-8503-075374f62b6e",
+        "managedByTenants": [],
+        "tags": {
+          "TagKey-9823": "TagValue-566",
+          "TagKey-3481": "TagValue-320",
+          "TagKey-4926": "TagValue-1187",
+          "TagKey-751": "TagValue-3921",
+          "TagKey-1866": "TagValue-8559",
+          "TagKey-3094": "TagValue-9190",
+          "TagKey-2449": "TagValue-9",
+          "TagKey-8379": "TagValue-164",
+          "TagKey-7470": "TagValue-2205",
+          "TagKey-4236": "TagValue-3698",
+          "TagKey-5316": "TagValue-2725"
+        },
+        "subscriptionId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c",
         "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-        "displayName": "Azure Messaging PM Playground",
+        "displayName": ".NET Mgmt SDK Test with TTL = 1 Day",
         "state": "Enabled",
         "subscriptionPolicies": {
           "locationPlacementId": "Internal_2014-09-01",
@@ -47,16 +57,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourcegroups/testeventhubRG-1868?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourcegroups/testeventhubRG-6601?api-version=2021-04-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "44",
         "Content-Type": "application/json",
-        "traceparent": "00-ea8e2a966c13244e9c807187b741a3e1-6ad9e668e3366941-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "c22dc770b49f243e1c8928dada4f7bee",
+        "traceparent": "00-2c2078f7862820428394609c47dd9563-be5a989d1d188948-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "8265f92a81079ab1f3c52fa6fb2dc46f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -70,19 +80,19 @@
         "Cache-Control": "no-cache",
         "Content-Length": "258",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:15:42 GMT",
+        "Date": "Wed, 12 Oct 2022 07:53:47 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "9b9a7cd6-e9da-4aa7-80ec-1a2eec1c8b83",
-        "x-ms-ratelimit-remaining-subscription-writes": "1199",
-        "x-ms-request-id": "9b9a7cd6-e9da-4aa7-80ec-1a2eec1c8b83",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161543Z:9b9a7cd6-e9da-4aa7-80ec-1a2eec1c8b83"
+        "x-ms-correlation-request-id": "6c43ba4d-9a12-44fb-b0b8-dc2a9ef84608",
+        "x-ms-ratelimit-remaining-subscription-writes": "1198",
+        "x-ms-request-id": "6c43ba4d-9a12-44fb-b0b8-dc2a9ef84608",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075347Z:6c43ba4d-9a12-44fb-b0b8-dc2a9ef84608"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868",
-        "name": "testeventhubRG-1868",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601",
+        "name": "testeventhubRG-6601",
         "type": "Microsoft.Resources/resourceGroups",
         "location": "eastus2",
         "tags": {
@@ -94,41 +104,41 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/providers/Microsoft.EventHub/checkNameAvailability?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.EventHub/checkNameAvailability?api-version=2021-11-01",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "32",
         "Content-Type": "application/json",
-        "traceparent": "00-8453d7fa2757e1449cf7962432da0a0b-4b1d4c9e94d0cb40-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "59c58f0ee8e4b1904439f43435b02cc2",
+        "traceparent": "00-ccc2d4166e905b47b292f98e9141e771-db128f6bb233da41-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "8832b7ea99d007c1abcc0bfa5ee858a4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "testnamespacemgmt4144"
+        "name": "testnamespacemgmt5586"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "53",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:15:43 GMT",
+        "Date": "Wed, 12 Oct 2022 07:53:48 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "59c58f0ee8e4b1904439f43435b02cc2",
-        "x-ms-correlation-request-id": "5c7e171f-0f1e-44b0-9e6b-709a2c996e28",
+        "x-ms-client-request-id": "8832b7ea99d007c1abcc0bfa5ee858a4",
+        "x-ms-correlation-request-id": "acec7f57-3cd5-4a10-b811-588e53083626",
         "x-ms-ratelimit-remaining-subscription-writes": "1199",
-        "x-ms-request-id": "923d32b2-91aa-40ea-9bfb-8aec0a84315d_M10SN1_M10SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161544Z:5c7e171f-0f1e-44b0-9e6b-709a2c996e28"
+        "x-ms-request-id": "b8baf161-c792-4ad5-ab8d-bb3ff8ee9356_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075348Z:acec7f57-3cd5-4a10-b811-588e53083626"
       },
       "ResponseBody": {
         "nameAvailable": true,
@@ -137,16 +147,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586?api-version=2021-11-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "48",
         "Content-Type": "application/json",
-        "traceparent": "00-4f57441ecd7a1344ab0adda9f7b3c703-45cab0a3b5673e46-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "88c0f06a5d0619d9d9539b111488f1eb",
+        "traceparent": "00-fa1ed0720093f546a317b49c0c3d3979-276c1bff222f6a4c-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "debe2614c2ae424dc140ab97aa71fe68",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -157,23 +167,23 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "738",
+        "Content-Length": "736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:15:48 GMT",
+        "Date": "Wed, 12 Oct 2022 07:53:53 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "88c0f06a5d0619d9d9539b111488f1eb",
-        "x-ms-correlation-request-id": "e1255dcb-110f-4b51-9070-890f760277fc",
-        "x-ms-ratelimit-remaining-subscription-resource-requests": "48",
-        "x-ms-request-id": "928d86fa-cc5d-4557-b533-99a74ee6ad67_M10SN1_M10SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161549Z:e1255dcb-110f-4b51-9070-890f760277fc"
+        "x-ms-client-request-id": "debe2614c2ae424dc140ab97aa71fe68",
+        "x-ms-correlation-request-id": "99eed6ad-5052-43af-a433-8bdd6b11e0ad",
+        "x-ms-ratelimit-remaining-subscription-resource-requests": "49",
+        "x-ms-request-id": "36e5720a-5afc-4de6-8a22-ca4a7997f60e_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075353Z:99eed6ad-5052-43af-a433-8bdd6b11e0ad"
       },
       "ResponseBody": {
         "sku": {
@@ -181,8 +191,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144",
-        "name": "testnamespacemgmt4144",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586",
+        "name": "testnamespacemgmt5586",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -193,486 +203,22 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt4144",
-          "createdAt": "2022-10-11T16:15:47.487Z",
-          "updatedAt": "2022-10-11T16:15:47.487Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt4144.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5586",
+          "createdAt": "2022-10-12T07:53:52.55Z",
+          "updatedAt": "2022-10-12T07:53:52.55Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5586.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-4f57441ecd7a1344ab0adda9f7b3c703-3ca6ac9b7dc5db4f-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "5f7017fc66bab0e7b6ab7f904c7e9dbc",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:15:50 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5f7017fc66bab0e7b6ab7f904c7e9dbc",
-        "x-ms-correlation-request-id": "e2eed065-e978-4650-88ee-6976c6716e1f",
-        "x-ms-ratelimit-remaining-subscription-reads": "11997",
-        "x-ms-request-id": "e4811958-ffa3-44c8-8cb6-9bffab994c57_M10SN1_M10SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161551Z:e2eed065-e978-4650-88ee-6976c6716e1f"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144",
-        "name": "testnamespacemgmt4144",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt4144",
-          "createdAt": "2022-10-11T16:15:47.487Z",
-          "updatedAt": "2022-10-11T16:15:47.487Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt4144.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-4f57441ecd7a1344ab0adda9f7b3c703-16f6b83619497b40-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "a13e094833f1635d63e1eaf5035ecfe8",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:15:51 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a13e094833f1635d63e1eaf5035ecfe8",
-        "x-ms-correlation-request-id": "b542fba7-d6cc-4ef6-8d72-492f67d36ce1",
-        "x-ms-ratelimit-remaining-subscription-reads": "11996",
-        "x-ms-request-id": "e9fca606-d229-4335-a88a-b6259636246e_M10SN1_M10SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161552Z:b542fba7-d6cc-4ef6-8d72-492f67d36ce1"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144",
-        "name": "testnamespacemgmt4144",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt4144",
-          "createdAt": "2022-10-11T16:15:47.487Z",
-          "updatedAt": "2022-10-11T16:15:47.487Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt4144.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-4f57441ecd7a1344ab0adda9f7b3c703-88923edccc52d745-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "fc15c26c91178f30ac0d42b987fb921e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:15:54 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "fc15c26c91178f30ac0d42b987fb921e",
-        "x-ms-correlation-request-id": "2da961d7-0975-41b4-a219-4a7b7f58f7d6",
-        "x-ms-ratelimit-remaining-subscription-reads": "11995",
-        "x-ms-request-id": "1996870c-1179-4964-8674-ab13a034dbbf_M10SN1_M10SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161554Z:2da961d7-0975-41b4-a219-4a7b7f58f7d6"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144",
-        "name": "testnamespacemgmt4144",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt4144",
-          "createdAt": "2022-10-11T16:15:47.487Z",
-          "updatedAt": "2022-10-11T16:15:47.487Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt4144.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-4f57441ecd7a1344ab0adda9f7b3c703-90c3dae85cdd974d-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "40329e7345b1c8e7ba0dfcd97bf1ad58",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:15:56 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "40329e7345b1c8e7ba0dfcd97bf1ad58",
-        "x-ms-correlation-request-id": "d766050b-41d4-4615-bca3-085d38037483",
-        "x-ms-ratelimit-remaining-subscription-reads": "11994",
-        "x-ms-request-id": "dee55490-4ee4-4bf3-8f73-d4a795f9411d_M10SN1_M10SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161556Z:d766050b-41d4-4615-bca3-085d38037483"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144",
-        "name": "testnamespacemgmt4144",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt4144",
-          "createdAt": "2022-10-11T16:15:47.487Z",
-          "updatedAt": "2022-10-11T16:15:47.487Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt4144.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-4f57441ecd7a1344ab0adda9f7b3c703-4622e22d5f127f48-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "892497dba068b6a4d9aff4e4f1a3dc67",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:15:59 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "892497dba068b6a4d9aff4e4f1a3dc67",
-        "x-ms-correlation-request-id": "d9fadc7b-4696-49de-aa4b-76421107cff6",
-        "x-ms-ratelimit-remaining-subscription-reads": "11993",
-        "x-ms-request-id": "db9a799f-7626-40c9-aa12-4d9bf1737225_M10SN1_M10SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161559Z:d9fadc7b-4696-49de-aa4b-76421107cff6"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144",
-        "name": "testnamespacemgmt4144",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt4144",
-          "createdAt": "2022-10-11T16:15:47.487Z",
-          "updatedAt": "2022-10-11T16:15:47.487Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt4144.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-4f57441ecd7a1344ab0adda9f7b3c703-f81fac7031738d47-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "6482cc4f8f2b2636db4c420a955713ba",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:16:04 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "6482cc4f8f2b2636db4c420a955713ba",
-        "x-ms-correlation-request-id": "7ab99b3e-9a8b-43ca-a401-8fb172ff7137",
-        "x-ms-ratelimit-remaining-subscription-reads": "11992",
-        "x-ms-request-id": "21961f37-5f82-4ba2-9b7d-c986fa60cdab_M10SN1_M10SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161604Z:7ab99b3e-9a8b-43ca-a401-8fb172ff7137"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144",
-        "name": "testnamespacemgmt4144",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt4144",
-          "createdAt": "2022-10-11T16:15:47.487Z",
-          "updatedAt": "2022-10-11T16:15:47.487Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt4144.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-4f57441ecd7a1344ab0adda9f7b3c703-00512063c18d504f-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "efdde96008d7d2b5f97b67025002d716",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:16:12 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "efdde96008d7d2b5f97b67025002d716",
-        "x-ms-correlation-request-id": "6a433f0d-605e-4cd3-82c4-c6c276c256a5",
-        "x-ms-ratelimit-remaining-subscription-reads": "11991",
-        "x-ms-request-id": "a46cad91-0bc3-45ff-8d23-c91275274c9a_M10SN1_M10SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161613Z:6a433f0d-605e-4cd3-82c4-c6c276c256a5"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144",
-        "name": "testnamespacemgmt4144",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt4144",
-          "createdAt": "2022-10-11T16:15:47.487Z",
-          "updatedAt": "2022-10-11T16:15:47.487Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt4144.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-4f57441ecd7a1344ab0adda9f7b3c703-5f2085196eccc64b-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "af899430486f4c2c60fdae1c5e992182",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "738",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:16:30 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "af899430486f4c2c60fdae1c5e992182",
-        "x-ms-correlation-request-id": "3dce438d-7ffd-4f07-a6f0-10eabd89e011",
-        "x-ms-ratelimit-remaining-subscription-reads": "11990",
-        "x-ms-request-id": "102e90ec-1436-4650-8027-0667ee948eca_M10SN1_M10SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161630Z:3dce438d-7ffd-4f07-a6f0-10eabd89e011"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144",
-        "name": "testnamespacemgmt4144",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {},
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Created",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt4144",
-          "createdAt": "2022-10-11T16:15:47.487Z",
-          "updatedAt": "2022-10-11T16:15:47.487Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt4144.servicebus.windows.net:443/",
-          "status": "Activating"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-4f57441ecd7a1344ab0adda9f7b3c703-747b6fbca2866247-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "07833a9becc5468f16af6bb02834d5d8",
+        "traceparent": "00-fa1ed0720093f546a317b49c0c3d3979-f6c9e6843b8c9146-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "07e602d6900528bc6af0c790ed295d39",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -681,21 +227,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:02 GMT",
+        "Date": "Wed, 12 Oct 2022 07:53:54 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "07833a9becc5468f16af6bb02834d5d8",
-        "x-ms-correlation-request-id": "e89f3df7-29ed-4dd0-8dcc-4a1521b70aed",
-        "x-ms-ratelimit-remaining-subscription-reads": "11989",
-        "x-ms-request-id": "6abe0018-7bec-4e7a-b0af-2d3b591d6b03_M10SN1_M10SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161703Z:e89f3df7-29ed-4dd0-8dcc-4a1521b70aed"
+        "x-ms-client-request-id": "07e602d6900528bc6af0c790ed295d39",
+        "x-ms-correlation-request-id": "a8dc912f-c224-4b91-9667-1ddde8c7c6c5",
+        "x-ms-ratelimit-remaining-subscription-reads": "11994",
+        "x-ms-request-id": "db3328c2-61cf-4293-bf56-ce6a9b2f9dcd_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075354Z:a8dc912f-c224-4b91-9667-1ddde8c7c6c5"
       },
       "ResponseBody": {
         "sku": {
@@ -703,8 +249,472 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144",
-        "name": "testnamespacemgmt4144",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586",
+        "name": "testnamespacemgmt5586",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5586",
+          "createdAt": "2022-10-12T07:53:52.55Z",
+          "updatedAt": "2022-10-12T07:53:52.55Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5586.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-fa1ed0720093f546a317b49c0c3d3979-abae46b30b092a4d-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "1b4ea2cd8d05e26acc5e3a3366979b21",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "736",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:53:55 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "1b4ea2cd8d05e26acc5e3a3366979b21",
+        "x-ms-correlation-request-id": "db954193-ced8-4ea4-9c80-15055d1a049b",
+        "x-ms-ratelimit-remaining-subscription-reads": "11993",
+        "x-ms-request-id": "d1facc51-1aa6-43b4-b56e-c845ea2f3928_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075356Z:db954193-ced8-4ea4-9c80-15055d1a049b"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586",
+        "name": "testnamespacemgmt5586",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5586",
+          "createdAt": "2022-10-12T07:53:52.55Z",
+          "updatedAt": "2022-10-12T07:53:52.55Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5586.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-fa1ed0720093f546a317b49c0c3d3979-b78b4fe2b27c434a-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a7c1ceabf78a1b6386ba60496ac9727a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "736",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:53:57 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a7c1ceabf78a1b6386ba60496ac9727a",
+        "x-ms-correlation-request-id": "b7a937be-2e52-46f8-85b3-8d281b0343b5",
+        "x-ms-ratelimit-remaining-subscription-reads": "11992",
+        "x-ms-request-id": "566da674-9dd1-4ef7-99e9-3c1bbdfa34a2_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075358Z:b7a937be-2e52-46f8-85b3-8d281b0343b5"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586",
+        "name": "testnamespacemgmt5586",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5586",
+          "createdAt": "2022-10-12T07:53:52.55Z",
+          "updatedAt": "2022-10-12T07:53:52.55Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5586.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-fa1ed0720093f546a317b49c0c3d3979-af33214d3bb7c844-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "03e8221e795048d797043aa65688c1d3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "736",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:53:59 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "03e8221e795048d797043aa65688c1d3",
+        "x-ms-correlation-request-id": "886f1dde-e9b8-41ba-9f1d-879e4760366d",
+        "x-ms-ratelimit-remaining-subscription-reads": "11991",
+        "x-ms-request-id": "18dacb7b-c07a-4d3d-a757-282394da4a02_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075359Z:886f1dde-e9b8-41ba-9f1d-879e4760366d"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586",
+        "name": "testnamespacemgmt5586",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5586",
+          "createdAt": "2022-10-12T07:53:52.55Z",
+          "updatedAt": "2022-10-12T07:53:52.55Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5586.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-fa1ed0720093f546a317b49c0c3d3979-cb05e95d6fa0e04a-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "1ee4a554b568d5ae3f33944b2d217703",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "736",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:54:02 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "1ee4a554b568d5ae3f33944b2d217703",
+        "x-ms-correlation-request-id": "c2af52b2-57e6-4a54-bd06-9a4001aa0536",
+        "x-ms-ratelimit-remaining-subscription-reads": "11990",
+        "x-ms-request-id": "88257d43-2a34-4c7d-b011-f8ff02db8244_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075402Z:c2af52b2-57e6-4a54-bd06-9a4001aa0536"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586",
+        "name": "testnamespacemgmt5586",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5586",
+          "createdAt": "2022-10-12T07:53:52.55Z",
+          "updatedAt": "2022-10-12T07:53:52.55Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5586.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-fa1ed0720093f546a317b49c0c3d3979-ac8f63eb5185cc44-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "4315bfec97af31d1f7780f86bcbcc5fd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "736",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:54:06 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "4315bfec97af31d1f7780f86bcbcc5fd",
+        "x-ms-correlation-request-id": "06587ea1-969c-44f4-95c3-ae49fe5455c2",
+        "x-ms-ratelimit-remaining-subscription-reads": "11989",
+        "x-ms-request-id": "0838b0a9-9cb7-435b-8ef8-e7c3caf28995_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075406Z:06587ea1-969c-44f4-95c3-ae49fe5455c2"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586",
+        "name": "testnamespacemgmt5586",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5586",
+          "createdAt": "2022-10-12T07:53:52.55Z",
+          "updatedAt": "2022-10-12T07:53:52.55Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5586.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-fa1ed0720093f546a317b49c0c3d3979-4f1d5ddac62d4f4c-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c5f48df853e468117412c41ce48c1b76",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "736",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:54:14 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "c5f48df853e468117412c41ce48c1b76",
+        "x-ms-correlation-request-id": "e0de2657-e437-48e7-8488-085dd0aeebe7",
+        "x-ms-ratelimit-remaining-subscription-reads": "11988",
+        "x-ms-request-id": "173158c0-aef1-4be3-acb8-385f07e61278_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075415Z:e0de2657-e437-48e7-8488-085dd0aeebe7"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586",
+        "name": "testnamespacemgmt5586",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5586",
+          "createdAt": "2022-10-12T07:53:52.55Z",
+          "updatedAt": "2022-10-12T07:53:52.55Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5586.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-fa1ed0720093f546a317b49c0c3d3979-3dad70ecedefbb4d-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "96b9378d7d73bd23d3b327f0a5281982",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "736",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:54:31 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "96b9378d7d73bd23d3b327f0a5281982",
+        "x-ms-correlation-request-id": "6d281f5d-320d-4708-a9a4-5f8e689134cf",
+        "x-ms-ratelimit-remaining-subscription-reads": "11987",
+        "x-ms-request-id": "d36ce517-7fc0-4cce-8cb4-d25cfee74337_M4CH3_M4CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075432Z:6d281f5d-320d-4708-a9a4-5f8e689134cf"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586",
+        "name": "testnamespacemgmt5586",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {},
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Created",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5586",
+          "createdAt": "2022-10-12T07:53:52.55Z",
+          "updatedAt": "2022-10-12T07:53:52.55Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5586.servicebus.windows.net:443/",
+          "status": "Activating"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-fa1ed0720093f546a317b49c0c3d3979-9cce13c8a77ef84e-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a052976eb12c991eadadcf9dd2b54c6a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "735",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:55:04 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a052976eb12c991eadadcf9dd2b54c6a",
+        "x-ms-correlation-request-id": "f69473cf-72a0-4838-847e-48f33d86fe77",
+        "x-ms-ratelimit-remaining-subscription-reads": "11986",
+        "x-ms-request-id": "c8221a9f-54df-43b0-b32e-2d54bb8adbf8_M10CH3_M10CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075504Z:f69473cf-72a0-4838-847e-48f33d86fe77"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586",
+        "name": "testnamespacemgmt5586",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {},
@@ -715,43 +725,43 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt4144",
-          "createdAt": "2022-10-11T16:15:47.487Z",
-          "updatedAt": "2022-10-11T16:16:39.627Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt4144.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5586",
+          "createdAt": "2022-10-12T07:53:52.55Z",
+          "updatedAt": "2022-10-12T07:54:43.627Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5586.servicebus.windows.net:443/",
           "status": "Active"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-5f6f56fc18e13e459ac01dbc91531cfb-674cb49c6b79814f-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "01da2b7464cd174bbd918fd95a99735f",
+        "traceparent": "00-6002066fcecca24da43465f0a9cdcadb-fc4fab47c64d964c-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "84f9995d2e027b8a6937f1302b21c24c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "17937",
+        "Content-Length": "17580",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:03 GMT",
+        "Date": "Wed, 12 Oct 2022 07:55:05 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "5858b9b0-1bbb-44a4-8baf-9cbaf16147cb",
-        "x-ms-ratelimit-remaining-subscription-reads": "11988",
-        "x-ms-request-id": "5858b9b0-1bbb-44a4-8baf-9cbaf16147cb",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161704Z:5858b9b0-1bbb-44a4-8baf-9cbaf16147cb"
+        "x-ms-correlation-request-id": "5a3c70aa-962f-47b6-8d7d-f7c1f84a4a6b",
+        "x-ms-ratelimit-remaining-subscription-reads": "11985",
+        "x-ms-request-id": "5a3c70aa-962f-47b6-8d7d-f7c1f84a4a6b",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075505Z:5a3c70aa-962f-47b6-8d7d-f7c1f84a4a6b"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/providers/Microsoft.Resources",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources",
         "namespace": "Microsoft.Resources",
         "authorizations": [
           {
@@ -1285,11 +1295,7 @@
               "Jio India West",
               "West US 3",
               "Qatar Central",
-              "Sweden Central",
-              "UAE Central",
-              "Norway West",
-              "East US 2 EUAP",
-              "Central US EUAP"
+              "Sweden Central"
             ],
             "apiVersions": [
               "2019-05-01",
@@ -1366,11 +1372,7 @@
               "Jio India West",
               "West US 3",
               "Qatar Central",
-              "Sweden Central",
-              "UAE Central",
-              "Norway West",
-              "East US 2 EUAP",
-              "Central US EUAP"
+              "Sweden Central"
             ],
             "apiVersions": [
               "2019-05-01",
@@ -1778,9 +1780,7 @@
               "West US",
               "South Central US",
               "West US 3",
-              "South Africa North",
-              "Central US EUAP",
-              "East US 2 EUAP"
+              "South Africa North"
             ],
             "apiVersions": [
               "2020-10-01",
@@ -1823,9 +1823,7 @@
               "West US",
               "South Central US",
               "West US 3",
-              "South Africa North",
-              "Central US EUAP",
-              "East US 2 EUAP"
+              "South Africa North"
             ],
             "apiVersions": [
               "2020-10-01",
@@ -1868,9 +1866,7 @@
               "West US",
               "South Central US",
               "West US 3",
-              "South Africa North",
-              "Central US EUAP",
-              "East US 2 EUAP"
+              "South Africa North"
             ],
             "apiVersions": [
               "2020-10-01",
@@ -1917,11 +1913,7 @@
               "West US",
               "West US 3",
               "South Central US",
-              "South Africa North",
-              "Central US EUAP",
-              "East US 2 EUAP",
-              "Norway West",
-              "UAE Central"
+              "South Africa North"
             ],
             "apiVersions": [
               "2022-02-01",
@@ -1970,11 +1962,7 @@
               "West US",
               "West US 3",
               "South Central US",
-              "South Africa North",
-              "Central US EUAP",
-              "East US 2 EUAP",
-              "Norway West",
-              "UAE Central"
+              "South Africa North"
             ],
             "apiVersions": [
               "2022-02-01",
@@ -2015,14 +2003,14 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-5f6f56fc18e13e459ac01dbc91531cfb-6254565d4e794646-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "1667e559d07f4450044398bfdd7b232c",
+        "traceparent": "00-6002066fcecca24da43465f0a9cdcadb-90a1cbd8f9d73b43-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "4dad41f87b3adb4a1820e8c6ae86ea1e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -2031,18 +2019,18 @@
         "Cache-Control": "no-cache",
         "Content-Length": "276",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:03 GMT",
+        "Date": "Wed, 12 Oct 2022 07:55:05 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "624e9596-002b-40ea-a8cd-9711501e1faf",
-        "x-ms-ratelimit-remaining-subscription-reads": "11987",
-        "x-ms-request-id": "624e9596-002b-40ea-a8cd-9711501e1faf",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161704Z:624e9596-002b-40ea-a8cd-9711501e1faf"
+        "x-ms-correlation-request-id": "78224264-c331-418e-9720-8ab3ace1b2e7",
+        "x-ms-ratelimit-remaining-subscription-reads": "11984",
+        "x-ms-request-id": "78224264-c331-418e-9720-8ab3ace1b2e7",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075506Z:78224264-c331-418e-9720-8ab3ace1b2e7"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144/providers/Microsoft.Resources/tags/default",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586/providers/Microsoft.Resources/tags/default",
         "name": "default",
         "type": "Microsoft.Resources/tags",
         "properties": {
@@ -2051,380 +2039,16 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "43",
-        "Content-Type": "application/json",
-        "traceparent": "00-5f6f56fc18e13e459ac01dbc91531cfb-88ca0061308f9e4f-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "33a7d52820bf36b4ee6c4a345db5eb7c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "properties": {
-          "tags": {
-            "key": "Sanitized"
-          }
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "293",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:08 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "5d1b6ee8-41ad-4880-864e-391cdf7c0188",
-        "x-ms-ratelimit-remaining-subscription-writes": "1198",
-        "x-ms-request-id": "5d1b6ee8-41ad-4880-864e-391cdf7c0188",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161709Z:5d1b6ee8-41ad-4880-864e-391cdf7c0188"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144/providers/Microsoft.Resources/tags/default",
-        "name": "default",
-        "type": "Microsoft.Resources/tags",
-        "properties": {
-          "tags": {
-            "key": "Sanitized"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-5f6f56fc18e13e459ac01dbc91531cfb-bb5b64bfc769cd4f-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "43560b3cbfcca459da96fc89cb8c3a41",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "753",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:10 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "43560b3cbfcca459da96fc89cb8c3a41",
-        "x-ms-correlation-request-id": "f7260dc2-edd8-4657-8367-af957ad960a1",
-        "x-ms-ratelimit-remaining-subscription-reads": "11986",
-        "x-ms-request-id": "ae52b88e-e8e0-4bda-a6e1-b15f6a76281d_M10SN1_M10SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161710Z:f7260dc2-edd8-4657-8367-af957ad960a1"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144",
-        "name": "testnamespacemgmt4144",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {
-          "key": "Sanitized"
-        },
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt4144",
-          "createdAt": "2022-10-11T16:15:47.487Z",
-          "updatedAt": "2022-10-11T16:17:08.197Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt4144.servicebus.windows.net:443/",
-          "status": "Active"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-9269e4432e5c01429ad517367e3898d7-3629122b9d63cf40-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "84b1626d40f239a030302713861ce64e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Date": "Tue, 11 Oct 2022 16:17:13 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "99fa0a41-7d1c-4ccb-865f-dbc06a3c63ec",
-        "x-ms-ratelimit-remaining-subscription-deletes": "14999",
-        "x-ms-request-id": "99fa0a41-7d1c-4ccb-865f-dbc06a3c63ec",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161714Z:99fa0a41-7d1c-4ccb-865f-dbc06a3c63ec"
-      },
-      "ResponseBody": null
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-9269e4432e5c01429ad517367e3898d7-6f48d260c8f6ef43-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "d1831c57e025685f7c025829232a6a62",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "276",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:13 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "f6a306a3-ae86-49d4-873e-b44b38b4e522",
-        "x-ms-ratelimit-remaining-subscription-reads": "11985",
-        "x-ms-request-id": "f6a306a3-ae86-49d4-873e-b44b38b4e522",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161714Z:f6a306a3-ae86-49d4-873e-b44b38b4e522"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144/providers/Microsoft.Resources/tags/default",
-        "name": "default",
-        "type": "Microsoft.Resources/tags",
-        "properties": {
-          "tags": {}
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "59",
-        "Content-Type": "application/json",
-        "traceparent": "00-9269e4432e5c01429ad517367e3898d7-1dd28b581558b94d-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "fac609316704fb896b1d129c97461ebe",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "properties": {
-          "tags": {
-            "key": "Sanitized",
-            "key1": "value1"
-          }
-        }
-      },
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Connection": "close",
-        "Content-Length": "249",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:15 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "fb08af3e-6d94-4dda-9606-2235302b9695",
-        "x-ms-failure-cause": "",
-        "x-ms-request-id": "fb08af3e-6d94-4dda-9606-2235302b9695",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161715Z:fb08af3e-6d94-4dda-9606-2235302b9695"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "ProviderError",
-          "message": "{\u0022error\u0022:{\u0022message\u0022:\u0022Namespace provisioning in transition. For more information visit https://aka.ms/eventhubsarmexceptions. CorrelationId: fb08af3e-6d94-4dda-9606-2235302b9695\u0022,\u0022code\u0022:\u0022429\u0022}}"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "59",
-        "Content-Type": "application/json",
-        "traceparent": "00-9269e4432e5c01429ad517367e3898d7-1dd28b581558b94d-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "fac609316704fb896b1d129c97461ebe",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "properties": {
-          "tags": {
-            "key": "Sanitized",
-            "key1": "value1"
-          }
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "309",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:22 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "660c0c63-883d-4d61-91e2-b2f470209e97",
-        "x-ms-ratelimit-remaining-subscription-writes": "1199",
-        "x-ms-request-id": "660c0c63-883d-4d61-91e2-b2f470209e97",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161722Z:660c0c63-883d-4d61-91e2-b2f470209e97"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144/providers/Microsoft.Resources/tags/default",
-        "name": "default",
-        "type": "Microsoft.Resources/tags",
-        "properties": {
-          "tags": {
-            "key": "Sanitized",
-            "key1": "value1"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144?api-version=2021-11-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-9269e4432e5c01429ad517367e3898d7-11e110b8ca1e4945-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "af32adaf68088d1c034908f0e7761505",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "768",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:23 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Server": [
-          "Service-Bus-Resource-Provider/SN1",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "af32adaf68088d1c034908f0e7761505",
-        "x-ms-correlation-request-id": "af4d4823-abd7-49bd-8aae-7ee02ff6ffb1",
-        "x-ms-ratelimit-remaining-subscription-reads": "11999",
-        "x-ms-request-id": "efa672ee-542f-4bd6-b36d-94594b3cb8de_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161723Z:af4d4823-abd7-49bd-8aae-7ee02ff6ffb1"
-      },
-      "ResponseBody": {
-        "sku": {
-          "name": "Standard",
-          "tier": "Standard",
-          "capacity": 1
-        },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144",
-        "name": "testnamespacemgmt4144",
-        "type": "Microsoft.EventHub/Namespaces",
-        "location": "East US 2",
-        "tags": {
-          "key": "Sanitized",
-          "key1": "value1"
-        },
-        "properties": {
-          "disableLocalAuth": false,
-          "zoneRedundant": false,
-          "isAutoInflateEnabled": false,
-          "maximumThroughputUnits": 0,
-          "kafkaEnabled": true,
-          "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt4144",
-          "createdAt": "2022-10-11T16:15:47.487Z",
-          "updatedAt": "2022-10-11T16:17:21.77Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt4144.servicebus.windows.net:443/",
-          "status": "Active"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-3a3f3e0ed3d06c489005b7e39d063aa4-87e0ca3415b25640-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "7de1c5c5ec56f04a92876607cdc2d136",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "309",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:23 GMT",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-        "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "08fb3c64-438a-4fc2-9864-6b1493633c9b",
-        "x-ms-ratelimit-remaining-subscription-reads": "11998",
-        "x-ms-request-id": "08fb3c64-438a-4fc2-9864-6b1493633c9b",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161724Z:08fb3c64-438a-4fc2-9864-6b1493633c9b"
-      },
-      "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144/providers/Microsoft.Resources/tags/default",
-        "name": "default",
-        "type": "Microsoft.Resources/tags",
-        "properties": {
-          "tags": {
-            "key": "Sanitized",
-            "key1": "value1"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "41",
         "Content-Type": "application/json",
-        "traceparent": "00-3a3f3e0ed3d06c489005b7e39d063aa4-02a181ddf237324e-00",
-        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "767a9ae4bbf8c959ec39f7bb5e9913f4",
+        "traceparent": "00-6002066fcecca24da43465f0a9cdcadb-bbd009b6aac2554d-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "0c92bc67942e40800dd736f5bfee6d8c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -2439,18 +2063,18 @@
         "Cache-Control": "no-cache",
         "Content-Length": "291",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:26 GMT",
+        "Date": "Wed, 12 Oct 2022 07:55:12 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-correlation-request-id": "ba952a16-4bf6-4115-8b21-01dd28869562",
-        "x-ms-ratelimit-remaining-subscription-writes": "1198",
-        "x-ms-request-id": "ba952a16-4bf6-4115-8b21-01dd28869562",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161727Z:ba952a16-4bf6-4115-8b21-01dd28869562"
+        "x-ms-correlation-request-id": "7aeeec35-f319-4af2-84aa-f356e1ca577c",
+        "x-ms-ratelimit-remaining-subscription-writes": "1197",
+        "x-ms-request-id": "7aeeec35-f319-4af2-84aa-f356e1ca577c",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075513Z:7aeeec35-f319-4af2-84aa-f356e1ca577c"
       },
       "ResponseBody": {
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144/providers/Microsoft.Resources/tags/default",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586/providers/Microsoft.Resources/tags/default",
         "name": "default",
         "type": "Microsoft.Resources/tags",
         "properties": {
@@ -2461,37 +2085,37 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144?api-version=2021-11-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586?api-version=2021-11-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-3a3f3e0ed3d06c489005b7e39d063aa4-1afa03b0638de44f-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "d2d70d07a164c26763411d810214bf40",
+        "traceparent": "00-6002066fcecca24da43465f0a9cdcadb-faedba6cd46dba4e-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "91a483eafe07e2304f1e6be246c3cce2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "754",
+        "Content-Length": "752",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:27 GMT",
+        "Date": "Wed, 12 Oct 2022 07:55:13 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "d2d70d07a164c26763411d810214bf40",
-        "x-ms-correlation-request-id": "31266ec8-6fb9-442f-8b7e-a06b0ec167ba",
-        "x-ms-ratelimit-remaining-subscription-reads": "11997",
-        "x-ms-request-id": "756df1a7-e8db-41db-8b7c-e849c300d4d5_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161727Z:31266ec8-6fb9-442f-8b7e-a06b0ec167ba"
+        "x-ms-client-request-id": "91a483eafe07e2304f1e6be246c3cce2",
+        "x-ms-correlation-request-id": "16f2274d-4001-4edb-b269-c69771f0641e",
+        "x-ms-ratelimit-remaining-subscription-reads": "11983",
+        "x-ms-request-id": "d1ad1fa2-6ea0-4102-b143-3e67df814913_M8CH3_M8CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075514Z:16f2274d-4001-4edb-b269-c69771f0641e"
       },
       "ResponseBody": {
         "sku": {
@@ -2499,8 +2123,8 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144",
-        "name": "testnamespacemgmt4144",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586",
+        "name": "testnamespacemgmt5586",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {
@@ -2513,46 +2137,202 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Updating",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt4144",
-          "createdAt": "2022-10-11T16:15:47.487Z",
-          "updatedAt": "2022-10-11T16:17:25.267Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt4144.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5586",
+          "createdAt": "2022-10-12T07:53:52.55Z",
+          "updatedAt": "2022-10-12T07:55:10.33Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5586.servicebus.windows.net:443/",
           "status": "Activating"
         }
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144?api-version=2021-11-01",
-      "RequestMethod": "GET",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-43219face8f0f94c9847038d0159cb5e-c19385e261291041-00",
-        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221011.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "4d0bd2779ffc0a0d6b18901cf48f92f8",
+        "traceparent": "00-8ba7a2040d109045a78f860b677a2631-9a06b0390317e947-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6fc9d34db68e641dc16d406244551b2a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "751",
+        "Content-Length": "0",
+        "Date": "Wed, 12 Oct 2022 07:55:16 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "53070370-2f3a-49d1-bb1d-55314fa3acd7",
+        "x-ms-ratelimit-remaining-subscription-deletes": "14999",
+        "x-ms-request-id": "53070370-2f3a-49d1-bb1d-55314fa3acd7",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075516Z:53070370-2f3a-49d1-bb1d-55314fa3acd7"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8ba7a2040d109045a78f860b677a2631-5ad83d61d7ff1a44-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "2bdc5cb359e268178bb0bd10289ef949",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "276",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 11 Oct 2022 16:17:38 GMT",
+        "Date": "Wed, 12 Oct 2022 07:55:16 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "3c3c3892-19a3-462d-a03b-0697793f969f",
+        "x-ms-ratelimit-remaining-subscription-reads": "11982",
+        "x-ms-request-id": "3c3c3892-19a3-462d-a03b-0697793f969f",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075517Z:3c3c3892-19a3-462d-a03b-0697793f969f"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586/providers/Microsoft.Resources/tags/default",
+        "name": "default",
+        "type": "Microsoft.Resources/tags",
+        "properties": {
+          "tags": {}
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "57",
+        "Content-Type": "application/json",
+        "traceparent": "00-8ba7a2040d109045a78f860b677a2631-ebb8122982f7db4f-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "eca7540afd2433fd6540cf99becd9dfa",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "properties": {
+          "tags": {
+            "key1": "value1",
+            "key2": "value2"
+          }
+        }
+      },
+      "StatusCode": 429,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Connection": "close",
+        "Content-Length": "249",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:55:17 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "98fa95e0-131e-43b3-b80a-e6d83663a662",
+        "x-ms-failure-cause": "",
+        "x-ms-request-id": "98fa95e0-131e-43b3-b80a-e6d83663a662",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075518Z:98fa95e0-131e-43b3-b80a-e6d83663a662"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "ProviderError",
+          "message": "{\u0022error\u0022:{\u0022message\u0022:\u0022Namespace provisioning in transition. For more information visit https://aka.ms/eventhubsarmexceptions. CorrelationId: 98fa95e0-131e-43b3-b80a-e6d83663a662\u0022,\u0022code\u0022:\u0022429\u0022}}"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "57",
+        "Content-Type": "application/json",
+        "traceparent": "00-8ba7a2040d109045a78f860b677a2631-ebb8122982f7db4f-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "eca7540afd2433fd6540cf99becd9dfa",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "properties": {
+          "tags": {
+            "key1": "value1",
+            "key2": "value2"
+          }
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "307",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:55:26 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "8be75399-ca5a-4a94-a710-68430b70801a",
+        "x-ms-ratelimit-remaining-subscription-writes": "1195",
+        "x-ms-request-id": "8be75399-ca5a-4a94-a710-68430b70801a",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075526Z:8be75399-ca5a-4a94-a710-68430b70801a"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586/providers/Microsoft.Resources/tags/default",
+        "name": "default",
+        "type": "Microsoft.Resources/tags",
+        "properties": {
+          "tags": {
+            "key1": "value1",
+            "key2": "value2"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8ba7a2040d109045a78f860b677a2631-bad0d8fdfd373845-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ea2f4102a1e7f400bc61e3def90c3b23",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "766",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:55:26 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Server": [
-          "Service-Bus-Resource-Provider/SN1",
+          "Service-Bus-Resource-Provider/CH3",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Server-SB": "Service-Bus-Resource-Provider/SN1",
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "4d0bd2779ffc0a0d6b18901cf48f92f8",
-        "x-ms-correlation-request-id": "c570a8bc-ec48-4cf7-b846-7bf7b5da7e5e",
-        "x-ms-ratelimit-remaining-subscription-reads": "11996",
-        "x-ms-request-id": "a3d28854-05c1-4881-949d-d03484674738_M2SN1_M2SN1",
-        "x-ms-routing-request-id": "SOUTHINDIA:20221011T161738Z:c570a8bc-ec48-4cf7-b846-7bf7b5da7e5e"
+        "x-ms-client-request-id": "ea2f4102a1e7f400bc61e3def90c3b23",
+        "x-ms-correlation-request-id": "3ed97d40-fd14-46e0-abd4-291a97329ab3",
+        "x-ms-ratelimit-remaining-subscription-reads": "11980",
+        "x-ms-request-id": "a0ab6278-4fcb-4891-8637-336f59c30cef_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075526Z:3ed97d40-fd14-46e0-abd4-291a97329ab3"
       },
       "ResponseBody": {
         "sku": {
@@ -2560,12 +2340,13 @@
           "tier": "Standard",
           "capacity": 1
         },
-        "id": "/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/resourceGroups/testeventhubRG-1868/providers/Microsoft.EventHub/namespaces/testnamespacemgmt4144",
-        "name": "testnamespacemgmt4144",
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586",
+        "name": "testnamespacemgmt5586",
         "type": "Microsoft.EventHub/Namespaces",
         "location": "East US 2",
         "tags": {
-          "key1": "value1"
+          "key1": "value1",
+          "key2": "value2"
         },
         "properties": {
           "disableLocalAuth": false,
@@ -2574,10 +2355,156 @@
           "maximumThroughputUnits": 0,
           "kafkaEnabled": true,
           "provisioningState": "Succeeded",
-          "metricId": "326100e2-f69d-4268-8503-075374f62b6e:testnamespacemgmt4144",
-          "createdAt": "2022-10-11T16:15:47.487Z",
-          "updatedAt": "2022-10-11T16:17:27.323Z",
-          "serviceBusEndpoint": "https://testnamespacemgmt4144.servicebus.windows.net:443/",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5586",
+          "createdAt": "2022-10-12T07:53:52.55Z",
+          "updatedAt": "2022-10-12T07:55:25.177Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5586.servicebus.windows.net:443/",
+          "status": "Active"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-3c25243a4524fc4fa17786641a920341-c7d9468e156d1b4d-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f058f6732eadb5065ea8c5a1897da9be",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "307",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:55:27 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "a1af9ce3-009c-4518-bdfc-fb0d877a44ef",
+        "x-ms-ratelimit-remaining-subscription-reads": "11979",
+        "x-ms-request-id": "a1af9ce3-009c-4518-bdfc-fb0d877a44ef",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075527Z:a1af9ce3-009c-4518-bdfc-fb0d877a44ef"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586/providers/Microsoft.Resources/tags/default",
+        "name": "default",
+        "type": "Microsoft.Resources/tags",
+        "properties": {
+          "tags": {
+            "key1": "value1",
+            "key2": "value2"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586/providers/Microsoft.Resources/tags/default?api-version=2021-04-01",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "41",
+        "Content-Type": "application/json",
+        "traceparent": "00-3c25243a4524fc4fa17786641a920341-66dc7c040f18eb47-00",
+        "User-Agent": "azsdk-net-ResourceManager/1.3.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "e70ec3120f6f696153b330c31a1f3a59",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "properties": {
+          "tags": {
+            "key2": "value2"
+          }
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "291",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:55:31 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "876bc7a5-71f1-4720-a4a0-290df9909fb2",
+        "x-ms-ratelimit-remaining-subscription-writes": "1194",
+        "x-ms-request-id": "876bc7a5-71f1-4720-a4a0-290df9909fb2",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075531Z:876bc7a5-71f1-4720-a4a0-290df9909fb2"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586/providers/Microsoft.Resources/tags/default",
+        "name": "default",
+        "type": "Microsoft.Resources/tags",
+        "properties": {
+          "tags": {
+            "key2": "value2"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586?api-version=2021-11-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-3c25243a4524fc4fa17786641a920341-ed0f7b2fe6548a40-00",
+        "User-Agent": "azsdk-net-ResourceManager.EventHubs/1.1.0-alpha.20221012.1 (.NET Framework 4.8.4515.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c825ac04ad75d34c3a798b3fdc5e6a3e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "750",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 12 Oct 2022 07:55:32 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Server": [
+          "Service-Bus-Resource-Provider/CH3",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Server-SB": "Service-Bus-Resource-Provider/CH3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "c825ac04ad75d34c3a798b3fdc5e6a3e",
+        "x-ms-correlation-request-id": "b4f97b98-471e-45b2-b9ee-86823c3c2b47",
+        "x-ms-ratelimit-remaining-subscription-reads": "11978",
+        "x-ms-request-id": "a486f9ae-a9e0-4af8-a717-dc8cc56f5a5f_M5CH3_M5CH3",
+        "x-ms-routing-request-id": "SOUTHEASTASIA:20221012T075533Z:b4f97b98-471e-45b2-b9ee-86823c3c2b47"
+      },
+      "ResponseBody": {
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard",
+          "capacity": 1
+        },
+        "id": "/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/resourceGroups/testeventhubRG-6601/providers/Microsoft.EventHub/namespaces/testnamespacemgmt5586",
+        "name": "testnamespacemgmt5586",
+        "type": "Microsoft.EventHub/Namespaces",
+        "location": "East US 2",
+        "tags": {
+          "key2": "value2"
+        },
+        "properties": {
+          "disableLocalAuth": false,
+          "zoneRedundant": false,
+          "isAutoInflateEnabled": false,
+          "maximumThroughputUnits": 0,
+          "kafkaEnabled": true,
+          "provisioningState": "Succeeded",
+          "metricId": "db1ab6f0-4769-4b27-930e-01e2ef9c123c:testnamespacemgmt5586",
+          "createdAt": "2022-10-12T07:53:52.55Z",
+          "updatedAt": "2022-10-12T07:55:31.173Z",
+          "serviceBusEndpoint": "https://testnamespacemgmt5586.servicebus.windows.net:443/",
           "status": "Active"
         }
       }
@@ -2585,8 +2512,8 @@
   ],
   "Variables": {
     "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "1609238295",
+    "RandomSeed": "1553164107",
     "RESOURCE_MANAGER_URL": null,
-    "SUBSCRIPTION_ID": "326100e2-f69d-4268-8503-075374f62b6e"
+    "SUBSCRIPTION_ID": "db1ab6f0-4769-4b27-930e-01e2ef9c123c"
   }
 }

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Tests/EventHubClusterTests.cs
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Tests/EventHubClusterTests.cs
@@ -65,9 +65,9 @@ namespace Azure.ResourceManager.EventHubs.Tests
             Assert.NotNull(subResource);
 
             //update the cluster
-            cluster.Data.Tags.Add("key", "value");
+            cluster.Data.Tags.Add("key1", "value1");
             cluster = (await cluster.UpdateAsync(WaitUntil.Completed, cluster.Data)).Value;
-            Assert.AreEqual(cluster.Data.Tags["key"], "value");
+            Assert.AreEqual(cluster.Data.Tags["key1"], "value1");
 
             //delete the cluster
             await cluster.DeleteAsync(WaitUntil.Completed);

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Tests/EventHubNamespaceTests.cs
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Tests/EventHubNamespaceTests.cs
@@ -674,6 +674,7 @@ namespace Azure.ResourceManager.EventHubs.Tests
         [TestCase(null)]
         [TestCase(true)]
         [TestCase(false)]
+        [RecordedTest]
         public async Task AddSetRemoveTag(bool? useTagResource)
         {
             SetTagResourceUsage(Client, useTagResource);
@@ -684,18 +685,18 @@ namespace Azure.ResourceManager.EventHubs.Tests
             EventHubsNamespaceResource eventHubNamespace = (await namespaceCollection.CreateOrUpdateAsync(WaitUntil.Completed, namespaceName, new EventHubsNamespaceData(DefaultLocation))).Value;
 
             //add a tag
-            eventHubNamespace = await eventHubNamespace.AddTagAsync("key", "value");
+            eventHubNamespace = await eventHubNamespace.AddTagAsync("key1", "value1");
             Assert.AreEqual(eventHubNamespace.Data.Tags.Count, 1);
-            Assert.AreEqual(eventHubNamespace.Data.Tags["key"], "value");
-
-            //set the tag
-            eventHubNamespace.Data.Tags.Add("key1", "value1");
-            eventHubNamespace = await eventHubNamespace.SetTagsAsync(eventHubNamespace.Data.Tags);
-            Assert.AreEqual(eventHubNamespace.Data.Tags.Count, 2);
             Assert.AreEqual(eventHubNamespace.Data.Tags["key1"], "value1");
 
+            //set the tag
+            eventHubNamespace.Data.Tags.Add("key2", "value2");
+            eventHubNamespace = await eventHubNamespace.SetTagsAsync(eventHubNamespace.Data.Tags);
+            Assert.AreEqual(eventHubNamespace.Data.Tags.Count, 2);
+            Assert.AreEqual(eventHubNamespace.Data.Tags["key2"], "value2");
+
             //remove a tag
-            eventHubNamespace = await eventHubNamespace.RemoveTagAsync("key");
+            eventHubNamespace = await eventHubNamespace.RemoveTagAsync("key1");
             Assert.AreEqual(eventHubNamespace.Data.Tags.Count, 1);
 
             //wait until provision state is succeeded


### PR DESCRIPTION
Open this PR to fix the broken tests in eventhubs as it turns out the sanitizer that we use in eventhubs' test will accidently applies to the tag operation's test recording and make the assertion fail.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
