### PR TITLE
Switch to script over pwsh to enable command logging

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -87,11 +87,11 @@ jobs:
             Write-Host "##vso[task.setvariable variable=CodeCoverageFilePattern]$(Build.SourcesDirectory)\sdk\${{parameters.ServiceDirectory}}\**\coverage.cobertura.xml"
           }
         displayName: Set variable for the project list file and coverage directory
-      - pwsh: >-
+      - script: >-
           dotnet test eng/service.proj
-          --filter '(TestCategory!=Manually) & (TestCategory!=Live) & ($(AdditionalTestFilters))'
+          --filter "(TestCategory!=Manually) & (TestCategory!=Live) & ($(AdditionalTestFilters))"
           --framework $(TestTargetFramework)
-          --logger 'trx;LogFileName=$(TestTargetFramework).trx' --logger:'console;verbosity=normal'
+          --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal"
           --blame-crash-dump-type full --blame-hang-dump-type full --blame-hang-timeout ${{parameters.TestTimeoutInMinutes}}minutes
           /p:SDKType=${{ parameters.SDKType }}
           /p:ServiceDirectory=${{ parameters.ServiceDirectory }}

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -131,11 +131,11 @@ jobs:
       - template: /eng/pipelines/templates/steps/install-dotnet.yml
         parameters:
           Container: ${{ parameters.UsePlatformContainer }}
-      - pwsh: >
+      - script: >
           dotnet test eng/service.proj
           --framework $(TestTargetFramework)
-          --filter 'TestCategory!=Manually & ($(AdditionalTestFilters))'
-          --logger 'trx'
+          --filter "TestCategory!=Manually & ($(AdditionalTestFilters))"
+          --logger "trx"
           --logger:"console;verbosity=normal"
           --blame-crash-dump-type full --blame-hang-dump-type full --blame-hang-timeout ${{parameters.TimeoutInMinutes}}minutes
           /p:SDKType=${{ parameters.SDKType }}


### PR DESCRIPTION
If we use the script block instead of pwsh the DevOPs task will output the script command line in the logs which is very helpful when trying to reproduce a test failure locally.

As part of this also need to switch to double quotes as single quotes don't work in the script block correctly.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
