### PR TITLE
[AzureMonitorExporter] add package tag for "ApplicationInsights"

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
@@ -3,7 +3,7 @@
     <Description>An OpenTelemetry .NET exporter that exports to Azure Monitor</Description>
     <AssemblyTitle>AzureMonitor OpenTelemetry Exporter</AssemblyTitle>
     <Version>1.0.0-beta.6</Version>
-    <PackageTags>Azure Monitor OpenTelemetry Exporter</PackageTags>
+    <PackageTags>Azure Monitor OpenTelemetry Exporter ApplicationInsights</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>


### PR DESCRIPTION
Adding "ApplicationInsights" to the PackageTags will help with discoverability. This tag is used today by all of the Application Insights SDKs, as well as other SDKs published from this repository.
We still refer to Application Insights in our ReadMe for the onboarding instructions and I think it's valid to include it here.

### Changes
- Add "ApplicationInsights" to the Package Tags.


[Azure Monitor Exporter](https://www.nuget.org/packages/Azure.Monitor.OpenTelemetry.Exporter):
![image](https://user-images.githubusercontent.com/28785781/202523334-62a3f402-74f8-4fe7-b124-eb760a1c3323.png)

[Application Insights SDK](https://www.nuget.org/packages/Microsoft.ApplicationInsights):
![image](https://user-images.githubusercontent.com/28785781/202523407-336ae932-d965-4c83-a2d4-6ac2623cd49f.png)
