### PR TITLE
[Event Hubs] Processor Release Prep

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -88,7 +88,7 @@
     <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.21" />
     <PackageReference Update="Azure.Data.SchemaRegistry" Version="1.2.0" />
     <PackageReference Update="Azure.Data.Tables" Version="12.5.0" />
-    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.7.3" />
+    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.7.4" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.10.0" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.11.0" />
     <PackageReference Update="Azure.Messaging.WebPubSub" Version="1.0.0" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -1,18 +1,18 @@
 # Release History
 
-## 5.8.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 5.7.4 (2022-11-08)
 
 ### Bugs Fixed
 
 - Telemetry will now use a parent activity instead of links when the event processor is configured to use a `CacheEventCount` of 1.
 
+- The reference for the AMQP transport library, `Microsoft.Azure.Amqp`, has been bumped to 2.5.12. This resolves a rare race condition encountered when creating an AMQP link that could cause the link to hang.
+
 ### Other Changes
 
 - Adjusted the frequency that a warning is logged when the processor owns more partitions than a basic heuristic believes is ideal.  Warnings will no longer log on each load balancing cycle, only when the number of partitions owned changes.
+
+- Added timing information to logs for AMQP publish and read operations.
 
 ## 5.7.3 (2022-10-11)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This library extends its Event Processor with durable storage for checkpoint information using Azure Blob storage.  For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.8.0-beta.1</Version>
+    <Version>5.7.4</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>5.7.3</ApiCompatVersion>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;Event Processor;EventProcessor;$(PackageCommonTags)</PackageTags>


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare the Event Hubs Processor package for its November release.

# Prerequisites

These changes cannot be merged until the `Azure.Messaging.EventHubs` package for version 5.7.4 (November, 2022) has been released.