### PR TITLE
[AzureMonitorExporter] Support Histogram Min/Max

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+* Add support for exporting Histogram Min and Max ([#32072](https://github.com/Azure/azure-sdk-for-net/pull/32072))
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricDataPoint.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricDataPoint.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using OpenTelemetry.Metrics;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Models
@@ -41,6 +40,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                     // Current schema only supports int values for count
                     // if the value is within integer range we will use it otherwise ignore it.
                     Count = histogramCount <= int.MaxValue ? (int?)histogramCount : null;
+
+                    if (metricPoint.HasMinMax())
+                    {
+                        Min = metricPoint.GetHistogramMin();
+                        Max = metricPoint.GetHistogramMax();
+                    }
 
                     break;
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Metrics/MetricDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Metrics/MetricDemo.cs
@@ -41,13 +41,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Metrics
             myFruitCounter.Add(4, new("name", "lemon"), new("color", "yellow"));
 
             // Histogram Example
-            Histogram<long> myHistogram = meter.CreateHistogram<long>("MyHistogram");
+            Histogram<long> myFruitSalePrice = meter.CreateHistogram<long>("MyFruitSalePrice");
 
             var random = new Random();
-            for (int i = 0; i < 1000; i++)
-            {
-                myHistogram.Record(random.Next(1, 1000), new("tag1", "value1"), new("tag2", "value2"));
-            }
+            myFruitSalePrice.Record(random.Next(1, 1000), new("name", "apple"), new("color", "red"));
+            myFruitSalePrice.Record(random.Next(1, 1000), new("name", "lemon"), new("color", "yellow"));
+            myFruitSalePrice.Record(random.Next(1, 1000), new("name", "lemon"), new("color", "yellow"));
+            myFruitSalePrice.Record(random.Next(1, 1000), new("name", "apple"), new("color", "green"));
+            myFruitSalePrice.Record(random.Next(1, 1000), new("name", "apple"), new("color", "red"));
+            myFruitSalePrice.Record(random.Next(1, 1000), new("name", "lemon"), new("color", "yellow"));
 
             // Guage Example
             var process = Process.GetCurrentProcess();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/MetricsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/MetricsTests.cs
@@ -88,11 +88,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             var meterName = $"meterName{uniqueTestId}";
             using var meter = new Meter(meterName, "1.0");
 
-            var exportedMetrics = new List<Metric>();
-
             var meterProviderBulider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meterName)
-                .AddInMemoryExporter(exportedMetrics)
                 .AddAzureMonitorMetricExporterForTest(out ConcurrentBag<TelemetryItem> telemetryItems);
 
             if (asView)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/MetricsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/MetricsTests.cs
@@ -88,8 +88,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             var meterName = $"meterName{uniqueTestId}";
             using var meter = new Meter(meterName, "1.0");
 
+            var exportedMetrics = new List<Metric>();
+
             var meterProviderBulider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meterName)
+                .AddInMemoryExporter(exportedMetrics)
                 .AddAzureMonitorMetricExporterForTest(out ConcurrentBag<TelemetryItem> telemetryItems);
 
             if (asView)
@@ -105,10 +108,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             var histogram = meter.CreateHistogram<long>("MyHistogram");
             var random = new Random();
             int loop = 20000, sum = 0;
+            double min = double.MaxValue, max = double.MinValue;
             for (int i = 0; i < loop; i++)
             {
                 var value = random.Next(1, 1000);
                 sum += value;
+                min = Math.Min(min, value);
+                max = Math.Max(max, value);
                 histogram.Record(value, new("tag1", "value1"), new("tag2", "value2"));
             }
 
@@ -126,6 +132,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedMetricDataPointNamespace: meterName,
                 expectedMetricDataPointValue: sum,
                 expectedMetricDataPointCount: loop,
+                expectedMetricDataPointMax:max,
+                expectedMetricDataPointMin:min,
                 expectedMetricsProperties: new Dictionary<string, string> { { "tag1", "value1" }, { "tag2", "value2" } });
         }
 


### PR DESCRIPTION
### Changes
- update `MetricDataPoint` to get/set Histogram Min and Max
- update `MetricsTests`
- Update `MetricDemo` with same example from [public doc](https://learn.microsoft.com/en-us/azure/azure-monitor/app/opentelemetry-enable?tabs=net#histogram-example)