### PR TITLE
Couple of small perf tweaks

### DIFF
--- a/sdk/core/Azure.Core/src/RequestUriBuilder.cs
+++ b/sdk/core/Azure.Core/src/RequestUriBuilder.cs
@@ -278,16 +278,7 @@ namespace Azure.Core
                 stringBuilder.Append(PathSeparator);
             }
 
-            // TODO: Escaping can be done in-place
-            if (!HasQuery)
-            {
-                stringBuilder.Append(_pathAndQuery);
-            }
-            else
-            {
-                stringBuilder.Append(_pathAndQuery.ToString(0, _queryIndex));
-                stringBuilder.Append(_pathAndQuery.ToString(_queryIndex, _pathAndQuery.Length - _queryIndex));
-            }
+            stringBuilder.Append(_pathAndQuery);
 
             return stringBuilder.ToString();
         }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageSharedKeyPipelinePolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageSharedKeyPipelinePolicy.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http.Headers;
@@ -76,6 +77,7 @@ namespace Azure.Storage
                 contentLengthString = contentLength.ToString(CultureInfo.InvariantCulture);
             }
             var uri = message.Request.Uri.ToUri();
+
             var stringBuilder = new StringBuilder(uri.AbsolutePath.Length + 64);
             stringBuilder.Append(message.Request.Method.ToString().ToUpperInvariant()).Append('\n');
             stringBuilder.Append(contentEncoding ?? "").Append('\n');
@@ -99,18 +101,24 @@ namespace Azure.Storage
         {
             // Grab all the "x-ms-*" headers, trim whitespace, lowercase, sort,
             // and combine them with their values (separated by a colon).
-            foreach (var header in
-                message.Request.Headers
-                .Where(static h => h.Name.StartsWith(Constants.HeaderNames.XMsPrefix, StringComparison.OrdinalIgnoreCase))
-#pragma warning disable CA1308 // Normalize strings to uppercase
-                .Select(static h => (h.Name.ToLowerInvariant(), h.Value))
-#pragma warning restore CA1308 // Normalize strings to uppercase
-                .OrderBy(static h => h.Item1.Trim()))
+            var headers = new List<HttpHeader>();
+            foreach (var header in message.Request.Headers)
             {
-                stringBuilder.Append(header.Item1);
-                stringBuilder.Append(':');
-                stringBuilder.Append(header.Value);
-                stringBuilder.Append('\n');
+                if (header.Name.StartsWith(Constants.HeaderNames.XMsPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    headers.Add(header);
+                }
+            }
+
+            headers.Sort(static (x, y) => string.CompareOrdinal(x.Name, y.Name));
+
+            foreach (var header in headers)
+            {
+                stringBuilder
+                    .Append(header.Name.ToLowerInvariant())
+                    .Append(':')
+                    .Append(header.Value)
+                    .Append('\n');
             }
         }
 


### PR DESCRIPTION
dotnet C:\GitHub\azure-sdk-for-net\artifacts\bin\Azure.Storage.Blobs.Perf\Release\net6.0\Azure.Storage.Blobs.Perf.dll DownloadBlob --size 16384 --parallel 1 --warmup 60 --duration 60

Before:
Completed 1,756 operations in a weighted-average of 59.97s (29.28 ops/s, 0.03415 s/op, 0.23% CPU)

After:
Completed 1,836 operations in a weighted-average of 59.99s (30.60 ops/s, 0.03268 s/op, 0.059% CPU)