### PR TITLE
[FormRecognizer] Updated error codes in tests to reflect service change

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/RecognizeBusinessCardsLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/RecognizeBusinessCardsLiveTests.cs
@@ -348,7 +348,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var invalidUri = new Uri("https://idont.ex.ist");
 
             RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await client.StartRecognizeBusinessCardsFromUriAsync(invalidUri));
-            Assert.AreEqual("FailedToDownloadImage", ex.ErrorCode);
+            Assert.AreEqual("InvalidImage", ex.ErrorCode);
         }
 
         [RecordedTest]

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/RecognizeContentLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/RecognizeContentLiveTests.cs
@@ -391,7 +391,7 @@ namespace Azure.AI.FormRecognizer.Tests
             using var stream = new MemoryStream(damagedFile);
 
             RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await client.StartRecognizeContentAsync(stream));
-            Assert.AreEqual("InvalidImage", ex.ErrorCode);
+            Assert.AreEqual("BadArgument", ex.ErrorCode);
         }
 
         /// <summary>
@@ -405,7 +405,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var invalidUri = new Uri("https://idont.ex.ist");
 
             RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await client.StartRecognizeContentFromUriAsync(invalidUri));
-            Assert.AreEqual("FailedToDownloadImage", ex.ErrorCode);
+            Assert.AreEqual("InvalidImage", ex.ErrorCode);
         }
 
         [RecordedTest]

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/RecognizeIdentityDocumentsLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/RecognizeIdentityDocumentsLiveTests.cs
@@ -187,7 +187,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var invalidUri = new Uri("https://idont.ex.ist");
 
             RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await client.StartRecognizeIdentityDocumentsFromUriAsync(invalidUri));
-            Assert.AreEqual("FailedToDownloadImage", ex.ErrorCode);
+            Assert.AreEqual("InvalidImage", ex.ErrorCode);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/RecognizeInvoicesLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/RecognizeInvoicesLiveTests.cs
@@ -357,7 +357,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var invalidUri = new Uri("https://idont.ex.ist");
 
             RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await client.StartRecognizeInvoicesFromUriAsync(invalidUri));
-            Assert.AreEqual("FailedToDownloadImage", ex.ErrorCode);
+            Assert.AreEqual("InvalidImage", ex.ErrorCode);
         }
 
         [RecordedTest]

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/RecognizeReceiptsLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/RecognizeReceiptsLiveTests.cs
@@ -455,7 +455,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var invalidUri = new Uri("https://idont.ex.ist");
 
             RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await client.StartRecognizeReceiptsFromUriAsync(invalidUri));
-            Assert.AreEqual("FailedToDownloadImage", ex.ErrorCode);
+            Assert.AreEqual("InvalidImage", ex.ErrorCode);
         }
 
         [RecordedTest]

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeBusinessCardsLiveTests/StartRecognizeBusinessCardsFromUriThrowsForNonExistingContent.json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeBusinessCardsLiveTests/StartRecognizeBusinessCardsFromUriThrowsForNonExistingContent.json
@@ -1,16 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1/prebuilt/businessCard/analyze?includeTextDetails=false",
+      "RequestUri": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/formrecognizer/v2.1/prebuilt/businessCard/analyze?includeTextDetails=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
+        "Connection": "keep-alive",
         "Content-Length": "22",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9f07796d75c5d940810bbef6d9d3fafd-4fea1576b847fe4d-00",
-        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20210510.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "f12a63ca961d68ea8fcc1e16051bc653",
+        "traceparent": "00-3c3eadc204294046aad67fcec73992f5-dfacd6ebea593d4c-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/4.1.0-alpha.20221101.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "4bca146c5d87fa69abe624ed0e0c1ea1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -18,28 +19,29 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "964af084-1e29-4d24-b195-12a3bdecef94",
-        "Content-Length": "161",
+        "apim-request-id": "db3dd17d-c866-4c23-8d02-f3e2b933c707",
+        "Content-Length": "170",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 May 2021 18:50:00 GMT",
+        "Date": "Tue, 01 Nov 2022 20:09:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "3891"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "102",
+        "x-ms-region": "Canada Central"
       },
       "ResponseBody": {
         "error": {
-          "code": "FailedToDownloadImage",
           "innerError": {
-            "requestId": "964af084-1e29-4d24-b195-12a3bdecef94"
+            "requestId": "db3dd17d-c866-4c23-8d02-f3e2b933c707"
           },
-          "message": "Failed to download image from input URL."
+          "code": "InvalidImage",
+          "message": "The input data is not a valid image or password protected."
         }
       }
     }
   ],
   "Variables": {
     "FORM_RECOGNIZER_API_KEY": "Sanitized",
-    "FORM_RECOGNIZER_ENDPOINT": "https://mariari-canada-central.cognitiveservices.azure.com/",
-    "RandomSeed": "1227656753"
+    "FORM_RECOGNIZER_ENDPOINT": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/",
+    "RandomSeed": "1768759290"
   }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeBusinessCardsLiveTests/StartRecognizeBusinessCardsFromUriThrowsForNonExistingContentAsync.json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeBusinessCardsLiveTests/StartRecognizeBusinessCardsFromUriThrowsForNonExistingContentAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1/prebuilt/businessCard/analyze?includeTextDetails=false",
+      "RequestUri": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/formrecognizer/v2.1/prebuilt/businessCard/analyze?includeTextDetails=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "22",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9025cd2ea48dc043b7cf0eb7e791ca2b-551989d12ea89441-00",
-        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20210510.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "3557ac817a8e74aafd0b74f8279d3ac1",
+        "traceparent": "00-04c0368d60665e4d95347bd7ba355ada-93646ac9c745c34d-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/4.1.0-alpha.20221101.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "533eb8eccda09256064a9db59e97e06a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -18,28 +18,29 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "46307443-37cb-418c-841b-2d6fd9988deb",
-        "Content-Length": "161",
+        "apim-request-id": "42145a27-0d97-43d0-a853-f766f25f8666",
+        "Content-Length": "170",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 May 2021 18:50:49 GMT",
+        "Date": "Tue, 01 Nov 2022 20:09:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "3627"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "166",
+        "x-ms-region": "Canada Central"
       },
       "ResponseBody": {
         "error": {
-          "code": "FailedToDownloadImage",
           "innerError": {
-            "requestId": "46307443-37cb-418c-841b-2d6fd9988deb"
+            "requestId": "42145a27-0d97-43d0-a853-f766f25f8666"
           },
-          "message": "Failed to download image from input URL."
+          "code": "InvalidImage",
+          "message": "The input data is not a valid image or password protected."
         }
       }
     }
   ],
   "Variables": {
     "FORM_RECOGNIZER_API_KEY": "Sanitized",
-    "FORM_RECOGNIZER_ENDPOINT": "https://mariari-canada-central.cognitiveservices.azure.com/",
-    "RandomSeed": "497174419"
+    "FORM_RECOGNIZER_ENDPOINT": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/",
+    "RandomSeed": "227871547"
   }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeContentLiveTests/StartRecognizeContentFromUriThrowsForNonExistingContent.json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeContentLiveTests/StartRecognizeContentFromUriThrowsForNonExistingContent.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1/layout/analyze",
+      "RequestUri": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/formrecognizer/v2.1/layout/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "22",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f3de808fe84eb541bfea62b0fee2e118-b385aecf44ecb74c-00",
-        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20210510.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "3fb24ee500b907e2e9685db142ae6e9f",
+        "traceparent": "00-02b7ae235419474eb2124dd58f1ed6e2-60c5560fe0bb8e47-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/4.1.0-alpha.20221101.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "baf58dcfad2563f604109087c8b97407",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -18,25 +18,26 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "a03ba744-1bb6-485e-bccf-a82363ea42ff",
-        "Content-Length": "95",
+        "apim-request-id": "a30148da-f69b-4b7a-a463-81d1ec76e56b",
+        "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 May 2021 18:52:04 GMT",
+        "Date": "Tue, 01 Nov 2022 20:09:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "55"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "222",
+        "x-ms-region": "Canada Central"
       },
       "ResponseBody": {
         "error": {
-          "code": "FailedToDownloadImage",
-          "message": "Failed to download image from input URL."
+          "code": "InvalidImage",
+          "message": "The file submitted couldn\u0027t be parsed. This can be due to one of the following reasons: the file format is not supported ( Supported formats include JPEG, PNG, BMP, PDF and TIFF), the file is corrupted or password protected."
         }
       }
     }
   ],
   "Variables": {
     "FORM_RECOGNIZER_API_KEY": "Sanitized",
-    "FORM_RECOGNIZER_ENDPOINT": "https://mariari-canada-central.cognitiveservices.azure.com/",
-    "RandomSeed": "968130052"
+    "FORM_RECOGNIZER_ENDPOINT": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/",
+    "RandomSeed": "1949108224"
   }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeContentLiveTests/StartRecognizeContentFromUriThrowsForNonExistingContentAsync.json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeContentLiveTests/StartRecognizeContentFromUriThrowsForNonExistingContentAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1/layout/analyze",
+      "RequestUri": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/formrecognizer/v2.1/layout/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "22",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4a991310b5513041918f92f11e9c5aa1-14456f2aa29ed140-00",
-        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20210510.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "ea9fc6f9db9f68f9a429f642ecc9ca32",
+        "traceparent": "00-f4c165389a4d414d91cf132bf38bbd2f-c2f2cfaf998c0044-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/4.1.0-alpha.20221101.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "f05491a6c81bf676d4da8cb988782e7b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -18,25 +18,26 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "050fef79-1f07-41eb-b055-ca0c7c95cb5d",
-        "Content-Length": "95",
+        "apim-request-id": "f33df83b-9dde-4180-a548-198be94fd797",
+        "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 May 2021 18:52:54 GMT",
+        "Date": "Tue, 01 Nov 2022 20:09:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "65"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "126",
+        "x-ms-region": "Canada Central"
       },
       "ResponseBody": {
         "error": {
-          "code": "FailedToDownloadImage",
-          "message": "Failed to download image from input URL."
+          "code": "InvalidImage",
+          "message": "The file submitted couldn\u0027t be parsed. This can be due to one of the following reasons: the file format is not supported ( Supported formats include JPEG, PNG, BMP, PDF and TIFF), the file is corrupted or password protected."
         }
       }
     }
   ],
   "Variables": {
     "FORM_RECOGNIZER_API_KEY": "Sanitized",
-    "FORM_RECOGNIZER_ENDPOINT": "https://mariari-canada-central.cognitiveservices.azure.com/",
-    "RandomSeed": "189591610"
+    "FORM_RECOGNIZER_ENDPOINT": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/",
+    "RandomSeed": "1754745537"
   }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeContentLiveTests/StartRecognizeContentThrowsForDamagedFile.json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeContentLiveTests/StartRecognizeContentThrowsForDamagedFile.json
@@ -1,40 +1,41 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1/layout/analyze",
+      "RequestUri": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/formrecognizer/v2.1/layout/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "7",
         "Content-Type": "application/pdf",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-95d2a8132bb02242857ab4881b95aa86-091334d58b4fe940-00",
-        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20210510.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "4f12a39c2e25754c898fc0118dad94f6",
+        "traceparent": "00-dac88354d5e4d94bbb816c8d18c38ccb-84e18f65ab65b94c-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/4.1.0-alpha.20221101.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "4530d25833565066ce49128445312e6b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": "JVBERlVVVQ==",
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "0e5bd808-e3da-44c3-bcd7-672b7131911d",
-        "Content-Length": "270",
+        "apim-request-id": "03fc9e00-92c6-4dc4-a44b-bbec39d349fe",
+        "Content-Length": "95",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 May 2021 18:52:04 GMT",
+        "Date": "Tue, 01 Nov 2022 20:09:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "Canada Central"
       },
       "ResponseBody": {
         "error": {
-          "code": "InvalidImage",
-          "message": "The file submitted couldn\u0027t be parsed. This can be due to one of the following reasons: the file format is not supported ( Supported formats include JPEG, PNG, BMP, PDF and TIFF), the file is corrupted or password protected."
+          "code": "BadArgument",
+          "message": "Bad or unrecognizable request JSON or binary file."
         }
       }
     }
   ],
   "Variables": {
     "FORM_RECOGNIZER_API_KEY": "Sanitized",
-    "FORM_RECOGNIZER_ENDPOINT": "https://mariari-canada-central.cognitiveservices.azure.com/",
-    "RandomSeed": "1402749806"
+    "FORM_RECOGNIZER_ENDPOINT": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/",
+    "RandomSeed": "145905535"
   }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeContentLiveTests/StartRecognizeContentThrowsForDamagedFileAsync.json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeContentLiveTests/StartRecognizeContentThrowsForDamagedFileAsync.json
@@ -1,40 +1,41 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1/layout/analyze",
+      "RequestUri": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/formrecognizer/v2.1/layout/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "7",
         "Content-Type": "application/pdf",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d3721384681dbf45ba56898f040ad654-f5d2fb1c07712f41-00",
-        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20210510.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "1a96039add4c15f6353ec7154c8a5229",
+        "traceparent": "00-22c599beb644004c8c9ece3dbb073517-1b8727431b4d0c48-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/4.1.0-alpha.20221101.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "ade7a73b13dc2206cb0f04556e53c107",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": "JVBERlVVVQ==",
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "f6e1e48c-d22f-4ef6-ae69-8edb35f04cbf",
-        "Content-Length": "270",
+        "apim-request-id": "2d0ca476-c12a-4af6-9580-237d0c69759d",
+        "Content-Length": "95",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 May 2021 18:52:54 GMT",
+        "Date": "Tue, 01 Nov 2022 20:09:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "3"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "4",
+        "x-ms-region": "Canada Central"
       },
       "ResponseBody": {
         "error": {
-          "code": "InvalidImage",
-          "message": "The file submitted couldn\u0027t be parsed. This can be due to one of the following reasons: the file format is not supported ( Supported formats include JPEG, PNG, BMP, PDF and TIFF), the file is corrupted or password protected."
+          "code": "BadArgument",
+          "message": "Bad or unrecognizable request JSON or binary file."
         }
       }
     }
   ],
   "Variables": {
     "FORM_RECOGNIZER_API_KEY": "Sanitized",
-    "FORM_RECOGNIZER_ENDPOINT": "https://mariari-canada-central.cognitiveservices.azure.com/",
-    "RandomSeed": "842876107"
+    "FORM_RECOGNIZER_ENDPOINT": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/",
+    "RandomSeed": "1867142212"
   }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeIdentityDocumentsLiveTests/StartRecognizeIdentityDocumentsFromUriThrowsForNonExistingContent.json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeIdentityDocumentsLiveTests/StartRecognizeIdentityDocumentsFromUriThrowsForNonExistingContent.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1/prebuilt/idDocument/analyze?includeTextDetails=false",
+      "RequestUri": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/formrecognizer/v2.1/prebuilt/idDocument/analyze?includeTextDetails=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "22",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-86624b9d82a3274cbbc44158718b2270-b76618bef7414c43-00",
-        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20210510.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "13363c247ac6d031e0d7f8e573170572",
+        "traceparent": "00-0971e138fe8cb9479994c1411cd40bef-3c80c2e6420d334c-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/4.1.0-alpha.20221101.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "7b95d62f4c4ce3e59f070eb6f7f0e8e0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -18,28 +18,29 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "01a29a2d-f455-461c-97d9-9a66aac735be",
-        "Content-Length": "161",
+        "apim-request-id": "e5676462-aebf-4b73-a6d6-8353466e9606",
+        "Content-Length": "170",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 May 2021 22:17:25 GMT",
+        "Date": "Tue, 01 Nov 2022 20:09:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "3868"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "382",
+        "x-ms-region": "Canada Central"
       },
       "ResponseBody": {
         "error": {
-          "code": "FailedToDownloadImage",
           "innerError": {
-            "requestId": "01a29a2d-f455-461c-97d9-9a66aac735be"
+            "requestId": "e5676462-aebf-4b73-a6d6-8353466e9606"
           },
-          "message": "Failed to download image from input URL."
+          "code": "InvalidImage",
+          "message": "The input data is not a valid image or password protected."
         }
       }
     }
   ],
   "Variables": {
     "FORM_RECOGNIZER_API_KEY": "Sanitized",
-    "FORM_RECOGNIZER_ENDPOINT": "https://mariari-canada-central.cognitiveservices.azure.com/",
-    "RandomSeed": "753512155"
+    "FORM_RECOGNIZER_ENDPOINT": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/",
+    "RandomSeed": "2099026495"
   }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeIdentityDocumentsLiveTests/StartRecognizeIdentityDocumentsFromUriThrowsForNonExistingContentAsync.json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeIdentityDocumentsLiveTests/StartRecognizeIdentityDocumentsFromUriThrowsForNonExistingContentAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1/prebuilt/idDocument/analyze?includeTextDetails=false",
+      "RequestUri": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/formrecognizer/v2.1/prebuilt/idDocument/analyze?includeTextDetails=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "22",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ebc0f9549451fd4d9af44f1426327bbd-0bf6b79b5d642649-00",
-        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20210510.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "6c5b31e6233d4a5cc136b05aa320e851",
+        "traceparent": "00-52acc1af250ef049aeb1d96b146a5148-cf5a6aa20f752842-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/4.1.0-alpha.20221101.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "7c435201d9e6c446c6bfeaf8ea97e740",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -18,28 +18,29 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "03063faa-ec16-4e25-90a1-2530b50d466b",
-        "Content-Length": "161",
+        "apim-request-id": "e5078baa-3ef8-4f8d-b54a-10bd2d798f96",
+        "Content-Length": "170",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 May 2021 22:17:40 GMT",
+        "Date": "Tue, 01 Nov 2022 20:09:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "3187"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "206",
+        "x-ms-region": "Canada Central"
       },
       "ResponseBody": {
         "error": {
-          "code": "FailedToDownloadImage",
           "innerError": {
-            "requestId": "03063faa-ec16-4e25-90a1-2530b50d466b"
+            "requestId": "e5078baa-3ef8-4f8d-b54a-10bd2d798f96"
           },
-          "message": "Failed to download image from input URL."
+          "code": "InvalidImage",
+          "message": "The input data is not a valid image or password protected."
         }
       }
     }
   ],
   "Variables": {
     "FORM_RECOGNIZER_API_KEY": "Sanitized",
-    "FORM_RECOGNIZER_ENDPOINT": "https://mariari-canada-central.cognitiveservices.azure.com/",
-    "RandomSeed": "1114832900"
+    "FORM_RECOGNIZER_ENDPOINT": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/",
+    "RandomSeed": "1014648272"
   }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeInvoicesLiveTests/StartRecognizeInvoicesFromUriThrowsForNonExistingContent.json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeInvoicesLiveTests/StartRecognizeInvoicesFromUriThrowsForNonExistingContent.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1/prebuilt/invoice/analyze?includeTextDetails=false",
+      "RequestUri": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/formrecognizer/v2.1/prebuilt/invoice/analyze?includeTextDetails=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "22",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-164439621a2c0549884a92959c33bfac-99d521c58af1a345-00",
-        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20210510.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "12b73e4b7489b764d48ae8b4959852ec",
+        "traceparent": "00-5ecfe81dd8dfca4f82704646c9f00e69-523e8aaaf13c4f4b-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/4.1.0-alpha.20221101.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "e64ddede843707e440a6061c856e5dc9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -18,28 +18,29 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "a97558d2-21cd-4688-8244-d5dad3a86267",
-        "Content-Length": "161",
+        "apim-request-id": "5919e6a7-b035-47df-b833-4db12af4a71c",
+        "Content-Length": "170",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 May 2021 21:59:43 GMT",
+        "Date": "Tue, 01 Nov 2022 20:09:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "4146"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "127",
+        "x-ms-region": "Canada Central"
       },
       "ResponseBody": {
         "error": {
-          "code": "FailedToDownloadImage",
           "innerError": {
-            "requestId": "a97558d2-21cd-4688-8244-d5dad3a86267"
+            "requestId": "5919e6a7-b035-47df-b833-4db12af4a71c"
           },
-          "message": "Failed to download image from input URL."
+          "code": "InvalidImage",
+          "message": "The input data is not a valid image or password protected."
         }
       }
     }
   ],
   "Variables": {
     "FORM_RECOGNIZER_API_KEY": "Sanitized",
-    "FORM_RECOGNIZER_ENDPOINT": "https://mariari-canada-central.cognitiveservices.azure.com/",
-    "RandomSeed": "1254441428"
+    "FORM_RECOGNIZER_ENDPOINT": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/",
+    "RandomSeed": "1710301121"
   }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeInvoicesLiveTests/StartRecognizeInvoicesFromUriThrowsForNonExistingContentAsync.json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeInvoicesLiveTests/StartRecognizeInvoicesFromUriThrowsForNonExistingContentAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1/prebuilt/invoice/analyze?includeTextDetails=false",
+      "RequestUri": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/formrecognizer/v2.1/prebuilt/invoice/analyze?includeTextDetails=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "22",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c5c91ccc1ed5c24e9928374e1a1ecd23-bae36ccdd77e7543-00",
-        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20210510.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "2c6d1007564505ff61a5f78cc93cfd9c",
+        "traceparent": "00-7c57bceff2f86f45baaa581b54f121aa-3c8dda5477305745-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/4.1.0-alpha.20221101.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "c31dac1fa5d8dd458715e59131eb3530",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -18,28 +18,29 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "6fe87b97-e533-4146-a96f-87d0a911c5fa",
-        "Content-Length": "161",
+        "apim-request-id": "b922dd6d-4409-4d3a-a8e0-4b581ea91638",
+        "Content-Length": "170",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 May 2021 22:00:43 GMT",
+        "Date": "Tue, 01 Nov 2022 20:09:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "3465"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "120",
+        "x-ms-region": "Canada Central"
       },
       "ResponseBody": {
         "error": {
-          "code": "FailedToDownloadImage",
           "innerError": {
-            "requestId": "6fe87b97-e533-4146-a96f-87d0a911c5fa"
+            "requestId": "b922dd6d-4409-4d3a-a8e0-4b581ea91638"
           },
-          "message": "Failed to download image from input URL."
+          "code": "InvalidImage",
+          "message": "The input data is not a valid image or password protected."
         }
       }
     }
   ],
   "Variables": {
     "FORM_RECOGNIZER_API_KEY": "Sanitized",
-    "FORM_RECOGNIZER_ENDPOINT": "https://mariari-canada-central.cognitiveservices.azure.com/",
-    "RandomSeed": "1511021704"
+    "FORM_RECOGNIZER_ENDPOINT": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/",
+    "RandomSeed": "1471325905"
   }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeReceiptsLiveTests/StartRecognizeReceiptsFromUriThrowsForNonExistingContent.json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeReceiptsLiveTests/StartRecognizeReceiptsFromUriThrowsForNonExistingContent.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1/prebuilt/receipt/analyze?includeTextDetails=false",
+      "RequestUri": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/formrecognizer/v2.1/prebuilt/receipt/analyze?includeTextDetails=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "22",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-795b22d87ede174d8f276d9fc7333b24-2c160ac4d0a19c4e-00",
-        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20210510.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "54db59a3122216058f2da23dc25f8d2a",
+        "traceparent": "00-0c9c911a187ed742987bc41718d0e09a-60d694805876934f-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/4.1.0-alpha.20221101.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "820379afba647ad2fa62867f7d7caba9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -18,28 +18,29 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "52284ab7-f567-4513-bdfc-175c003bf330",
-        "Content-Length": "161",
+        "apim-request-id": "ed705ff4-6f33-4d19-8acd-f33a8fa34081",
+        "Content-Length": "170",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 May 2021 22:10:01 GMT",
+        "Date": "Tue, 01 Nov 2022 20:09:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "3561"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "94",
+        "x-ms-region": "Canada Central"
       },
       "ResponseBody": {
         "error": {
-          "code": "FailedToDownloadImage",
           "innerError": {
-            "requestId": "52284ab7-f567-4513-bdfc-175c003bf330"
+            "requestId": "ed705ff4-6f33-4d19-8acd-f33a8fa34081"
           },
-          "message": "Failed to download image from input URL."
+          "code": "InvalidImage",
+          "message": "The input data is not a valid image or password protected."
         }
       }
     }
   ],
   "Variables": {
     "FORM_RECOGNIZER_API_KEY": "Sanitized",
-    "FORM_RECOGNIZER_ENDPOINT": "https://mariari-canada-central.cognitiveservices.azure.com/",
-    "RandomSeed": "343780180"
+    "FORM_RECOGNIZER_ENDPOINT": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/",
+    "RandomSeed": "558138752"
   }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeReceiptsLiveTests/StartRecognizeReceiptsFromUriThrowsForNonExistingContentAsync.json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/RecognizeReceiptsLiveTests/StartRecognizeReceiptsFromUriThrowsForNonExistingContentAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1/prebuilt/receipt/analyze?includeTextDetails=false",
+      "RequestUri": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/formrecognizer/v2.1/prebuilt/receipt/analyze?includeTextDetails=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "22",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-74c64c2d220e6e459ad8aa730f19fe05-589bc61833dec346-00",
-        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20210510.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "eea21153064a7cdf5d442d236b154082",
+        "traceparent": "00-589fb79f2f535447b0bd1969bbb0bbd4-94d8910f78a98543-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/4.1.0-alpha.20221101.1 (.NET Framework 4.8.9075.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "f976b0f7c0ce6fc557e1e1c3f3aaf0a5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -18,28 +18,29 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "b980e9ac-6cd7-4b65-bde7-23615bd3cbb1",
-        "Content-Length": "161",
+        "apim-request-id": "e361c615-3c5c-4ecc-bdda-94dda599774f",
+        "Content-Length": "170",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 May 2021 22:10:58 GMT",
+        "Date": "Tue, 01 Nov 2022 20:09:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "3405"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "263",
+        "x-ms-region": "Canada Central"
       },
       "ResponseBody": {
         "error": {
-          "code": "FailedToDownloadImage",
           "innerError": {
-            "requestId": "b980e9ac-6cd7-4b65-bde7-23615bd3cbb1"
+            "requestId": "e361c615-3c5c-4ecc-bdda-94dda599774f"
           },
-          "message": "Failed to download image from input URL."
+          "code": "InvalidImage",
+          "message": "The input data is not a valid image or password protected."
         }
       }
     }
   ],
   "Variables": {
     "FORM_RECOGNIZER_API_KEY": "Sanitized",
-    "FORM_RECOGNIZER_ENDPOINT": "https://mariari-canada-central.cognitiveservices.azure.com/",
-    "RandomSeed": "313658198"
+    "FORM_RECOGNIZER_ENDPOINT": "https://camaiaor-formrec-canadacentral.cognitiveservices.azure.com/",
+    "RandomSeed": "1276963218"
   }
 }


### PR DESCRIPTION
The reason for this change is fully described in this issue: https://github.com/Azure/azure-sdk-for-net/issues/32222

In short, the service introduced a change in behavior and we're updating our tests to reduce the amount of failures in our pipelines. This was not expected since the change happened in a service version that has already gone GA. The service team has been notified and, depending on their resolution, we may undo these changes in the future.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/32090.