### PR TITLE
[WebPubSub]Release a stable version for the fixed bug

### DIFF
--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/CHANGELOG.md
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.1.0 (2022-10-28)
 
+### Bugs Fixed
+- Fix the issue that `expiresAfter` might be 0
+
 ## 1.1.0-beta.1 (2022-08-06)
 
 ### Bugs Fixed

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/CHANGELOG.md
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/CHANGELOG.md
@@ -1,14 +1,6 @@
 # Release History
 
-## 1.1.0-beta.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+## 1.1.0 (2022-10-28)
 
 ## 1.1.0-beta.1 (2022-08-06)
 

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/src/Azure.Messaging.WebPubSub.csproj
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/src/Azure.Messaging.WebPubSub.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Azure SDK client library for the WebPubSub service</Description>
     <AssemblyTitle>Azure SDK for WebPubSub</AssemblyTitle>
-    <Version>1.1.0-beta.2</Version>
+    <Version>1.1.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.0.0</ApiCompatVersion>
     <PackageTags>Azure, WebPubSub, SignalR</PackageTags>


### PR DESCRIPTION
We have a customer complaining about the 'expiresAfter' bug, so we'd like to release a stable version SDK for the bug fix

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
