### PR TITLE
AOA Conversion: Prepare for 3.0-beta.6 release

### DIFF
--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/CHANGELOG.md
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.3.0-beta.6 (Unreleased)
+## 0.3.0-beta.6 (2022-11-03)
 
 ### Bugs Fixed
 


### PR DESCRIPTION
  - This change updates the 3.0-beta.6 release date for release.
