### PR TITLE
Nit fix in AzureMonitor OTel metric

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricDataPoint.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricDataPoint.cs
@@ -40,7 +40,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                     long histogramCount = metricPoint.GetHistogramCount();
                     // Current schema only supports int values for count
                     // if the value is within integer range we will use it otherwise ignore it.
-                    Count = (histogramCount <= int.MaxValue && histogramCount >= int.MinValue) ? (int?)histogramCount : null;
+                    Count = histogramCount <= int.MaxValue ? (int?)histogramCount : null;
 
                     break;
             }


### PR DESCRIPTION
Count is not expected to be -ve ever from OTel SDK.