### PR TITLE
Undid change in StorageSharedKeyPipelinePolicy that broke requests th…

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageSharedKeyPipelinePolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageSharedKeyPipelinePolicy.cs
@@ -101,24 +101,18 @@ namespace Azure.Storage
         {
             // Grab all the "x-ms-*" headers, trim whitespace, lowercase, sort,
             // and combine them with their values (separated by a colon).
-            var headers = new List<HttpHeader>();
-            foreach (var header in message.Request.Headers)
+            foreach (var header in
+                message.Request.Headers
+                .Where(static h => h.Name.StartsWith(Constants.HeaderNames.XMsPrefix, StringComparison.OrdinalIgnoreCase))
+#pragma warning disable CA1308 // Normalize strings to uppercase
+                .Select(static h => (h.Name.ToLowerInvariant(), h.Value))
+#pragma warning restore CA1308 // Normalize strings to uppercase
+                .OrderBy(static h => h.Item1.Trim()))
             {
-                if (header.Name.StartsWith(Constants.HeaderNames.XMsPrefix, StringComparison.OrdinalIgnoreCase))
-                {
-                    headers.Add(header);
-                }
-            }
-
-            headers.Sort(static (x, y) => string.CompareOrdinal(x.Name, y.Name));
-
-            foreach (var header in headers)
-            {
-                stringBuilder
-                    .Append(header.Name.ToLowerInvariant())
-                    .Append(':')
-                    .Append(header.Value)
-                    .Append('\n');
+                stringBuilder.Append(header.Item1);
+                stringBuilder.Append(':');
+                stringBuilder.Append(header.Value);
+                stringBuilder.Append('\n');
             }
         }
 

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageSharedKeyPipelinePolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageSharedKeyPipelinePolicy.cs
@@ -56,6 +56,7 @@ namespace Azure.Storage
             message.Request.Headers.SetValue(Constants.HeaderNames.Authorization, key);
         }
 
+        // If you change this method, make sure live tests are passing before merging PR.
         private string BuildStringToSign(HttpMessage message)
         {
             // https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key
@@ -97,6 +98,7 @@ namespace Azure.Storage
             return stringBuilder.ToString();
         }
 
+        // If you change this method, make sure live tests are passing before merging PR.
         private static void BuildCanonicalizedHeaders(StringBuilder stringBuilder, HttpMessage message)
         {
             // Grab all the "x-ms-*" headers, trim whitespace, lowercase, sort,
@@ -116,6 +118,7 @@ namespace Azure.Storage
             }
         }
 
+        // If you change this method, make sure live tests are passing before merging PR.
         private void BuildCanonicalizedResource(StringBuilder stringBuilder, Uri resource)
         {
             // https://docs.microsoft.com/en-us/rest/api/storageservices/authentication-for-the-azure-storage-services


### PR DESCRIPTION
…at have metadata

Undid part of the change that was made here, which caused all metadata-related requests in storage to fail - https://github.com/Azure/azure-sdk-for-net/pull/31793