### PR TITLE
Fix GenericResourceData Properties Serialization

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Generated/Models/GenericResourceData.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Generated/Models/GenericResourceData.Serialization.cs
@@ -27,12 +27,7 @@ namespace Azure.ResourceManager.Resources
             if (Optional.IsDefined(Properties))
             {
                 writer.WritePropertyName("properties");
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(Properties);
-#else
-                JsonSerializer.Serialize(writer, JsonDocument.Parse(Properties.ToString()).RootElement);
-#endif
-            }
+                writer.WriteObjectValue(Properties);
             if (Optional.IsDefined(Kind))
             {
                 writer.WritePropertyName("kind");


### PR DESCRIPTION
Was hitting some issues having the Properties serialized on GenericResourceData.

Update serialization for GenericResourceData properties to use WriteObjectValue.