### PR TITLE
[AzureMonitorExporter] remove IsSupportedType(MetricType)

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricDataPoint.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricDataPoint.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
 using OpenTelemetry.Metrics;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Models
@@ -49,6 +50,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                         Max = metricPoint.GetHistogramMax();
                     }
 
+                    break;
+                default:
+                    AzureMonitorExporterEventSource.Log.WriteWarning("MetricDataPoint", $"Unsupported MetricType '{metric.MetricType}'");
                     break;
             }
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricsData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricsData.cs
@@ -32,18 +32,5 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                 }
             }
         }
-
-        internal static bool IsSupportedType(MetricType metricType) =>
-            metricType switch
-            {
-                MetricType.DoubleGauge => true,
-                MetricType.DoubleSum => true,
-                MetricType.LongGauge => true,
-                MetricType.LongSum => true,
-                MetricType.Histogram => true,
-                MetricType.DoubleSumNonMonotonic => true,
-                MetricType.LongSumNonMonotonic => true,
-                _ => false
-            };
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/MetricHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/MetricHelper.cs
@@ -19,23 +19,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             List<TelemetryItem> telemetryItems = new();
             foreach (var metric in batch)
             {
-                if (MetricsData.IsSupportedType(metric.MetricType))
+                foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                 {
-                    foreach (ref readonly var metricPoint in metric.GetMetricPoints())
+                    telemetryItems.Add(new TelemetryItem(metricPoint.EndTime.UtcDateTime, roleName, roleInstance, instrumentationKey)
                     {
-                        telemetryItems.Add(new TelemetryItem(metricPoint.EndTime.UtcDateTime, roleName, roleInstance, instrumentationKey)
+                        Data = new MonitorBase
                         {
-                            Data = new MonitorBase
-                            {
-                                BaseType = "MetricData",
-                                BaseData = new MetricsData(Version, metric, metricPoint)
-                            }
-                        });
-                    }
-                }
-                else
-                {
-                    // log not supported
+                            BaseType = "MetricData",
+                            BaseData = new MetricsData(Version, metric, metricPoint)
+                        }
+                    });
                 }
             }
 


### PR DESCRIPTION

### Changes
- remove `IsSupportedType(MetricType)`
  This is no longer needed. See comment: https://github.com/Azure/azure-sdk-for-net/pull/32170#discussion_r1008342069
- added log warning to `MetricDataPoint`.