### PR TITLE
make CommunicationIdentifierModelKind internal

### DIFF
--- a/sdk/communication/Azure.Communication.MediaComposition/api/Azure.Communication.MediaComposition.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.MediaComposition/api/Azure.Communication.MediaComposition.netstandard2.0.cs
@@ -1,26 +1,3 @@
-namespace Azure.Communication
-{
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly partial struct CommunicationIdentifierModelKind : System.IEquatable<Azure.Communication.CommunicationIdentifierModelKind>
-    {
-        private readonly object _dummy;
-        private readonly int _dummyPrimitive;
-        public CommunicationIdentifierModelKind(string value) { throw null; }
-        public static Azure.Communication.CommunicationIdentifierModelKind CommunicationUser { get { throw null; } }
-        public static Azure.Communication.CommunicationIdentifierModelKind MicrosoftTeamsUser { get { throw null; } }
-        public static Azure.Communication.CommunicationIdentifierModelKind PhoneNumber { get { throw null; } }
-        public static Azure.Communication.CommunicationIdentifierModelKind Unknown { get { throw null; } }
-        public bool Equals(Azure.Communication.CommunicationIdentifierModelKind other) { throw null; }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public override bool Equals(object obj) { throw null; }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public override int GetHashCode() { throw null; }
-        public static bool operator ==(Azure.Communication.CommunicationIdentifierModelKind left, Azure.Communication.CommunicationIdentifierModelKind right) { throw null; }
-        public static implicit operator Azure.Communication.CommunicationIdentifierModelKind (string value) { throw null; }
-        public static bool operator !=(Azure.Communication.CommunicationIdentifierModelKind left, Azure.Communication.CommunicationIdentifierModelKind right) { throw null; }
-        public override string ToString() { throw null; }
-    }
-}
 namespace Azure.Communication.MediaComposition
 {
     public partial class ActivePresenter : Azure.Communication.MediaComposition.Models.MediaInput

--- a/sdk/communication/Azure.Communication.MediaComposition/src/Generated/Models/CommunicationIdentifierModelKind.cs
+++ b/sdk/communication/Azure.Communication.MediaComposition/src/Generated/Models/CommunicationIdentifierModelKind.cs
@@ -11,7 +11,7 @@ using System.ComponentModel;
 namespace Azure.Communication
 {
     /// <summary> The identifier kind, for example &apos;communicationUser&apos; or &apos;phoneNumber&apos;. </summary>
-    public readonly partial struct CommunicationIdentifierModelKind : IEquatable<CommunicationIdentifierModelKind>
+    internal readonly partial struct CommunicationIdentifierModelKind : IEquatable<CommunicationIdentifierModelKind>
     {
         private readonly string _value;
 

--- a/sdk/communication/Azure.Communication.MediaComposition/src/Models/CommunicationIdentifierModelKind.cs
+++ b/sdk/communication/Azure.Communication.MediaComposition/src/Models/CommunicationIdentifierModelKind.cs
@@ -6,7 +6,7 @@ using Azure.Core;
 namespace Azure.Communication
 {
     [CodeGenModel("CommunicationIdentifierModelKind")]
-    public readonly partial struct CommunicationIdentifierModelKind
+    internal readonly partial struct CommunicationIdentifierModelKind
     {
     }
 }


### PR DESCRIPTION
# Contributing to the Azure SDK

`CommunicationIdentifierModelKind` is an internal struct on other Comminication SDKs. This change is made to make MediaCompostion to use the same approach.
