### PR TITLE
[AzureMonitorExporter] Refactor RestClient and DebugWritter

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * Update OpenTelemetry dependencies ([#32047](https://github.com/Azure/azure-sdk-for-net/pull/32047))
   - OpenTelemetry v1.4.0-beta.2
+* Debugging Output now includes Telemetry sent from storage. ([#32172](https://github.com/Azure/azure-sdk-for-net/pull/32172))
 
 ## 1.0.0-beta.4 (2022-10-07)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TelemetryDebugWriter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TelemetryDebugWriter.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Diagnostics;
+using System.Text;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 {
@@ -16,7 +18,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
             if (Debugger.IsAttached && Debugger.IsLogging())
             {
-                Debugger.Log(0, null, message);
+                Debugger.Log(0, null, message + "\n");
             }
         }
 
@@ -30,6 +32,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             if (Debugger.IsAttached && Debugger.IsLogging())
             {
                 Debugger.Log(0, null, content.ToString());
+            }
+        }
+
+        public static void WriteTelemetryFromStorage(ReadOnlyMemory<byte> content)
+        {
+            if (Debugger.IsAttached && Debugger.IsLogging())
+            {
+                Debugger.Log(0, null, "(TRANSMITTING TELEMETRY FROM STORAGE)\n" + Encoding.UTF8.GetString(content.ToArray()));
             }
         }
     }


### PR DESCRIPTION

### Changes
- refactor RestClient
  - cache the `RawRequestUriBuilder` to reduce allocations
  - remove dupe code
  - fix SendFromStorage
    This was creating a `NDJsonWriter` that was never used
- refactor DebugWritter
  - `WriteMessage` wasn't writing a new-line. 
  - add `WriteTelemetryFromStorage` to print the `ReadOnlyMemory<byte>` 


![image](https://user-images.githubusercontent.com/28785781/198730131-0301610c-545c-4591-b1b5-57777df194ed.png)

