### PR TITLE
WIP: Use operator precedence to avoid unnecessary parentheses and nesting

### DIFF
--- a/sdk/tables/Azure.Data.Tables/src/Queryable/ExpressionPrecedenceComparer.cs
+++ b/sdk/tables/Azure.Data.Tables/src/Queryable/ExpressionPrecedenceComparer.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Azure.Data.Tables.Queryable
+{
+    internal sealed class ExpressionPrecedenceComparer : IComparer<Expression>
+    {
+        //From (2.2.3.6.1.1.2 Operator Precedence) https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-odata/f3380585-3f87-41d9-a2dc-ff46cc38e7a6
+        private const byte PrimaryPrecedenceCategory = 8;
+        private const byte UnaryPrecedenceCategory = 7;
+        private const byte MultiplicativePrecedenceCategory = 6;
+        private const byte AdditivePrecedenceCategory = 5;
+        private const byte RelationalPrecedenceCategory = 4;
+        private const byte EqualityPrecedenceCategory = 3;
+        private const byte ConditionalAndPrecedenceCategory = 2;
+        private const byte ConditionalOrPrecedenceCategory = 1;
+
+        private static Dictionary<ExpressionType, byte> _operatorPrecedence = new Dictionary<ExpressionType, byte>
+        {
+            {
+                ExpressionType.MemberAccess, PrimaryPrecedenceCategory
+            },
+            {
+                ExpressionType.Call, PrimaryPrecedenceCategory
+            },
+            {
+                ExpressionType.Negate, UnaryPrecedenceCategory
+            },
+            {
+                ExpressionType.Not, UnaryPrecedenceCategory
+            },
+            {
+                ExpressionType.Convert, UnaryPrecedenceCategory
+            },
+            {
+                ExpressionType.Multiply, MultiplicativePrecedenceCategory
+            },
+            {
+                ExpressionType.MultiplyChecked, MultiplicativePrecedenceCategory
+            },
+            {
+                ExpressionType.Divide, MultiplicativePrecedenceCategory
+            },
+            {
+                ExpressionType.Add, AdditivePrecedenceCategory
+            },
+            {
+                ExpressionType.AddChecked, AdditivePrecedenceCategory
+            },
+            {
+                ExpressionType.Subtract, AdditivePrecedenceCategory
+            },
+            {
+                ExpressionType.SubtractChecked, AdditivePrecedenceCategory
+            },
+            {
+                ExpressionType.LessThan, RelationalPrecedenceCategory
+            },
+            {
+                ExpressionType.GreaterThan, RelationalPrecedenceCategory
+            },
+            {
+                ExpressionType.LessThanOrEqual, RelationalPrecedenceCategory
+            },
+            {
+                ExpressionType.GreaterThanOrEqual, RelationalPrecedenceCategory
+            },
+            {
+                ExpressionType.Equal, EqualityPrecedenceCategory
+            },
+            {
+                ExpressionType.NotEqual, EqualityPrecedenceCategory
+            },
+            {
+                ExpressionType.And, ConditionalAndPrecedenceCategory
+            },
+            {
+                ExpressionType.AndAlso, ConditionalAndPrecedenceCategory
+            },
+            {
+                ExpressionType.Or, ConditionalOrPrecedenceCategory
+            },
+            {
+                ExpressionType.OrElse, ConditionalOrPrecedenceCategory
+            }
+        };
+
+        static ExpressionPrecedenceComparer()
+        {
+            Instance = new ExpressionPrecedenceComparer();
+        }
+
+        public static ExpressionPrecedenceComparer Instance { get; }
+
+        private ExpressionPrecedenceComparer()
+        {
+        }
+        public int Compare(Expression x, Expression y)
+        {
+            if (_operatorPrecedence.TryGetValue(x.NodeType, out var xPrecedence) && _operatorPrecedence.TryGetValue(y.NodeType, out var yPrecedence))
+            {
+                return xPrecedence.CompareTo(yPrecedence);
+            }
+            return 0;
+        }
+    }
+}

--- a/sdk/tables/Azure.Data.Tables/tests/TableClientQueryExpressionTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableClientQueryExpressionTests.cs
@@ -78,6 +78,7 @@ namespace Azure.Data.Tables.Tests
         private static readonly Expression<Func<TableEntity, bool>> s_binaryExpDE = ent => ent.GetBinaryData("Binary") == s_someBinaryData;
         private static readonly Expression<Func<ComplexEntity, bool>> s_complexExp = ent => ent.String.CompareTo(SomeString) >= 0 && ent.Int64 >= SomeInt64 && ent.Int32 >= SomeInt && ent.DateTime >= s_someDateTime;
         private static readonly Expression<Func<TableEntity, bool>> s_complexExpDE = ent => ent.GetString("String").CompareTo(SomeString) >= 0 && ent.GetInt64("Int64") >= SomeInt64 && ent.GetInt32("Int32") >= SomeInt && ent.GetDateTime("DateTime") >= s_someDateTime;
+        private static readonly Expression<Func<ComplexEntity, bool>> s_veryComplexExp = ent => ent.String.CompareTo(SomeString) >= 0 && (ent.Int64 >= SomeInt64 || ent.Int32 >= SomeInt) && ent.DateTime >= s_someDateTime && !ent.Bool;
         private static readonly Expression<Func<ComplexEntity, bool>> s_complexExpImplicitBooleanCmp = ent => ent.Bool;
         private static readonly Expression<Func<ComplexEntity, bool>> s_complexExpImplicitNullableBooleanCmp = ent => ent.BoolN.Value;
         private static readonly Expression<Func<ComplexEntity, bool>> s_complexExpImplicitBooleanCmpNot = ent => !ent.Bool;
@@ -91,12 +92,12 @@ namespace Azure.Data.Tables.Tests
 
         public static object[] TableEntityExpressionTestCases =
         {
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey ne '{Row}')", s_ne },
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey gt '{Row}')", s_gt },
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey ge '{Row}')", s_ge },
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey lt '{Row}')", s_lt },
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey le '{Row}')", s_le },
-            new object[] { $"(PartitionKey eq '{Partition}') or (RowKey eq '{Row}')", s_or },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey ne '{Row}'", s_ne },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey gt '{Row}'", s_gt },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey ge '{Row}'", s_ge },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey lt '{Row}'", s_lt },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey le '{Row}'", s_le },
+            new object[] { $"PartitionKey eq '{Partition}' or RowKey eq '{Row}'", s_or },
             new object[] { $"String ge '{SomeString}'", s_compareToExp },
             new object[] { $"Guid eq guid'{s_someGuidString}'", s_guidExp },
             new object[] { $"Int64 ge {SomeInt64}L", s_int64Exp },
@@ -108,13 +109,14 @@ namespace Azure.Data.Tables.Tests
             new object[] { $"Bool eq false", s_boolFalseExp },
             new object[] { $"Binary eq X'{string.Join(string.Empty, s_someBinary.Select(b => b.ToString("X2")))}'", s_binaryExp },
             new object[] { $"Binary eq X'{string.Join(string.Empty, s_someBinaryData.ToArray().Select(b => b.ToString("X2")))}'", s_binaryExp },
-            new object[] { $"(((String ge '{SomeString}') and (Int64 ge {SomeInt64}L)) and (Int32 ge {SomeInt})) and (DateTime ge datetime'{s_someDateTimeOffsetRoundtrip}')", s_complexExp },
+            new object[] { $"String ge '{SomeString}' and Int64 ge {SomeInt64}L and Int32 ge {SomeInt} and DateTime ge datetime'{s_someDateTimeOffsetRoundtrip}'", s_complexExp },
+            new object[] { $"String ge '{SomeString}' and (Int64 ge {SomeInt64}L or Int32 ge {SomeInt}) and DateTime ge datetime'{s_someDateTimeOffsetRoundtrip}' and not (Bool eq true)", s_veryComplexExp },
             new object[] { $"Bool eq true", s_complexExpImplicitBooleanCmp },
             new object[] { $"BoolN eq true", s_complexExpImplicitNullableBooleanCmp },
             new object[] { $"not (Bool eq true)", s_complexExpImplicitBooleanCmpNot },
             new object[] { $"BoolN eq true", s_complexExpImplicitCastedNullableBooleanCmp },
-            new object[] { $"(Bool eq true) and (BoolN eq true)", s_complexExpImplicitBooleanCmpAnd },
-            new object[] { $"(Bool eq true) or (BoolN eq true)", s_complexExpImplicitCastedBooleanCmpOr }
+            new object[] { $"Bool eq true and BoolN eq true", s_complexExpImplicitBooleanCmpAnd },
+            new object[] { $"Bool eq true or BoolN eq true", s_complexExpImplicitCastedBooleanCmpOr }
         };
 
         public static object[] TableItemExpressionTestCases =
@@ -122,20 +124,20 @@ namespace Azure.Data.Tables.Tests
             new object[] { $"TableName ne '{TableName}'", s_ne_TI },
             new object[] { $"TableName gt '{TableName}'", s_gt_TI },
             new object[] { $"TableName ge '{TableName}'", s_ge_TI },
-            new object[] { $"(TableName le '{TableName}') and (TableName ge '{TableName2}')", s_lege_TI },
+            new object[] { $"TableName le '{TableName}' and TableName ge '{TableName2}'", s_lege_TI },
             new object[] { $"TableName lt '{TableName}'", s_lt_TI },
             new object[] { $"TableName le '{TableName}'", s_le_TI },
-            new object[] { $"(TableName eq '{TableName}') or (TableName eq '{TableName2}')", s_or_TI },
+            new object[] { $"TableName eq '{TableName}' or TableName eq '{TableName2}'", s_or_TI },
         };
 
         public static object[] DictionaryTableEntityExpressionTestCases =
         {
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey ne '{Row}')", s_neDE },
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey gt '{Row}')", s_gtDE },
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey ge '{Row}')", s_geDE },
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey lt '{Row}')", s_ltDE },
-            new object[] { $"(PartitionKey eq '{Partition}') and (RowKey le '{Row}')", s_leDE },
-            new object[] { $"(PartitionKey eq '{Partition}') or (RowKey eq '{Row}')", s_orDE },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey ne '{Row}'", s_neDE },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey gt '{Row}'", s_gtDE },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey ge '{Row}'", s_geDE },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey lt '{Row}'", s_ltDE },
+            new object[] { $"PartitionKey eq '{Partition}' and RowKey le '{Row}'", s_leDE },
+            new object[] { $"PartitionKey eq '{Partition}' or RowKey eq '{Row}'", s_orDE },
             new object[] { $"String ge '{SomeString}'", s_compareToExpDE },
             new object[] { $"Guid eq guid'{s_someGuidString}'", s_guidExpDE },
             new object[] { $"Int64 ge {SomeInt64}L", s_int64ExpDE },
@@ -147,10 +149,10 @@ namespace Azure.Data.Tables.Tests
             new object[] { $"Bool eq false", s_boolFalseExpDE },
             new object[] { $"Binary eq X'{string.Join(string.Empty, s_someBinary.Select(b => b.ToString("X2")))}'", s_binaryExpDE },
             new object[] { $"Binary eq X'{string.Join(string.Empty, s_someBinaryData.ToArray().Select(b => b.ToString("X2")))}'", s_binaryExpDE },
-            new object[] { $"(((String ge '{SomeString}') and (Int64 ge {SomeInt64}L)) and (Int32 ge {SomeInt})) and (DateTime ge datetime'{s_someDateTimeOffsetRoundtrip}')", s_complexExpDE },
+            new object[] { $"String ge '{SomeString}' and Int64 ge {SomeInt64}L and Int32 ge {SomeInt} and DateTime ge datetime'{s_someDateTimeOffsetRoundtrip}'", s_complexExpDE },
             new object[] { $"Bool eq true", s_tableEntExpImplicitBooleanCmp },
             new object[] { $"Bool eq true", s_tableEntExpImplicitBooleanCmpCasted },
-            new object[] { $"(Bool eq true) or (Bool eq true)", s_tableEntExpImplicitBooleanCmpOr },
+            new object[] { $"Bool eq true or Bool eq true", s_tableEntExpImplicitBooleanCmpOr },
             new object[] { $"not (Bool eq true)", s_tableEntExpImplicitBooleanCmpNot }
         };
 


### PR DESCRIPTION
When the LINQ expression is converted to a query string, lots of parentheses are included, for good measure. It's certainly correct, but:

1. It increases the length, sometimes significantly. 
2. The parser on the receiving end doesn't like the nesting.

This PR was initiated by what happened when we moved from the old Cosmos library to this. We had a very large, dynamically generated query (one partitionkey, lots of suggested rowkeys), which utilized the old TableQuery class to generate the query string. We converted this to a LINQ expression but ran into issues in production, when the table service responded with a Bad Request: "Recursion depth exceeded allowed limit". 
We realized this was due to all the "RowKey='a' or (RowKey='b' or (RowKey='c' .....", where every binary expression is encapsulated in parentheses. An OData "in" would have been nicer, but the table service doesn't support it.

The PR attempts to check operator precedence in order to insert parentheses only when it's necessary.