### PR TITLE
[AzureMonitorExporter] updating track activity events method to also track non-exception events

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
@@ -32,7 +32,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 // Check for Exceptions events
                 if (activity.Events.Any())
                 {
-                    AddExceptionTelemetryFromActivityExceptionEvents(activity, telemetryItem, telemetryItems);
+                    AddExceptionAndEventTelemetryFromActivityEvents(activity, telemetryItem, telemetryItems);
                 }
 
                 switch (activity.GetTelemetryType())
@@ -175,7 +175,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             return activity.DisplayName;
         }
 
-        private static void AddExceptionTelemetryFromActivityExceptionEvents(Activity activity, TelemetryItem telemetryItem, List<TelemetryItem> telemetryItems)
+        private static void AddExceptionAndEventTelemetryFromActivityEvents(Activity activity, TelemetryItem telemetryItem, List<TelemetryItem> telemetryItems)
         {
             foreach (var evnt in activity.Events)
             {
@@ -185,7 +185,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     {
                         TryAddExceptionTelemetryFromActivityExceptionEvents(activity, telemetryItem, telemetryItems, evnt);
                     }
-                    else
+                    else if (!string.IsNullOrWhiteSpace(evnt.Name))
                     {
                         TryAddEventTelemetryFromActivityEvents(activity, telemetryItem, telemetryItems, evnt);
                     }
@@ -213,7 +213,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             var eventData = GetEventDataDetailsOnTelemetryItem(evnt.Name, evnt.Tags);
             if (eventData != null)
             {
-                var eventTelemetryItem = new TelemetryItem(telemetryItem, activity.SpanId, activity.Kind, evnt.Timestamp);
+                var eventTelemetryItem = new TelemetryItem(telemetryItem, activity.SpanId, activity.Kind, evnt.Timestamp, isAnEvent: true);
                 eventTelemetryItem.Data = eventData;
                 telemetryItems.Add(eventTelemetryItem);
             }
@@ -278,7 +278,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         internal static MonitorBase GetEventDataDetailsOnTelemetryItem(string eventName, IEnumerable<KeyValuePair<string, object>> activityEventTags)
         {
             var eventData = new TelemetryEventData(Version, eventName);
-            foreach(var tag in activityEventTags)
+            foreach (var tag in activityEventTags)
             {
                 eventData.Properties.Add(tag.Key, tag.Value.ToString());
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
@@ -280,7 +280,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             var eventData = new TelemetryEventData(Version, eventName);
             foreach (var tag in activityEventTags)
             {
-                eventData.Properties.Add(tag.Key, tag.Value.ToString());
+                if (double.TryParse(tag.Value.ToString(), out var value))
+                {
+                    eventData.Measurements.Add(tag.Key, value);
+                }
+                else
+                {
+                    eventData.Properties.Add(tag.Key, tag.Value.ToString());
+                }
             }
 
             return new MonitorBase


### PR DESCRIPTION
Currently this exporter only logs exception events:

https://github.com/Azure/azure-sdk-for-net/blob/edd266f12d23344706e36da6e3b8eaab08de1a41/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs#L180-L200

As we can see in the official Application Insights API documentation (https://learn.microsoft.com/en-us/azure/azure-monitor/app/api-custom-events-metrics#api-summary) we can create different tracking records. I would like to use the [TrackEvent](https://learn.microsoft.com/en-us/azure/azure-monitor/app/api-custom-events-metrics#trackevent) method to store the other non-captured events.

Currently the official Application Insights Library for dotnet creates a new `EventTelemetry`:

https://github.com/microsoft/ApplicationInsights-dotnet/blob/7191788b3fb7169394e9aed64982d1128c9c9fd6/BASE/src/Microsoft.ApplicationInsights/DataContracts/EventTelemetry.cs

And it stores the properties and the metrics inside this object:

https://github.com/microsoft/ApplicationInsights-dotnet/blob/7191788b3fb7169394e9aed64982d1128c9c9fd6/BASE/src/Microsoft.ApplicationInsights/TelemetryClient.cs#L115-L130

In the other hand, I have found in the Go-Lang exporter it saves the tags as `Measurements` when it is a number and as `Properties` in other case:

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/azuremonitorexporter/trace_to_envelope.go#L647-L666


So, I have created this PR to add those currently ignored events to the "customEvents" collection:

https://github.com/Azure/azure-sdk-for-net/blob/e801e77feaebad625e9b9095746fd9ada443d96d/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs#L180-L197

To do that I have modified the `TelemetryItem` to understand items of type "Event":

https://github.com/Azure/azure-sdk-for-net/blob/e801e77feaebad625e9b9095746fd9ada443d96d/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs#L58-L61

I have added the same logic we can find in the Go-Lang exporter to create these events:

https://github.com/Azure/azure-sdk-for-net/blob/33e40783989a3cd6212692ff89daecc05e667578/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs#L278-L298

And I have created some tests to validate it works well.