### PR TITLE
[.NET] Azure.Communication.Common release updates

### DIFF
--- a/sdk/communication/Azure.Communication.Common/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.Common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.1 (2022-11-08)
+## 1.2.1 (2022-11-01)
 
 ### Bugs Fixed
 - Fixed the logic of `PhoneNumberIdentifier` to always maintain the original phone number string whether it included the leading + sign or not.

--- a/sdk/communication/Azure.Communication.Common/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.Common/CHANGELOG.md
@@ -1,14 +1,9 @@
 # Release History
 
-## 1.2.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.2.1 (2022-11-08)
 
 ### Bugs Fixed
-
-### Other Changes
+- Fixed the logic of `PhoneNumberIdentifier` to always maintain the original phone number string whether it included the leading + sign or not.
 
 ## 1.2.0 (2022-09-01)
 


### PR DESCRIPTION
# Contributing to the Azure SDK
Fixed of the logic of `PhoneNumberIdentifier` release of the Azure.Communication.Identity SDK - 1.2.0

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
