### PR TITLE
Fix sharelink Key Vault sample

### DIFF
--- a/sdk/keyvault/samples/sharelink/ShareLink.csproj
+++ b/sdk/keyvault/samples/sharelink/ShareLink.csproj
@@ -18,7 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" />
     <PackageReference Include="System.CommandLine" VersionOverride="2.0.0-beta1.21216.1" />
@@ -26,13 +25,14 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsSample)' == 'true'">
+    <ProjectReference Include="..\..\..\core\Azure.Core\src\Azure.Core.csproj" />
     <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsSample)' != 'true'">
     <!-- Use decentralized package references when building outside https://github.com/Azure/azure-sdk-for-net -->
     <PackageReference Include="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20210602.1" PrivateAssets="All" />
-    <PackageReference Update="Azure.Core" Version="1.14.0" />
+    <PackageReference Include="Azure.Core" Version="1.14.0" />
     <PackageReference Update="Azure.Identity" Version="1.4.0" />
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.1.1" />
     <PackageReference Update="System.CommandLine" Version="%(VersionOverride)" />


### PR DESCRIPTION
PR #31790 added types not yet in Azure.Core. Switch to ProjectReference when in-repo, and will need to update the PackageReference for Azure.Core once it ships (#32065).
