### PR TITLE
[For Discussion] RetryPolicy/GeoRedundantPolicy exploration

### DIFF
--- a/sdk/core/Azure.Core/Azure.Core.sln
+++ b/sdk/core/Azure.Core/Azure.Core.sln
@@ -31,7 +31,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager", "..\..\resourcemanager\Azure.ResourceManager\src\Azure.ResourceManager.csproj", "{8E60A748-3973-471A-B103-EC9406BB3313}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core.TestFramework.Tests", "..\Azure.Core.TestFramework\tests\Azure.Core.TestFramework.Tests.csproj", "{33C299B5-ABDA-47BC-838F-973E62C067F9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework.Tests", "..\Azure.Core.TestFramework\tests\Azure.Core.TestFramework.Tests.csproj", "{33C299B5-ABDA-47BC-838F-973E62C067F9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleApp", "SampleApp\SampleApp.csproj", "{270B1719-4AB5-4522-AAC4-4E0A0F6073AD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -99,6 +101,10 @@ Global
 		{33C299B5-ABDA-47BC-838F-973E62C067F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{33C299B5-ABDA-47BC-838F-973E62C067F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{33C299B5-ABDA-47BC-838F-973E62C067F9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{270B1719-4AB5-4522-AAC4-4E0A0F6073AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{270B1719-4AB5-4522-AAC4-4E0A0F6073AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{270B1719-4AB5-4522-AAC4-4E0A0F6073AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{270B1719-4AB5-4522-AAC4-4E0A0F6073AD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/core/Azure.Core/SampleApp/Program.cs
+++ b/sdk/core/Azure.Core/SampleApp/Program.cs
@@ -1,0 +1,47 @@
+﻿// See https://aka.ms/new-console-template for more information
+using Azure;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Identity;
+using Polly;
+using SampleApp;
+
+Console.WriteLine("Hello, World!");
+
+// User can replace pipeline policy
+var options = ClientOptions.Default;
+options.ReplacePolicy(new PollyPolicy(), PipelinePolicyReplacement.RetryPolicy);
+
+var client = new SampleClient(new Uri("endpoint"), new DefaultAzureCredential(), options);
+
+// User can sub out RetryPolicy per-invocation
+RequestContext context = new();
+context.ReplacePolicy(new CustomRetryPolicy(), PipelinePolicyReplacement.RetryPolicy);
+client.GetWithSpecialRetries(RequestContent.Create("value"), context);
+
+public class PollyPolicy : HttpPipelinePolicy
+{
+    public override void Process(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+    {
+        Policy.HandleResult<Response>(r => r.Status >= 400)
+            .WaitAndRetry(3, retryAttempt => {
+                message.PipelineContext.RetryAttempt = retryAttempt;
+                return TimeSpan.FromSeconds(Math.Pow(2, retryAttempt))})
+            .Execute(() => ProcessWithResponse(message, pipeline));
+    }
+
+    private Response ProcessWithResponse(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+    {
+        ProcessNext(message, pipeline);
+        return message.Response;
+    }
+
+    public override ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+public class CustomRetryPolicy : HttpPipelineSynchronousPolicy
+{
+}

--- a/sdk/core/Azure.Core/SampleApp/SampleApp.csproj
+++ b/sdk/core/Azure.Core/SampleApp/SampleApp.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.7.0" />
+    <PackageReference Include="Polly" Version="7.2.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Azure.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sdk/core/Azure.Core/SampleApp/SampleClient.cs
+++ b/sdk/core/Azure.Core/SampleApp/SampleClient.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+namespace SampleApp
+{
+    public class SampleClient
+    {
+        private readonly HttpPipeline _pipeline;
+
+        internal static int MyServiceSLAMinutes;
+
+        public SampleClient(Uri endpoint, TokenCredential credential, ClientOptions options)
+        {
+            // Pipeline author can add retry conditions or override the default retry policy
+            HttpPipelineOptions pipelineOptions = new HttpPipelineOptions(options);
+            pipelineOptions.RetryConditions.Add(new GlobalTimeoutRetryCondition(TimeSpan.FromMinutes(MyServiceSLAMinutes)));
+
+            _pipeline = HttpPipelineBuilder.Build(pipelineOptions);
+        }
+
+        public Response GetWithSpecialRetries(RequestContent content, RequestContext context = default)
+        {
+            HttpMessage message = _pipeline.CreateMessage(context);
+
+            // In reality, we would use the protocol method send that takes context, but it's not in Core yet.
+            _pipeline.Send(message, context.CancellationToken);
+            return message.Response;
+        }
+    }
+
+    public class GlobalTimeoutRetryCondition : RetryCondition
+    {
+        private TimeSpan _maxTime;
+
+        public GlobalTimeoutRetryCondition(TimeSpan maxTime)
+        {
+            _maxTime = maxTime;
+        }
+
+        public override bool TryGetShouldRetry(HttpMessage message, out bool shouldRetry)
+        {
+            if ((message.PipelineContext.CreatedOn + _maxTime) >= DateTimeOffset.UtcNow)
+            {
+                shouldRetry = false;
+                return true;
+            }
+
+            shouldRetry = true;
+            return false;
+        }
+    }
+}

--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -199,6 +199,7 @@ namespace Azure
         public void AddClassifier(int statusCode, bool isError) { }
         public void AddPolicy(Azure.Core.Pipeline.HttpPipelinePolicy policy, Azure.Core.HttpPipelinePosition position) { }
         public static implicit operator Azure.RequestContext (Azure.ErrorOptions options) { throw null; }
+        public void ReplacePolicy(Azure.Core.Pipeline.HttpPipelinePolicy policy, Azure.Core.PipelinePolicyReplacement replace) { }
     }
     public partial class RequestFailedException : System.Exception, System.Runtime.Serialization.ISerializable
     {
@@ -362,6 +363,7 @@ namespace Azure.Core
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
+        public void ReplacePolicy(Azure.Core.Pipeline.HttpPipelinePolicy policy, Azure.Core.PipelinePolicyReplacement replace) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string? ToString() { throw null; }
     }
@@ -451,6 +453,7 @@ namespace Azure.Core
         public System.Threading.CancellationToken CancellationToken { get { throw null; } }
         public bool HasResponse { get { throw null; } }
         public System.TimeSpan? NetworkTimeout { get { throw null; } set { } }
+        public Azure.Core.PipelineContext PipelineContext { get { throw null; } }
         public Azure.Core.Request Request { get { throw null; } }
         public Azure.Response Response { get { throw null; } set { } }
         public Azure.Core.ResponseClassifier ResponseClassifier { get { throw null; } set { } }
@@ -469,6 +472,16 @@ namespace Azure.Core
     {
         public static Azure.Response[] Parse(Azure.Response response, bool expectCrLf, System.Threading.CancellationToken cancellationToken) { throw null; }
         public static System.Threading.Tasks.Task<Azure.Response[]> ParseAsync(Azure.Response response, bool expectCrLf, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+    public partial class PipelineContext
+    {
+        internal PipelineContext() { }
+        public System.DateTimeOffset CreatedOn { get { throw null; } }
+        public int RetryAttempt { get { throw null; } set { } }
+    }
+    public enum PipelinePolicyReplacement
+    {
+        RetryPolicy = 0,
     }
     public abstract partial class Request : System.IDisposable
     {
@@ -649,6 +662,11 @@ namespace Azure.Core
         public bool TryGetValue(string name, out string? value) { throw null; }
         public bool TryGetValues(string name, out System.Collections.Generic.IEnumerable<string>? values) { throw null; }
     }
+    public abstract partial class RetryCondition
+    {
+        protected RetryCondition() { }
+        public abstract bool TryGetShouldRetry(Azure.Core.HttpMessage message, out bool shouldRetry);
+    }
     public enum RetryMode
     {
         Fixed = 0,
@@ -662,6 +680,7 @@ namespace Azure.Core
         public int MaxRetries { get { throw null; } set { } }
         public Azure.Core.RetryMode Mode { get { throw null; } set { } }
         public System.TimeSpan NetworkTimeout { get { throw null; } set { } }
+        public void AddRetryCondition(Azure.Core.RetryCondition condition) { }
     }
     public partial class StatusCodeClassifier : Azure.Core.ResponseClassifier
     {
@@ -958,6 +977,8 @@ namespace Azure.Core.Pipeline
         public System.Collections.Generic.IList<Azure.Core.Pipeline.HttpPipelinePolicy> PerRetryPolicies { get { throw null; } }
         public Azure.Core.RequestFailedDetailsParser RequestFailedDetailsParser { get { throw null; } set { } }
         public Azure.Core.ResponseClassifier? ResponseClassifier { get { throw null; } set { } }
+        public System.Collections.Generic.IList<Azure.Core.RetryCondition> RetryConditions { get { throw null; } }
+        public Azure.Core.Pipeline.HttpPipelinePolicy? RetryPolicy { get { throw null; } set { } }
     }
     public abstract partial class HttpPipelinePolicy
     {

--- a/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
@@ -199,6 +199,7 @@ namespace Azure
         public void AddClassifier(int statusCode, bool isError) { }
         public void AddPolicy(Azure.Core.Pipeline.HttpPipelinePolicy policy, Azure.Core.HttpPipelinePosition position) { }
         public static implicit operator Azure.RequestContext (Azure.ErrorOptions options) { throw null; }
+        public void ReplacePolicy(Azure.Core.Pipeline.HttpPipelinePolicy policy, Azure.Core.PipelinePolicyReplacement replace) { }
     }
     public partial class RequestFailedException : System.Exception, System.Runtime.Serialization.ISerializable
     {
@@ -362,6 +363,7 @@ namespace Azure.Core
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
+        public void ReplacePolicy(Azure.Core.Pipeline.HttpPipelinePolicy policy, Azure.Core.PipelinePolicyReplacement replace) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string? ToString() { throw null; }
     }
@@ -451,6 +453,7 @@ namespace Azure.Core
         public System.Threading.CancellationToken CancellationToken { get { throw null; } }
         public bool HasResponse { get { throw null; } }
         public System.TimeSpan? NetworkTimeout { get { throw null; } set { } }
+        public Azure.Core.PipelineContext PipelineContext { get { throw null; } }
         public Azure.Core.Request Request { get { throw null; } }
         public Azure.Response Response { get { throw null; } set { } }
         public Azure.Core.ResponseClassifier ResponseClassifier { get { throw null; } set { } }
@@ -469,6 +472,16 @@ namespace Azure.Core
     {
         public static Azure.Response[] Parse(Azure.Response response, bool expectCrLf, System.Threading.CancellationToken cancellationToken) { throw null; }
         public static System.Threading.Tasks.Task<Azure.Response[]> ParseAsync(Azure.Response response, bool expectCrLf, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+    public partial class PipelineContext
+    {
+        internal PipelineContext() { }
+        public System.DateTimeOffset CreatedOn { get { throw null; } }
+        public int RetryAttempt { get { throw null; } set { } }
+    }
+    public enum PipelinePolicyReplacement
+    {
+        RetryPolicy = 0,
     }
     public abstract partial class Request : System.IDisposable
     {
@@ -649,6 +662,11 @@ namespace Azure.Core
         public bool TryGetValue(string name, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out string? value) { throw null; }
         public bool TryGetValues(string name, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Collections.Generic.IEnumerable<string>? values) { throw null; }
     }
+    public abstract partial class RetryCondition
+    {
+        protected RetryCondition() { }
+        public abstract bool TryGetShouldRetry(Azure.Core.HttpMessage message, out bool shouldRetry);
+    }
     public enum RetryMode
     {
         Fixed = 0,
@@ -662,6 +680,7 @@ namespace Azure.Core
         public int MaxRetries { get { throw null; } set { } }
         public Azure.Core.RetryMode Mode { get { throw null; } set { } }
         public System.TimeSpan NetworkTimeout { get { throw null; } set { } }
+        public void AddRetryCondition(Azure.Core.RetryCondition condition) { }
     }
     public partial class StatusCodeClassifier : Azure.Core.ResponseClassifier
     {
@@ -958,6 +977,8 @@ namespace Azure.Core.Pipeline
         public System.Collections.Generic.IList<Azure.Core.Pipeline.HttpPipelinePolicy> PerRetryPolicies { get { throw null; } }
         public Azure.Core.RequestFailedDetailsParser RequestFailedDetailsParser { get { throw null; } set { } }
         public Azure.Core.ResponseClassifier? ResponseClassifier { get { throw null; } set { } }
+        public System.Collections.Generic.IList<Azure.Core.RetryCondition> RetryConditions { get { throw null; } }
+        public Azure.Core.Pipeline.HttpPipelinePolicy? RetryPolicy { get { throw null; } set { } }
     }
     public abstract partial class HttpPipelinePolicy
     {

--- a/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
@@ -199,6 +199,7 @@ namespace Azure
         public void AddClassifier(int statusCode, bool isError) { }
         public void AddPolicy(Azure.Core.Pipeline.HttpPipelinePolicy policy, Azure.Core.HttpPipelinePosition position) { }
         public static implicit operator Azure.RequestContext (Azure.ErrorOptions options) { throw null; }
+        public void ReplacePolicy(Azure.Core.Pipeline.HttpPipelinePolicy policy, Azure.Core.PipelinePolicyReplacement replace) { }
     }
     public partial class RequestFailedException : System.Exception, System.Runtime.Serialization.ISerializable
     {
@@ -362,6 +363,7 @@ namespace Azure.Core
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
+        public void ReplacePolicy(Azure.Core.Pipeline.HttpPipelinePolicy policy, Azure.Core.PipelinePolicyReplacement replace) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string? ToString() { throw null; }
     }
@@ -451,6 +453,7 @@ namespace Azure.Core
         public System.Threading.CancellationToken CancellationToken { get { throw null; } }
         public bool HasResponse { get { throw null; } }
         public System.TimeSpan? NetworkTimeout { get { throw null; } set { } }
+        public Azure.Core.PipelineContext PipelineContext { get { throw null; } }
         public Azure.Core.Request Request { get { throw null; } }
         public Azure.Response Response { get { throw null; } set { } }
         public Azure.Core.ResponseClassifier ResponseClassifier { get { throw null; } set { } }
@@ -469,6 +472,16 @@ namespace Azure.Core
     {
         public static Azure.Response[] Parse(Azure.Response response, bool expectCrLf, System.Threading.CancellationToken cancellationToken) { throw null; }
         public static System.Threading.Tasks.Task<Azure.Response[]> ParseAsync(Azure.Response response, bool expectCrLf, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+    public partial class PipelineContext
+    {
+        internal PipelineContext() { }
+        public System.DateTimeOffset CreatedOn { get { throw null; } }
+        public int RetryAttempt { get { throw null; } set { } }
+    }
+    public enum PipelinePolicyReplacement
+    {
+        RetryPolicy = 0,
     }
     public abstract partial class Request : System.IDisposable
     {
@@ -649,6 +662,11 @@ namespace Azure.Core
         public bool TryGetValue(string name, out string? value) { throw null; }
         public bool TryGetValues(string name, out System.Collections.Generic.IEnumerable<string>? values) { throw null; }
     }
+    public abstract partial class RetryCondition
+    {
+        protected RetryCondition() { }
+        public abstract bool TryGetShouldRetry(Azure.Core.HttpMessage message, out bool shouldRetry);
+    }
     public enum RetryMode
     {
         Fixed = 0,
@@ -662,6 +680,7 @@ namespace Azure.Core
         public int MaxRetries { get { throw null; } set { } }
         public Azure.Core.RetryMode Mode { get { throw null; } set { } }
         public System.TimeSpan NetworkTimeout { get { throw null; } set { } }
+        public void AddRetryCondition(Azure.Core.RetryCondition condition) { }
     }
     public partial class StatusCodeClassifier : Azure.Core.ResponseClassifier
     {
@@ -958,6 +977,8 @@ namespace Azure.Core.Pipeline
         public System.Collections.Generic.IList<Azure.Core.Pipeline.HttpPipelinePolicy> PerRetryPolicies { get { throw null; } }
         public Azure.Core.RequestFailedDetailsParser RequestFailedDetailsParser { get { throw null; } set { } }
         public Azure.Core.ResponseClassifier? ResponseClassifier { get { throw null; } set { } }
+        public System.Collections.Generic.IList<Azure.Core.RetryCondition> RetryConditions { get { throw null; } }
+        public Azure.Core.Pipeline.HttpPipelinePolicy? RetryPolicy { get { throw null; } set { } }
     }
     public abstract partial class HttpPipelinePolicy
     {

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -199,6 +199,7 @@ namespace Azure
         public void AddClassifier(int statusCode, bool isError) { }
         public void AddPolicy(Azure.Core.Pipeline.HttpPipelinePolicy policy, Azure.Core.HttpPipelinePosition position) { }
         public static implicit operator Azure.RequestContext (Azure.ErrorOptions options) { throw null; }
+        public void ReplacePolicy(Azure.Core.Pipeline.HttpPipelinePolicy policy, Azure.Core.PipelinePolicyReplacement replace) { }
     }
     public partial class RequestFailedException : System.Exception, System.Runtime.Serialization.ISerializable
     {
@@ -362,6 +363,7 @@ namespace Azure.Core
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
+        public void ReplacePolicy(Azure.Core.Pipeline.HttpPipelinePolicy policy, Azure.Core.PipelinePolicyReplacement replace) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string? ToString() { throw null; }
     }
@@ -451,6 +453,7 @@ namespace Azure.Core
         public System.Threading.CancellationToken CancellationToken { get { throw null; } }
         public bool HasResponse { get { throw null; } }
         public System.TimeSpan? NetworkTimeout { get { throw null; } set { } }
+        public Azure.Core.PipelineContext PipelineContext { get { throw null; } }
         public Azure.Core.Request Request { get { throw null; } }
         public Azure.Response Response { get { throw null; } set { } }
         public Azure.Core.ResponseClassifier ResponseClassifier { get { throw null; } set { } }
@@ -469,6 +472,16 @@ namespace Azure.Core
     {
         public static Azure.Response[] Parse(Azure.Response response, bool expectCrLf, System.Threading.CancellationToken cancellationToken) { throw null; }
         public static System.Threading.Tasks.Task<Azure.Response[]> ParseAsync(Azure.Response response, bool expectCrLf, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+    public partial class PipelineContext
+    {
+        internal PipelineContext() { }
+        public System.DateTimeOffset CreatedOn { get { throw null; } }
+        public int RetryAttempt { get { throw null; } set { } }
+    }
+    public enum PipelinePolicyReplacement
+    {
+        RetryPolicy = 0,
     }
     public abstract partial class Request : System.IDisposable
     {
@@ -649,6 +662,11 @@ namespace Azure.Core
         public bool TryGetValue(string name, out string? value) { throw null; }
         public bool TryGetValues(string name, out System.Collections.Generic.IEnumerable<string>? values) { throw null; }
     }
+    public abstract partial class RetryCondition
+    {
+        protected RetryCondition() { }
+        public abstract bool TryGetShouldRetry(Azure.Core.HttpMessage message, out bool shouldRetry);
+    }
     public enum RetryMode
     {
         Fixed = 0,
@@ -662,6 +680,7 @@ namespace Azure.Core
         public int MaxRetries { get { throw null; } set { } }
         public Azure.Core.RetryMode Mode { get { throw null; } set { } }
         public System.TimeSpan NetworkTimeout { get { throw null; } set { } }
+        public void AddRetryCondition(Azure.Core.RetryCondition condition) { }
     }
     public partial class StatusCodeClassifier : Azure.Core.ResponseClassifier
     {
@@ -958,6 +977,8 @@ namespace Azure.Core.Pipeline
         public System.Collections.Generic.IList<Azure.Core.Pipeline.HttpPipelinePolicy> PerRetryPolicies { get { throw null; } }
         public Azure.Core.RequestFailedDetailsParser RequestFailedDetailsParser { get { throw null; } set { } }
         public Azure.Core.ResponseClassifier? ResponseClassifier { get { throw null; } set { } }
+        public System.Collections.Generic.IList<Azure.Core.RetryCondition> RetryConditions { get { throw null; } }
+        public Azure.Core.Pipeline.HttpPipelinePolicy? RetryPolicy { get { throw null; } set { } }
     }
     public abstract partial class HttpPipelinePolicy
     {

--- a/sdk/core/Azure.Core/src/ClientOptions.cs
+++ b/sdk/core/Azure.Core/src/ClientOptions.cs
@@ -110,6 +110,17 @@ namespace Azure.Core
             Policies.Add((position, policy));
         }
 
+        /// <summary>
+        /// Replaces a default <see cref="HttpPipeline"/> policy in the client pipeline.
+        /// The specific policy to replace is specified by <paramref name="replace"/> parameter.
+        /// </summary>
+        /// <param name="policy">The <see cref="HttpPipelinePolicy"/> to replace the default policy with.</param>
+        /// <param name="replace">Identifies which default policy to replace.</param>
+        public void ReplacePolicy(HttpPipelinePolicy policy, PipelinePolicyReplacement replace)
+        {
+            throw new NotImplementedException();
+        }
+
         internal List<(HttpPipelinePosition Position, HttpPipelinePolicy Policy)>? Policies { get; private set; }
 
         /// <inheritdoc />

--- a/sdk/core/Azure.Core/src/HttpMessage.cs
+++ b/sdk/core/Azure.Core/src/HttpMessage.cs
@@ -33,6 +33,7 @@ namespace Azure.Core
             Request = request;
             ResponseClassifier = responseClassifier;
             BufferResponse = true;
+            PipelineContext = new PipelineContext(DateTimeOffset.UtcNow);
         }
 
         /// <summary>
@@ -84,6 +85,11 @@ namespace Azure.Core
         /// Defaults to <c>null</c>.
         /// </summary>
         public TimeSpan? NetworkTimeout { get; set; }
+
+        /// <summary>
+        /// Gets metadata describing the flow of the message through the pipeline.
+        /// </summary>
+        public PipelineContext PipelineContext { get; internal set; }
 
         internal void ApplyRequestContext(RequestContext? context, ResponseClassifier? classifier)
         {

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelineBuilder.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelineBuilder.cs
@@ -153,7 +153,7 @@ namespace Azure.Core.Pipeline
             }
 
             RetryOptions retryOptions = buildOptions.ClientOptions.Retry;
-            policies.Add(new RetryPolicy(retryOptions.Mode, retryOptions.Delay, retryOptions.MaxDelay, retryOptions.MaxRetries));
+            policies.Add(new RetryPolicy(retryOptions.Mode, retryOptions.Delay, retryOptions.MaxDelay, retryOptions.MaxRetries, retryOptions.RetryConditions));
 
             policies.Add(RedirectPolicy.Shared);
 

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelineOptions.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelineOptions.cs
@@ -23,6 +23,7 @@ namespace Azure.Core.Pipeline
             PerCallPolicies = new List<HttpPipelinePolicy>();
             PerRetryPolicies = new List<HttpPipelinePolicy>();
             RequestFailedDetailsParser = new DefaultRequestFailedDetailsParser();
+            RetryConditions = new List<RetryCondition>();
         }
 
         /// <summary>
@@ -39,6 +40,16 @@ namespace Azure.Core.Pipeline
         /// Client provided per-retry policies.
         /// </summary>
         public IList<HttpPipelinePolicy> PerRetryPolicies { get; }
+
+        /// <summary>
+        /// Replacement for the default retry policy.
+        /// </summary>
+        public HttpPipelinePolicy? RetryPolicy { get; set; }
+
+        /// <summary>
+        /// Conditions to add to the default retry policy to help it decide whether to retry a request.
+        /// </summary>
+        public IList<RetryCondition> RetryConditions { get;}
 
         /// <summary>
         /// The client provided response classifier.

--- a/sdk/core/Azure.Core/src/PipelineContext.cs
+++ b/sdk/core/Azure.Core/src/PipelineContext.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Core
+{
+    /// <summary>
+    /// Metadata describing the flow of the HttpMessage through the pipeline
+    /// in a given invocation.
+    /// </summary>
+    public class PipelineContext
+    {
+        internal PipelineContext(DateTimeOffset createdOn)
+        {
+            CreatedOn = createdOn;
+        }
+
+        /// <summary>
+        /// The time this HttpMessage was created.
+        /// </summary>
+        public DateTimeOffset CreatedOn { get; }
+
+        private int? _retryAttempt;
+
+        /// <summary>
+        /// The number indicating which retry attempt is currently in progress.
+        /// </summary>
+        public int RetryAttempt
+        {
+            get
+            {
+                if (_retryAttempt == null)
+                {
+                    throw new InvalidOperationException("Tried to read RetryAttempt when it did not have a value. " +
+                        "This can happen because you've accessed RetryAttempt before the RetryPolicy in the pipeline, " +
+                        "or because a custom RetryPolicy failed to set RetryAttempt.");
+                }
+
+                return _retryAttempt.Value;
+            }
+
+            set { _retryAttempt = value; }
+        }
+    }
+}

--- a/sdk/core/Azure.Core/src/PipelinePolicyReplacement.cs
+++ b/sdk/core/Azure.Core/src/PipelinePolicyReplacement.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Core
+{
+    /// <summary>
+    /// Represents a policy to replace in the pipeline.
+    /// </summary>
+    public enum PipelinePolicyReplacement
+    {
+        /// <summary>
+        /// Replace the default pipeline retry policy with a custom
+        /// retry policy. The provided retry policy will need to set
+        /// relevant values in PipelineContext on HttpMessage.
+        /// </summary>
+        RetryPolicy
+    }
+}

--- a/sdk/core/Azure.Core/src/RequestContext.cs
+++ b/sdk/core/Azure.Core/src/RequestContext.cs
@@ -62,6 +62,18 @@ namespace Azure
         }
 
         /// <summary>
+        /// Replaces a default <see cref="HttpPipeline"/> policy in the client pipeline
+        /// for the given method invocation.
+        /// The specific policy to replace is specified by <paramref name="replace"/> parameter.
+        /// </summary>
+        /// <param name="policy">The <see cref="HttpPipelinePolicy"/> to replace the default policy with.</param>
+        /// <param name="replace">Identifies which default policy to replace.</param>
+        public void ReplacePolicy(HttpPipelinePolicy policy, PipelinePolicyReplacement replace)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Customizes the <see cref="ResponseClassifier"/> for this operation to change
         /// the default <see cref="Response"/> classification behavior so that it considers
         /// the passed-in status code to be an error or not, as specified.

--- a/sdk/core/Azure.Core/src/RetryCondition.cs
+++ b/sdk/core/Azure.Core/src/RetryCondition.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Core
+{
+    /// <summary>
+    /// A condition to check to determine whether or not to retry the request.
+    /// </summary>
+    public abstract class RetryCondition
+    {
+        /// <summary>
+        /// Populates the <code>shouldRetry</code> out parameter to indicate whether or not
+        /// the message's request should be retried.
+        /// </summary>
+        /// <param name="message">The message to use to determine whether the condition shoudl be applied.</param>
+        /// <param name="shouldRetry">Whether the message's request should be retried by the default RetryPolicy.</param>
+        /// <returns><code>true</code> if the condition provided a retry decision for this message; <code>false</code> otherwise.</returns>
+        public abstract bool TryGetShouldRetry(HttpMessage message, out bool shouldRetry);
+    }
+}

--- a/sdk/core/Azure.Core/src/RetryOptions.cs
+++ b/sdk/core/Azure.Core/src/RetryOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 
 namespace Azure.Core
 {
@@ -31,6 +32,11 @@ namespace Azure.Core
                 MaxDelay = retryOptions.MaxDelay;
                 Mode = retryOptions.Mode;
                 NetworkTimeout = retryOptions.NetworkTimeout;
+                RetryConditions = retryOptions.RetryConditions;
+            }
+            else
+            {
+                RetryConditions = new List<RetryCondition>();
             }
         }
 
@@ -61,5 +67,20 @@ namespace Azure.Core
         /// The timeout applied to an individual network operations.
         /// </summary>
         public TimeSpan NetworkTimeout { get; set; } = TimeSpan.FromSeconds(100);
+
+        /// <summary>
+        /// Adds a condition to help determine whether or not a request should be retried.
+        /// Adding a <see cref="RetryCondition"/> changes the "should retry" behavior of the default
+        /// pipeline RetryPolicy. Conditions are applied in order, so the most recently added
+        /// condition takes precendece over those that were previously added.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <exception cref="NotImplementedException"></exception>
+        public void AddRetryCondition(RetryCondition condition)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal IList<RetryCondition> RetryConditions { get; }
     }
 }


### PR DESCRIPTION
### Description
Some thoughts in response to @JoshLove-msft's work on RetryPolicy:
- [RetryPolicy Gist](https://gist.github.com/JoshLove-msft/28993cd17754b2b23671092b7c45336d)
- [Prior work by @JoshLove-msft that this is building on](https://github.com/Azure/azure-sdk-for-net/pull/31187)

### Motivating Scenarios
- Implement [Polly](https://github.com/App-vNext/Polly#usage--fault-handling-reactive-policies) retry policy: [Sample](https://github.com/Azure/azure-sdk-for-net/pull/31892/files#diff-35c33a1cf3598d8668ff885a81242466d8dfe659fe245c32d628ebfe5f22af8bR12-R15)
- Enable GeoRedundant policy logic to be implemented with knowledge of retries. [Sample](https://gist.github.com/JoshLove-msft/28993cd17754b2b23671092b7c45336d#option-2---retrycontext-on-httpmessage)
- Let callers compose simple retry logic conditions: [Sample](https://github.com/Azure/azure-sdk-for-net/pull/31892/files#diff-77158d2866ddb3696077cbc90380dfca5694a3e2d134995c0b44429f6562df09R22)

### Design Goals
- Pipeline policy PerCall/PerRetry semantics are respected
- Single responsibility: retry logic lives in a single policy
- Design indicates RetryPolicy replacement is an advanced scenario
- Precedence of modifications to policy is clear and respected: Per invocation (end-user)/Per client (end-user)/Per client (library author)
- Avoid adding lots of policies to the pipeline
- Library author can do same modifications to retry logic as end-user, but end-user options take precedence
- Safeguard against policy replacement having negative side effects elsewhere in the pipeline
- Leverage patterns that appear elsewhere in Core (i.e. condition/classifier chaining, APIs for modifying pipeline).

