### PR TITLE
[AzureMonitorExporter] update OTel to 1.4.0-beta3

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -116,7 +116,7 @@
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
 
     <!-- OpenTelemetry dependency approved for Azure.Monitor.OpenTelemetry.Exporter package only -->
-    <PackageReference Update="OpenTelemetry" Version="[1.4.0-beta.2]"  Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
+    <PackageReference Update="OpenTelemetry" Version="[1.4.0-beta.3]"  Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
     <PackageReference Update="OpenTelemetry.Extensions.PersistentStorage" Version="1.0.0-beta.1" Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
   </ItemGroup>
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-* Update OpenTelemetry dependencies ([]())
+* Update OpenTelemetry dependencies ([#32345](https://github.com/Azure/azure-sdk-for-net/pull/32345))
   - OpenTelemetry v1.4.0-beta.3
 
 ## 1.0.0-beta.5 (2022-11-08)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Other Changes
 
+* Update OpenTelemetry dependencies ([]())
+  - OpenTelemetry v1.4.0-beta.3
+
 ## 1.0.0-beta.5 (2022-11-08)
 
 ### Features Added

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricDataPoint.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricDataPoint.cs
@@ -44,10 +44,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                     // if the value is within integer range we will use it otherwise ignore it.
                     Count = histogramCount <= int.MaxValue ? (int?)histogramCount : null;
 
-                    if (metricPoint.HasMinMax())
+                    if (metricPoint.TryGetHistogramMinMaxValues(out double min, out double max))
                     {
-                        Min = metricPoint.GetHistogramMin();
-                        Max = metricPoint.GetHistogramMax();
+                        Min = min;
+                        Max = max;
                     }
 
                     break;


### PR DESCRIPTION
### Changes
- update OTel to 1.4.0-beta3.
  https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.4.0-beta.3
  - this includes one breaking change for Histogram Min/Max.