### PR TITLE
[Service Bus] Add maximum length exception documentation.

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -674,6 +674,15 @@ namespace Azure.Messaging.ServiceBus
         ///     </item>
         ///   </list>
         /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <list type="bullet">
+        ///     <item>
+        ///       <description>
+        ///         The dead letter reason or dead letter error description exceeded the maximum length of 4096.
+        ///       </description>
+        ///     </item>
+        ///   </list>
+        /// </exception>
         public virtual async Task DeadLetterMessageAsync(
             ServiceBusReceivedMessage message,
             IDictionary<string, object> propertiesToModify = null,
@@ -727,6 +736,15 @@ namespace Azure.Messaging.ServiceBus
         ///     <item>
         ///       <description>
         ///         The dead letter reason or dead letter error exception was specified in both the parameter and the properties dictionary.
+        ///       </description>
+        ///     </item>
+        ///   </list>
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <list type="bullet">
+        ///     <item>
+        ///       <description>
+        ///         The dead letter reason or dead letter error description exceeded the maximum length of 4096.
         ///       </description>
         ///     </item>
         ///   </list>
@@ -795,6 +813,15 @@ namespace Azure.Messaging.ServiceBus
         ///       <description>
         ///         The lock for the session has expired or the message has already been completed. This only applies for session-enabled entities.
         ///         The <see cref="ServiceBusException.Reason" /> will be set to <see cref="ServiceBusFailureReason.SessionLockLost"/> in this case.
+        ///       </description>
+        ///     </item>
+        ///   </list>
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <list type="bullet">
+        ///     <item>
+        ///       <description>
+        ///         The dead letter reason or dead letter error description exceeded the maximum length of 4096.
         ///       </description>
         ///     </item>
         ///   </list>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -674,15 +674,6 @@ namespace Azure.Messaging.ServiceBus
         ///     </item>
         ///   </list>
         /// </exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        ///   <list type="bullet">
-        ///     <item>
-        ///       <description>
-        ///         The dead letter reason or dead letter error description exceeded the maximum length of 4096.
-        ///       </description>
-        ///     </item>
-        ///   </list>
-        /// </exception>
         public virtual async Task DeadLetterMessageAsync(
             ServiceBusReceivedMessage message,
             IDictionary<string, object> propertiesToModify = null,


### PR DESCRIPTION
This adds more exceptions documentation when the length of the dead letter reason and description exceeds 4096.