### PR TITLE
Search project directory for test-resources files first

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -102,12 +102,23 @@ jobs:
           SubscriptionConfiguration: ${{ parameters.CloudConfig.SubscriptionConfiguration }}
           SubscriptionConfigurations: ${{ parameters.CloudConfig.SubscriptionConfigurations }}
 
+      - pwsh: |
+          $project = "${{ parameters.Project }}"
+          $directory = "${{ parameters.ServiceDirectory }}"
+          if ($project -and $project -ne "**" -and (Test-Path "$(Build.SourcesDirectory)/sdk/$directory/$project/test-resources.*")) {
+            $directory = "$directory/$project"
+          }
+          Write-Host "Setting TestResourcesDirectory to '$directory'"
+          Write-Host "##vso[task.setvariable variable=TestResourcesDirectory]$directory"
+        displayName: Set TestResources Location
+
       - ${{ if parameters.DeployTestResources }}:
         - template: /eng/common/TestResources/deploy-test-resources.yml
           parameters:
             ${{ if or(parameters.Location, parameters.CloudConfig.Location) }}:
               Location: ${{ coalesce(parameters.Location, parameters.CloudConfig.Location) }}
             ServiceDirectory: '${{ parameters.ServiceDirectory }}'
+            TestResourcesDirectory: '$(TestResourcesDirectory)'
             SubscriptionConfiguration: $(SubscriptionConfiguration)
             ArmTemplateParameters: $(ArmTemplateParameters)
 


### PR DESCRIPTION
Partially resolves https://github.com/Azure/azure-sdk-tools/issues/4450
Depends on https://github.com/Azure/azure-sdk-tools/pull/4623
Replaces https://github.com/Azure/azure-sdk-for-net/pull/32288 which won't re-open for some reason.

I decided it would be better to add detection at the language repository yaml level for template existence in the project directory, rather than enable the deploy script to fall back to the service directory if the project directory did not have a bicep template. This way we can fail fast locally when people intend to specify a TestResourcesDirectory override but make a mistake with the file path/existence. The downside is we have to add extra yaml handling in the languages.
