### PR TITLE
[Service Bus] Split Resource Manager Tests

### DIFF
--- a/sdk/servicebus/service.projects
+++ b/sdk/servicebus/service.projects
@@ -21,7 +21,6 @@
   <ItemGroup Condition="'$(SDKType)' == 'client'">
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Messaging.*\**\*.csproj" />
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Microsoft.Azure.WebJobs.Extensions.ServiceBus\**\*.csproj" />
-    <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.ResourceManager.*\**\*.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SDKType)' == 'mgmtclient'">


### PR DESCRIPTION
# Summary

The focus of these changes is to split the Resource Manager Tests from the client tests.  A dedicated pipeline already exists, but the management packages were still associated with the client runs.