### PR TITLE
[EngSys] Moq version bump

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -239,7 +239,7 @@
     <PackageReference Update="Microsoft.Rest.ClientRuntime.Azure.TestFramework" Version="[1.7.7, 2.0.0)" />
     <PackageReference Update="Microsoft.ServiceFabric.Data" Version="3.3.624" />
     <PackageReference Update="Microsoft.Spatial" Version="7.5.3" />
-    <PackageReference Update="Moq" Version="4.10.1" />
+    <PackageReference Update="Moq" Version="4.18.2" />
     <PackageReference Update="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Update="MSTest.TestFramework" Version="1.3.2" />
     <PackageReference Update="Newtonsoft.Json" Version="10.0.3" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -191,7 +191,7 @@
     <PackageReference Update="Azure.Storage.Blobs" Version="12.13.1" />
     <PackageReference Update="Azure.Storage.Files.DataLake" Version="12.8.0" />
     <PackageReference Update="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Update="Castle.Core" Version="4.4.0" />
+    <PackageReference Update="Castle.Core" Version="5.1.0" />
     <PackageReference Update="CommandLineParser" Version="2.8.0" />
     <PackageReference Update="FluentAssertions" Version="5.10.3" />
     <PackageReference Update="FsCheck.Xunit" Version="2.14.0" />


### PR DESCRIPTION
# Summary

The focus of these changes is to bump the version of Moq referenced by tests.  The previous version was from 2018, and there have been many enhancements since.  Several of our tests which mock ETW sources occasionally fail with an `IndexOutOfRange` exception related to the event source, the root cause of which has not been found.  My hope is that using a newer Moq version may resolve the issue.

### NOTE

If there are specific test pipelines that you would like to validate against, please feel free to kick off a run or mention them in a comment.

# References and Resources

- [Moq Changelog](https://github.com/moq/moq4/blob/main/CHANGELOG.md)
- [Sample Moq + ETW failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1958029&view=ms.vss-test-web.build-test-results-tab&runId=36512202&resultId=100654&paneView=debug) _(Microsoft internal)_