### PR TITLE
[Smoke Tests] MSAL Native Interop Fix

### DIFF
--- a/common/SmokeTests/SmokeTest/Program.cs
+++ b/common/SmokeTests/SmokeTest/Program.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -53,7 +54,7 @@ foreach (var assembly in LoadAssemblies(Assembly.GetEntryAssembly(), AssemblyFil
             ProcessType(type);
         }
     }
-    catch (ReflectionTypeLoadException ex) when (ex.Message.Contains("does not have an implementation"))
+    catch (ReflectionTypeLoadException ex) when (ex.LoaderExceptions.All(lex => lex.Message.Contains("does not have an implementation")))
     {
         // Expected for some assemblies that serve as runtime shims or type-forwarding
         // assemblies.

--- a/common/SmokeTests/SmokeTest/Program.cs
+++ b/common/SmokeTests/SmokeTest/Program.cs
@@ -247,7 +247,7 @@ IEnumerable<Assembly> LoadAssemblies(Assembly rootAssembly, string assemblyFileM
     {
         var assembly = assembliesToProcess.Pop();
 
-        if ((!assembly.FullName.StartsWith("System.")) && (!processedAssemblies.Contains(assembly.FullName)))
+        if ((ShouldLoadAssembly(assembly)) && (!processedAssemblies.Contains(assembly.FullName)))
         {
             processedAssemblies.Add(assembly.FullName);
             yield return assembly;
@@ -290,4 +290,11 @@ bool ShouldIgnoreFileLoadException(FileLoadException ex) => ex switch
 
     // By default, do not ignore.
     _ => false
+};
+
+bool ShouldLoadAssembly(Assembly assembly) => assembly.FullName switch
+{
+    string name when name.StartsWith("System.") => false,
+    string name when name.Contains("NativeInterop") => false,
+    _ => true
 };

--- a/common/SmokeTests/SmokeTest/Program.cs
+++ b/common/SmokeTests/SmokeTest/Program.cs
@@ -53,6 +53,11 @@ foreach (var assembly in LoadAssemblies(Assembly.GetEntryAssembly(), AssemblyFil
             ProcessType(type);
         }
     }
+    catch (ReflectionTypeLoadException ex) when (ex.Message.Contains("does not have an implementation"))
+    {
+        // Expected for some assemblies that serve as runtime shims or type-forwarding
+        // assemblies.
+    }
     catch (ReflectionTypeLoadException) when (assembly.FullName.StartsWith("System."))
     {
         // Not expected, but not impactful.  System assemblies aren't indicative of


### PR DESCRIPTION
# Summary

The focus of these changes is to correct an issue loading the MSAL native interop assembly introduced with the new Azure.Identity.BrokeredAuthentication library.  Going forward, assemblies named to indicate native interoperability will no longer be loaded/type sniffed.