### PR TITLE
Use TryAdd when registering MessagingProvider so that we don't override custom provider

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -89,8 +89,8 @@
     <PackageReference Update="Azure.Data.SchemaRegistry" Version="1.2.0" />
     <PackageReference Update="Azure.Data.Tables" Version="12.5.0" />
     <PackageReference Update="Azure.Messaging.EventHubs" Version="5.7.4" />
-    <PackageReference Update="Azure.Messaging.EventGrid" Version="4.10.0" />
-    <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.11.0" />
+    <PackageReference Update="Azure.Messaging.EventGrid" Version="4.12.0" />
+    <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.11.1" />
     <PackageReference Update="Azure.Messaging.WebPubSub" Version="1.0.0" />
     <PackageReference Update="Azure.Monitor.Query" Version="1.1.0" />
     <PackageReference Update="Azure.Identity" Version="1.7.0" />

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 5.9.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 5.8.1 (2022-11-09)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fixed issue where custom `MessagingProvider` could be replaced by the library `MessagingProvider`.
 
 ## 5.8.0 (2022-10-11)
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Extensions.Hosting
                 });
 
             builder.Services.AddAzureClientsCore();
-            builder.Services.AddSingleton<MessagingProvider>();
+            builder.Services.TryAddSingleton<MessagingProvider>();
             builder.Services.AddSingleton<ServiceBusClientFactory>();
             return builder;
         }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>Microsoft Azure WebJobs SDK ServiceBus Extension</Description>
-    <Version>5.9.0-beta.1</Version>
+    <Version>5.8.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>5.8.0</ApiCompatVersion>
     <NoWarn>$(NoWarn);AZC0001;CS1591;SA1636</NoWarn>


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/32379

We have existing test coverage for custom messaging provider, but the custom messaging provider is always added last (as explained in the issue apparently because it is defined in the same assembly). Adding a separate assembly to verify the behavior is probably not worth it.