### PR TITLE
[Identity] Hide dev credential timeout API for 1.8.0 release

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -1,13 +1,8 @@
 # Release History
 
-## 1.8.0-beta.1 (Unreleased)
+## 1.8.0-beta.1 (2022-10-13)
 
 ### Features Added
-- Credentials that are implemented via launching a sub-process to acquire tokens now have configurable timeouts. This addresses scenarios where these proceses can take longer than the current default timeout values. (A community contribution, courtesy of _[reynaldoburgos](https://github.com/reynaldoburgos)_). The affected credentials and their associated options are:
-  - `AzureCliCredential` and `AzureCliCredentialOptions.CliProcessTimeout`
-  - `AzurePowerShellCredential` and `AzurePowerShellCredentialOptions.PowerShellProcessTimeout`
-  - `VisualStudioCredential` and `VisualStudioCredentialOptions.VisualStudioProcessTimeout`
-  - `DefaultAzureCredential` and `DefaultAzureCredentialOptions.DeveloperCredentialTimeout`  Note: this option applies to all developer credentials above when using `DefaultAzureCredential`.
 - Reintroduced `ManagedIdentityCredential` token caching support from 1.7.0-beta.1
 - `EnvironmentCredential` updated to support specifying a certificate password via the `AZURE_CLIENT_CERTIFICATE_PASSWORD` environment variable
 

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -9,16 +9,6 @@
 ### Breaking Changes
 - Excluded `VisualStudioCodeCredential` from `DefaultAzureCredential` token chain by default as SDK authentication via Visual Studio Code is broken due to issue [#27263](https://github.com/Azure/azure-sdk-for-net/issues/27263). The `VisualStudioCodeCredential` will be re-enabled in the `DefaultAzureCredential` flow once a fix is in place. Issue [#30525](https://github.com/Azure/azure-sdk-for-net/issues/30525) tracks this. In the meantime Visual Studio Code users can authenticate their development environment using the [Azure CLI](https://learn.microsoft.com/cli/azure/).
 
-### Bugs Fixed
-
-### Other Changes
-
-### Acknowledgments
-
-Thank you to our developer community members who helped to make Azure Identity better with their contributions to this release:
-
-- _[reynaldoburgos](https://github.com/reynaldoburgos)_
-
 ## 1.7.0 (2022-09-19)
 
 ### Features Added

--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -60,7 +60,6 @@ namespace Azure.Identity
     {
         public AzureCliCredentialOptions() { }
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
-        public System.TimeSpan? CliProcessTimeout { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
     }
     public partial class AzurePowerShellCredential : Azure.Core.TokenCredential
@@ -74,7 +73,6 @@ namespace Azure.Identity
     {
         public AzurePowerShellCredentialOptions() { }
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
-        public System.TimeSpan? PowerShellProcessTimeout { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
     }
     public partial class ChainedTokenCredential : Azure.Core.TokenCredential
@@ -149,7 +147,6 @@ namespace Azure.Identity
     {
         public DefaultAzureCredentialOptions() { }
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
-        public System.TimeSpan? DeveloperCredentialTimeout { get { throw null; } set { } }
         public bool ExcludeAzureCliCredential { get { throw null; } set { } }
         public bool ExcludeAzurePowerShellCredential { get { throw null; } set { } }
         public bool ExcludeEnvironmentCredential { get { throw null; } set { } }
@@ -381,6 +378,5 @@ namespace Azure.Identity
         public VisualStudioCredentialOptions() { }
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public string TenantId { get { throw null; } set { } }
-        public System.TimeSpan? VisualStudioProcessTimeout { get { throw null; } set { } }
     }
 }

--- a/sdk/identity/Azure.Identity/src/Credentials/AzureCliCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzureCliCredentialOptions.cs
@@ -26,6 +26,6 @@ namespace Azure.Identity
         /// <summary>
         /// The Cli process timeout.
         /// </summary>
-        public TimeSpan? CliProcessTimeout { get; set; }
+        internal TimeSpan? CliProcessTimeout { get; set; }
     }
 }

--- a/sdk/identity/Azure.Identity/src/Credentials/AzurePowerShellCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzurePowerShellCredentialOptions.cs
@@ -26,6 +26,6 @@ namespace Azure.Identity
         /// <summary>
         /// The Powershell process timeout.
         /// </summary>
-        public TimeSpan? PowerShellProcessTimeout { get; set; } = TimeSpan.FromSeconds(10);
+        internal TimeSpan? PowerShellProcessTimeout { get; set; } = TimeSpan.FromSeconds(10);
     }
 }

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -198,7 +198,7 @@ namespace Azure.Identity
         /// <summary>
         /// Specifies timeout for Developer credentials. e.g. Visual Studio, Azure CLI, Azure Powershell.
         /// </summary>
-        public TimeSpan? DeveloperCredentialTimeout { get; set; } = TimeSpan.FromSeconds(30);
+        internal TimeSpan? DeveloperCredentialTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
         /// <summary>
         /// Specifies whether the <see cref="EnvironmentCredential"/> will be excluded from the authentication flow. Setting to true disables reading

--- a/sdk/identity/Azure.Identity/src/Credentials/VisualStudioCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/VisualStudioCredentialOptions.cs
@@ -32,6 +32,6 @@ namespace Azure.Identity
         /// <summary>
         /// The VisualStudio process timeout.
         /// </summary>
-        public TimeSpan? VisualStudioProcessTimeout { get; set; }
+        internal TimeSpan? VisualStudioProcessTimeout { get; set; }
     }
 }


### PR DESCRIPTION
Hides the following APIs for the 1.8.0-beta.1 and 1.8.0 release:
  - `AzureCliCredentialOptions.CliProcessTimeout`
  - `AzurePowerShellCredentialOptions.PowerShellProcessTimeout`
  - `VisualStudioCredentialOptions.VisualStudioProcessTimeout`
  - `DefaultAzureCredentialOptions.DeveloperCredentialTimeout`

These will be included in the 1.9.0-beta.1 release.