### PR TITLE
Skip failing T1 live tests

### DIFF
--- a/sdk/eventgrid/Microsoft.Azure.EventGrid/tests/Tests/ScenarioTests.PublishEvents.cs
+++ b/sdk/eventgrid/Microsoft.Azure.EventGrid/tests/Tests/ScenarioTests.PublishEvents.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.EventGrid.Tests.ScenarioTests
 {
     public partial class ScenarioTests
     {
-        [Fact]
+        [Fact(Skip = "Requires interactive login")]
         public void PublishEventsToTopic()
         {
             using (MockContext context = MockContext.Start(this.GetType()))
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.EventGrid.Tests.ScenarioTests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Requires interactive login")]
         public void PublishEventsToDomain()
         {
             using (MockContext context = MockContext.Start(this.GetType()))


### PR DESCRIPTION
We've already split out the T1 live test pipeline, but the pipeline always fails due to tests requiring interactive login.