### PR TITLE
Add ReadOnlySpan<char> signatures to RequestUriBuilder methods

### DIFF
--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -554,11 +554,15 @@ namespace Azure.Core
         public string? Host { get { throw null; } set { } }
         public string Path { get { throw null; } set { } }
         public string PathAndQuery { get { throw null; } }
+        protected int PathLength { get { throw null; } }
         public int Port { get { throw null; } set { } }
         public string Query { get { throw null; } set { } }
+        protected int QueryLength { get { throw null; } }
         public string? Scheme { get { throw null; } set { } }
+        public void AppendPath(System.ReadOnlySpan<char> value, bool escape) { }
         public void AppendPath(string value) { }
         public void AppendPath(string value, bool escape) { }
+        public void AppendQuery(System.ReadOnlySpan<char> name, System.ReadOnlySpan<char> value, bool escapeValue) { }
         public void AppendQuery(string name, string value) { }
         public void AppendQuery(string name, string value, bool escapeValue) { }
         public void Reset(System.Uri value) { }

--- a/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
@@ -554,11 +554,15 @@ namespace Azure.Core
         public string? Host { get { throw null; } set { } }
         public string Path { get { throw null; } set { } }
         public string PathAndQuery { get { throw null; } }
+        protected int PathLength { get { throw null; } }
         public int Port { get { throw null; } set { } }
         public string Query { get { throw null; } set { } }
+        protected int QueryLength { get { throw null; } }
         public string? Scheme { get { throw null; } set { } }
+        public void AppendPath(System.ReadOnlySpan<char> value, bool escape) { }
         public void AppendPath(string value) { }
         public void AppendPath(string value, bool escape) { }
+        public void AppendQuery(System.ReadOnlySpan<char> name, System.ReadOnlySpan<char> value, bool escapeValue) { }
         public void AppendQuery(string name, string value) { }
         public void AppendQuery(string name, string value, bool escapeValue) { }
         public void Reset(System.Uri value) { }

--- a/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
@@ -554,11 +554,15 @@ namespace Azure.Core
         public string? Host { get { throw null; } set { } }
         public string Path { get { throw null; } set { } }
         public string PathAndQuery { get { throw null; } }
+        protected int PathLength { get { throw null; } }
         public int Port { get { throw null; } set { } }
         public string Query { get { throw null; } set { } }
+        protected int QueryLength { get { throw null; } }
         public string? Scheme { get { throw null; } set { } }
+        public void AppendPath(System.ReadOnlySpan<char> value, bool escape) { }
         public void AppendPath(string value) { }
         public void AppendPath(string value, bool escape) { }
+        public void AppendQuery(System.ReadOnlySpan<char> name, System.ReadOnlySpan<char> value, bool escapeValue) { }
         public void AppendQuery(string name, string value) { }
         public void AppendQuery(string name, string value, bool escapeValue) { }
         public void Reset(System.Uri value) { }

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -554,11 +554,15 @@ namespace Azure.Core
         public string? Host { get { throw null; } set { } }
         public string Path { get { throw null; } set { } }
         public string PathAndQuery { get { throw null; } }
+        protected int PathLength { get { throw null; } }
         public int Port { get { throw null; } set { } }
         public string Query { get { throw null; } set { } }
+        protected int QueryLength { get { throw null; } }
         public string? Scheme { get { throw null; } set { } }
+        public void AppendPath(System.ReadOnlySpan<char> value, bool escape) { }
         public void AppendPath(string value) { }
         public void AppendPath(string value, bool escape) { }
+        public void AppendQuery(System.ReadOnlySpan<char> name, System.ReadOnlySpan<char> value, bool escapeValue) { }
         public void AppendQuery(string name, string value) { }
         public void AppendQuery(string name, string value, bool escapeValue) { }
         public void Reset(System.Uri value) { }

--- a/sdk/core/Azure.Core/tests/RequestUriBuilderTest.cs
+++ b/sdk/core/Azure.Core/tests/RequestUriBuilderTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.IO;
 using NUnit.Framework;
 
 namespace Azure.Core.Tests
@@ -36,7 +37,9 @@ namespace Azure.Core.Tests
             Assert.AreEqual(uri.Host, uriBuilder.Host);
             Assert.AreEqual(uri.Port, uriBuilder.Port);
             Assert.AreEqual(uri.AbsolutePath, uriBuilder.Path);
+            Assert.AreEqual(uri.AbsolutePath.Length > 0, uriBuilder.HasPath);
             Assert.AreEqual(uri.Query, uriBuilder.Query);
+            Assert.AreEqual(uri.Query.Length > 0, uriBuilder.HasQuery);
             Assert.AreEqual(uri, uriBuilder.ToUri());
             Assert.AreSame(uri, uriBuilder.ToUri());
         }
@@ -173,10 +176,12 @@ namespace Azure.Core.Tests
                 Port = 80,
                 Query = initialQuery
             };
+
             uriBuilder.AppendQuery("a", "b");
             uriBuilder.AppendQuery("c", "d");
 
             Assert.AreEqual(expectedResult, uriBuilder.ToUri().ToString());
+            Assert.IsTrue(uriBuilder.HasQuery);
         }
 
         [TestCase(null, new[] {""}, "q", "http://localhost/?q")]
@@ -201,33 +206,20 @@ namespace Azure.Core.Tests
         [TestCase("", new[] {"%E1%88%B4"}, "", "http://localhost/%E1%88%B4", false)]
         [TestCase("", new[] {"\u1234"}, "", "http://localhost/%E1%88%B4", true)]
         [TestCase("", new[] {"%E1%88%B4"}, "", "http://localhost/%25E1%2588%25B4", true)]
-        public void AppendPathWorks(string initialPath, string[] appends, string query, string expectedResult, bool escape = false)
+        public void AppendPathWorks(string initialPath, string[] appends, string initialQuery, string expectedResult, bool escape = false)
         {
             var uriBuilder = new RequestUriBuilder
             {
                 Scheme = "http",
                 Host = "localhost",
                 Port = 80,
-                Path = initialPath
+                Path = initialPath,
+                Query = initialQuery
             };
-            if (!string.IsNullOrEmpty(query))
-            {
-                uriBuilder.Query = query;
-            }
 
-            if (escape)
+            foreach (var append in appends)
             {
-                foreach (var append in appends)
-                {
-                    uriBuilder.AppendPath(append);
-                }
-            }
-            else
-            {
-                foreach (var append in appends)
-                {
-                    uriBuilder.AppendPath(append, escape: false);
-                }
+                uriBuilder.AppendPath(append, escape);
             }
 
             Assert.AreEqual(expectedResult, uriBuilder.ToUri().OriginalString);

--- a/sdk/core/Azure.Core/tests/RequestUriBuilderTest.cs
+++ b/sdk/core/Azure.Core/tests/RequestUriBuilderTest.cs
@@ -37,9 +37,7 @@ namespace Azure.Core.Tests
             Assert.AreEqual(uri.Host, uriBuilder.Host);
             Assert.AreEqual(uri.Port, uriBuilder.Port);
             Assert.AreEqual(uri.AbsolutePath, uriBuilder.Path);
-            Assert.AreEqual(uri.AbsolutePath.Length > 0, uriBuilder.PathLength > 0);
             Assert.AreEqual(uri.Query, uriBuilder.Query);
-            Assert.AreEqual(uri.Query.Length > 0, uriBuilder.QueryLength > 0);
             Assert.AreEqual(uri, uriBuilder.ToUri());
             Assert.AreSame(uri, uriBuilder.ToUri());
         }
@@ -181,7 +179,6 @@ namespace Azure.Core.Tests
             uriBuilder.AppendQuery("c", "d");
 
             Assert.AreEqual(expectedResult, uriBuilder.ToUri().ToString());
-            Assert.IsTrue(uriBuilder.QueryLength > 0);
         }
 
         [TestCase(null, new[] {""}, "q", "http://localhost/?q")]

--- a/sdk/core/Azure.Core/tests/RequestUriBuilderTest.cs
+++ b/sdk/core/Azure.Core/tests/RequestUriBuilderTest.cs
@@ -37,9 +37,9 @@ namespace Azure.Core.Tests
             Assert.AreEqual(uri.Host, uriBuilder.Host);
             Assert.AreEqual(uri.Port, uriBuilder.Port);
             Assert.AreEqual(uri.AbsolutePath, uriBuilder.Path);
-            Assert.AreEqual(uri.AbsolutePath.Length > 0, uriBuilder.HasPath);
+            Assert.AreEqual(uri.AbsolutePath.Length > 0, uriBuilder.PathLength > 0);
             Assert.AreEqual(uri.Query, uriBuilder.Query);
-            Assert.AreEqual(uri.Query.Length > 0, uriBuilder.HasQuery);
+            Assert.AreEqual(uri.Query.Length > 0, uriBuilder.QueryLength > 0);
             Assert.AreEqual(uri, uriBuilder.ToUri());
             Assert.AreSame(uri, uriBuilder.ToUri());
         }
@@ -181,7 +181,7 @@ namespace Azure.Core.Tests
             uriBuilder.AppendQuery("c", "d");
 
             Assert.AreEqual(expectedResult, uriBuilder.ToUri().ToString());
-            Assert.IsTrue(uriBuilder.HasQuery);
+            Assert.IsTrue(uriBuilder.QueryLength > 0);
         }
 
         [TestCase(null, new[] {""}, "q", "http://localhost/?q")]


### PR DESCRIPTION
`RawRequestUriBuilder` creates enormous amount of unnecessary small strings that often get promoted to gen 1. First set of changes is added in https://github.com/Azure/autorest.csharp/pull/2782. These changes in `RequestUriBuilder` are required to reduce these allocations even further.