### PR TITLE
[Messaging] Clarify batch references to buffers

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
@@ -146,9 +146,13 @@ namespace Azure.Messaging.EventHubs.Producer
         /// <returns><c>true</c> if the event was added; otherwise, <c>false</c>.</returns>
         ///
         /// <remarks>
-        ///   When an event is accepted into the batch, its content and state are frozen; any
-        ///   changes made to the event will not be reflected in the batch nor will any state
-        ///   transitions be reflected to the original instance.
+        ///   When an event is accepted into the batch, changes made to its properties
+        ///   will not be reflected in the batch nor will any state transitions be reflected
+        ///   to the original instance.
+        ///
+        ///   An important consideration to note is that any <see cref="ReadOnlyMemory{T}" /> or byte array
+        ///   passed to the event or a <see cref="BinaryData" /> instance associated with the event
+        ///   is referenced by the batch and must remain valid and unchanged until the batch is disposed.
         /// </remarks>
         ///
         /// <exception cref="InvalidOperationException">

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
@@ -150,9 +150,9 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   will not be reflected in the batch nor will any state transitions be reflected
         ///   to the original instance.
         ///
-        ///   An important consideration to note is that any <see cref="ReadOnlyMemory{T}" /> or byte array
-        ///   passed to the event or a <see cref="BinaryData" /> instance associated with the event
-        ///   is referenced by the batch and must remain valid and unchanged until the batch is disposed.
+        ///   Note: Any <see cref="ReadOnlyMemory{T}" />, byte array, or <see cref="BinaryData" />
+        ///   instance associated with the event is referenced by the batch and must remain valid and
+        ///   unchanged until the batch is disposed.
         /// </remarks>
         ///
         /// <exception cref="InvalidOperationException">

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusMessageBatch.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusMessageBatch.cs
@@ -78,15 +78,22 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         ///   Attempts to add a message to the batch, ensuring that the size
-        ///   of the batch does not exceed its maximum. If the message is modified
-        ///   after being added to the batch, the batch will fail to send if the modification
-        ///   caused the batch to exceed the maximum allowable size. Therefore it is best
-        ///   to not modify a message after adding it to the batch.
+        ///   of the batch does not exceed its maximum.
         /// </summary>
         ///
         /// <param name="message">The message to attempt to add to the batch.</param>
         ///
         /// <returns><c>true</c> if the message was added; otherwise, <c>false</c>.</returns>
+        ///
+        /// <remarks>
+        ///   When a message is accepted into the batch, changes made to its properties
+        ///   will not be reflected in the batch nor will any state transitions be reflected
+        ///   to the original instance.
+        ///
+        ///   An important consideration to note is that any <see cref="ReadOnlyMemory{T}" /> or byte array
+        ///   passed to the message or a <see cref="BinaryData" /> instance associated with the message
+        ///   is referenced by the batch and must remain valid and unchanged until the batch is disposed.
+        /// </remarks>
         ///
         /// <exception cref="InvalidOperationException">
         ///   When a batch is sent, it will be locked for the duration of that operation.  During this time,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusMessageBatch.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusMessageBatch.cs
@@ -90,9 +90,9 @@ namespace Azure.Messaging.ServiceBus
         ///   will not be reflected in the batch nor will any state transitions be reflected
         ///   to the original instance.
         ///
-        ///   An important consideration to note is that any <see cref="ReadOnlyMemory{T}" /> or byte array
-        ///   passed to the message or a <see cref="BinaryData" /> instance associated with the message
-        ///   is referenced by the batch and must remain valid and unchanged until the batch is disposed.
+        ///   Note: Any <see cref="ReadOnlyMemory{T}" />, byte array, or <see cref="BinaryData" />
+        ///   instance associated with the event is referenced by the batch and must remain valid and
+        ///   unchanged until the batch is disposed.
         /// </remarks>
         ///
         /// <exception cref="InvalidOperationException">


### PR DESCRIPTION
# Summary

The focus of these changes is to update the documentation for the `EventDataBatch` and `ServiceBusMessageBatch` to clarify that the batch holds a reference to the memory buffers used for event/message bodies, calling out that those buffers need to remain available and unchanged.

# References and Related

- [EventDataBatch.TryAdd does not copy buffer to batch as documentation indicates (#31395)](https://github.com/Azure/azure-sdk-for-net/issues/31395)
- [[Event Hubs] Data body copy for EventDataBatch (#31845)](https://github.com/Azure/azure-sdk-for-net/issues/31845)