### PR TITLE
[AzureMonitorExporter] cleanup csproj. add missing XML comments

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
@@ -27,7 +27,7 @@
   <PropertyGroup>
     <!-- TODO: As part of release process, this PropertyGroup can be removed once RP is approved for namespace
       https://github.com/Azure/azure-sdk-for-net/issues/17155 -->
-    <NoWarn>$(NoWarn);AZC0001;CS0108;CS1591</NoWarn>
+    <NoWarn>$(NoWarn);AZC0001</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
@@ -39,6 +39,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             this.Version = version;
         }
 
+        /// <summary>
+        /// The versions of Azure Monitor supported by this client library.
+        /// </summary>
         [SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "This naming format is defined in the Azure SDK Design Guidelines.")]
         public enum ServiceVersion
         {
@@ -48,8 +51,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             V2020_09_15_Preview = 1,
         }
 
+        /// <summary>
+        /// Override the default directory for offline storage.
+        /// </summary>
         public string StorageDirectory { get; set; }
 
+        /// <summary>
+        /// Disable offilne storage.
+        /// </summary>
         public bool DisableOfflineStorage { get; set; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
@@ -57,7 +57,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public string StorageDirectory { get; set; }
 
         /// <summary>
-        /// Disable offilne storage.
+        /// Disable offline storage.
         /// </summary>
         public bool DisableOfflineStorage { get; set; }
     }


### PR DESCRIPTION

### Changes
- remove NoWarn from csproj
- Resolve CS1591: Missing XML comment for publicaly visible type or member.