### PR TITLE
Fix namespace typo (Identitiy)

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/AzureCliCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzureCliCredential.cs
@@ -12,7 +12,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
-using Azure.Identitiy;
 
 namespace Azure.Identity
 {

--- a/sdk/identity/Azure.Identity/src/Credentials/AzurePowerShellCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzurePowerShellCredential.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using Azure.Core;
 using Azure.Core.Pipeline;
-using Azure.Identitiy;
 
 namespace Azure.Identity
 {

--- a/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
@@ -10,7 +10,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
-using Azure.Identitiy;
 
 namespace Azure.Identity
 {

--- a/sdk/identity/Azure.Identity/src/Credentials/VisualStudioCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/VisualStudioCredential.cs
@@ -13,7 +13,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
-using Azure.Identitiy;
 
 namespace Azure.Identity
 {

--- a/sdk/identity/Azure.Identity/src/MsalClientBase.cs
+++ b/sdk/identity/Azure.Identity/src/MsalClientBase.cs
@@ -4,7 +4,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
-using Azure.Identitiy;
 using Microsoft.Identity.Client;
 
 namespace Azure.Identity

--- a/sdk/identity/Azure.Identity/src/TokenHelper.cs
+++ b/sdk/identity/Azure.Identity/src/TokenHelper.cs
@@ -4,9 +4,8 @@
 using System;
 using System.Text.Json;
 using Azure.Core;
-using Azure.Identity;
 
-namespace Azure.Identitiy
+namespace Azure.Identity
 {
     internal static class TokenHelper
     {

--- a/sdk/identity/Azure.Identity/tests/TokenHelperTests.cs
+++ b/sdk/identity/Azure.Identity/tests/TokenHelperTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using Azure.Identity;
 using NUnit.Framework;
 using Azure.Core.TestFramework;
 using System.Diagnostics.Tracing;

--- a/sdk/identity/Azure.Identity/tests/TokenHelperTests.cs
+++ b/sdk/identity/Azure.Identity/tests/TokenHelperTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using Azure.Identitiy;
+using Azure.Identity;
 using NUnit.Framework;
 using Azure.Core.TestFramework;
 using System.Diagnostics.Tracing;


### PR DESCRIPTION
Even though that namespace has only the internal class, it still shows up in IntelliSense as you type `using Azure.Ident`, and that is a bit confusing.