### PR TITLE
[Event Hubs] Data body copy for EventDataBatch

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -10,7 +10,11 @@
 
 ### Other Changes
 
+<<<<<<< Updated upstream
 - Adjusted the frequency that a warning is logged when the processor owns more partitions than a basic heuristic believes is ideal.  Warnings will no longer log on each load balancing cycle, only when the number of partitions owned changes.
+=======
+- The AMQP transport library (Microsoft.Azure.Amqp) has been updated to v2.5.12
+>>>>>>> Stashed changes
 
 ## 5.7.3 (2022-10-11)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -10,11 +10,9 @@
 
 ### Other Changes
 
-<<<<<<< Updated upstream
 - Adjusted the frequency that a warning is logged when the processor owns more partitions than a basic heuristic believes is ideal.  Warnings will no longer log on each load balancing cycle, only when the number of partitions owned changes.
-=======
+
 - The AMQP transport library (Microsoft.Azure.Amqp) has been updated to v2.5.12
->>>>>>> Stashed changes
 
 ## 5.7.3 (2022-10-11)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventDataExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventDataExtensions.cs
@@ -31,7 +31,7 @@ namespace Azure.Messaging.EventHubs.Tests
             // If the events are the same instance, they're equal.  This should only happen
             // if both are null or they are the exact same instance.
 
-            if (Object.ReferenceEquals(instance, other))
+            if (ReferenceEquals(instance, other))
             {
                 return true;
             }
@@ -94,7 +94,7 @@ namespace Azure.Messaging.EventHubs.Tests
             // Since we know that the event bodies and system properties are equal, if the property sets are the
             // same instance, then we know that the events are equal.  This should only happen if both are null.
 
-            if (Object.ReferenceEquals(instance.Properties, other.Properties))
+            if (ReferenceEquals(instance.Properties, other.Properties))
             {
                 return true;
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - Adjusted the frequency that a warning logged when the processor owns more partitions than a basic heuristic believes is ideal.  Warnings will no longer log on each load balancing cycle, only when the number of partitions owned changes.
 
+- The AMQP transport library (Microsoft.Azure.Amqp) has been updated to v2.5.12.
+
 ## 5.7.3 (2022-10-11)
 
 ### Acknowledgments

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- `EventDataBatch` will now make a defensive copy of the data body of an `EventData` when accepted into the batch, using a shared buffer that has been rented. When the batch is disposed, the buffer is returned.  This corrects an edge case where an event batch could be mutated by changing the underlying `ReadOnlyMemory<byte>` buffer passed to the `EventData`.   _([issue #31395](https://github.com/Azure/azure-sdk-for-net/issues/31395))_
+
 ### Other Changes
 
 - Adjusted the frequency that a warning logged when the processor owns more partitions than a basic heuristic believes is ideal.  Warnings will no longer log on each load balancing cycle, only when the number of partitions owned changes.


### PR DESCRIPTION
# Summary

The focus of these changes is to avoid an unintentional loophole allowing an event batch to be mutated by mutating the data body of an `EventData` instance that has been added to it.  When an `EventData` is serialized into the interim `AmqpMessage` format used by the transport library, a projection over the existing `ReadOnlyMemory<byte>` buffer has been used to avoid allocations.

To combat this, the batch will now make a defensive copy of the data body of an `EventData` when accepted into the batch, using a shared buffer that has been rented.  When the batch is disposed, the buffer is returned.

**Additional context:**

Though the buffer is typed as `ReadOnlyMemory<byte>`, since the it was passed to the EventData constructor, and the scope of the "call" is the lifetime of the associated instance.  We explicitly intend that the `EventData` instance is no longer relevant to the batch after `TryAdd` completes. Because of this, it should not matter what a caller does with the body buffer after, the batch should be fully immutable.

# References and Related

- [EventDataBatch.TryAdd does not copy buffer to batch as documentation indicates (#31395)](https://github.com/Azure/azure-sdk-for-net/issues/31395)