### PR TITLE
[Docs] Fixing broken links

### DIFF
--- a/sdk/tables/Azure.Data.Tables/README.md
+++ b/sdk/tables/Azure.Data.Tables/README.md
@@ -280,7 +280,7 @@ For more information see the [Code of Conduct FAQ][coc_faq] or contact
 [table_client_samples]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tables/Azure.Data.Tables/samples
 [table_client_src]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tables/Azure.Data.Tables/src
 [table_change_log]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tables/Azure.Data.Tables/CHANGELOG.md
-[api_reference]: https://docs.microsoft.com/dotnet/api/overview/azure/data.tables-readme-pre?view=azure-dotnet-preview
+[api_reference]: https://docs.microsoft.com/dotnet/api/overview/azure/data.tables-readme
 [logging]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/Diagnostics.md
 [cla]: https://cla.microsoft.com
 [coc]: https://opensource.microsoft.com/codeofconduct/

--- a/sdk/translation/Azure.AI.Translation.Document/README.md
+++ b/sdk/translation/Azure.AI.Translation.Document/README.md
@@ -451,7 +451,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 <!-- LINKS -->
 [documenttranslation_client_src]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/translation/Azure.AI.Translation.Document/src
 [documenttranslation_docs]: https://docs.microsoft.com/azure/cognitive-services/translator/document-translation/overview
-[documenttranslation_refdocs]: https://aka.ms/azsdk/net/documenttranslation/docs
+[documenttranslation_refdocs]: https://aka.ms/azsdk/net/docs/documenttranslation
 [documenttranslation_nuget_package]: https://www.nuget.org/packages/Azure.AI.Translation.Document
 [documenttranslation_samples]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/translation/Azure.AI.Translation.Document/samples/README.md
 [documenttranslation_rest_api]: https://github.com/Azure/azure-rest-api-specs/blob/master/specification/cognitiveservices/data-plane/TranslatorText/stable/v1.0/TranslatorBatch.json


### PR DESCRIPTION
# Summary

The focus of these changes is to fix broken links discovered by a validation pass.  While fixing broken links, some aka.ms aliases were adjusted to conform to common patterns.

# References and Related

- [Link validation report](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1957410&view=logs&j=d41e9505-d81b-5b3c-5b50-be71bc9b0ccb&t=2521f384-3a28-5bc9-41e5-2f3e6ef99ecd) _(Microsoft internal)_