### PR TITLE
[AzureMonitorExporter] Update OpenTelemetry dependency

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -249,7 +249,7 @@
     <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.3" />
     <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.3" />
     <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.3" />
-    <PackageReference Update="OpenTelemetry.Exporter.InMemory" Version="1.3.1" />
+    <PackageReference Update="OpenTelemetry.Exporter.InMemory" Version="1.4.0-beta.2" />
     <PackageReference Update="Polly" Version="7.1.0" />
     <PackageReference Update="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.9.0" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -246,9 +246,9 @@
     <PackageReference Update="NSubstitute" Version="3.1.0" />
     <PackageReference Update="NUnit" Version="3.13.2" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.3.0-alpha-net7.4" />
-    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.3" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.3" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.3" />
+    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.8" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.8" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.8" />
     <PackageReference Update="OpenTelemetry.Exporter.InMemory" Version="1.4.0-beta.2" />
     <PackageReference Update="Polly" Version="7.1.0" />
     <PackageReference Update="Polly.Contrib.WaitAndRetry" Version="1.1.1" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -247,8 +247,8 @@
     <PackageReference Update="NUnit" Version="3.13.2" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.3.0-alpha-net7.4" />
     <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.8" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.8" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.8" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.5" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.6" />
     <PackageReference Update="OpenTelemetry.Exporter.InMemory" Version="1.4.0-beta.2" />
     <PackageReference Update="Polly" Version="7.1.0" />
     <PackageReference Update="Polly.Contrib.WaitAndRetry" Version="1.1.1" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -116,7 +116,7 @@
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
 
     <!-- OpenTelemetry dependency approved for Azure.Monitor.OpenTelemetry.Exporter package only -->
-    <PackageReference Update="OpenTelemetry" Version="1.3.1"  Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
+    <PackageReference Update="OpenTelemetry" Version="1.4.0-beta.2"  Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
     <PackageReference Update="OpenTelemetry.Extensions.PersistentStorage" Version="1.0.0-beta.1" Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
   </ItemGroup>
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Other Changes
 
+* Update OpenTelemetry dependencies ([#32047](https://github.com/Azure/azure-sdk-for-net/pull/32047))
+  - OpenTelemetry v1.4.0-beta.2
+
 ## 1.0.0-beta.4 (2022-10-07)
 
 ### Features Added

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
@@ -9,7 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--Versions are defined in eng/Packages.Data.props -->
+    <!-- Versions are defined in eng/Packages.Data.props -->
+    <!-- Whenever updating OpenTelemetry dependencies, confirm that Test dependencies are also updated. -->
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="OpenTelemetry" />

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>An OpenTelemetry .NET exporter that exports to Azure Monitor</Description>
     <AssemblyTitle>AzureMonitor OpenTelemetry Exporter</AssemblyTitle>
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!--Versions are defined in eng/Packages.Data.props -->
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="OpenTelemetry" />


### PR DESCRIPTION
### Changes
- update to [OpenTelemetry 1.4.0-beta.2](https://www.nuget.org/packages/OpenTelemetry/1.4.0-beta.2)
- update test dependencies
  - OpenTelemetry.Extensions.Hosting
  - OpenTelemetry.Instrumentation.AspNetCore
  - OpenTelemetry.Instrumentation.Http
  - OpenTelemetry.Exporter.InMemory