### PR TITLE
AzmonExporter - Limit OTel version to be specific

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -116,7 +116,7 @@
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
 
     <!-- OpenTelemetry dependency approved for Azure.Monitor.OpenTelemetry.Exporter package only -->
-    <PackageReference Update="OpenTelemetry" Version="1.4.0-beta.2"  Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
+    <PackageReference Update="OpenTelemetry" Version="[1.4.0-beta.2]"  Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
     <PackageReference Update="OpenTelemetry.Extensions.PersistentStorage" Version="1.0.0-beta.1" Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
   </ItemGroup>
 


### PR DESCRIPTION
AzMonExporter has a dependency on non-stable version of OTel SDK. As the OTel SDK can have breaking changes, we should restrict upper bound, else exporter might break if user updates to a newer version of OTel SDK, which has breaking changes.

Once the dependency is updated to stable version, we should still cap upper bound at 2.0], instead of leaving upper bound open.