### PR TITLE
[AzureMonitorExporter] Add support for UpDownCounter and ObservableUpDownCounter

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 * Add support for exporting Histogram Min and Max ([#32072](https://github.com/Azure/azure-sdk-for-net/pull/32072))
-* Add support for exporting UpDownCounter and ObservableUpDownCounter ([TODO]())
+* Add support for exporting UpDownCounter and ObservableUpDownCounter ([#32170](https://github.com/Azure/azure-sdk-for-net/pull/32170))
 
 ### Breaking Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 * Add support for exporting Histogram Min and Max ([#32072](https://github.com/Azure/azure-sdk-for-net/pull/32072))
+* Add support for exporting UpDownCounter and ObservableUpDownCounter ([TODO]())
 
 ### Breaking Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricDataPoint.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricDataPoint.cs
@@ -15,6 +15,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             switch (metric.MetricType)
             {
                 case MetricType.DoubleSum:
+                case MetricType.DoubleSumNonMonotonic:
                     Value = metricPoint.GetSumDouble();
 
                     break;
@@ -23,6 +24,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 
                     break;
                 case MetricType.LongSum:
+                case MetricType.LongSumNonMonotonic:
                     // potential for minor precision loss implicitly going from long->double
                     // see: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/numeric-conversions#implicit-numeric-conversions
                     Value = metricPoint.GetSumLong();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricsData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricsData.cs
@@ -41,6 +41,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                 MetricType.LongGauge => true,
                 MetricType.LongSum => true,
                 MetricType.Histogram => true,
+                MetricType.DoubleSumNonMonotonic => true,
+                MetricType.LongSumNonMonotonic => true,
                 _ => false
             };
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/AzureMonitorExporterTestExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/AzureMonitorExporterTestExtensions.cs
@@ -50,6 +50,23 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
         }
 
         /// <summary>
+        /// Extension methods to simplify registering of <see cref="AzureMonitorMetricExporter"/> with <see cref="MockTransmitter"/> for unit tests.
+        /// </summary>
+        internal static MeterProviderBuilder AddAzureMonitorMetricExporterForTest(this MeterProviderBuilder builder, out ConcurrentBag<TelemetryItem> telemetryItems, out MetricReader metricReader)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            telemetryItems = new ConcurrentBag<TelemetryItem>();
+
+            metricReader = new PeriodicExportingMetricReader(new AzureMonitorMetricExporter(new MockTransmitter(telemetryItems)));
+
+            return builder.AddReader(metricReader);
+        }
+
+        /// <summary>
         /// Extension methods to simplify registering of <see cref="AzureMonitorTraceExporter"/> with <see cref="MockTransmitter"/> for unit tests.
         /// </summary>
         internal static TracerProviderBuilder AddAzureMonitorTraceExporterForTest(this TracerProviderBuilder builder, out ConcurrentBag<TelemetryItem> telemetryItems)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/MetricsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/MetricsTests.cs
@@ -178,5 +178,107 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedMetricDataPointValue: 123.45,
                 expectedMetricsProperties: new Dictionary<string, string> { { "tag1", "value1" } });
         }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void VerifyUpDownCounter(bool asView)
+        {
+            // SETUP
+            var uniqueTestId = Guid.NewGuid();
+
+            var meterName = $"meterName{uniqueTestId}";
+            using var meter = new Meter(meterName, "1.0");
+
+            var meterProviderBulider = Sdk.CreateMeterProviderBuilder()
+                .AddMeter(meterName)
+                .AddAzureMonitorMetricExporterForTest(out ConcurrentBag<TelemetryItem> telemetryItems);
+
+            if (asView)
+            {
+                meterProviderBulider
+                .AddView(instrumentName: "MyUpDownCounter", name: "MyUpDownCounterRenamed");
+            }
+
+            var meterProvider = meterProviderBulider.Build();
+
+            // ACT
+            var upDownCounter = meter.CreateUpDownCounter<long>("MyUpDownCounter");
+
+            upDownCounter.Add(1, new("tag1", "value1"), new("tag2", "value2"));
+            upDownCounter.Add(-2, new("tag1", "value1"), new("tag2", "value2"));
+            upDownCounter.Add(3, new("tag1", "value1"), new("tag2", "value2"));
+            upDownCounter.Add(-4, new("tag1", "value1"), new("tag2", "value2"));
+
+            // CLEANUP
+            meterProvider.Dispose();
+
+            // ASSERT
+            Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
+            this.telemetryOutput.Write(telemetryItems);
+            var telemetryItem = telemetryItems.Single();
+
+            TelemetryItemValidationHelper.AssertMetricTelemetry(
+                telemetryItem: telemetryItem,
+                expectedMetricDataPointName: asView ? "MyUpDownCounterRenamed" : "MyUpDownCounter",
+                expectedMetricDataPointNamespace: meterName,
+                expectedMetricDataPointValue: -2,
+                expectedMetricsProperties: new Dictionary<string, string> { { "tag1", "value1" }, { "tag2", "value2" } });
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void VerifyObservableUpDownCounter(bool asView)
+        {
+            // SETUP
+            var uniqueTestId = Guid.NewGuid();
+
+            var meterName = $"meterName{uniqueTestId}";
+            using var meter = new Meter(meterName, "1.0");
+
+            var meterProviderBulider = Sdk.CreateMeterProviderBuilder()
+                .AddMeter(meterName)
+                .AddAzureMonitorMetricExporterForTest(out ConcurrentBag<TelemetryItem> telemetryItems, out MetricReader metricReader);
+
+            if (asView)
+            {
+                meterProviderBulider
+                .AddView(instrumentName: "MyUpDownCounter", name: "MyUpDownCounterRenamed");
+            }
+
+            using var meterProvider = meterProviderBulider.Build();
+
+            // ACT
+            var value = 1;
+            var upDownCounter = meter.CreateObservableUpDownCounter<long>("MyUpDownCounter", () =>
+            {
+                value = value * -2;
+                return new Measurement<long>(value, new("tag1", "value1"), new("tag2", "value2"));
+            });
+
+            // ASSERT
+            metricReader.Collect();
+            Assert.True(telemetryItems.Count == 1);
+            Assert.True(telemetryItems.TryTake(out var telemetryItem));
+            this.telemetryOutput.Write(telemetryItem);
+            TelemetryItemValidationHelper.AssertMetricTelemetry(
+                telemetryItem: telemetryItem,
+                expectedMetricDataPointName: asView ? "MyUpDownCounterRenamed" : "MyUpDownCounter",
+                expectedMetricDataPointNamespace: meterName,
+                expectedMetricDataPointValue: -2,
+                expectedMetricsProperties: new Dictionary<string, string> { { "tag1", "value1" }, { "tag2", "value2" } });
+
+            metricReader.Collect();
+            Assert.True(telemetryItems.Count == 1);
+            Assert.True(telemetryItems.TryTake(out telemetryItem));
+            this.telemetryOutput.Write(telemetryItem);
+            TelemetryItemValidationHelper.AssertMetricTelemetry(
+                telemetryItem: telemetryItem,
+                expectedMetricDataPointName: asView ? "MyUpDownCounterRenamed" : "MyUpDownCounter",
+                expectedMetricDataPointNamespace: meterName,
+                expectedMetricDataPointValue: 4,
+                expectedMetricsProperties: new Dictionary<string, string> { { "tag1", "value1" }, { "tag2", "value2" } });
+        }
     }
 }


### PR DESCRIPTION
### Changes
- Add support for UpDownCounter and ObservableUpDownCounter
- Update TestExtensions to return the MetricReader.
  This is needed to invoke collection of Observable Metrics.