### PR TITLE
Fix BlobBaseClient.SetNameFields - trim slashes according to ClientCo…

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -567,7 +567,7 @@ namespace Azure.Storage.Blobs.Specialized
         {
             if (_name == null || _containerName == null || _accountName == null)
             {
-                var builder = new BlobUriBuilder(Uri);
+                var builder = new BlobUriBuilder(Uri, ClientConfiguration.TrimBlobNameSlashes);
                 _name = builder.BlobName;
                 _containerName = builder.BlobContainerName;
                 _accountName = builder.AccountName;

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -7382,31 +7382,6 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [RecordedTest]
-        public void SetNameFields_TrimBlobNameSlashes([Values("blobname", "/blobname", "//blobname", "vdir//blobname", "/vdir//blobname")] string blobName, [Values(true, false)] bool trimBlobNameSlashes)
-        {
-            // arrange
-            var accountName = "account";
-            var containerName = "container";
-            var uriPrefix = $"https://{accountName}.blob.core.windows.net/{containerName}/";
-            var options = new BlobClientOptions() { TrimBlobNameSlashes = trimBlobNameSlashes };
-
-            // act
-            var blobBase = new BlobBaseClient(new Uri(string.Concat(uriPrefix, blobName)), options);
-
-            // verify
-            if (trimBlobNameSlashes)
-            {
-                Assert.AreEqual(blobName.Trim('/'), blobBase.Name);
-            }
-            else
-            {
-                Assert.AreEqual(blobName, blobBase.Name);
-            }
-            Assert.AreEqual(containerName, blobBase.BlobContainerName);
-            Assert.AreEqual(accountName, blobBase.AccountName);
-        }
-
-        [RecordedTest]
         public void CanMockParentContainerClientRetrieval()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -7382,6 +7382,31 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [RecordedTest]
+        public void SetNameFields_TrimBlobNameSlashes([Values("blobname", "/blobname", "//blobname", "vdir//blobname", "/vdir//blobname")] string blobName, [Values(true, false)] bool trimBlobNameSlashes)
+        {
+            // arrange
+            var accountName = "account";
+            var containerName = "container";
+            var uriPrefix = $"https://{accountName}.blob.core.windows.net/{containerName}/";
+            var options = new BlobClientOptions() { TrimBlobNameSlashes = trimBlobNameSlashes };
+
+            // act
+            var blobBase = new BlobBaseClient(new Uri(string.Concat(uriPrefix, blobName)), options);
+
+            // verify
+            if (trimBlobNameSlashes)
+            {
+                Assert.AreEqual(blobName.Trim('/'), blobBase.Name);
+            }
+            else
+            {
+                Assert.AreEqual(blobName, blobBase.Name);
+            }
+            Assert.AreEqual(containerName, blobBase.BlobContainerName);
+            Assert.AreEqual(accountName, blobBase.AccountName);
+        }
+
+        [RecordedTest]
         public void CanMockParentContainerClientRetrieval()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobUriBuilderTests.cs
@@ -974,5 +974,30 @@ namespace Azure.Storage.Blobs.Test
                 Assert.IsTrue(e.Message.Contains("was not recognized as a valid DateTime."));
             }
         }
+
+        [RecordedTest]
+        public void BlobBaseClient_SetNameFields_TrimBlobNameSlashes([Values("blobname", "/blobname", "//blobname", "vdir//blobname", "/vdir//blobname")] string blobName, [Values(true, false)] bool trimBlobNameSlashes)
+        {
+            // arrange
+            var accountName = "account";
+            var containerName = "container";
+            var uriPrefix = $"https://{accountName}.blob.core.windows.net/{containerName}/";
+            var options = new BlobClientOptions() { TrimBlobNameSlashes = trimBlobNameSlashes };
+
+            // act
+            var blobBase = new BlobBaseClient(new Uri(string.Concat(uriPrefix, blobName)), options);
+
+            // verify
+            if (trimBlobNameSlashes)
+            {
+                Assert.AreEqual(blobName.Trim('/'), blobBase.Name);
+            }
+            else
+            {
+                Assert.AreEqual(blobName, blobBase.Name);
+            }
+            Assert.AreEqual(containerName, blobBase.BlobContainerName);
+            Assert.AreEqual(accountName, blobBase.AccountName);
+        }
     }
 }


### PR DESCRIPTION
Follow up fix for newly introduced support for leading and trailing '/' in v. 12.14.0 (2022-10-12).

If a new BlobBaseClient is created directly from a URI with BlobClientOptions, TrimBlobNameSlashes set to true
e.g.
https://accountName.blob.core.windows.net/containerName///blobName.

The URI would be indeed correctly preserved with the leading slash, but the .Name property would be trimmed, therefore not reflecting the actual blobName in the container.