### PR TITLE
[Text Analytics] Re-enable and re-record AAD tests, disable statistics tests

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeHealthcareEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeHealthcareEntitiesTests.cs
@@ -305,16 +305,17 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
-        // TODO: https://github.com/Azure/azure-sdk-for-net/issues/31978.
-        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeHealthcareEntitiesBatchConvenienceWithStatisticsTest()
         {
             TextAnalyticsClient client = GetClient();
 
-            AnalyzeHealthcareEntitiesOptions options = new AnalyzeHealthcareEntitiesOptions()
+            AnalyzeHealthcareEntitiesOptions options = new AnalyzeHealthcareEntitiesOptions();
+
+            // TODO: https://github.com/Azure/azure-sdk-for-net/issues/31978.
+            if (ServiceVersion is not TextAnalyticsClientOptions.ServiceVersion.V3_1)
             {
-                IncludeStatistics = true
-            };
+                options.IncludeStatistics = true;
+            }
 
             AnalyzeHealthcareEntitiesOperation operation = await client.StartAnalyzeHealthcareEntitiesAsync(s_batchConvenienceDocuments, "en", options);
 
@@ -322,7 +323,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
             ValidateOperationProperties(operation);
 
-            //Take the first page
+            // Take the first page.
             AnalyzeHealthcareEntitiesResultCollection resultCollection = operation.Value.ToEnumerableAsync().Result.FirstOrDefault();
 
             var expectedOutput = new Dictionary<string, List<string>>()
@@ -358,16 +359,17 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
-        // TODO: https://github.com/Azure/azure-sdk-for-net/issues/31978.
-        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeHealthcareEntitiesBatchWithStatisticsTest()
         {
             TextAnalyticsClient client = GetClient();
 
-            AnalyzeHealthcareEntitiesOptions options = new AnalyzeHealthcareEntitiesOptions()
+            AnalyzeHealthcareEntitiesOptions options = new AnalyzeHealthcareEntitiesOptions();
+
+            // TODO: https://github.com/Azure/azure-sdk-for-net/issues/31978.
+            if (ServiceVersion is not TextAnalyticsClientOptions.ServiceVersion.V3_1)
             {
-                IncludeStatistics = true
-            };
+                options.IncludeStatistics = true;
+            }
 
             AnalyzeHealthcareEntitiesOperation operation = await client.StartAnalyzeHealthcareEntitiesAsync(s_batchDocuments, options);
 
@@ -550,16 +552,20 @@ namespace Azure.AI.TextAnalytics.Tests
         {
             Assert.That(results.ModelVersion, Is.Not.Null.And.Not.Empty);
 
-            if (includeStatistics)
+            // TODO: https://github.com/Azure/azure-sdk-for-net/issues/31978.
+            if (ServiceVersion is not TextAnalyticsClientOptions.ServiceVersion.V3_1)
             {
-                Assert.IsNotNull(results.Statistics);
-                Assert.Greater(results.Statistics.DocumentCount, 0);
-                Assert.Greater(results.Statistics.TransactionCount, 0);
-                Assert.GreaterOrEqual(results.Statistics.InvalidDocumentCount, 0);
-                Assert.GreaterOrEqual(results.Statistics.ValidDocumentCount, 0);
+                if (includeStatistics)
+                {
+                    Assert.IsNotNull(results.Statistics);
+                    Assert.Greater(results.Statistics.DocumentCount, 0);
+                    Assert.Greater(results.Statistics.TransactionCount, 0);
+                    Assert.GreaterOrEqual(results.Statistics.InvalidDocumentCount, 0);
+                    Assert.GreaterOrEqual(results.Statistics.ValidDocumentCount, 0);
+                }
+                else
+                    Assert.IsNull(results.Statistics);
             }
-            else
-                Assert.IsNull(results.Statistics);
 
             foreach (AnalyzeHealthcareEntitiesResult entitiesInDocument in results)
             {
@@ -570,15 +576,19 @@ namespace Azure.AI.TextAnalytics.Tests
                 //Even though statistics are not asked for, TA 5.0.0 shipped with Statistics default always present.
                 Assert.IsNotNull(entitiesInDocument.Statistics);
 
-                if (includeStatistics)
+                // TODO: https://github.com/Azure/azure-sdk-for-net/issues/31978.
+                if (ServiceVersion is not (TextAnalyticsClientOptions.ServiceVersion.V2022_05_01 or TextAnalyticsClientOptions.ServiceVersion.V3_1))
                 {
-                    Assert.GreaterOrEqual(entitiesInDocument.Statistics.CharacterCount, 0);
-                    Assert.Greater(entitiesInDocument.Statistics.TransactionCount, 0);
-                }
-                else
-                {
-                    Assert.AreEqual(0, entitiesInDocument.Statistics.CharacterCount);
-                    Assert.AreEqual(0, entitiesInDocument.Statistics.TransactionCount);
+                    if (includeStatistics)
+                    {
+                        Assert.GreaterOrEqual(entitiesInDocument.Statistics.CharacterCount, 0);
+                        Assert.Greater(entitiesInDocument.Statistics.TransactionCount, 0);
+                    }
+                    else
+                    {
+                        Assert.AreEqual(0, entitiesInDocument.Statistics.CharacterCount);
+                        Assert.AreEqual(0, entitiesInDocument.Statistics.TransactionCount);
+                    }
                 }
 
                 Assert.IsNotNull(entitiesInDocument.Warnings);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeHealthcareEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeHealthcareEntitiesTests.cs
@@ -54,8 +54,6 @@ namespace Azure.AI.TextAnalytics.Tests
         };
 
         [RecordedTest]
-        // TODO: Temporarily setting max version to V2022-05-01 since V2022-10-01-preview does not support AAD yet (https://github.com/Azure/azure-sdk-for-net/issues/31854).
-        [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         public async Task AnalyzeHealthcareEntitiesWithAADTest()
         {
             TextAnalyticsClient client = GetClient(useTokenCredential: true);
@@ -307,6 +305,8 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        // TODO: https://github.com/Azure/azure-sdk-for-net/issues/31978.
+        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeHealthcareEntitiesBatchConvenienceWithStatisticsTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -358,6 +358,8 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        // TODO: https://github.com/Azure/azure-sdk-for-net/issues/31978.
+        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeHealthcareEntitiesBatchWithStatisticsTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -507,7 +509,7 @@ namespace Azure.AI.TextAnalytics.Tests
                 FhirVersion = WellKnownFhirVersion.V4_0_1,
             }));
 
-            Assert.AreEqual("AnalyzeHealthcareEntitiesOptions.FhirVersion is not available in API version 2022-05-01. Use service API version 2022-10-01-preview or newer.", ex.Message);
+            Assert.That(ex.Message.EndsWith("Use service API version 2022-10-01-preview or newer."));
         }
 
         [RecordedTest]
@@ -523,7 +525,7 @@ namespace Azure.AI.TextAnalytics.Tests
                 DocumentType = HealthcareDocumentType.DischargeSummary
             }));
 
-            Assert.AreEqual("AnalyzeHealthcareEntitiesOptions.DocumentType is not available in API version 2022-05-01. Use service API version 2022-10-01-preview or newer.", ex.Message);
+            Assert.That(ex.Message.EndsWith("Use service API version 2022-10-01-preview or newer."));
         }
 
         private void ValidateInDocumenResult(IReadOnlyCollection<HealthcareEntity> entities, List<string> minimumExpectedOutput)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationTests.cs
@@ -38,8 +38,6 @@ namespace Azure.AI.TextAnalytics.Tests
         };
 
         [RecordedTest]
-        // TODO: Temporarily setting max version to V2022-05-01 since V2022-10-01-preview does not support AAD yet (https://github.com/Azure/azure-sdk-for-net/issues/31854).
-        [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         public async Task AnalyzeOperationWithAADTest()
         {
             TextAnalyticsClient client = GetClient(useTokenCredential: true);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeSentimentTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeSentimentTests.cs
@@ -39,8 +39,6 @@ namespace Azure.AI.TextAnalytics.Tests
         };
 
         [RecordedTest]
-        // TODO: Temporarily setting max version to V2022-05-01 since V2022-10-01-preview does not support AAD yet (https://github.com/Azure/azure-sdk-for-net/issues/31854).
-        [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         public async Task AnalyzeSentimentWithAADTest()
         {
             TextAnalyticsClient client = GetClient(useTokenCredential: true);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/DetectLanguageTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/DetectLanguageTests.cs
@@ -54,8 +54,6 @@ namespace Azure.AI.TextAnalytics.Tests
         };
 
         [RecordedTest]
-        // TODO: Temporarily setting max version to V2022-05-01 since V2022-10-01-preview does not support AAD yet (https://github.com/Azure/azure-sdk-for-net/issues/31854).
-        [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         public async Task DetectLanguageWithAADTest()
         {
             TextAnalyticsClient client = GetClient(useTokenCredential: true);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/ExtractKeyPhrasesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/ExtractKeyPhrasesTests.cs
@@ -39,8 +39,6 @@ namespace Azure.AI.TextAnalytics.Tests
         };
 
         [RecordedTest]
-        // TODO: Temporarily setting max version to V2022-05-01 since V2022-10-01-preview does not support AAD yet (https://github.com/Azure/azure-sdk-for-net/issues/31854).
-        [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         public async Task ExtractKeyPhrasesWithAADTest()
         {
             TextAnalyticsClient client = GetClient(useTokenCredential: true);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/TextAnalyticsClientLiveTestBase.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/TextAnalyticsClientLiveTestBase.cs
@@ -25,7 +25,7 @@ namespace Azure.AI.TextAnalytics.Tests
         protected TextAnalyticsClientOptions.ServiceVersion ServiceVersion { get; }
 
         public TextAnalyticsClientLiveTestBase(bool isAsync, TextAnalyticsClientOptions.ServiceVersion serviceVersion)
-            : base(isAsync, RecordedTestMode.Live)
+            : base(isAsync)
         {
             ServiceVersion = serviceVersion;
             SanitizedHeaders.Add("Ocp-Apim-Subscription-Key");

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/TextAnalyticsClientLiveTestBase.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/TextAnalyticsClientLiveTestBase.cs
@@ -22,12 +22,12 @@ namespace Azure.AI.TextAnalytics.Tests
         /// The version of the REST API to test against.  This will be passed
         /// to the .ctor via ClientTestFixture's values.
         /// </summary>
-        private readonly TextAnalyticsClientOptions.ServiceVersion _serviceVersion;
+        protected TextAnalyticsClientOptions.ServiceVersion ServiceVersion { get; }
 
         public TextAnalyticsClientLiveTestBase(bool isAsync, TextAnalyticsClientOptions.ServiceVersion serviceVersion)
-            : base(isAsync)
+            : base(isAsync, RecordedTestMode.Live)
         {
-            _serviceVersion = serviceVersion;
+            ServiceVersion = serviceVersion;
             SanitizedHeaders.Add("Ocp-Apim-Subscription-Key");
         }
 
@@ -41,7 +41,7 @@ namespace Azure.AI.TextAnalytics.Tests
             bool useTokenCredential = default)
         {
             var endpoint = new Uri(TestEnvironment.Endpoint);
-            options ??= new TextAnalyticsClientOptions(_serviceVersion);
+            options ??= new TextAnalyticsClientOptions(ServiceVersion);
 
             // While we use a persistent resource for live tests, we need to increase our retries.
             // We should remove when having dynamic resource again

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeCustomEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeCustomEntitiesTests.cs
@@ -65,7 +65,7 @@ namespace Azure.AI.TextAnalytics.Tests
         };
 
         [RecordedTest]
-        public async Task RecognizeCustomEntitiesWithADDTest()
+        public async Task RecognizeCustomEntitiesWithAADTest()
         {
             TextAnalyticsClient client = GetClient(useTokenCredential: true);
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeCustomEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeCustomEntitiesTests.cs
@@ -65,8 +65,6 @@ namespace Azure.AI.TextAnalytics.Tests
         };
 
         [RecordedTest]
-        // TODO: Temporarily setting max version to V2022-05-01 since V2022-10-01-preview does not support AAD yet (https://github.com/Azure/azure-sdk-for-net/issues/31854).
-        [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         public async Task RecognizeCustomEntitiesWithADDTest()
         {
             TextAnalyticsClient client = GetClient(useTokenCredential: true);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeEntitiesTests.cs
@@ -53,8 +53,6 @@ namespace Azure.AI.TextAnalytics.Tests
         };
 
         [RecordedTest]
-        // TODO: Temporarily setting max version to V2022-05-01 since V2022-10-01-preview does not support AAD yet (https://github.com/Azure/azure-sdk-for-net/issues/31854).
-        [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         public async Task RecognizeEntitiesWithAADTest()
         {
             TextAnalyticsClient client = GetClient(useTokenCredential: true);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeLinkedEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeLinkedEntitiesTests.cs
@@ -54,8 +54,6 @@ namespace Azure.AI.TextAnalytics.Tests
         };
 
         [RecordedTest]
-        // TODO: Temporarily setting max version to V2022-05-01 since V2022-10-01-preview does not support AAD yet (https://github.com/Azure/azure-sdk-for-net/issues/31854).
-        [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         public async Task RecognizeLinkedEntitiesWithAADTest()
         {
             TextAnalyticsClient client = GetClient(useTokenCredential: true);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizePiiEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizePiiEntitiesTests.cs
@@ -53,8 +53,6 @@ namespace Azure.AI.TextAnalytics.Tests
         };
 
         [RecordedTest]
-        // TODO: Temporarily setting max version to V2022-05-01 since V2022-10-01-preview does not support AAD yet (https://github.com/Azure/azure-sdk-for-net/issues/31854).
-        [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         public async Task RecognizePiiEntitiesWithAADTest()
         {
             TextAnalyticsClient client = GetClient(useTokenCredential: true);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeHealthcareEntitiesTests/AnalyzeHealthcareEntitiesWithAADTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeHealthcareEntitiesTests/AnalyzeHealthcareEntitiesWithAADTest.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-10-01-preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "322",
         "Content-Type": "application/json",
-        "traceparent": "00-aefb8d6699e1d6b2d564152d9eac5cc7-55443b0f5f41b9fe-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "569449f9c52526193a5d4489a0a87a46",
+        "traceparent": "00-91a8773ddf1bdf3b237abd1c2069f6b9-2c4ae427b649f40f-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6ca40ac9f3c7040048fcecb2c2f7b177",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -39,79 +39,44 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "db1bc391-1444-4b1a-aa5b-9b93952b3f19",
+        "apim-request-id": "c551d4c7-83fd-4b42-bb56-94bb9c71642a",
         "Content-Length": "0",
-        "Date": "Thu, 21 Jul 2022 23:27:50 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/2d2700ba-da48-47b2-b9d4-4d38d4966ee6?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 20:02:13 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/5528c2ae-7a8f-4fec-b89a-c698e0708b79?api-version=2022-10-01-preview",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "144"
+        "x-envoy-upstream-service-time": "3436",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/2d2700ba-da48-47b2-b9d4-4d38d4966ee6?api-version=2022-05-01\u0026showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/5528c2ae-7a8f-4fec-b89a-c698e0708b79?api-version=2022-10-01-preview\u0026showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "c954e5887c361e5a21da952a5a560331",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "caecb08dab3e689ff57a3b5f3740ea06",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9f23a8c1-25f2-4a17-9cf9-8401531f933f",
-        "Content-Length": "283",
+        "apim-request-id": "0adf8c1b-f226-41a5-87b3-b6d3bd6de83c",
+        "Content-Length": "10257",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Jul 2022 23:27:50 GMT",
+        "Date": "Mon, 24 Oct 2022 20:02:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "4168",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2d2700ba-da48-47b2-b9d4-4d38d4966ee6",
-        "lastUpdatedDateTime": "2022-07-21T23:27:51Z",
-        "createdDateTime": "2022-07-21T23:27:51Z",
-        "expirationDateTime": "2022-07-22T23:27:51Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/2d2700ba-da48-47b2-b9d4-4d38d4966ee6?api-version=2022-05-01\u0026showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "3fe005033d17de3157495df636c4aafc",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "666ed275-9c69-4c17-9b1a-6a94980d9a12",
-        "Content-Length": "10214",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Jul 2022 23:27:52 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "39"
-      },
-      "ResponseBody": {
-        "jobId": "2d2700ba-da48-47b2-b9d4-4d38d4966ee6",
-        "lastUpdatedDateTime": "2022-07-21T23:27:52Z",
-        "createdDateTime": "2022-07-21T23:27:51Z",
-        "expirationDateTime": "2022-07-22T23:27:51Z",
+        "jobId": "5528c2ae-7a8f-4fec-b89a-c698e0708b79",
+        "lastUpdateDateTime": "2022-10-24T20:02:16Z",
+        "createdDateTime": "2022-10-24T20:02:14Z",
+        "expirationDateTime": "2022-10-25T20:02:14Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -122,7 +87,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-07-21T23:27:52.1173516Z",
+              "lastUpdateDateTime": "2022-10-24T20:02:16.9119201Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -276,6 +241,7 @@
                     ],
                     "relations": [
                       {
+                        "confidenceScore": 1.0,
                         "relationType": "DosageOfMedication",
                         "entities": [
                           {
@@ -289,6 +255,7 @@
                         ]
                       },
                       {
+                        "confidenceScore": 1.0,
                         "relationType": "FrequencyOfMedication",
                         "entities": [
                           {
@@ -1126,8 +1093,8 @@
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "962877704",
+    "AZURE_AUTHORITY_HOST": null,
+    "RandomSeed": "268205122",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeHealthcareEntitiesTests/AnalyzeHealthcareEntitiesWithAADTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeHealthcareEntitiesTests/AnalyzeHealthcareEntitiesWithAADTestAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-10-01-preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "322",
         "Content-Type": "application/json",
-        "traceparent": "00-d10078c17b0a09943b478470819572bf-1b79527234f123db-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "be5520c5b1b544639450976bb013100b",
+        "traceparent": "00-7e6d57bae8bce9c5ac96911ad47a42aa-84df04b22d4fc34a-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "84232ccb784f436d12a51c8491723dd9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -39,79 +39,44 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "d0d3223c-74ba-4b10-b5f3-cb8e850436a3",
+        "apim-request-id": "0cb53d95-4791-4d12-926a-c1435d33fd9e",
         "Content-Length": "0",
-        "Date": "Thu, 21 Jul 2022 23:28:02 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/63f6b741-28d9-4586-9ead-b9babb3ba4df?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 20:13:45 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/e292807f-2290-40b4-af2e-d213ff738757?api-version=2022-10-01-preview",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "218"
+        "x-envoy-upstream-service-time": "226",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/63f6b741-28d9-4586-9ead-b9babb3ba4df?api-version=2022-05-01\u0026showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/e292807f-2290-40b4-af2e-d213ff738757?api-version=2022-10-01-preview\u0026showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "ff6830787272f3b3879aafd7442e166c",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "443fbbb8dbfe2fa3e5f79e9e1370e0bc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8143b42e-9ed7-49a1-9dbf-14f953a0b21b",
-        "Content-Length": "283",
+        "apim-request-id": "1723a4e4-da71-4654-b62b-8e8f56d62e64",
+        "Content-Length": "10256",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Jul 2022 23:28:02 GMT",
+        "Date": "Mon, 24 Oct 2022 20:13:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "4760",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "63f6b741-28d9-4586-9ead-b9babb3ba4df",
-        "lastUpdatedDateTime": "2022-07-21T23:28:03Z",
-        "createdDateTime": "2022-07-21T23:28:03Z",
-        "expirationDateTime": "2022-07-22T23:28:03Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/63f6b741-28d9-4586-9ead-b9babb3ba4df?api-version=2022-05-01\u0026showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "f3b5e92539eeb30262286ab03090d15c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "f288c1cf-535d-45a0-9901-a99bd5031113",
-        "Content-Length": "10214",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Jul 2022 23:28:04 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
-      },
-      "ResponseBody": {
-        "jobId": "63f6b741-28d9-4586-9ead-b9babb3ba4df",
-        "lastUpdatedDateTime": "2022-07-21T23:28:04Z",
-        "createdDateTime": "2022-07-21T23:28:03Z",
-        "expirationDateTime": "2022-07-22T23:28:03Z",
+        "jobId": "e292807f-2290-40b4-af2e-d213ff738757",
+        "lastUpdateDateTime": "2022-10-24T20:13:47Z",
+        "createdDateTime": "2022-10-24T20:13:45Z",
+        "expirationDateTime": "2022-10-25T20:13:45Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -122,7 +87,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-07-21T23:28:04.2345325Z",
+              "lastUpdateDateTime": "2022-10-24T20:13:47.418714Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -276,6 +241,7 @@
                     ],
                     "relations": [
                       {
+                        "confidenceScore": 1.0,
                         "relationType": "DosageOfMedication",
                         "entities": [
                           {
@@ -289,6 +255,7 @@
                         ]
                       },
                       {
+                        "confidenceScore": 1.0,
                         "relationType": "FrequencyOfMedication",
                         "entities": [
                           {
@@ -1126,8 +1093,8 @@
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "1186188158",
+    "AZURE_AUTHORITY_HOST": null,
+    "RandomSeed": "1486273223",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithAADTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithAADTest.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-10-01-preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "241",
         "Content-Type": "application/json",
-        "traceparent": "00-e57cac0176e61dd03245ab7c6a058ca7-65bc0db741bdee9a-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "251f5aa0f66d31d7c92a5cd5ccda3ca6",
+        "traceparent": "00-370edd51d70740ef717e3cc8ecc4957b-a802aacf69b562d6-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9321c1623f110d6b8a4f639f3ffa102a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -37,42 +37,82 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "05ee0543-5df7-472f-bd7f-3bf120796c99",
+        "apim-request-id": "6605b356-295e-44c5-a2b7-a12b2135bc8c",
         "Content-Length": "0",
-        "Date": "Thu, 21 Jul 2022 23:21:35 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/2152f646-fa61-4251-8aa4-6bee7ee1e1b2?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 20:14:13 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/67680190-c12c-4ac6-8706-90b58f7aa9fe?api-version=2022-10-01-preview",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "128"
+        "x-envoy-upstream-service-time": "3096",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/2152f646-fa61-4251-8aa4-6bee7ee1e1b2?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/67680190-c12c-4ac6-8706-90b58f7aa9fe?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "330e47b3eb65bedbc6d4e65d903a9749",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ca2a1bb3b68d019e60c8836561477a8a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fb64f400-7505-4411-a6f3-24d8c2ebeae6",
-        "Content-Length": "280",
+        "apim-request-id": "89147cd1-23c5-4ff7-a801-f948d7c37293",
+        "Content-Length": "282",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Jul 2022 23:21:35 GMT",
+        "Date": "Mon, 24 Oct 2022 20:14:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "32",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2152f646-fa61-4251-8aa4-6bee7ee1e1b2",
-        "lastUpdatedDateTime": "2022-07-21T23:21:36Z",
-        "createdDateTime": "2022-07-21T23:21:35Z",
-        "expirationDateTime": "2022-07-22T23:21:35Z",
+        "jobId": "67680190-c12c-4ac6-8706-90b58f7aa9fe",
+        "lastUpdateDateTime": "2022-10-24T20:14:13Z",
+        "createdDateTime": "2022-10-24T20:14:13Z",
+        "expirationDateTime": "2022-10-25T20:14:13Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/67680190-c12c-4ac6-8706-90b58f7aa9fe?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "685196a00918d086bdaa773ce1e3c610",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "bb9e1eff-75fe-4f08-a49b-3419955009b6",
+        "Content-Length": "279",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 20:14:18 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "4255",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "67680190-c12c-4ac6-8706-90b58f7aa9fe",
+        "lastUpdateDateTime": "2022-10-24T20:14:13Z",
+        "createdDateTime": "2022-10-24T20:14:13Z",
+        "expirationDateTime": "2022-10-25T20:14:13Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -85,31 +125,32 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/2152f646-fa61-4251-8aa4-6bee7ee1e1b2?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/67680190-c12c-4ac6-8706-90b58f7aa9fe?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "5f250ef139c09c016f2b3ff9d31b1836",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c6a0dcff4a3fac0e231f3249bc06ab43",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a3728c67-2805-4a88-9983-9eb13f825144",
-        "Content-Length": "280",
+        "apim-request-id": "ea5f8971-3250-471f-a58c-8e1790c5d38d",
+        "Content-Length": "279",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Jul 2022 23:21:37 GMT",
+        "Date": "Mon, 24 Oct 2022 20:14:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "21",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2152f646-fa61-4251-8aa4-6bee7ee1e1b2",
-        "lastUpdatedDateTime": "2022-07-21T23:21:36Z",
-        "createdDateTime": "2022-07-21T23:21:35Z",
-        "expirationDateTime": "2022-07-22T23:21:35Z",
+        "jobId": "67680190-c12c-4ac6-8706-90b58f7aa9fe",
+        "lastUpdateDateTime": "2022-10-24T20:14:13Z",
+        "createdDateTime": "2022-10-24T20:14:13Z",
+        "expirationDateTime": "2022-10-25T20:14:13Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -122,31 +163,32 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/2152f646-fa61-4251-8aa4-6bee7ee1e1b2?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/67680190-c12c-4ac6-8706-90b58f7aa9fe?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "24d8f48408c4b47b7e605f981079a18e",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a9fed9d5a7a9a91295590ce33e621f7c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "20d167f3-7d63-42b9-9157-6b08da52cb31",
-        "Content-Length": "590",
+        "apim-request-id": "d01fa78b-c2a3-4155-8a1d-97e9541c0c9a",
+        "Content-Length": "589",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Jul 2022 23:21:38 GMT",
+        "Date": "Mon, 24 Oct 2022 20:14:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "46"
+        "x-envoy-upstream-service-time": "82",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2152f646-fa61-4251-8aa4-6bee7ee1e1b2",
-        "lastUpdatedDateTime": "2022-07-21T23:21:37Z",
-        "createdDateTime": "2022-07-21T23:21:35Z",
-        "expirationDateTime": "2022-07-22T23:21:35Z",
+        "jobId": "67680190-c12c-4ac6-8706-90b58f7aa9fe",
+        "lastUpdateDateTime": "2022-10-24T20:14:19Z",
+        "createdDateTime": "2022-10-24T20:14:13Z",
+        "expirationDateTime": "2022-10-25T20:14:13Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -157,7 +199,7 @@
           "items": [
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-07-21T23:21:37.6519713Z",
+              "lastUpdateDateTime": "2022-10-24T20:14:19.9555541Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -180,7 +222,7 @@
                   }
                 ],
                 "errors": [],
-                "modelVersion": "2022-07-01"
+                "modelVersion": "2022-10-01"
               }
             }
           ]
@@ -189,8 +231,8 @@
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "1066582852",
+    "AZURE_AUTHORITY_HOST": null,
+    "RandomSeed": "627739595",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithAADTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithAADTestAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-10-01-preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "241",
         "Content-Type": "application/json",
-        "traceparent": "00-ba6c64ed1c5c958925e5a30124494a0f-b5481e3f4c8000ec-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "00b6b87cd88b9bf01332f2088cbf6183",
+        "traceparent": "00-ee16ac1e37d8e889c16ce3ae86b5c61c-ae0d90538befc19b-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "09822a99e38f3b30f6888ac8093261d6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -37,116 +37,44 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "4f75a469-34df-4571-909e-18047baaf1a6",
+        "apim-request-id": "21a23b87-adb9-4d47-829e-1e9b1494e658",
         "Content-Length": "0",
-        "Date": "Thu, 21 Jul 2022 23:22:31 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/52d77b87-a02c-41dc-aa53-2e961e2daf04?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 20:14:20 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/8d5a0cb1-7d3d-4cea-ac00-fd4d10d8d93f?api-version=2022-10-01-preview",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "135"
+        "x-envoy-upstream-service-time": "160",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/52d77b87-a02c-41dc-aa53-2e961e2daf04?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/8d5a0cb1-7d3d-4cea-ac00-fd4d10d8d93f?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "cf3f09f926b3523f2adea37e5c05ca19",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "85d746c588b414c9c345dcb652b0cff7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4ba3e25c-6f52-4a53-aa6b-71fcfe3a280d",
-        "Content-Length": "283",
+        "apim-request-id": "cde3b4b6-bd40-4e28-bb20-7051c8c5c867",
+        "Content-Length": "589",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Jul 2022 23:22:31 GMT",
+        "Date": "Mon, 24 Oct 2022 20:14:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "x-envoy-upstream-service-time": "4254",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "52d77b87-a02c-41dc-aa53-2e961e2daf04",
-        "lastUpdatedDateTime": "2022-07-21T23:22:32Z",
-        "createdDateTime": "2022-07-21T23:22:32Z",
-        "expirationDateTime": "2022-07-22T23:22:32Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/52d77b87-a02c-41dc-aa53-2e961e2daf04?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "c9b2a83c94a6d27c3aca636729b9b86f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "5bfd6016-b90d-431d-b390-a1f93bd57c8c",
-        "Content-Length": "280",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Jul 2022 23:22:33 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "52d77b87-a02c-41dc-aa53-2e961e2daf04",
-        "lastUpdatedDateTime": "2022-07-21T23:22:32Z",
-        "createdDateTime": "2022-07-21T23:22:32Z",
-        "expirationDateTime": "2022-07-22T23:22:32Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/52d77b87-a02c-41dc-aa53-2e961e2daf04?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "a0e52b2db2e155ff7964d6ad35713e0e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "00b2b9c8-7a97-4241-a8f6-2f67e3534587",
-        "Content-Length": "590",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Jul 2022 23:22:34 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "71"
-      },
-      "ResponseBody": {
-        "jobId": "52d77b87-a02c-41dc-aa53-2e961e2daf04",
-        "lastUpdatedDateTime": "2022-07-21T23:22:34Z",
-        "createdDateTime": "2022-07-21T23:22:32Z",
-        "expirationDateTime": "2022-07-22T23:22:32Z",
+        "jobId": "8d5a0cb1-7d3d-4cea-ac00-fd4d10d8d93f",
+        "lastUpdateDateTime": "2022-10-24T20:14:22Z",
+        "createdDateTime": "2022-10-24T20:14:21Z",
+        "expirationDateTime": "2022-10-25T20:14:21Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -157,7 +85,7 @@
           "items": [
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-07-21T23:22:34.1269472Z",
+              "lastUpdateDateTime": "2022-10-24T20:14:22.8807963Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -180,7 +108,7 @@
                   }
                 ],
                 "errors": [],
-                "modelVersion": "2022-07-01"
+                "modelVersion": "2022-10-01"
               }
             }
           ]
@@ -189,8 +117,8 @@
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "1469792222",
+    "AZURE_AUTHORITY_HOST": null,
+    "RandomSeed": "248757240",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithAADTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithAADTest.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-10-01-preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "179",
         "Content-Type": "application/json",
-        "traceparent": "00-e8ace897c17574bc97df870c113117e8-c158d41178211339-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "26cdf6d1e05008c0fa1433dfd28d402c",
+        "traceparent": "00-f355fac432bd16887a453098881a5f8d-733d519b9b7e620f-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3beccde41e433e494d997d2eb87d5c1a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -30,14 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e03abbdb-58ce-4b5b-a60b-d76986077d3b",
-        "Content-Length": "386",
+        "apim-request-id": "d7df2a16-2944-4df3-aaa5-7e41a0dfb425",
+        "Content-Length": "384",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Thu, 21 Jul 2022 23:23:08 GMT",
+        "Date": "Mon, 24 Oct 2022 20:14:26 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "15"
+        "x-envoy-upstream-service-time": "20",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",
@@ -47,7 +49,7 @@
               "id": "0",
               "sentiment": "positive",
               "confidenceScores": {
-                "positive": 0.99,
+                "positive": 1.0,
                 "neutral": 0.0,
                 "negative": 0.0
               },
@@ -55,7 +57,7 @@
                 {
                   "sentiment": "positive",
                   "confidenceScores": {
-                    "positive": 0.99,
+                    "positive": 1.0,
                     "neutral": 0.0,
                     "negative": 0.0
                   },
@@ -68,14 +70,14 @@
             }
           ],
           "errors": [],
-          "modelVersion": "2022-06-01"
+          "modelVersion": "2022-10-01"
         }
       }
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "2050661247",
+    "AZURE_AUTHORITY_HOST": null,
+    "RandomSeed": "859029732",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithAADTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithAADTestAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-10-01-preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "179",
         "Content-Type": "application/json",
-        "traceparent": "00-f806dbbc685967ff68cbb87cb913161b-6013c67e6483c4ea-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "be5c9eebc6e44b741ed6c11962850552",
+        "traceparent": "00-3bc98d53427d8ffd1d615b00942fac36-4580f223a8d0b7e5-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5456f65252cd15f3ec0843ddc99cee6e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -30,14 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b7d652b0-ba62-4aa9-aa55-8cee38bff426",
-        "Content-Length": "386",
+        "apim-request-id": "57603959-fdfd-4309-a880-5c971080be5c",
+        "Content-Length": "384",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Thu, 21 Jul 2022 23:23:10 GMT",
+        "Date": "Mon, 24 Oct 2022 20:14:26 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "15"
+        "x-envoy-upstream-service-time": "20",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",
@@ -47,7 +49,7 @@
               "id": "0",
               "sentiment": "positive",
               "confidenceScores": {
-                "positive": 0.99,
+                "positive": 1.0,
                 "neutral": 0.0,
                 "negative": 0.0
               },
@@ -55,7 +57,7 @@
                 {
                   "sentiment": "positive",
                   "confidenceScores": {
-                    "positive": 0.99,
+                    "positive": 1.0,
                     "neutral": 0.0,
                     "negative": 0.0
                   },
@@ -68,14 +70,14 @@
             }
           ],
           "errors": [],
-          "modelVersion": "2022-06-01"
+          "modelVersion": "2022-10-01"
         }
       }
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "1879502239",
+    "AZURE_AUTHORITY_HOST": null,
+    "RandomSeed": "1736261324",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithAADTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithAADTest.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-10-01-preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "127",
         "Content-Type": "application/json",
-        "traceparent": "00-3ffd047af7fbd9ac0969c6b4a884b0d3-d1bd7f768418209c-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "822f7d3be03d6d16a5f3bf6c0fc0fa3b",
+        "traceparent": "00-5735b9d3c523feded9cdfcf70659b9b7-2074c2162c53aea2-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fe441dba9cfca3c35a7e55603a3eb75c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -27,14 +27,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "573cf883-678e-4830-aae4-eeef596e24c4",
+        "apim-request-id": "7d0797d4-e9c2-48c3-bb1f-2eceeaf542be",
         "Content-Length": "205",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Thu, 21 Jul 2022 23:23:10 GMT",
+        "Date": "Mon, 24 Oct 2022 20:14:26 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "12",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",
@@ -51,14 +53,14 @@
             }
           ],
           "errors": [],
-          "modelVersion": "2021-11-20"
+          "modelVersion": "2022-10-01"
         }
       }
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "599162669",
+    "AZURE_AUTHORITY_HOST": null,
+    "RandomSeed": "1735338419",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithAADTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithAADTestAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-10-01-preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "127",
         "Content-Type": "application/json",
-        "traceparent": "00-7f942a1b9c73ef63a0ba7c5f8ff7539b-27327a960018a322-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "ad8a40dd736166f1bfcc8deefdf36f62",
+        "traceparent": "00-fc930b4393ea5ec3c09c12faab7caa43-4003c874b87113b8-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "19da4a3cbb7707cf9aa95b06b971f5e5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -27,14 +27,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a5a30b44-d20a-46d2-9122-621563d172d2",
+        "apim-request-id": "5d03e434-3e0e-43df-bba0-099aee6c64e0",
         "Content-Length": "205",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Thu, 21 Jul 2022 23:23:12 GMT",
+        "Date": "Mon, 24 Oct 2022 20:14:26 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "13"
+        "x-envoy-upstream-service-time": "13",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",
@@ -51,14 +53,14 @@
             }
           ],
           "errors": [],
-          "modelVersion": "2021-11-20"
+          "modelVersion": "2022-10-01"
         }
       }
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "1016982347",
+    "AZURE_AUTHORITY_HOST": null,
+    "RandomSeed": "2109686413",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesWithAADTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesWithAADTest.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-10-01-preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "139",
         "Content-Type": "application/json",
-        "traceparent": "00-4b7ab6a9092071a104b29e63f8614af9-89be8a54b1fbb0f8-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "8008b532816e724d0b09127a984c520d",
+        "traceparent": "00-eed16a7d05f4a99cffe0bb5fed1a5e4a-999970381bcd6081-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7849c2f92f70dd2b2fd2232f2b4f969e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -27,14 +27,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8fada4ff-d543-4c1e-93c1-08fcb3fa01a5",
+        "apim-request-id": "9bfe3d7a-cfb6-43bc-82c0-cf464649effb",
         "Content-Length": "164",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Thu, 21 Jul 2022 23:23:13 GMT",
+        "Date": "Mon, 24 Oct 2022 20:14:27 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "x-envoy-upstream-service-time": "14",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "KeyPhraseExtractionResults",
@@ -50,14 +52,14 @@
             }
           ],
           "errors": [],
-          "modelVersion": "2022-07-01"
+          "modelVersion": "2022-10-01"
         }
       }
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "1785277674",
+    "AZURE_AUTHORITY_HOST": null,
+    "RandomSeed": "402628126",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesWithAADTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesWithAADTestAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-10-01-preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "139",
         "Content-Type": "application/json",
-        "traceparent": "00-b374d795f9c4683b98517ff4685dfb89-18445c7fe4557552-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "be0a4b3cc6e983d808810ac18448f7fb",
+        "traceparent": "00-d3163326b8bd6ee539b13724569604e5-ef1359bc1cc38a06-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "47ebfb9fe54af868dcbe4e99dbb0f010",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -27,14 +27,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e5486ab6-bcfc-4ab1-b343-d0ab6ec838cc",
+        "apim-request-id": "6228b2a8-eda9-48a1-a5c5-3d09ab46a8fd",
         "Content-Length": "164",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Thu, 21 Jul 2022 23:23:14 GMT",
+        "Date": "Mon, 24 Oct 2022 20:14:27 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "x-envoy-upstream-service-time": "12",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "KeyPhraseExtractionResults",
@@ -50,14 +52,14 @@
             }
           ],
           "errors": [],
-          "modelVersion": "2022-07-01"
+          "modelVersion": "2022-10-01"
         }
       }
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "806354846",
+    "AZURE_AUTHORITY_HOST": null,
+    "RandomSeed": "1049057311",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesWithAADTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesWithAADTest.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-10-01-preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "328",
         "Content-Type": "application/json",
-        "traceparent": "00-e22bc840e2b7b3ad7039f43d7928db09-91e0da0a9fe28c1f-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "cd6a8b8dcb99cc0cf50d21dc075a6e15",
+        "traceparent": "00-4ec3c8725f5e2f4e8ef4c9c621e78719-ba907d048e06dc45-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET Core 3.1.30; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "589b2e00e17e485ef854dfe7e9dbbc96",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -35,42 +35,44 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "7f7420d3-008d-468e-a7b6-b9df64a950ce",
+        "apim-request-id": "8be55498-878e-4ec5-a28c-1f73904596e1",
         "Content-Length": "0",
-        "Date": "Thu, 21 Jul 2022 23:26:16 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/ee277e02-f118-4c26-b02d-bbd30f969c31?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 20:42:22 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/d9f61871-bb78-4b1e-8393-acb20233d973?api-version=2022-10-01-preview",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "182"
+        "x-envoy-upstream-service-time": "119",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/ee277e02-f118-4c26-b02d-bbd30f969c31?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/d9f61871-bb78-4b1e-8393-acb20233d973?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "6ed6d2b2e1a60471d7f6f2d9ac76a84e",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET Core 3.1.30; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f7f0d4f376e336c0bb1ddb5246bffc33",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f5647ff1-de21-4c84-a767-7e6fb3d3efe2",
-        "Content-Length": "283",
+        "apim-request-id": "72440863-19bf-414d-ad80-37e3c4564591",
+        "Content-Length": "282",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Jul 2022 23:26:16 GMT",
+        "Date": "Mon, 24 Oct 2022 20:42:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "13",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "ee277e02-f118-4c26-b02d-bbd30f969c31",
-        "lastUpdatedDateTime": "2022-07-21T23:26:16Z",
-        "createdDateTime": "2022-07-21T23:26:16Z",
-        "expirationDateTime": "2022-07-22T23:26:16Z",
+        "jobId": "d9f61871-bb78-4b1e-8393-acb20233d973",
+        "lastUpdateDateTime": "2022-10-24T20:42:22Z",
+        "createdDateTime": "2022-10-24T20:42:22Z",
+        "expirationDateTime": "2022-10-25T20:42:22Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -83,31 +85,32 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/ee277e02-f118-4c26-b02d-bbd30f969c31?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/d9f61871-bb78-4b1e-8393-acb20233d973?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "51a73d0bbba6750fcac09b61fbbbd65e",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET Core 3.1.30; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "02a6f489a133a7d4dd716f3651a5951d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bf1810c8-831e-4c55-a4f7-bcfff4971d00",
-        "Content-Length": "1135",
+        "apim-request-id": "2ddb33ed-723e-420a-aa1b-1e2bfc429004",
+        "Content-Length": "1134",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Jul 2022 23:26:27 GMT",
+        "Date": "Mon, 24 Oct 2022 20:42:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "69"
+        "x-envoy-upstream-service-time": "62",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "ee277e02-f118-4c26-b02d-bbd30f969c31",
-        "lastUpdatedDateTime": "2022-07-21T23:26:17Z",
-        "createdDateTime": "2022-07-21T23:26:16Z",
-        "expirationDateTime": "2022-07-22T23:26:16Z",
+        "jobId": "d9f61871-bb78-4b1e-8393-acb20233d973",
+        "lastUpdateDateTime": "2022-10-24T20:42:22Z",
+        "createdDateTime": "2022-10-24T20:42:22Z",
+        "expirationDateTime": "2022-10-25T20:42:22Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -118,7 +121,7 @@
           "items": [
             {
               "kind": "CustomEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-07-21T23:26:17.2341708Z",
+              "lastUpdateDateTime": "2022-10-24T20:42:22.9719929Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -182,8 +185,8 @@
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "1720263811",
+    "AZURE_AUTHORITY_HOST": null,
+    "RandomSeed": "1217425695",
     "TEXTANALYTICS_CUSTOM_ENTITIES_DEPLOYMENT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
     "TEXTANALYTICS_CUSTOM_ENTITIES_PROJECT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesWithAADTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesWithAADTestAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-10-01-preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "328",
         "Content-Type": "application/json",
-        "traceparent": "00-be1373619827ad8e493b1f5b4531d55c-cf93ea5ba1eddd0f-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "af5ce472d959b9bbb97aedd4e5d8cfe0",
+        "traceparent": "00-ab22b424607a5941a7d333e286f23bfe-10564ce58771d945-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET Core 3.1.30; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bc5b04e201ede1021bc1b748e63f77cc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -35,43 +35,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "4fd1a7ac-cd76-4107-81ca-7802b3d2fd57",
+        "apim-request-id": "d2ac4c48-301f-410d-970e-30ec8ca85876",
         "Content-Length": "0",
-        "Date": "Thu, 21 Jul 2022 23:27:19 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/a116bce6-f439-4819-a0d7-aabdf621bb22?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 20:42:33 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/f53cc2fd-27d1-4b1a-a27f-1a1cf44512ca?api-version=2022-10-01-preview",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "157"
+        "x-envoy-upstream-service-time": "124",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/a116bce6-f439-4819-a0d7-aabdf621bb22?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/f53cc2fd-27d1-4b1a-a27f-1a1cf44512ca?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "f691426e681118dea6d5bbfe3292481c",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET Core 3.1.30; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "33b92333e639d7eab295b9c96145f4ed",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "72638840-122f-4467-91ae-b759b352628d",
-        "Content-Length": "280",
+        "apim-request-id": "160a9f37-a3ff-4bb9-8f79-f986e39c787f",
+        "Content-Length": "282",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Jul 2022 23:27:19 GMT",
+        "Date": "Mon, 24 Oct 2022 20:42:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "12"
+        "x-envoy-upstream-service-time": "12",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a116bce6-f439-4819-a0d7-aabdf621bb22",
-        "lastUpdatedDateTime": "2022-07-21T23:27:19Z",
-        "createdDateTime": "2022-07-21T23:27:19Z",
-        "expirationDateTime": "2022-07-22T23:27:19Z",
-        "status": "running",
+        "jobId": "f53cc2fd-27d1-4b1a-a27f-1a1cf44512ca",
+        "lastUpdateDateTime": "2022-10-24T20:42:33Z",
+        "createdDateTime": "2022-10-24T20:42:32Z",
+        "expirationDateTime": "2022-10-25T20:42:32Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -83,31 +85,32 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/a116bce6-f439-4819-a0d7-aabdf621bb22?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/f53cc2fd-27d1-4b1a-a27f-1a1cf44512ca?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "d797cff883f77687ebc023444fdb28b5",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET Core 3.1.30; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1752cdfa4493f0cfeb85ddc66206c70c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e8af5579-7412-4251-9757-371ad0105170",
-        "Content-Length": "1135",
+        "apim-request-id": "1559de2f-7f7b-4597-9e66-3dd8a88ddf72",
+        "Content-Length": "1134",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Jul 2022 23:27:29 GMT",
+        "Date": "Mon, 24 Oct 2022 20:42:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "85"
+        "x-envoy-upstream-service-time": "25",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a116bce6-f439-4819-a0d7-aabdf621bb22",
-        "lastUpdatedDateTime": "2022-07-21T23:27:20Z",
-        "createdDateTime": "2022-07-21T23:27:19Z",
-        "expirationDateTime": "2022-07-22T23:27:19Z",
+        "jobId": "f53cc2fd-27d1-4b1a-a27f-1a1cf44512ca",
+        "lastUpdateDateTime": "2022-10-24T20:42:33Z",
+        "createdDateTime": "2022-10-24T20:42:32Z",
+        "expirationDateTime": "2022-10-25T20:42:32Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -118,7 +121,7 @@
           "items": [
             {
               "kind": "CustomEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-07-21T23:27:20.2476981Z",
+              "lastUpdateDateTime": "2022-10-24T20:42:33.9513878Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -182,8 +185,8 @@
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "1868868670",
+    "AZURE_AUTHORITY_HOST": null,
+    "RandomSeed": "1791248510",
     "TEXTANALYTICS_CUSTOM_ENTITIES_DEPLOYMENT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
     "TEXTANALYTICS_CUSTOM_ENTITIES_PROJECT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithAADTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithAADTest.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-10-01-preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "197",
         "Content-Type": "application/json",
-        "traceparent": "00-294a75bc5854eccaba6466bfa22b39d2-e0cc376605541b9f-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "ead91da1309ac9adc4e5733894635b87",
+        "traceparent": "00-f3631aad2457a74556121e88761c3cc3-801c8eb747d95793-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f630f61290b31eb288e97965c7345561",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -30,14 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9f26828b-f522-4b3b-a60a-9b780040fd7c",
+        "apim-request-id": "5c9b9424-0bab-4f30-9b40-48e7e34000b2",
         "Content-Length": "406",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Thu, 21 Jul 2022 23:27:40 GMT",
+        "Date": "Mon, 24 Oct 2022 20:14:27 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "22"
+        "x-envoy-upstream-service-time": "35",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",
@@ -78,8 +80,8 @@
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "445630104",
+    "AZURE_AUTHORITY_HOST": null,
+    "RandomSeed": "931286471",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithAADTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithAADTestAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-10-01-preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "197",
         "Content-Type": "application/json",
-        "traceparent": "00-3ca94ac8d841161c127ceeeaf2e36582-b0c8d16cfa044056-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "028ff0bff43be5a49a7e551991ad3117",
+        "traceparent": "00-def7134cda0296ae953c2fe5acf00680-9daf3ec854b4791c-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b27a6fe6ba5302dcd318778dbb25a86b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -30,14 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5b44d92e-eebb-45bb-abd2-4e1a0291bb21",
+        "apim-request-id": "3a4ec68c-0e49-4b81-9cb9-9476fc1496ef",
         "Content-Length": "406",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Thu, 21 Jul 2022 23:27:41 GMT",
+        "Date": "Mon, 24 Oct 2022 20:14:27 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "34",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",
@@ -78,8 +80,8 @@
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "1869086242",
+    "AZURE_AUTHORITY_HOST": null,
+    "RandomSeed": "894510443",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesWithAADTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesWithAADTest.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-10-01-preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "193",
         "Content-Type": "application/json",
-        "traceparent": "00-ef698d7dc2602d3921e52a507f735401-38802f9777b02c56-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "2ea828e16e7b954951964acc9541f06c",
+        "traceparent": "00-2da3e208f7d298da95d5e61125262fca-93bcec12a4c2a7e1-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "081a68715737c1d3d994c0a2de01f608",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -30,14 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "17f6cfd5-2b6c-409f-9824-35a86b7caa5d",
+        "apim-request-id": "47db862c-b424-4fdc-8ece-b5c19389cdef",
         "Content-Length": "906",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Thu, 21 Jul 2022 23:28:06 GMT",
+        "Date": "Mon, 24 Oct 2022 20:14:28 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "x-envoy-upstream-service-time": "15",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityLinkingResults",
@@ -105,8 +107,8 @@
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "1070561720",
+    "AZURE_AUTHORITY_HOST": null,
+    "RandomSeed": "2081390397",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesWithAADTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesWithAADTestAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-10-01-preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "193",
         "Content-Type": "application/json",
-        "traceparent": "00-aa9a73a55eca1316f5ac9a03b1975ab3-053d63ed51c1beeb-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "90ac52f32c9ef269cee2a4a931e03c9e",
+        "traceparent": "00-5212886cfd1367998452067a22459e6b-16433639ec06c9e9-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cf73ba1b41c3e7c9b1419cc11cdd16fe",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -30,14 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4e3b0819-0818-4227-b997-65d0b9c613d4",
+        "apim-request-id": "79d92c82-9e2b-42e6-b277-1077bb1efc55",
         "Content-Length": "906",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Thu, 21 Jul 2022 23:28:07 GMT",
+        "Date": "Mon, 24 Oct 2022 20:14:28 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "x-envoy-upstream-service-time": "95",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityLinkingResults",
@@ -105,8 +107,8 @@
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "1494159955",
+    "AZURE_AUTHORITY_HOST": null,
+    "RandomSeed": "1019262539",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithAADTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithAADTest.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-10-01-preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "272",
         "Content-Type": "application/json",
-        "traceparent": "00-e98765e0cc0bad54b061237bba1c1950-0f0c35d0db94a38c-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "b7085cf203af958eb3a69932a0f92fca",
+        "traceparent": "00-01a9fc870752965a52f0ea47c9a628fe-66aa844e6007512c-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fe4afb25ea9b86fe73cb3497c5450a33",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -30,14 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3eecafc0-e490-4864-9779-4be5b28e78fc",
+        "apim-request-id": "76482f2e-c39a-40a4-8552-af25f41d5466",
         "Content-Length": "668",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Thu, 21 Jul 2022 23:28:07 GMT",
+        "Date": "Mon, 24 Oct 2022 20:14:28 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "43"
+        "x-envoy-upstream-service-time": "264",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",
@@ -86,8 +88,8 @@
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "705644345",
+    "AZURE_AUTHORITY_HOST": null,
+    "RandomSeed": "1537586289",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithAADTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithAADTestAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-05-01",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/:analyze-text?api-version=2022-10-01-preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "272",
         "Content-Type": "application/json",
-        "traceparent": "00-7e8b9c8a8e74e664a7f4a1fa6b802470-4c1f74fc48ec65bc-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20220721.1 (.NET 6.0.7; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "6a85c8ca1a3fcf8242c1d01b23cc39ea",
+        "traceparent": "00-f46a998a0b2f9287258adbc18bb83dde-6aa47801d25312c4-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221023.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4f36c8b27613a211f38e6bf27b3cc3f7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -30,14 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ae6756f0-81be-4fd3-9fc1-c868bfce13ba",
+        "apim-request-id": "43c0c56e-35ed-47da-b045-61fa987f6fba",
         "Content-Length": "668",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Thu, 21 Jul 2022 23:28:09 GMT",
+        "Date": "Mon, 24 Oct 2022 20:14:29 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "36"
+        "x-envoy-upstream-service-time": "55",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",
@@ -86,8 +88,8 @@
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
-    "RandomSeed": "972656605",
+    "AZURE_AUTHORITY_HOST": null,
+    "RandomSeed": "416351089",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }
 }


### PR DESCRIPTION
Resolves: #31854

Now that the service has enabled AAD for version 2022-10-01-preview, I can re-enable and re-record these tests.

However, I'm also taking the chance to disable the healthcare tests that use statistics (a.k.a. `showStats`), which are failing in some older versions due to a known service regression. More specifically:
- In version 2022-05-01, no stats are returned.
- In version 3.1, the request fails with a 500 Internal Server Error.