### PR TITLE
AOA Conversion: Set the AccountDomain property

### DIFF
--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/Azure.MixedReality.ObjectAnchors.Conversion.sln
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/Azure.MixedReality.ObjectAnchors.Conversion.sln
@@ -1,7 +1,7 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30907.101
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32825.248
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.MixedReality.ObjectAnchors.Conversion", "src\Azure.MixedReality.ObjectAnchors.Conversion.csproj", "{F2DECE5E-D006-41CC-A4F2-2ACE91D18E16}"
 EndProject

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/CHANGELOG.md
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## 0.3.0-beta.6 (Unreleased)
 
+### Bugs Fixed
+
+- The `AccountDomain` property on the `ObjectAnchorsConversionClient` is not properly set to the value passed into the
+  constructor.
+
 ### Features Added
 
-- Added DisableDetectScaleUnits to AssetConversionOptions. 
-- In version 0.3.2+ we will by default detect and use the scale units in FBX files if it is valid, the property DisableDetectScaleUnits controls if users want that behavior or not.
-- In version below 0.3.2, the property is ignored so that we are compatible with old SDK versions.
+- As of API version `0.3-preview.2`, we have begun detecting and using asset scale units embedded in FBX files for asset
+  conversion. The detected scale unit will be used by default. To disable this behavior, you can set the new
+  `DisableDetectScaleUnits` option in `AssetConversionOptions` to `true`. The `DisableDetectScaleUnits` option is
+  ignored in previous API versions.
 
 ## 0.3.0-beta.5 (2022-09-12)
 

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/ObjectAnchorsConversionClient.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/ObjectAnchorsConversionClient.cs
@@ -103,6 +103,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
             Uri serviceEndpoint = options.ServiceEndpoint ?? ConstructObjectAnchorsEndpointUrl(accountDomain);
 
             AccountId = accountId;
+            AccountDomain = accountDomain;
             SupportedAssetFileTypesSet = options.SupportedAssetFileTypes;
             _clientDiagnostics = new ClientDiagnostics(options);
             _pipeline = HttpPipelineBuilder.Build(options, new BearerTokenAuthenticationPolicy(mrTokenCredential, GetDefaultScope(serviceEndpoint)));

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/ObjectAnchorsConversionClientOptions.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/ObjectAnchorsConversionClientOptions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using Azure.Core;
 using Azure.MixedReality.Authentication;

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/ObjectAnchorsConversionClientTests.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/ObjectAnchorsConversionClientTests.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.TestFramework;
+using Azure.Identity;
+using Azure.MixedReality.Authentication;
 using Moq;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
@@ -53,6 +55,74 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Tests
             };
 
         [Test]
+        public void Constructor()
+        {
+            // Arrange
+            Guid accountId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+            string accountDomain = "my.domain.com";
+            AccessToken token = new AccessToken("dummykey", new DateTimeOffset(new DateTime(3000, 1, 1)));
+            AzureKeyCredential keyCredential = new AzureKeyCredential("MyAccessKey");
+            ObjectAnchorsConversionClientOptions options = new ObjectAnchorsConversionClientOptions();
+            TokenCredential credential = new StaticAccessTokenCredential(token);
+
+            // Act
+            ObjectAnchorsConversionClient client = new ObjectAnchorsConversionClient(accountId, accountDomain, keyCredential);
+
+            // Assert
+            Assert.AreEqual(accountId, client.AccountId);
+            Assert.AreEqual(accountDomain, client.AccountDomain);
+            Assert.NotNull(client.SupportedAssetFileTypes);
+
+            // Act and assert
+
+            // new(Guid accountId, string accountDomain, AzureKeyCredential keyCredential)
+            AssertArgumentException<ArgumentException>(nameof(accountId),
+                () => new ObjectAnchorsConversionClient(default, accountDomain, keyCredential));
+            AssertArgumentException<ArgumentNullException>(nameof(accountDomain),
+                () => new ObjectAnchorsConversionClient(accountId, null!, keyCredential));
+            AssertArgumentException<ArgumentException>(nameof(accountDomain),
+                () => new ObjectAnchorsConversionClient(accountId, string.Empty, keyCredential));
+            AssertArgumentException<ArgumentException>(nameof(accountDomain),
+                () => new ObjectAnchorsConversionClient(accountId, " ", keyCredential));
+            AssertArgumentException<ArgumentNullException>(nameof(keyCredential),
+                () => new ObjectAnchorsConversionClient(accountId, accountDomain, null!));
+
+            // new(Guid accountId, string accountDomain, AzureKeyCredential keyCredential, ObjectAnchorsConversionClientOptions options)
+            AssertArgumentException<ArgumentException>(nameof(accountId),
+                () => new ObjectAnchorsConversionClient(default, accountDomain, keyCredential, options));
+            AssertArgumentException<ArgumentNullException>(nameof(accountDomain),
+                () => new ObjectAnchorsConversionClient(accountId, null!, keyCredential, options));
+            AssertArgumentException<ArgumentException>(nameof(accountDomain),
+                () => new ObjectAnchorsConversionClient(accountId, string.Empty, keyCredential, options));
+            AssertArgumentException<ArgumentException>(nameof(accountDomain),
+                () => new ObjectAnchorsConversionClient(accountId, " ", keyCredential, options));
+            AssertArgumentException<ArgumentNullException>(nameof(keyCredential),
+                () => new ObjectAnchorsConversionClient(accountId, accountDomain, (AzureKeyCredential)null!, options));
+
+            // new(Guid accountId, string accountDomain, AccessToken token, ObjectAnchorsConversionClientOptions options = null)
+            AssertArgumentException<ArgumentException>(nameof(accountId),
+                () => new ObjectAnchorsConversionClient(default, accountDomain, token, options));
+            AssertArgumentException<ArgumentNullException>(nameof(accountDomain),
+                () => new ObjectAnchorsConversionClient(accountId, null!, token, options));
+            AssertArgumentException<ArgumentException>(nameof(accountDomain),
+                () => new ObjectAnchorsConversionClient(accountId, string.Empty, token, options));
+            AssertArgumentException<ArgumentException>(nameof(accountDomain),
+                () => new ObjectAnchorsConversionClient(accountId, " ", token, options));
+
+            // new(Guid accountId, string accountDomain, TokenCredential credential, ObjectAnchorsConversionClientOptions options = null)
+            AssertArgumentException<ArgumentException>(nameof(accountId),
+                () => new ObjectAnchorsConversionClient(default, accountDomain, credential, options));
+            AssertArgumentException<ArgumentNullException>(nameof(accountDomain),
+                () => new ObjectAnchorsConversionClient(accountId, null!, credential, options));
+            AssertArgumentException<ArgumentException>(nameof(accountDomain),
+                () => new ObjectAnchorsConversionClient(accountId, string.Empty, credential, options));
+            AssertArgumentException<ArgumentException>(nameof(accountDomain),
+                () => new ObjectAnchorsConversionClient(accountId, " ", credential, options));
+            AssertArgumentException<ArgumentNullException>(nameof(credential),
+                () => new ObjectAnchorsConversionClient(accountId, accountDomain, (TokenCredential)null!, options));
+        }
+
+        [Test]
         [TestCaseSource(nameof(BadClientArgumentsTestData))]
         public void BadClientArguments(Guid accountId, string accountDomain, AccessToken credential, bool shouldSucceed)
         {
@@ -89,6 +159,13 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Tests
             }
 
             Assert.True(exceptedWithUnsupportedFileType);
+        }
+
+        private static void AssertArgumentException<TException>(string argumentName, TestDelegate code)
+            where TException : ArgumentException
+        {
+            TException exception = Assert.Throws<TException>(code);
+            Assert.AreEqual(argumentName, exception.ParamName);
         }
     }
 }


### PR DESCRIPTION
  - We missed setting a property with a value passed into the constructor.
  - Updated the solution to VS 2022.
