### PR TITLE
[Event Hubs] Tune processor ownership docs

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Adjusted the frequency that a warning logged when the processor owns more partitions than a basic heuristic believes is ideal.  Warnings will no longer log on each load balancing cycle, only when the number of partitions owned changes.
+- Adjusted the frequency that a warning is logged when the processor owns more partitions than a basic heuristic believes is ideal.  Warnings will no longer log on each load balancing cycle, only when the number of partitions owned changes.
 
 ## 5.7.3 (2022-10-11)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Adjusted the frequency that a warning logged when the processor owns more partitions than a basic heuristic believes is ideal.  Warnings will no longer log on each load balancing cycle, only when the number of partitions owned changes.
+
 ## 5.7.3 (2022-10-11)
 
 ### Other Changes

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample02_EventProcessorConfiguration.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample02_EventProcessorConfiguration.md
@@ -6,7 +6,7 @@ To begin, please ensure that you're familiar with the items discussed in the [Ge
 
 ## Table of contents
 
-- [Choosing the number of processors for the consumer group](choosing-the-number-of-processors-for-the-consumer-group)
+- [Choosing the number of processors for the consumer group](#choosing-the-number-of-processors-for-the-consumer-group)
 - [Influencing load balancing behavior](#influencing-load-balancing-behavior)
     - [Load balancing strategy](#load-balancing-strategy)
     - [Load balancing intervals](#load-balancing-intervals)

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample02_EventProcessorConfiguration.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample02_EventProcessorConfiguration.md
@@ -6,6 +6,7 @@ To begin, please ensure that you're familiar with the items discussed in the [Ge
 
 ## Table of contents
 
+- [Choosing the number of processors for the consumer group](choosing-the-number-of-processors-for-the-consumer-group)
 - [Influencing load balancing behavior](#influencing-load-balancing-behavior)
     - [Load balancing strategy](#load-balancing-strategy)
     - [Load balancing intervals](#load-balancing-intervals)
@@ -17,6 +18,14 @@ To begin, please ensure that you're familiar with the items discussed in the [Ge
 - [Configuring the client retry thresholds](#configuring-the-client-retry-thresholds)
 - [Configuring the timeout used for Event Hubs service operations](#configuring-the-timeout-used-for-event-hubs-service-operations)
 - [Using a custom retry policy](#using-a-custom-retry-policy)
+
+## Choosing the number of processors for the consumer group
+
+The `EventProcessorClient` will coordinate with other instances using the same consumer group and Blob Storage container to process the Event Hub cooperatively.  The processors will dynamically distribute and share the Event Hub's partitions, ensuring each has a single processor responsible for reading it.  As `EventProcessorClient` instances are added or removed from the group, partition ownership will be re-balanced to ensure the load is shared evenly among them.
+
+When a processor owns too many partitions, it will often experience contention in the thread pool, potentially leading to starvation. During this time, activities will stall causing delays in `EventProcessorClient` operations. Because there is no fairness guarantee in scheduling, some partitions may appear to stop processing or load balancing may not be able to update ownership, causing partitions to "bounce" between owners.
+
+Because of this, it is important to carefully consider how many `EventProcessorClient` instances are needed in the consumer group for your application.  Generally, it is recommended each processor own no more than 3 partitions for every 1 CPU core of the host. Since the ratio will vary for each application, it is often helpful to start with using 1.5 partitions for each CPU core and test increasing the number of owned partitions gradually to measure what works best for your application.
 
 ## Influencing load balancing behavior
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Adjusted the frequency that a warning logged when the processor owns more partitions than a basic heuristic believes is ideal.  Warnings will no longer log on each load balancing cycle, only when the number of partitions owned changes.
+
 ## 5.7.3 (2022-10-11)
 
 ### Acknowledgments

--- a/sdk/eventhub/Azure.Messaging.EventHubs/TROUBLESHOOTING.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/TROUBLESHOOTING.md
@@ -227,7 +227,7 @@ The event processor works in a concurrent and highly asynchronous manner.  Each 
 
 When a processor owns too many partitions, it will often experience contention in the thread pool leading to starvation.  During this time, continuations will start to queue while waiting to be scheduled causing stalls in the processor.  Because there is no fairness guarantee in scheduling, some partitions may appear to stop processing or load balancing may not be able to update ownership, causing partitions to "bounce" between owners.
 
-Generally, it is recommended that an event processor own no more than 3 partitions for every 1 CPU core of the host.  Since the ratio will vary for each application, it is often helpful to start with using 1.5 partitions for each CPU core and test increasing the number of owned partitions gradually to measure what works best for your application.
+Generally, it is recommended that an event processor own no more than 3 partitions for every 1 CPU core of the host.  Since the ratio will vary for each application, it is often helpful to start with 1.5 partitions for each CPU core and increase the number of owned partitions gradually to determine what works best for your application.
 
 Further reading:
 - [Debug ThreadPool Starvation][DebugThreadPoolStarvation]

--- a/sdk/eventhub/Azure.Messaging.EventHubs/TROUBLESHOOTING.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/TROUBLESHOOTING.md
@@ -227,7 +227,7 @@ The event processor works in a concurrent and highly asynchronous manner.  Each 
 
 When a processor owns too many partitions, it will often experience contention in the thread pool leading to starvation.  During this time, continuations will start to queue while waiting to be scheduled causing stalls in the processor.  Because there is no fairness guarantee in scheduling, some partitions may appear to stop processing or load balancing may not be able to update ownership, causing partitions to "bounce" between owners.
 
-It is generally recommended that an event processor own no more than three partitions for every 1 CPU core of the host.  It is often helpful to start a ratio of 1.5 partitions for each CPU core and test increasing the number of owned partitions gradually to measure what works best for the specific application.
+Generally, it is recommended that an event processor own no more than 3 partitions for every 1 CPU core of the host.  Since the ratio will vary for each application, it is often helpful to start with using 1.5 partitions for each CPU core and test increasing the number of owned partitions gradually to measure what works best for your application.
 
 Further reading:
 - [Debug ThreadPool Starvation][DebugThreadPoolStarvation]

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
@@ -1594,7 +1594,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                     }
 
                     // If the number of partitions owned has changed since the cycle started and is above maximum advisable set, emit a warning.  This is
-                    // an inaccurate heuristic and does not apply to all workloads.  The error handler will not be pinged to avoid false positive notifications.
+                    // a loose heuristic and does not apply to all workloads.  The error handler will not be pinged to avoid false positive notifications.
 
                     if ((startingOwnedPartitionCount != endingOwnedPartitionCount) && (endingOwnedPartitionCount > MaximumAdvisedOwnedPartitions))
                     {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
@@ -32,7 +32,7 @@ namespace Azure.Messaging.EventHubs.Tests
     public partial class EventProcessorTests
     {
         /// <summary>An empty event batch to use for mocking.</summary>
-        private readonly IReadOnlyList<EventData> EmptyBatch = new List<EventData>(0);
+        private static readonly IReadOnlyList<EventData> EmptyBatch = new List<EventData>(0);
 
         /// <summary>
         ///   Retrieves the load balancer for an event processor instance, using its private accessor.


### PR DESCRIPTION
# Summary

The focus of these changes is to add guidance for choosing the number of processor instances to the configuration sample and reduce the frequency that the "owns too many partitions" warning is logged.  It will now occur only when the owned partition count changes, rather than on each load balancing cycle.