### PR TITLE
Attempt to drain receiver before closing

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -1336,9 +1336,20 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
             RequestResponseLockedMessages.Dispose();
 
-            if (_receiveLink?.TryGetOpenedObject(out var _) == true)
+            if (_receiveLink?.TryGetOpenedObject(out var link) == true)
             {
                 cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+                // Allow in-flight messages to drain so that they do not remain locked by the service after closing the link.
+                // This should be updated when the AMQP library adds deterministic support for draining via an async method to remove the
+                // somewhat arbitrary delay and to also work for prefetch.
+
+                if (!_isSessionReceiver && !link.Settings.AutoSendFlow && link.LinkCredit > 0)
+                {
+                    link.IssueCredit(link.LinkCredit, true, AmqpConstants.NullBinary);
+                    await Task.Delay(200, cancellationToken).ConfigureAwait(false);
+                }
+
                 await _receiveLink.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -79,11 +79,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
         [Test]
         public async Task ReceiverDrainsOnClosing()
         {
-            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false, lockDuration: ShortLockDuration))
             {
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 using var cts = new CancellationTokenSource();
-                cts.CancelAfter(TimeSpan.FromSeconds(100));
+                cts.CancelAfter(TimeSpan.FromSeconds(30));
 
                 List<Task> tasks = new();
                 tasks.Add(Send());
@@ -117,7 +117,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                     {
                         await Task.Delay(500);
                         await using var sender = client.CreateSender(scope.QueueName);
-                        await sender.SendMessagesAsync(ServiceBusTestUtilities.GetMessages(1));
+                        await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
                     }
                 }
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -72,6 +72,57 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             }
         }
 
+        /// <summary>
+        /// This test validates that outstanding link credits are drained when the receiver is closed so messages do not remain locked.
+        /// This is a best effort attempt at draining until better support is added in the AMQP library, <see href="https://github.com/Azure/azure-amqp/issues/229"/>.
+        /// </summary>
+        [Test]
+        public async Task ReceiverDrainsOnClosing()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                using var cts = new CancellationTokenSource();
+                cts.CancelAfter(TimeSpan.FromSeconds(100));
+
+                List<Task> tasks = new();
+                tasks.Add(Send());
+
+                for (int i = 0; i < 100; i++)
+                {
+                    tasks.Add(Receive());
+                }
+
+                await Task.WhenAll(tasks);
+
+                async Task Receive()
+                {
+                    while (!cts.IsCancellationRequested)
+                    {
+                        await using var receiver = client.CreateReceiver(scope.QueueName);
+
+                        var message = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(2));
+
+                        if (message != null)
+                        {
+                            Assert.AreEqual(1, message.DeliveryCount);
+                            await receiver.CompleteMessageAsync(message);
+                        }
+                    }
+                }
+
+                async Task Send()
+                {
+                    while (!cts.IsCancellationRequested)
+                    {
+                        await Task.Delay(500);
+                        await using var sender = client.CreateSender(scope.QueueName);
+                        await sender.SendMessagesAsync(ServiceBusTestUtilities.GetMessages(1));
+                    }
+                }
+            }
+        }
+
         [Test]
         public async Task PeekUsingConnectionStringWithSas()
         {


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/31883