### PR TITLE
Update Packages.Data.props

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -245,7 +245,7 @@
     <PackageReference Update="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Update="NSubstitute" Version="3.1.0" />
     <PackageReference Update="NUnit" Version="3.13.2" />
-    <PackageReference Update="NUnit3TestAdapter" Version="4.3.0-alpha-net7.4" />
+    <PackageReference Update="NUnit3TestAdapter" Version="4.3.0" />
     <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.8" />
     <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.5" />
     <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.6" />


### PR DESCRIPTION
The NUnit3TestAdapter 4.3.0 has now been released with .net 7 support, so the alpha version can be replaced with the release version.   See Issue #31365

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
