### PR TITLE
Search project directory for test-resources files first

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -102,12 +102,22 @@ jobs:
           SubscriptionConfiguration: ${{ parameters.CloudConfig.SubscriptionConfiguration }}
           SubscriptionConfigurations: ${{ parameters.CloudConfig.SubscriptionConfigurations }}
 
+      - pwsh: |
+          $project = "${{ parameters.Project }}"
+          $directory = "${{ parameters.ServiceDirectory }}"
+          if ($project -and $project -ne "**" -and (Test-Path "$(Build.SourcesDirectory)/sdk/$directory/$project/test-resources.*")) {
+            $directory = "$directory/$project"
+          }
+          Write-Host "Setting TestResourcesDirectory to '$directory'"
+          Write-Host "##vso[task.setvariable variable=TestResourcesDirectory]$directory"
+        displayName: Set TestResources Location
+
       - ${{ if parameters.DeployTestResources }}:
         - template: /eng/common/TestResources/deploy-test-resources.yml
           parameters:
             ${{ if or(parameters.Location, parameters.CloudConfig.Location) }}:
               Location: ${{ coalesce(parameters.Location, parameters.CloudConfig.Location) }}
-            ServiceDirectory: '${{ parameters.ServiceDirectory }}'
+            ServiceDirectory: '$(TestResourcesDirectory)'
             SubscriptionConfiguration: $(SubscriptionConfiguration)
             ArmTemplateParameters: $(ArmTemplateParameters)
 


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-tools/issues/4450

ServiceDirectory is equivalent to the test resources search path in the deploy script, so to add a secondary parameter would be redundant aside from affecting resource naming. I think it's better to handle this at a higher level for now.