### PR TITLE
Refactor logic of deserialization of CommunicationIdentifierModel

### DIFF
--- a/sdk/communication/Azure.Communication.CallAutomation/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.CallAutomation/CHANGELOG.md
@@ -11,6 +11,7 @@ This is a Public Preview version, so breaking changes are possible in subsequent
 - Play audio in the call.
 - Add and remove participants from the call.
 - Recording download apis.
+- Added support for an optional `kind` property for `CommunicationIdentifierSerializer`.
 
 <!-- LINKS -->
 [read_me]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/communication/Azure.Communication.CallAutomation/README.md

--- a/sdk/communication/Azure.Communication.CallAutomation/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.CallAutomation/CHANGELOG.md
@@ -11,7 +11,7 @@ This is a Public Preview version, so breaking changes are possible in subsequent
 - Play audio in the call.
 - Add and remove participants from the call.
 - Recording download apis.
-- Added support for an optional `kind` property for `CommunicationIdentifierSerializer`.
+- Optimized the logic for deserializing types derived from the `CommunicationIdentifier`.
 
 <!-- LINKS -->
 [read_me]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/communication/Azure.Communication.CallAutomation/README.md

--- a/sdk/communication/Azure.Communication.CallingServer/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.CallingServer/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 - concept of in-call and out-call removed 
-- Added support for an optional `kind` property for `CommunicationIdentifierSerializer`.
+- Optimized the logic for deserializing types derived from the `CommunicationIdentifier`.
 
 ### Breaking Changes
 - CallConnection object removed due to everything now being out-call

--- a/sdk/communication/Azure.Communication.CallingServer/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.CallingServer/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features Added
 - concept of in-call and out-call removed 
+- Added support for an optional `kind` property for `CommunicationIdentifierSerializer`.
 
 ### Breaking Changes
 - CallConnection object removed due to everything now being out-call

--- a/sdk/communication/Azure.Communication.Chat/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.Chat/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.0-beta.1 (Unreleased)
 
 ### Features Added
+- Added support for an optional `kind` property for `CommunicationIdentifierSerializer`.
 
 ### Breaking Changes
 

--- a/sdk/communication/Azure.Communication.Chat/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.Chat/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.2.0-beta.1 (Unreleased)
 
 ### Features Added
-- Added support for an optional `kind` property for `CommunicationIdentifierSerializer`.
+- Optimized the logic for deserializing types derived from the `CommunicationIdentifier`.
 
 ### Breaking Changes
 

--- a/sdk/communication/Azure.Communication.MediaComposition/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.MediaComposition/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0-beta.1 (Unreleased)
 
 ### Features Added
+- Added support for an optional `kind` property for `CommunicationIdentifierSerializer`.
 
 ### Breaking Changes
 

--- a/sdk/communication/Azure.Communication.MediaComposition/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.MediaComposition/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.0.0-beta.1 (Unreleased)
 
 ### Features Added
-- Added support for an optional `kind` property for `CommunicationIdentifierSerializer`.
+- Optimized the logic for deserializing types derived from the `CommunicationIdentifier`.
 
 ### Breaking Changes
 

--- a/sdk/communication/Shared/src/CommunicationIdentifierSerializer.cs
+++ b/sdk/communication/Shared/src/CommunicationIdentifierSerializer.cs
@@ -59,7 +59,7 @@ namespace Azure.Communication
             }
         }
 
-        public static CommunicationIdentifierModelKind GetKind(CommunicationIdentifierModel identifier)
+        private static CommunicationIdentifierModelKind GetKind(CommunicationIdentifierModel identifier)
         {
             if (identifier.CommunicationUser is not null)
             {

--- a/sdk/communication/Shared/src/CommunicationIdentifierSerializer.cs
+++ b/sdk/communication/Shared/src/CommunicationIdentifierSerializer.cs
@@ -15,56 +15,31 @@ namespace Azure.Communication
 
             AssertMaximumOneNestedModel(identifier);
 
-            if (identifier.Kind is not null)
+            var kind = identifier.Kind ?? GetKind(identifier);
+
+            if (kind == CommunicationIdentifierModelKind.CommunicationUser
+                && identifier.CommunicationUser is not null)
             {
-                if (identifier.Kind == CommunicationIdentifierModelKind.CommunicationUser
-                    && identifier.CommunicationUser is not null)
-                {
-                    return new CommunicationUserIdentifier(AssertNotNull(identifier.CommunicationUser.Id, nameof(identifier.CommunicationUser.Id), nameof(CommunicationUserIdentifierModel)));
-                }
-
-                if (identifier.Kind == CommunicationIdentifierModelKind.PhoneNumber
-                    && identifier.PhoneNumber is not null)
-                {
-                    return new PhoneNumberIdentifier(
-                        AssertNotNull(identifier.PhoneNumber.Value, nameof(identifier.PhoneNumber.Value), nameof(PhoneNumberIdentifierModel)),
-                        AssertNotNull(identifier.RawId, nameof(identifier.RawId), nameof(PhoneNumberIdentifierModel)));
-                }
-
-                if (identifier.Kind == CommunicationIdentifierModelKind.MicrosoftTeamsUser
-                    && identifier.MicrosoftTeamsUser is not null)
-                {
-                    var user = identifier.MicrosoftTeamsUser;
-                    return new MicrosoftTeamsUserIdentifier(
-                          AssertNotNull(user.UserId, nameof(user.UserId), nameof(MicrosoftTeamsUserIdentifierModel)),
-                          AssertNotNull(user.IsAnonymous, nameof(user.IsAnonymous), nameof(MicrosoftTeamsUserIdentifierModel)),
-                          Deserialize(AssertNotNull(user.Cloud, nameof(user.Cloud), nameof(MicrosoftTeamsUserIdentifierModel))),
-                          rawId);
-                }
-
-                return new UnknownIdentifier(rawId);
+                return new CommunicationUserIdentifier(AssertNotNull(identifier.CommunicationUser.Id, nameof(identifier.CommunicationUser.Id), nameof(CommunicationUserIdentifierModel)));
             }
 
-            if (identifier.CommunicationUser is CommunicationUserIdentifierModel communicationUser)
-            {
-                return new CommunicationUserIdentifier(
-                    AssertNotNull(communicationUser.Id, nameof(communicationUser.Id), nameof(CommunicationUserIdentifierModel)));
-            }
-
-            if (identifier.PhoneNumber is PhoneNumberIdentifierModel phoneNumber)
+            if (kind == CommunicationIdentifierModelKind.PhoneNumber
+                && identifier.PhoneNumber is not null)
             {
                 return new PhoneNumberIdentifier(
-                    AssertNotNull(phoneNumber.Value, nameof(phoneNumber.Value), nameof(PhoneNumberIdentifierModel)),
+                    AssertNotNull(identifier.PhoneNumber.Value, nameof(identifier.PhoneNumber.Value), nameof(PhoneNumberIdentifierModel)),
                     AssertNotNull(identifier.RawId, nameof(identifier.RawId), nameof(PhoneNumberIdentifierModel)));
             }
 
-            if (identifier.MicrosoftTeamsUser is MicrosoftTeamsUserIdentifierModel teamsUser)
+            if (kind == CommunicationIdentifierModelKind.MicrosoftTeamsUser
+                && identifier.MicrosoftTeamsUser is not null)
             {
+                var user = identifier.MicrosoftTeamsUser;
                 return new MicrosoftTeamsUserIdentifier(
-                    AssertNotNull(teamsUser.UserId, nameof(teamsUser.UserId), nameof(MicrosoftTeamsUserIdentifierModel)),
-                    AssertNotNull(teamsUser.IsAnonymous, nameof(teamsUser.IsAnonymous), nameof(MicrosoftTeamsUserIdentifierModel)),
-                    Deserialize(AssertNotNull(teamsUser.Cloud, nameof(teamsUser.Cloud), nameof(MicrosoftTeamsUserIdentifierModel))),
-                    rawId);
+                      AssertNotNull(user.UserId, nameof(user.UserId), nameof(MicrosoftTeamsUserIdentifierModel)),
+                      AssertNotNull(user.IsAnonymous, nameof(user.IsAnonymous), nameof(MicrosoftTeamsUserIdentifierModel)),
+                      Deserialize(AssertNotNull(user.Cloud, nameof(user.Cloud), nameof(MicrosoftTeamsUserIdentifierModel))),
+                      rawId);
             }
 
             return new UnknownIdentifier(rawId);
@@ -82,6 +57,26 @@ namespace Azure.Communication
                 if (presentProperties.Count > 1)
                     throw new JsonException($"Only one of the properties in {{{string.Join(", ", presentProperties)}}} should be present.");
             }
+        }
+
+        public static CommunicationIdentifierModelKind GetKind(CommunicationIdentifierModel identifier)
+        {
+            if (identifier.CommunicationUser is not null)
+            {
+                return CommunicationIdentifierModelKind.CommunicationUser;
+            }
+
+            if (identifier.PhoneNumber is not null)
+            {
+                return CommunicationIdentifierModelKind.PhoneNumber;
+            }
+
+            if (identifier.MicrosoftTeamsUser is not null)
+            {
+                return CommunicationIdentifierModelKind.MicrosoftTeamsUser;
+            }
+
+            return CommunicationIdentifierModelKind.Unknown;
         }
 
         private static CommunicationCloudEnvironment Deserialize(CommunicationCloudEnvironmentModel cloud)


### PR DESCRIPTION
# Description

Refactored logic of deserialization of `CommunicationIdentifierModel` using `CommunicationIdentifierModelKind` and updated changelog files for respective modalities.

[User Story 3013988](https://skype.visualstudio.com/SPOOL/_workitems/edit/3013988): [SDK][Common][AllLangs] Prefer the "kind" property when deserializing the CommunicationIdentifier - follow up