### PR TITLE
[AzureMonitorExporter] add `Activity` Exception demo and test

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/TraceDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/TraceDemo.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using Azure.Monitor.OpenTelemetry.Exporter.Tracing.Customization;
 using OpenTelemetry;
 using OpenTelemetry.Extensions.AzureMonitor;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/TraceDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/TraceDemo.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Azure.Monitor.OpenTelemetry.Exporter.Tracing.Customization;
 using OpenTelemetry;
 using OpenTelemetry.Extensions.AzureMonitor;
@@ -63,6 +64,19 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Traces
                 {
                     nestedActivity?.SetTag("bar", "Hello, World!");
                     nestedActivity?.SetStatus(ActivityStatusCode.Ok);
+                }
+            }
+
+            using (var activity = activitySource.StartActivity("ExceptionExample"))
+            {
+                try
+                {
+                    throw new Exception("Test exception");
+                }
+                catch (Exception ex)
+                {
+                    activity?.SetStatus(ActivityStatusCode.Error);
+                    activity?.RecordException(ex);
                 }
             }
         }


### PR DESCRIPTION
Working on examples of recording an Exception with Activity.

### Changes
- add `activity?.RecordException(ex);` to our TraceDemo
- add `activity?.RecordException(ex);` to unit test.
  -  added helper method to verify exception.