### PR TITLE
Handle Managed Identity json parse errors as CredentialUnAvailableException

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 - Fixed error message parsing in `AzureCliCredential` which would misinterpret AAD errors with the need to login with `az login`.
+- `ManagedIdentityCredential` will no longer fail when a response received from the endpoint is invalid JSON. It now treats this scenario as if the credential is unavailable.
 
 ### Other Changes
 

--- a/sdk/identity/Azure.Identity/src/ManagedIdentitySource.cs
+++ b/sdk/identity/Azure.Identity/src/ManagedIdentitySource.cs
@@ -61,6 +61,10 @@ namespace Azure.Identity
 
                 message = GetMessageFromResponse(json.RootElement);
             }
+            catch (JsonException jex)
+            {
+                throw new CredentialUnavailableException(UnexpectedResponse, jex);
+            }
             catch (Exception e)
             {
                 exception = e;

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
@@ -692,7 +692,7 @@ namespace Azure.Identity.Tests
         }
 
         [Test]
-        public async Task VerifyClientAuthenticateReturnsInvalidJson([Values(200, 404)] int status)
+        public async Task VerifyClientAuthenticateReturnsInvalidJson([Values(200, 404, 403)] int status)
         {
             using var environment = new TestEnvVar(
                 new()

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
@@ -15,6 +15,7 @@ using Azure.Core.TestFramework;
 using Azure.Identity.Tests.Mock;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Diagnostics.Runtime.Interop;
+using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace Azure.Identity.Tests
@@ -709,8 +710,8 @@ namespace Azure.Identity.Tests
 
             ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential("mock-client-id", pipeline));
 
-            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
-            Assert.IsInstanceOf(typeof(RequestFailedException), ex.InnerException);
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            Assert.IsInstanceOf(typeof(System.Text.Json.JsonException), ex.InnerException);
             Assert.That(ex.Message, Does.Contain(ManagedIdentitySource.UnexpectedResponse));
             await Task.CompletedTask;
         }


### PR DESCRIPTION
fixes #32061
fixes #30467
