### PR TITLE
[FormRecognizer] Updated FormRecongizer samples to use RecordedTestBase

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/DocumentAnalysisSamples.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/DocumentAnalysisSamples.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
+using Azure.Core.TestFramework;
+
+namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
+{
+    [LiveOnly]
+    [IgnoreServiceError(400, "InvalidRequest", Message = "Content is not accessible: Invalid data URL", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28923")]
+    public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
+    {
+    }
+}

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/DocumentAnalysisSamples.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/DocumentAnalysisSamples.cs
@@ -8,7 +8,10 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
     [LiveOnly]
     [IgnoreServiceError(400, "InvalidRequest", Message = "Content is not accessible: Invalid data URL", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28923")]
-    public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
+    public partial class DocumentAnalysisSamples : RecordedTestBase<DocumentAnalysisTestEnvironment>
     {
+        public DocumentAnalysisSamples(bool isAsync) : base(isAsync, RecordedTestMode.Live)
+        {
+        }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/SampleSnippets.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/SampleSnippets.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Threading.Tasks;
-using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
@@ -11,8 +10,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
     /// <summary>
     /// Samples that are used in the associated README.md file.
     /// </summary>
-    [LiveOnly]
-    public partial class Snippets : SamplesBase<DocumentAnalysisTestEnvironment>
+    public partial class DocumentAnalysisSamples
     {
         [RecordedTest]
         public void CreateDocumentAnalysisClient()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/SampleSnippets.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/SampleSnippets.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
+using Azure.Identity;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltDocumentFromFileAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltDocumentFromFileAsync.cs
@@ -9,9 +9,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
-    [LiveOnly]
-    [IgnoreServiceError(400, "InvalidRequest", Message = "Content is not accessible: Invalid data URL", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28923")]
-    public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
+    public partial class DocumentAnalysisSamples
     {
         [RecordedTest]
         public async Task AnalyzePrebuiltDocumentFromFileAsync()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltDocumentFromUriAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltDocumentFromUriAsync.cs
@@ -8,7 +8,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
-    public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
+    public partial class DocumentAnalysisSamples
     {
         [RecordedTest]
         public async Task AnalyzePrebuiltDocumentFromUriAsync()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromFileAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromFileAsync.cs
@@ -9,7 +9,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
-    public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
+    public partial class DocumentAnalysisSamples
     {
         [RecordedTest]
         public async Task AnalyzePrebuiltReadFromFileAsync()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromUriAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromUriAsync.cs
@@ -8,7 +8,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
-    public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
+    public partial class DocumentAnalysisSamples
     {
         [RecordedTest]
         public async Task AnalyzePrebuiltReadFromUriAsync()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithCustomModelFromFileAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithCustomModelFromFileAsync.cs
@@ -10,7 +10,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
-    public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
+    public partial class DocumentAnalysisSamples
     {
         [RecordedTest]
         public async Task AnalyzeWithCustomModelFromFileAsync()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithCustomModelFromUriAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithCustomModelFromUriAsync.cs
@@ -9,7 +9,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
-    public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
+    public partial class DocumentAnalysisSamples
     {
         [RecordedTest]
         public async Task AnalyzeWithCustomModelFromUriAsync()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromFileAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromFileAsync.cs
@@ -10,7 +10,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
-    public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
+    public partial class DocumentAnalysisSamples
     {
         [RecordedTest]
         public async Task AnalyzeWithPrebuiltModelFromFileAsync()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromUriAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromUriAsync.cs
@@ -9,7 +9,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
-    public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
+    public partial class DocumentAnalysisSamples
     {
         [RecordedTest]
         public async Task AnalyzeWithPrebuiltModelFromUriAsync()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_BuildCustomModelAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_BuildCustomModelAsync.cs
@@ -4,12 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
-    public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
+    public partial class DocumentAnalysisSamples
     {
         [RecordedTest]
         public async Task BuildCustomModelAsync()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ComposeModelAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ComposeModelAsync.cs
@@ -4,12 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
-    public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
+    public partial class DocumentAnalysisSamples
     {
         [RecordedTest]
         public async Task ComposeModelAsync()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_CopyModelToAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_CopyModelToAsync.cs
@@ -3,12 +3,11 @@
 
 using System;
 using System.Threading.Tasks;
-using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
-    public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
+    public partial class DocumentAnalysisSamples
     {
         [RecordedTest]
         public async Task CopyModelToAsync()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ExtractLayoutFromFileAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ExtractLayoutFromFileAsync.cs
@@ -9,7 +9,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
-    public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
+    public partial class DocumentAnalysisSamples
     {
         [RecordedTest]
         public async Task ExtractLayoutFromFileAsync()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ExtractLayoutFromUriAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ExtractLayoutFromUriAsync.cs
@@ -8,7 +8,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
-    public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
+    public partial class DocumentAnalysisSamples
     {
         [RecordedTest]
         public async Task ExtractLayoutFromUriAsync()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_GetAndListOperationsAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_GetAndListOperationsAsync.cs
@@ -3,12 +3,11 @@
 
 using System;
 using System.Threading.Tasks;
-using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
-    public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
+    public partial class DocumentAnalysisSamples
     {
         [RecordedTest]
         public async Task GetAndListOperationsAsync()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ManageModels.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ManageModels.cs
@@ -9,7 +9,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
-    public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
+    public partial class DocumentAnalysisSamples
     {
         [RecordedTest]
         public void ManageModels()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ManageModelsAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ManageModelsAsync.cs
@@ -3,12 +3,11 @@
 
 using System;
 using System.Threading.Tasks;
-using Azure.AI.FormRecognizer.DocumentAnalysis.Tests;
 using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
-    public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
+    public partial class DocumentAnalysisSamples
     {
         [RecordedTest]
         public async Task ManageModelsAsync()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_MockClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_MockClient.cs
@@ -12,7 +12,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
-    [IgnoreServiceError(200, "3014", Message = "Generic error during training.", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28913")]
     public partial class DocumentAnalysisSamples
     {
         [RecordedTest]

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/FormRecognizerSamples.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/FormRecognizerSamples.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.AI.FormRecognizer.Tests;
+using Azure.Core.TestFramework;
+
+namespace Azure.AI.FormRecognizer.Samples
+{
+    [LiveOnly]
+    [IgnoreServiceError(200, "3014", Message = "Generic error during training.", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28913")]
+    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    {
+    }
+}

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/FormRecognizerSamples.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/FormRecognizerSamples.cs
@@ -8,7 +8,10 @@ namespace Azure.AI.FormRecognizer.Samples
 {
     [LiveOnly]
     [IgnoreServiceError(200, "3014", Message = "Generic error during training.", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28913")]
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples : RecordedTestBase<FormRecognizerTestEnvironment>
     {
+        public FormRecognizerSamples(bool isAsync) : base(isAsync, RecordedTestMode.Live)
+        {
+        }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample10_DifferentiateOutputModelsTrainedWithAndWithoutLabels.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample10_DifferentiateOutputModelsTrainedWithAndWithoutLabels.cs
@@ -12,7 +12,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         /// This sample demonstrates the differences in output that arise when StartRecognizeCustomForms
         /// is called with custom models trained with labels and without labels.

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample11_ComposedModel.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample11_ComposedModel.cs
@@ -13,7 +13,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public async Task CreateComposedModel()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample12_RecognizeBusinessCardsFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample12_RecognizeBusinessCardsFromFile.cs
@@ -11,7 +11,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public async Task RecognizeBusinessCardsFromFile()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample12_RecognizeBusinessCardsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample12_RecognizeBusinessCardsFromUri.cs
@@ -10,7 +10,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public async Task RecognizeBusinessCardsFromUri()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample13_RecognizeInvoicesFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample13_RecognizeInvoicesFromFile.cs
@@ -12,7 +12,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public async Task RecognizeInvoicesFromFile()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample13_RecognizeInvoicesFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample13_RecognizeInvoicesFromUri.cs
@@ -11,7 +11,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public async Task RecognizeInvoicesFromUri()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample14_RecognizeIdentityDocumentsFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample14_RecognizeIdentityDocumentsFromFile.cs
@@ -11,7 +11,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public async Task RecognizeIdentityDocumentsFromFile()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample14_RecognizeIdentityDocumentsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample14_RecognizeIdentityDocumentsFromUri.cs
@@ -10,7 +10,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public async Task RecognizeIdentityDocumentsFromUri()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample15_DifferentiateOutputLabeledTables.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample15_DifferentiateOutputLabeledTables.cs
@@ -11,7 +11,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         /// This sample demonstrates the differences in output that arise when BeginRecognizeCustomForms
         /// is called with custom models trained with fixed vs. dynamic table tags.

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample1_RecognizeContentFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample1_RecognizeContentFromFile.cs
@@ -10,7 +10,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public async Task RecognizeContentFromFile()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample1_RecognizeContentFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample1_RecognizeContentFromUri.cs
@@ -9,7 +9,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public async Task RecognizeContentFromUri()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample2_RecognizeCustomFormsFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample2_RecognizeCustomFormsFromFile.cs
@@ -11,7 +11,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public async Task RecognizeCustomFormsFromFile()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample2_RecognizeCustomFormsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample2_RecognizeCustomFormsFromUri.cs
@@ -10,7 +10,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public async Task RecognizeCustomFormsFromUri()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample3_RecognizeReceiptsFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample3_RecognizeReceiptsFromFile.cs
@@ -11,7 +11,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public async Task RecognizeReceiptsFromFile()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample3_RecognizeReceiptsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample3_RecognizeReceiptsFromUri.cs
@@ -10,7 +10,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public async Task RecognizeReceiptsFromUri()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample4_StronglyTypingARecognizedForm.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample4_StronglyTypingARecognizedForm.cs
@@ -9,7 +9,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public async Task StronglyTypingARecognizedForm()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample5_TrainModelWithForms.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample5_TrainModelWithForms.cs
@@ -3,13 +3,12 @@
 
 using System;
 using System.Threading.Tasks;
-using Azure.AI.FormRecognizer.Tests;
 using Azure.AI.FormRecognizer.Training;
 using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public async Task TrainModelWithForms()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample6_TrainModelWithFormsAndLabels.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample6_TrainModelWithFormsAndLabels.cs
@@ -3,13 +3,12 @@
 
 using System;
 using System.Threading.Tasks;
-using Azure.AI.FormRecognizer.Tests;
 using Azure.AI.FormRecognizer.Training;
 using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public async Task TrainModelWithFormsAndLabels()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample7_ManageCustomModels.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample7_ManageCustomModels.cs
@@ -4,13 +4,12 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Azure.AI.FormRecognizer.Tests;
 using Azure.AI.FormRecognizer.Training;
 using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public async Task ManageCustomModels()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample7_ManageCustomModelsAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample7_ManageCustomModelsAsync.cs
@@ -3,13 +3,12 @@
 
 using System;
 using System.Threading.Tasks;
-using Azure.AI.FormRecognizer.Tests;
 using Azure.AI.FormRecognizer.Training;
 using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public async Task ManageCustomModelsAsync()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample8_CopyModel.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample8_CopyModel.cs
@@ -3,13 +3,12 @@
 
 using System;
 using System.Threading.Tasks;
-using Azure.AI.FormRecognizer.Tests;
 using Azure.AI.FormRecognizer.Training;
 using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public async Task CopyModel()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample9_FieldBoundingBox.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample9_FieldBoundingBox.cs
@@ -10,7 +10,7 @@ using Azure.Core.TestFramework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    public partial class FormRecognizerSamples : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         /// <summary>
         /// This sample illustrates how to consume a FieldBoundingBox type data that is available across the Form Recognizer library.

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/SampleSnippets.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/SampleSnippets.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
-using Azure.AI.FormRecognizer.Tests;
 using Azure.AI.FormRecognizer.Training;
 using Azure.Core.TestFramework;
 
@@ -13,8 +12,7 @@ namespace Azure.AI.FormRecognizer.Samples
     /// <summary>
     /// Samples that are used in the associated README.md file.
     /// </summary>
-    [LiveOnly]
-    public partial class Snippets : SamplesBase<FormRecognizerTestEnvironment>
+    public partial class FormRecognizerSamples
     {
         [RecordedTest]
         public void CreateFormRecognizerClient()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/SampleSnippets.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/SampleSnippets.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Training;
 using Azure.Core.TestFramework;
+using Azure.Identity;
 
 namespace Azure.AI.FormRecognizer.Samples
 {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample_MockClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample_MockClient.cs
@@ -14,8 +14,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.FormRecognizer.Samples
 {
-    [LiveOnly]
-    [IgnoreServiceError(200, "3014", Message = "Generic error during training.", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28913")]
     public partial class FormRecognizerSamples
     {
         [RecordedTest]


### PR DESCRIPTION
This ensures the `IgnoreServiceError` attribute will work with samples, making our pipeline green again.

For more context, this issue describes the service errors we've been seeing in the last couple of months: https://github.com/Azure/azure-sdk-for-net/issues/31914

Issues https://github.com/Azure/azure-sdk-for-net/issues/28913 and https://github.com/Azure/azure-sdk-for-net/issues/28923 track our uses of the `IgnoreServiceError` attribute, to make sure we don't forget to remove them when the service fixes these errors.