### PR TITLE
Redirect customers from sources to samples

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -9,6 +9,7 @@ omitted_paths:
   - samples/*
   - sdk/*/*.Management.*/*
   - sdk/*/*/perf/*
+  - sdk/*/*/tests/samples/*
   - sdk/*/*/samples/*
   - sdk/*/samples/*
   - sdk/*/swagger/*
@@ -69,16 +70,16 @@ known_presence_issues:
   - ['sdk/keyvault/Microsoft.Azure.KeyVault.Cryptography','Track 1']
   - ['sdk/keyvault/Microsoft.Azure.KeyVault.Extensions','Track 1']
   - ['sdk/keyvault/Microsoft.Azure.KeyVault.WebKey','Track 1']
-  - ['sdk/operationalinsights/Microsoft.Azure.OperationalInsights','Track 1']  
+  - ['sdk/operationalinsights/Microsoft.Azure.OperationalInsights','Track 1']
   - ['sdk/search/Microsoft.Azure.Search.Common','Track 1']
   - ['sdk/search/Microsoft.Azure.Search.Data','Track 1']
-  - ['sdk/search/Microsoft.Azure.Search.Service','Track 1']  
+  - ['sdk/search/Microsoft.Azure.Search.Service','Track 1']
   - ['sdk/operationalinsights/Microsoft.Azure.OperationalInsights','Track 1']
   - ['sdk/search/Microsoft.Azure.Search','Track 1']
   - ['sdk/search/Microsoft.Azure.Search.Common/CHANGELOG.md','Track 1']
   - ['sdk/search/Microsoft.Azure.Search.Data/CHANGELOG.md','Track 1']
   - ['sdk/search/Microsoft.Azure.Search.Service/CHANGELOG.md','Track 1']
-  
+
   - ['sdk/eventgrid/Azure.Messaging.EventGrid/EventGridSourceGenerator','https://github.com/Azure/azure-sdk-tools/issues/2444']
 
 known_content_issues:
@@ -100,7 +101,7 @@ known_content_issues:
   - ['sdk/eventhub/README.md','Not a package: azure-sdk-tools/issues/42']
   - ['sdk/extensions/README.md','Not a package: azure-sdk-tools/issues/42']
   - ['sdk/personalizer/README.md','Not a package: azure-sdk-tools/issues/42']
-  - ['sdk/search/README.md','Not a package: azure-sdk-tools/issues/42']  
+  - ['sdk/search/README.md','Not a package: azure-sdk-tools/issues/42']
   - ['sdk/storage/README.md','Not a package: azure-sdk-tools/issues/42']
 
   - ['sdk/core/Azure.Core.Amqp/README.md', 'Opt out of sections: https://github.com/Azure/azure-sdk-tools/issues/404']

--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -9,6 +9,7 @@ omitted_paths:
   - samples/*
   - sdk/*/*.Management.*/*
   - sdk/*/*/perf/*
+  - sdk/*/*/tests/Samples/*
   - sdk/*/*/tests/samples/*
   - sdk/*/*/samples/*
   - sdk/*/samples/*

--- a/sdk/anomalydetector/Azure.AI.AnomalyDetector/samples/Sample1_DetectEntireSeriesAnomaly.md
+++ b/sdk/anomalydetector/Azure.AI.AnomalyDetector/samples/Sample1_DetectEntireSeriesAnomaly.md
@@ -82,9 +82,6 @@ catch (Exception ex)
     throw;
 }
 ```
-To see the full example source files, see:
-
-* [Detect Entire Series Anomaly](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/anomalydetector/Azure.AI.AnomalyDetector/tests/samples/Sample1_DetectEntireSeriesAnomaly.cs)
 
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/anomalydetector/Azure.AI.AnomalyDetector/README.md
 [SampleData]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/anomalydetector/Azure.AI.AnomalyDetector/tests/samples/data/request-data.csv

--- a/sdk/anomalydetector/Azure.AI.AnomalyDetector/samples/Sample2_DetectLastPointAnomaly.md
+++ b/sdk/anomalydetector/Azure.AI.AnomalyDetector/samples/Sample2_DetectLastPointAnomaly.md
@@ -77,9 +77,6 @@ catch (Exception ex)
     throw;
 }
 ```
-To see the full example source files, see:
-
-* [Detect Last Point Anomaly](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/anomalydetector/Azure.AI.AnomalyDetector/tests/samples/Sample2_DetectLastPointAnomaly.cs)
 
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/anomalydetector/Azure.AI.AnomalyDetector/README.md
 [SampleData]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/anomalydetector/Azure.AI.AnomalyDetector/tests/samples/data/request-data.csv

--- a/sdk/anomalydetector/Azure.AI.AnomalyDetector/samples/Sample3_DetectChangePoint.md
+++ b/sdk/anomalydetector/Azure.AI.AnomalyDetector/samples/Sample3_DetectChangePoint.md
@@ -70,9 +70,6 @@ else
     Console.WriteLine("No change point detected in the series.");
 }
 ```
-To see the full example source files, see:
-
-* [Detect Change Point](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/anomalydetector/Azure.AI.AnomalyDetector/tests/samples/Sample3_DetectChangePoint.cs)
 
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/anomalydetector/Azure.AI.AnomalyDetector/README.md
 [SampleData]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/anomalydetector/Azure.AI.AnomalyDetector/tests/samples/data/request-data.csv

--- a/sdk/anomalydetector/Azure.AI.AnomalyDetector/samples/Sample4_MultivariateDetect.md
+++ b/sdk/anomalydetector/Azure.AI.AnomalyDetector/samples/Sample4_MultivariateDetect.md
@@ -27,7 +27,7 @@ Create a new private async task as below to handle training your model. You will
 
 You could add the data source, along with start time and end time to a `ModelInfo` object to create a data feed. The data source is a shared access signature(SAS) link in the format https://\[placeholder\]/. To generate the datasource link, you could first download our [sample data][datasource], then upload it to a azure container according to the [Upload a block blob][upload_blob] documentation and get the SAS link of the data according to the [Create SAS tokens for blobs in the Azure portal][generate_sas] documentation.
 
-Call `TrainMultivariateModel` with the created data feed and extract the model ID from the response header. Afterwards, you can get the model info, including the model status, by calling `GetMultivariateModelAsync` with the model ID . Wait until the model status is ready. 
+Call `TrainMultivariateModel` with the created data feed and extract the model ID from the response header. Afterwards, you can get the model info, including the model status, by calling `GetMultivariateModelAsync` with the model ID . Wait until the model status is ready.
 
 ```C# Snippet:TrainMultivariateModel
 private async Task<Guid?> TrainAsync(AnomalyDetectorClient client, string datasource, DateTimeOffset start_time, DateTimeOffset end_time, int max_tryout = 500)
@@ -83,7 +83,7 @@ private async Task<Guid?> TrainAsync(AnomalyDetectorClient client, string dataso
 
 ## Detect anomalies
 
-To detect anomalies using your newly trained model, create a private async Task named `DetectAsync`. You will create a new `DetectionRequest`, pass that as a parameter to `DetectAnomalyAsync` and await the response. From the header of the response, you could extract the result ID. With the result ID, you could get the detection content and detection status by `GetDetectionResultAsync`. Return the detection content when the detection status is ready. 
+To detect anomalies using your newly trained model, create a private async Task named `DetectAsync`. You will create a new `DetectionRequest`, pass that as a parameter to `DetectAnomalyAsync` and await the response. From the header of the response, you could extract the result ID. With the result ID, you could get the detection content and detection status by `GetDetectionResultAsync`. Return the detection content when the detection status is ready.
 
 ```C# Snippet:DetectMultivariateAnomaly
 private async Task<DetectionResult> DetectAsync(AnomalyDetectorClient client, string datasource, Guid model_id,DateTimeOffset start_time, DateTimeOffset end_time, int max_tryout = 500)
@@ -125,7 +125,7 @@ private async Task<DetectionResult> DetectAsync(AnomalyDetectorClient client, st
 
 ## Detect last anomalies
 
-To detect anomalies using your newly trained model, create a private async Task named `DetectLastAsync`. You will create a new `LastDetectionRequest`, you could assign how many last points you want to detect in the request. Pass `LastDetectionRequest` as a parameter to `LastDetectAnomalyAsync` and await the response. Return the detection content when the detection status is ready. 
+To detect anomalies using your newly trained model, create a private async Task named `DetectLastAsync`. You will create a new `LastDetectionRequest`, you could assign how many last points you want to detect in the request. Pass `LastDetectionRequest` as a parameter to `LastDetectAnomalyAsync` and await the response. Return the detection content when the detection status is ready.
 
 ```C# Snippet:DetectLastMultivariateAnomaly
 private async Task<LastDetectionResult> DetectLastAsync(AnomalyDetectorClient client, Guid model_id)
@@ -217,10 +217,6 @@ private async Task<int> GetModelNumberAsync(AnomalyDetectorClient client, bool d
     return count;
 }
 ```
-
-To see the full example source files, see:
-
-* [Multivariate Detect](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/anomalydetector/Azure.AI.AnomalyDetector/tests/samples/Sample4_MultivariateDetect.cs)
 
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/anomalydetector/Azure.AI.AnomalyDetector/README.md
 [datasource]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/anomalydetector/Azure.AI.AnomalyDetector/tests/samples/data/sample_data_20_3000.zip

--- a/sdk/anomalydetector/Azure.AI.AnomalyDetector/tests/samples/README.md
+++ b/sdk/anomalydetector/Azure.AI.AnomalyDetector/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/anomalydetector/Azure.AI.AnomalyDetector/samples) for more explanation about how to use this client library.

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample7_MockClient.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample7_MockClient.md
@@ -4,7 +4,7 @@ This sample illustrates how to use [Moq](https://github.com/Moq/moq4/) to create
 
 ## Define method that uses `ConfigurationClient`
 
-To show the usage of mocks, define a method that will be tested with mocked objects. For more details about this sample method, see "[Update a Configuration If Unchanged](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample6_UpdateSettingIfUnchanged.md)" sample.  
+To show the usage of mocks, define a method that will be tested with mocked objects. For more details about this sample method, see "[Update a Configuration If Unchanged](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample6_UpdateSettingIfUnchanged.md)" sample.
 
 ```C# Snippet:AzConfigSample7_MethodToTest
 private static async Task<int> UpdateAvailableVmsAsync(ConfigurationClient client, int releasedVMs, CancellationToken cancellationToken)
@@ -58,5 +58,3 @@ ConfigurationClient client = mockClient.Object;
 int availableVms = await UpdateAvailableVmsAsync(client, 2, default);
 Assert.AreEqual(12, availableVms);
 ```
-
-

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/README.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/appconfiguration/Azure.Data.AppConfiguration/samples) for more explanation about how to use this client library.

--- a/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/tests/Samples/README.md
+++ b/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/samples) for more explanation about how to use this client library.

--- a/sdk/cdn/Azure.ResourceManager.Cdn/tests/Samples/README.md
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/cdn/Azure.ResourceManager.Cdn/samples) for more explanation about how to use this client library.

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/README.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples) for more explanation about how to use this client library.

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/Samples/README.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/samples) for more explanation about how to use this client library.

--- a/sdk/communication/Azure.Communication.AlphaIds/tests/Samples/README.md
+++ b/sdk/communication/Azure.Communication.AlphaIds/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/communication/Azure.Communication.AlphaIds/samples) for more explanation about how to use this client library.

--- a/sdk/communication/Azure.Communication.CallAutomation/samples/Sample1_CreateCall.md
+++ b/sdk/communication/Azure.Communication.CallAutomation/samples/Sample1_CreateCall.md
@@ -31,8 +31,4 @@ CreateCallResult createCallResult = callAutomationClient.CreateCall(
 Console.WriteLine($"Call connection id: {createCallResult.CallConnectionProperties.CallConnectionId}");
 ```
 
-To see the full example source files, see:
-
-* [Make a call to a phone number recipient](https://github.com/Azure/azure-sdk-for-net/blob/a20e269162fa88a43e5ba0e5bb28f2e76c74a484/sdk/communication/Azure.Communication.CallingServer/tests/samples/Sample1_CallClient.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/a20e269162fa88a43e5ba0e5bb28f2e76c74a484/sdk/communication/Azure.Communication.CallingServer/README.md#getting-started

--- a/sdk/communication/Azure.Communication.CallAutomation/samples/Sample1_CreateCallAsync.md
+++ b/sdk/communication/Azure.Communication.CallAutomation/samples/Sample1_CreateCallAsync.md
@@ -31,8 +31,4 @@ CreateCallResult createCallResult = await callAutomationClient.CreateCallAsync(
 Console.WriteLine($"Call connection id: {createCallResult.CallConnectionProperties.CallConnectionId}");
 ```
 
-To see the full example source files, see:
-
-* [Make a call to a phone number recipient](https://github.com/Azure/azure-sdk-for-net/blob/a20e269162fa88a43e5ba0e5bb28f2e76c74a484/sdk/communication/Azure.Communication.CallingServer/tests/samples/Sample1_CallClient.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/a20e269162fa88a43e5ba0e5bb28f2e76c74a484/sdk/communication/Azure.Communication.CallingServer/README.md#getting-started

--- a/sdk/communication/Azure.Communication.CallingServer/samples/Sample1_CreateCall.md
+++ b/sdk/communication/Azure.Communication.CallingServer/samples/Sample1_CreateCall.md
@@ -31,8 +31,4 @@ CreateCallResult createCallResult = callAutomationClient.CreateCall(
 Console.WriteLine($"Call connection id: {createCallResult.CallConnectionProperties.CallConnectionId}");
 ```
 
-To see the full example source files, see:
-
-* [Make a call to a phone number recipient](https://github.com/Azure/azure-sdk-for-net/blob/a20e269162fa88a43e5ba0e5bb28f2e76c74a484/sdk/communication/Azure.Communication.CallingServer/tests/samples/Sample1_CallClient.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/a20e269162fa88a43e5ba0e5bb28f2e76c74a484/sdk/communication/Azure.Communication.CallingServer/README.md#getting-started

--- a/sdk/communication/Azure.Communication.CallingServer/samples/Sample1_CreateCallAsync.md
+++ b/sdk/communication/Azure.Communication.CallingServer/samples/Sample1_CreateCallAsync.md
@@ -31,8 +31,4 @@ CreateCallResult createCallResult = await callAutomationClient.CreateCallAsync(
 Console.WriteLine($"Call connection id: {createCallResult.CallConnectionProperties.CallConnectionId}");
 ```
 
-To see the full example source files, see:
-
-* [Make a call to a phone number recipient](https://github.com/Azure/azure-sdk-for-net/blob/a20e269162fa88a43e5ba0e5bb28f2e76c74a484/sdk/communication/Azure.Communication.CallingServer/tests/samples/Sample1_CallClient.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/a20e269162fa88a43e5ba0e5bb28f2e76c74a484/sdk/communication/Azure.Communication.CallingServer/README.md#getting-started

--- a/sdk/communication/Azure.Communication.Email/tests/Samples/README.md
+++ b/sdk/communication/Azure.Communication.Email/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/communication/Azure.Communication.Email/samples) for more explanation about how to use this client library.

--- a/sdk/communication/Azure.Communication.Identity/samples/Sample1_CommunicationIdentityClient.md
+++ b/sdk/communication/Azure.Communication.Identity/samples/Sample1_CommunicationIdentityClient.md
@@ -102,14 +102,8 @@ string token = tokenResponse.Value.Token;
 Console.WriteLine($"Token: {token}");
 ```
 
-<!--
-To see the full example source files, see:
-* [Generate user token][GenerateUserTokenCode]
--->
-
 <!-- LINKS -->
 <!--[scopes](https://github.com/mikben/azure-docs-pr/blob/release-project-spool/articles/project-spool/concepts/identity-model.md)
 [ReadMe](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/communication/Azure.Communication.Administration/samples/ReadMe.md)
-[GenerateUserTokenCode](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/communication/Azure.Communication.Administration/tests/samples/Sample1_CommunicationIdentityClient.cs)
 
  -->

--- a/sdk/communication/Azure.Communication.Identity/samples/Sample1_CommunicationIdentityClientAsync.md
+++ b/sdk/communication/Azure.Communication.Identity/samples/Sample1_CommunicationIdentityClientAsync.md
@@ -103,13 +103,7 @@ string token = tokenResponse.Value.Token;
 Console.WriteLine($"Token: {token}");
 ```
 
-<!--
-To see the full example source files, see:
-* [Generate user token][GenerateUserTokenCode]
--->
-
 <!-- LINKS -->
 <!--
 [ReadMe](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/communication/Azure.Communication.Administration/samples/ReadMe.md)
-[GenerateUserTokenCode](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/communication/Azure.Communication.Administration/tests/samples/Sample1_CommunicationIdentityClient.cs)
 -->

--- a/sdk/communication/Azure.Communication.Identity/tests/samples/README.md
+++ b/sdk/communication/Azure.Communication.Identity/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/communication/Azure.Communication.Identity/samples) for more explanation about how to use this client library.

--- a/sdk/communication/Azure.Communication.JobRouter/tests/Samples/README.md
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/communication/Azure.Communication.JobRouter/samples) for more explanation about how to use this client library.

--- a/sdk/communication/Azure.Communication.NetworkTraversal/tests/samples/README.md
+++ b/sdk/communication/Azure.Communication.NetworkTraversal/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/communication/Azure.Communication.NetworkTraversal/samples) for more explanation about how to use this client library.

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/samples/README.md
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/communication/Azure.Communication.PhoneNumbers/samples) for more explanation about how to use this client library.

--- a/sdk/communication/Azure.Communication.Sms/samples/Sample1_SendSms.md
+++ b/sdk/communication/Azure.Communication.Sms/samples/Sample1_SendSms.md
@@ -45,7 +45,5 @@ foreach (SmsSendResult result in response.Value)
     Console.WriteLine($"Send Result Successful: {result.Successful}");
 }
 ```
-* [Send SMS to single recipient](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/communication/Azure.Communication.Sms/tests/samples/Sample1_SmsClient.cs)
-* [Send SMS to multiple recipients with options](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/communication/Azure.Communication.Sms/tests/samples/Sample1_SmsClient.cs)
 
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/communication/Azure.Communication.Sms/README.md#getting-started

--- a/sdk/communication/Azure.Communication.Sms/samples/Sample1_SendSmsAsync.md
+++ b/sdk/communication/Azure.Communication.Sms/samples/Sample1_SendSmsAsync.md
@@ -46,9 +46,4 @@ foreach (SmsSendResult result in response.Value)
 }
 ```
 
-To see the full example source files, see:
-
-* [Send SMS to single recipient](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/communication/Azure.Communication.Sms/tests/samples/Sample1_SmsClient.cs)
-* [Send SMS to multiple recipients with options](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/communication/Azure.Communication.Sms/tests/samples/Sample1_SmsClient.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/communication/Azure.Communication.Sms/README.md#getting-started

--- a/sdk/communication/Azure.Communication.Sms/tests/samples/README.md
+++ b/sdk/communication/Azure.Communication.Sms/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/communication/Azure.Communication.Sms/samples) for more explanation about how to use this client library.

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/Samples/README.md
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/communication/Azure.ResourceManager.Communication/samples) for more explanation about how to use this client library.

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/Samples/README.md
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/compute/Azure.ResourceManager.Compute/samples) for more explanation about how to use this client library.

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/Samples/README.md
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/containerregistry/Azure.Containers.ContainerRegistry/samples) for more explanation about how to use this client library.

--- a/sdk/core/Azure.Core/tests/samples/README.md
+++ b/sdk/core/Azure.Core/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/core/Azure.Core/samples) for more explanation about how to use this client library.

--- a/sdk/devcenter/Azure.Developer.DevCenter/samples/Sample_CreateDeleteDevBoxAsync.md
+++ b/sdk/devcenter/Azure.Developer.DevCenter/samples/Sample_CreateDeleteDevBoxAsync.md
@@ -2,7 +2,4 @@ To use these samples, you'll first need to set up resources. See [getting starte
 
 ## <scenario> Asynchronously create, connect to, and delete a Dev Box
 
-You can create a clients and fetch available DevCenter Projects and Pools, then use those resources to create a Dev Box, connect to the Dev Box, then delete it when you're finished. 
-
-To see the full example source files, see:
-* [CreateDeleteDevBoxAsync](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/devcenter/Azure.Developer.DevCenter/tests/Samples/Sample_CreateDeleteDevBoxAsync.cs)
+You can create a clients and fetch available DevCenter Projects and Pools, then use those resources to create a Dev Box, connect to the Dev Box, then delete it when you're finished.

--- a/sdk/devcenter/Azure.Developer.DevCenter/samples/Sample_CreateDeleteEnvironmentAsync.md
+++ b/sdk/devcenter/Azure.Developer.DevCenter/samples/Sample_CreateDeleteEnvironmentAsync.md
@@ -2,7 +2,4 @@ To use these samples, you'll first need to set up resources. See [getting starte
 
 ## <scenario> Asynchronously create, fetch artifacts for, and delete an environment
 
-You can create a clients and fetch available DevCenter Projects, Catalog Items, and Environment Types, then use those resources to create an Environment, fetch deployment artifacts, then delete it when you're finished. 
-
-To see the full example source files, see:
-* [CreateDeleteEnvironmentAsync](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/devcenter/Azure.Developer.DevCenter/tests/Samples/Sample_CreateDeleteEnvironmentAsync.cs)
+You can create a clients and fetch available DevCenter Projects, Catalog Items, and Environment Types, then use those resources to create an Environment, fetch deployment artifacts, then delete it when you're finished.

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/Samples/README.md
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/devcenter/Azure.Developer.DevCenter/samples) for more explanation about how to use this client library.

--- a/sdk/deviceupdate/Azure.IoT.DeviceUpdate/tests/Samples/README.md
+++ b/sdk/deviceupdate/Azure.IoT.DeviceUpdate/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/deviceupdate/Azure.IoT.DeviceUpdate/samples) for more explanation about how to use this client library.

--- a/sdk/deviceupdate/Azure.ResourceManager.DeviceUpdate/tests/Samples/README.md
+++ b/sdk/deviceupdate/Azure.ResourceManager.DeviceUpdate/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/deviceupdate/Azure.ResourceManager.DeviceUpdate/samples) for more explanation about how to use this client library.

--- a/sdk/dns/Azure.ResourceManager.Dns/tests/Samples/README.md
+++ b/sdk/dns/Azure.ResourceManager.Dns/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/dns/Azure.ResourceManager.Dns/samples) for more explanation about how to use this client library.

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/samples/Sample1_PublishEventsToTopic.md
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/samples/Sample1_PublishEventsToTopic.md
@@ -12,7 +12,7 @@ EventGridPublisherClient client = new EventGridPublisherClient(
     new AzureKeyCredential(topicAccessKey));
 ```
 
-Event Grid also supports authenticating with a shared access signature which allows for providing access to a resource that expires by a certain time without sharing your access key. 
+Event Grid also supports authenticating with a shared access signature which allows for providing access to a resource that expires by a certain time without sharing your access key.
 Generally, the workflow would be that one application would generate the SAS string and hand off the string to another application that would consume the string.
 Generate the SAS:
 ```C# Snippet:GenerateSas
@@ -108,8 +108,3 @@ List<CloudEvent> eventsList = new List<CloudEvent>
 // Send the events
 await client.SendEventsAsync(eventsList);
 ```
-
-## Source
-
-To view the full example source, see:
-- [Sample1_SendEventsToTopicAndDomain.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventgrid/Azure.Messaging.EventGrid/tests/Samples/Sample1_SendEventsToTopicAndDomain.cs)

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/samples/Sample2_PublishEventsToDomain.md
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/samples/Sample2_PublishEventsToDomain.md
@@ -40,8 +40,3 @@ List<EventGridEvent> eventsList = new List<EventGridEvent>
 // Send the events
 await client.SendEventsAsync(eventsList);
 ```
-
-## Source
-
-To view the full example source, see:
-- [Sample1_SendEventsToTopicAndDomain.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventgrid/Azure.Messaging.EventGrid/tests/Samples/Sample1_SendEventsToTopicAndDomain.cs)

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/samples/Sample3_ParseAndDeserializeEvents.md
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/samples/Sample3_ParseAndDeserializeEvents.md
@@ -94,7 +94,3 @@ foreach (EventGridEvent egEvent in egEvents)
     }
 }
 ```
-
-## Source
-To view the full example source, see:
-- [Sample2_ParseAndDeserializeEvents.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventgrid/Azure.Messaging.EventGrid/tests/Samples/Sample2_ParseAndDeserializeEvents.cs)

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/tests/Samples/README.md
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/eventgrid/Azure.Messaging.EventGrid/samples) for more explanation about how to use this client library.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample10_AzureEventSourceListener.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample10_AzureEventSourceListener.md
@@ -79,7 +79,7 @@ finally
 
 ## Apply filtering logic to logs
 
-This examples demonstrates using a callback with the listener to allow custom logic, such as filtering, of the log messages.  This can help to reduce log spam when troubleshooting by capturing just the log entries that are helpful.   
+This examples demonstrates using a callback with the listener to allow custom logic, such as filtering, of the log messages.  This can help to reduce log spam when troubleshooting by capturing just the log entries that are helpful.
 
 In the snippet below, the `Verbose` messages for the `Azure-Identity` event source are captured and written to `Trace` output.  Log messages for the `Azure-Messaging-EventHubs` event source are filtered to capture only a specific set to aid in debugging publishing, which are then written to the standard `Console` output.
 
@@ -127,7 +127,7 @@ finally
 
 ## Capture filtered logs to a file
 
-For scenarios where capturing logs to `Trace` or `Console` outputs isn't ideal, log information can be streamed into a variety of targets, such as Azure Storage, databases, and files for durable persistence.    This example demonstrates capturing error logs to a text file so that they can be analyzed later, while capturing non-error information to `Console` output.  
+For scenarios where capturing logs to `Trace` or `Console` outputs isn't ideal, log information can be streamed into a variety of targets, such as Azure Storage, databases, and files for durable persistence.    This example demonstrates capturing error logs to a text file so that they can be analyzed later, while capturing non-error information to `Console` output.
 
 ```C# Snippet:EventHubs_Sample10_CustomListenerWithFile
 var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
@@ -175,15 +175,15 @@ finally
 
 ## Finding the desired events
 
-The Event Hubs client library logs using several event sources for different areas of functionality.  Each event source contains multiple log events, with most grouped into logical sets that follow the pattern:  
+The Event Hubs client library logs using several event sources for different areas of functionality.  Each event source contains multiple log events, with most grouped into logical sets that follow the pattern:
 
 - `{ Operation Name }Start`
 - `{ Operation Name }Error`
 - `{ Operation Name }Complete`
 
-Each operation will always emit its "Start" and "Complete" log events, and will only emit its "Error" event as needed.  For AMQP operations, the "Complete" event will detail the number of retries that were used for that operation.  
+Each operation will always emit its "Start" and "Complete" log events, and will only emit its "Error" event as needed.  For AMQP operations, the "Complete" event will detail the number of retries that were used for that operation.
 
-Unfortunately, there is currently way to easily view all of the log events offered.  To discover the available log events, inspecting the associated source code is the best option. 
+Unfortunately, there is currently way to easily view all of the log events offered.  To discover the available log events, inspecting the associated source code is the best option.
 
 ### Event Source: "Azure-Messaging-EventHubs"
 

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Samples/README.md
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/eventhub/Azure.ResourceManager.EventHubs/samples) for more explanation about how to use this client library.

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltDocument.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltDocument.md
@@ -194,9 +194,4 @@ for (int i = 0; i < result.Tables.Count; i++)
 }
 ```
 
-To see the full example source files, see:
-
-* [Analyze with prebuilt general document from URI](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltDocumentFromUriAsync.cs)
-* [Analyze with prebuilt general document from file](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltDocumentFromFileAsync.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltRead.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltRead.md
@@ -128,9 +128,4 @@ foreach (DocumentStyle style in result.Styles)
 }
 ```
 
-To see the full example source files, see:
-
-* [Analyze with prebuilt read from URI](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromUriAsync.cs)
-* [Analyze with prebuilt read from file](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromFileAsync.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithCustomModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithCustomModel.md
@@ -79,10 +79,5 @@ foreach (AnalyzedDocument document in result.Documents)
 }
 ```
 
-To see the full example source files, see:
-
-* [Analyze with custom model from URI](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithCustomModelFromUriAsync.cs)
-* [Analyze with custom model from file](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithCustomModelFromFileAsync.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started
 [build_a_model]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_BuildCustomModel.md

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithPrebuiltModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithPrebuiltModel.md
@@ -229,11 +229,6 @@ for (int i = 0; i < result.Documents.Count; i++)
 }
 ```
 
-To see the full example source files, see:
-
-* [Analyze with prebuilt model from URI](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromUriAsync.cs)
-* [Analyze with prebuilt model from file](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromFileAsync.cs)
-
 [invoice_fields]: https://aka.ms/azsdk/formrecognizer/invoicefieldschema
 [formreco_models]: https://aka.ms/azsdk/formrecognizer/models
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_BuildCustomModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_BuildCustomModel.md
@@ -63,8 +63,5 @@ foreach (KeyValuePair<string, DocumentTypeDetails> documentType in model.Documen
 }
 ```
 
-To see the full example source files, see:
-* [Build a model](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_BuildCustomModelAsync.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started
 [labeling_tool]: https://aka.ms/azsdk/formrecognizer/labelingtool

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_CopyCustomModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_CopyCustomModel.md
@@ -55,7 +55,4 @@ Console.WriteLine($"Original model ID => {modelId}");
 Console.WriteLine($"Copied model ID => {newModel.ModelId}");
 ```
 
-To see the full example source files, see:
-* [Copy custom models](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_CopyModelToAsync.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ExtractLayout.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ExtractLayout.md
@@ -190,10 +190,5 @@ for (int i = 0; i < result.Tables.Count; i++)
 }
 ```
 
-To see the full example source files, see:
-
-* [Extract layout from URI](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ExtractLayoutFromUriAsync.cs)
-* [Extract layout from file](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ExtractLayoutFromFileAsync.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started
 [document_sample]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltDocument.md

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_GetAndListOperations.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_GetAndListOperations.md
@@ -94,8 +94,4 @@ else
     Console.WriteLine($"My {operationDetails.Kind} operation status is {operationDetails.Status}");
 ```
 
-To see the full example source files, see:
-
-* [Get and List document model operations](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_GetAndListOperationsAsync.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ManageModels.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ManageModels.md
@@ -111,8 +111,4 @@ Console.WriteLine($"  Created on: {newCreatedModel.CreatedOn}");
 client.DeleteDocumentModel(newCreatedModel.ModelId);
 ```
 
-To see the full example source files, see:
-* [Manage models (Asynchronous)](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ManageModelsAsync.cs)
-* [Manage models (Synchronous)](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ManageModels.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_MockClient.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_MockClient.md
@@ -1,6 +1,6 @@
 # Mock a client for testing using the Moq library
 
-This sample illustrates how to use [Moq][moq] to create a unit test that mocks the response from a `DocumentAnalysisClient` method. For more examples of mocking, see [Moq samples][moq_samples].
+This sample illustrates how to use [Moq][moq] to create a unit test that mocks the response from a `DocumentAnalysisClient` method.
 
 ## Define a method that uses a DocumentAnalysisClient
 To show the usage of mocks, define a method that will be tested with mocked objects. For this case, assume we have a custom model that's able to analyze groceries lists. We are going to create a method that will calculate whether the total price of a list is expensive (total price > $100), only if the recognized field has a confidence greater than 70%.
@@ -101,5 +101,4 @@ Assert.IsTrue(isExpensive);
 ```
 
 [moq]: https://github.com/Moq/moq4/
-[moq_samples]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_MockClient.cs
 [lros]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#long-running-operations

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ModelCompose.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ModelCompose.md
@@ -74,8 +74,5 @@ if (string.IsNullOrEmpty(purchaseOrderModel.Description))
 Console.WriteLine($"  Created on: {purchaseOrderModel.CreatedOn}");
 ```
 
-To see the full example source files, see:
-* [Compose a model](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ComposeModelAsync.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started
 [labeling_tool]: https://aka.ms/azsdk/formrecognizer/labelingtool

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample10_RecognizeInvoices.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample10_RecognizeInvoices.md
@@ -288,10 +288,5 @@ if (invoice.Fields.TryGetValue("InvoiceTotal", out FormField invoiceTotalField))
 }
 ```
 
-To see the full example source files, see:
-
-* [Recognize invoices from URI](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample13_RecognizeInvoicesFromUri.cs)
-* [Recognize invoices from file](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample13_RecognizeInvoicesFromFile.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started
 [strongly_typing_a_recognized_form]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample4_StronglyTypingARecognizedForm.md

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample11_RecognizeIdentityDocuments.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample11_RecognizeIdentityDocuments.md
@@ -219,10 +219,5 @@ if (identityDocument.Fields.TryGetValue("Sex", out FormField sexfield))
 }
 ```
 
-To see the full example source files, see:
-
-* [Recognize identity documents from URI](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample14_RecognizeIdentityDocumentsFromUri.cs)
-* [Recognize identity documents from file](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample14_RecognizeIdentityDocumentsFromFile.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started
 [strongly_typing_a_recognized_form]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample4_StronglyTypingARecognizedForm.md

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample1_RecognizeFormContent.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample1_RecognizeFormContent.md
@@ -136,9 +136,4 @@ foreach (FormPage page in formPages)
 }
 ```
 
-To see the full example source files, see:
-
-* [Recognize form content from URI](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample1_RecognizeContentFromUri.cs)
-* [Recognize form content from file](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample1_RecognizeContentFromFile.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample2_RecognizeCustomForms.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample2_RecognizeCustomForms.md
@@ -139,11 +139,6 @@ foreach (RecognizedForm form in forms)
 }
 ```
 
-To see the full example source files, see:
-
-* [Recognize custom forms from URI](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample2_RecognizeCustomFormsFromUri.cs)
-* [Recognize custom forms from file](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample2_RecognizeCustomFormsFromFile.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started
 [strongly_typing_a_recognized_form]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample4_StronglyTypingARecognizedForm.md
 [train_a_model]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample5_TrainModel.md

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample3_RecognizeReceipts.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample3_RecognizeReceipts.md
@@ -192,10 +192,5 @@ foreach (RecognizedForm receipt in receipts)
 }
 ```
 
-To see the full example source files, see:
-
-* [Recognize receipts from URI](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample3_RecognizeReceiptsFromUri.cs)
-* [Recognize receipts from file](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample3_RecognizeReceiptsFromFile.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started
 [strongly_typing_a_recognized_form]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample4_StronglyTypingARecognizedForm.md

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample4_StronglyTypingARecognizedForm.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample4_StronglyTypingARecognizedForm.md
@@ -21,10 +21,7 @@ var client = new FormRecognizerClient(new Uri(endpoint), credential);
 
 Recognized receipts and custom forms are returned as `RecognizedForm` objects from the Form Recognizer client. Even though all recognized information can be obtained from them, sometimes they can be inconvenient to handle and, for this reason, we'll illustrate how to create a wrapper class to make the relevant fields easily accessible.
 
-We'll be using a recognized receipt as a sample, so we'll call our wrapper class `Receipt`. To store items listed in the receipt, we'll use a similar wrapper called `ReceiptItem`. To see the full source files, see:
-
-* [Receipt class](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Receipt.cs)
-* [ReceiptItem class](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/ReceiptItem.cs)
+We'll be using a recognized receipt as a sample, so we'll call our wrapper class `Receipt`. To store items listed in the receipt, we'll use a similar wrapper called `ReceiptItem`.
 
 The `Receipt` class is composed of multiple `FormField<T>` properties. `FormField<T>` is a class defined in the main Form Recognizer library and used as a strongly-typed version of `FormField`, and it's more convenient to handle since there's no need to perform type checking.
 
@@ -104,9 +101,5 @@ foreach (RecognizedForm recognizedForm in recognizedForms)
 ```
 
 Using `FormField<T>` to make your fields strongly-typed, and populating a custom wrapper class, such as `Receipt`, is the recommended approach for handling forms where fields have known labels.
-
-To see the full example source files, see:
-
-* [Strongly typing a recognized form](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample4_StronglyTypingARecognizedForm.cs)
 
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample5_TrainModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample5_TrainModel.md
@@ -109,10 +109,5 @@ foreach (CustomFormSubmodel submodel in model.Submodels)
 }
 ```
 
-To see the full example source files, see:
-
-* [Train a model with forms](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample5_TrainModelWithForms.cs)
-* [Train a model with forms and labels](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample6_TrainModelWithFormsAndLabels.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started
 [labeling_tool]: https://docs.microsoft.com/azure/cognitive-services/form-recognizer/label-tool?tabs=v2-1

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample6_ManageCustomModels.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample6_ManageCustomModels.md
@@ -134,9 +134,4 @@ foreach (CustomFormSubmodel submodel in modelCopy.Submodels)
 client.DeleteModel(model.ModelId);
 ```
 
-To see the full example source files, see:
-
-* [Manage custom models (Asynchronous)](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample7_ManageCustomModelsAsync.cs)
-* [Manage custom models (Synchronous)](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample7_ManageCustomModels.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample7_CopyCustomModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample7_CopyCustomModel.md
@@ -66,8 +66,4 @@ Console.WriteLine($"Original model ID => {modelId}");
 Console.WriteLine($"Copied model ID => {newModel.ModelId}");
 ```
 
-
-To see the full example source files, see:
-* [Copy custom models](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample8_CopyModel.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample8_ModelCompose.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample8_ModelCompose.md
@@ -144,9 +144,5 @@ foreach (CustomFormSubmodel model in purchaseOrderModel.Submodels)
 }
 ```
 
-To see the full example source files, see:
-
-* [Composed Model](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample11_ComposedModel.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started
 [labeling_tool]: https://docs.microsoft.com/azure/cognitive-services/form-recognizer/label-tool?tabs=v2-1

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample9_RecognizeBusinessCards.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample9_RecognizeBusinessCards.md
@@ -292,10 +292,5 @@ foreach (RecognizedForm businessCard in businessCards)
 }
 ```
 
-To see the full example source files, see:
-
-* [Recognize business cards from URI](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample12_RecognizeBusinessCardsFromUri.cs)
-* [Recognize business cards from file](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample12_RecognizeBusinessCardsFromFile.cs)
-
 [README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started
 [strongly_typing_a_recognized_form]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample4_StronglyTypingARecognizedForm.md

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample_MockClient.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample_MockClient.md
@@ -1,6 +1,6 @@
 # Mock a client for testing using the Moq library
 
-This sample illustrates how to use [Moq][moq] to create a unit test that mocks the response from a `FormRecognizerClient` method. For more examples of mocking, see [Moq samples][moq_samples].
+This sample illustrates how to use [Moq][moq] to create a unit test that mocks the response from a `FormRecognizerClient` method.
 
 ## Define a method that uses a FormRecognizerClient
 To show the usage of mocks, define a method that will be tested with mocked objects. For this case, assume we have a pre-trained custom model that's able to recognize groceries list. We are going to create a method that will calculate whether the total price of a list is expensive (total price > $100), only if the recognized field has a confidence greater than 70%.
@@ -83,5 +83,4 @@ Assert.IsTrue(result);
 ```
 
 [moq]: https://github.com/Moq/moq4/
-[moq_samples]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample_MockClient.cs
 [lros]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#long-running-operations

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples) for more explanation about how to use this client library.

--- a/sdk/identity/Azure.Identity/tests/samples/README.md
+++ b/sdk/identity/Azure.Identity/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/identity/Azure.Identity/samples) for more explanation about how to use this client library.

--- a/sdk/keyvault/Azure.ResourceManager.KeyVault/tests/Samples/README.md
+++ b/sdk/keyvault/Azure.ResourceManager.KeyVault/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/keyvault/Azure.ResourceManager.KeyVault/samples) for more explanation about how to use this client library.

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/samples/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/keyvault/Azure.Security.KeyVault.Administration/samples) for more explanation about how to use this client library.

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/samples/Sample1_HelloWorld.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/samples/Sample1_HelloWorld.md
@@ -86,11 +86,4 @@ while (!operation.HasCompleted)
 }
 ```
 
-## Source
-
-To see the full example source, see:
-
-* [Synchronous Sample1_HelloWorld.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample1_HelloWorld.cs)
-* [ASynchronous Sample1_HelloWorldAsync.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample1_HelloWorldAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/samples/Sample2_GetCertificates.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/samples/Sample2_GetCertificates.md
@@ -108,11 +108,4 @@ foreach (DeletedCertificate deletedCert in client.GetDeletedCertificates())
 }
 ```
 
-## Source
-
-To see the full example source, see:
-
-* [Synchronous Sample2_GetCertificates.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample2_GetCertificates.cs)
-* [Asynchronous Sample2_GetCertificatesAsync.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample2_GetCertificatesAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/samples/Sample2_ImportCertificate.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/samples/Sample2_ImportCertificate.md
@@ -62,11 +62,4 @@ ImportCertificateOptions importOptions = new ImportCertificateOptions(name, pem)
 client.ImportCertificate(importOptions);
 ```
 
-## Source
-
-To see the full example source, see:
-
-* [Synchronous Sample3_ImportCertificate.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample3_ImportCertificate.cs)
-* [Asynchronous Sample3_ImportCertificateAsync.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample3_ImportCertificateAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/samples/Sample4_DownloadCertificate.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/samples/Sample4_DownloadCertificate.md
@@ -87,11 +87,4 @@ bool verified = publicKey.VerifyHash(hash, signature, HashAlgorithmName.SHA256, 
 Debug.WriteLine($"Signature verified: {verified}");
 ```
 
-## Source
-
-To see the full example source, see:
-
-* [Synchronous Sample4_DownloadCertificate.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample4_DownloadCertificate.cs)
-* [Asynchronous Sample4_DownloadCertificateAsync.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample4_DownloadCertificateAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/keyvault/Azure.Security.KeyVault.Certificates/samples) for more explanation about how to use this client library.

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample1_HelloWorld.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample1_HelloWorld.md
@@ -102,9 +102,4 @@ await operation.WaitForCompletionAsync();
 await client.PurgeDeletedKeyAsync(rsaKeyName);
 ```
 
-## Source
-
-* [Synchronous Sample1_HelloWorld.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample1_HelloWorld.cs)
-* [Asynchronous Sample1_HelloWorldAsync.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample1_HelloWorldAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample2_BackupAndRestore.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample2_BackupAndRestore.md
@@ -48,11 +48,4 @@ If the key is deleted for any reason, we can use the backup value to restore it 
 KeyVaultKey restoredKey = client.RestoreKeyBackup(memoryStream.ToArray());
 ```
 
-## Source
-
-To see the full example source, see:
-
-* [Synchronous Sample2_BackupAndRestore.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample2_BackupAndRestore.cs)
-* [Asynchronous Sample2_BackupAndRestore.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample2_BackupAndRestoreAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample3_GetKeys.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample3_GetKeys.md
@@ -112,11 +112,4 @@ foreach (DeletedKey key in keysDeleted)
 }
 ```
 
-## Source
-
-To see the full example source, see:
-
-* [Synchronous Sample3_GetKeys.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample3_GetKeys.cs)
-* [ASynchronous Sample3_GetKeysAsync.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample3_GetKeysAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample4_EncryptDecrypt.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample4_EncryptDecrypt.md
@@ -101,11 +101,4 @@ DecryptParameters decryptParams = DecryptParameters.A256GcmParameters(
 DecryptResult decryptResult = cryptoClient.Decrypt(decryptParams);
 ```
 
-## Source
-
-To see the full example source, see:
-
-* [Synchronous Sample4_EncryptDecrypt.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample4_EncryptDecrypt.cs)
-* [ASynchronous Sample4_EncryptDecryptAsync.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample4_EncryptDecryptAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample5_SignVerify.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample5_SignVerify.md
@@ -106,11 +106,4 @@ VerifyResult ecVerifyDataResult = ecCryptoClient.VerifyData(SignatureAlgorithm.E
 Debug.WriteLine($"Verified the signature using the algorithm {ecVerifyDataResult.Algorithm}, with key {ecVerifyDataResult.KeyId}. Signature is valid: {ecVerifyDataResult.IsValid}");
 ```
 
-## Source
-
-To see the full example source, see:
-
-* [Synchronous Sample5_SignVerify.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample5_SignVerify.cs)
-* [Asynchronous Sample5_SignVerifyAsync.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample5_SignVerifyAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample6_WrapUnwrap.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample6_WrapUnwrap.md
@@ -64,11 +64,4 @@ UnwrapResult unwrapResult = cryptoClient.UnwrapKey(KeyWrapAlgorithm.RsaOaep, wra
 Debug.WriteLine($"Decrypted data using the algorithm {unwrapResult.Algorithm}, with key {unwrapResult.KeyId}. The resulting decrypted data is {Encoding.UTF8.GetString(unwrapResult.Key)}");
 ```
 
-## Source
-
-To see the full example source, see:
-
-* [Synchronous Sample6_WrapUnwrap.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample6_WrapUnwrap.cs)
-* [Asynchronous Sample6_WrapUnwrapAsync.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample6_WrapUnwrapAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample7_SerializeJsonWebKey.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample7_SerializeJsonWebKey.md
@@ -83,13 +83,6 @@ DecryptResult decrypted = decryptClient.Decrypt(DecryptParameters.RsaOaepParamet
 Debug.WriteLine($"Decrypted: {Encoding.UTF8.GetString(decrypted.Plaintext)}");
 ```
 
-## Source
-
-To see the full example source, see:
-
-* [Synchronous Sample7_SerializeJsonWebKey.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample7_SerializeJsonWebKey.cs)
-* [Asynchronous Sample7_SerializeJsonWebKeyAsync.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample7_SerializeJsonWebKeyAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 [JWK]: https://datatracker.ietf.org/doc/html/rfc7517
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Keys/README.md

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample8_KeyRotation.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample8_KeyRotation.md
@@ -60,12 +60,5 @@ KeyVaultKey newRsaKey = keyClient.RotateKey(rsaKeyName);
 Debug.WriteLine($"Rotated key {newRsaKey.Name} with version {newRsaKey.Properties.Version}");
 ```
 
-## Source
-
-To see the full example source, see:
-
-* [Synchronous Sample8_KeyRotation.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample8_KeyRotation.cs)
-* [Asynchronous Sample8_KeyRotationAsync.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample8_KeyRotationAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Keys/README.md

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/keyvault/Azure.Security.KeyVault.Keys/samples) for more explanation about how to use this client library.

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample1_HelloWorld.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample1_HelloWorld.md
@@ -97,11 +97,4 @@ await operation.WaitForCompletionAsync();
 await client.PurgeDeletedSecretAsync(secretName);
 ```
 
-## Source
-
-To see the full example source, see:
-
-* [Synchronous Sample1_HelloWorld.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample1_HelloWorld.cs)
-* [Asynchronous Sample1_HelloWorld.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample1_HelloWorldAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample2_BackupAndRestore.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample2_BackupAndRestore.md
@@ -49,11 +49,4 @@ byte[] secretBackupToRestore = File.ReadAllBytes(backupPath);
 SecretProperties restoreSecret = client.RestoreSecretBackup(secretBackupToRestore);
 ```
 
-## Source
-
-To see the full example source, see:
-
-* [Synchronous Sample2_BackupAndRestore.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample2_BackupAndRestore.cs)
-* [Asynchronous Sample2_BackupAndRestore.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample2_BackupAndRestoreAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample3_GetSecrets.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample3_GetSecrets.md
@@ -123,11 +123,4 @@ foreach (DeletedSecret secret in secretsDeleted)
 }
 ```
 
-## Source
-
-To see the full example source, see:
-
-* [Synchronous Sample3_GetSecrets.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample3_GetSecrets.cs)
-* [Asynchronous Sample3_GetSecrets.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample3_GetSecretsAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples) for more explanation about how to use this client library.

--- a/sdk/loadtestservice/Azure.Developer.LoadTesting/samples/Sample1_CreateOrUpdateTest.md
+++ b/sdk/loadtestservice/Azure.Developer.LoadTesting/samples/Sample1_CreateOrUpdateTest.md
@@ -1,4 +1,4 @@
-# Create or Update Load Test 
+# Create or Update Load Test
 
 To use these samples, you'll first need to set up resources. See [getting started](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/loadtestservice/Azure.Developer.LoadTesting/README.md#getting-started) for details.
 
@@ -81,6 +81,3 @@ catch (Exception e)
     Console.WriteLine(String.Format("Error : ", e.Message));
 }
 ```
-
-To see the full example source files, see:
-* [Sample1_CreateOrUpdateTest.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/loadtestservice/Azure.Developer.LoadTesting/tests/Samples/Sample1_CreateOrUpdateTest.cs) 

--- a/sdk/loadtestservice/Azure.Developer.LoadTesting/samples/Sample1_CreateOrUpdateTestAsync.md
+++ b/sdk/loadtestservice/Azure.Developer.LoadTesting/samples/Sample1_CreateOrUpdateTestAsync.md
@@ -85,6 +85,3 @@ catch (Exception e)
     Console.WriteLine(string.Format("Error : ", e.Message));
 }
 ```
-
-To see the full example source files, see:
-* [Sample1_CreateOrUpdateTestAsync.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/loadtestservice/Azure.Developer.LoadTesting/tests/Samples/Sample1_CreateOrUpdateTestAsync.cs)

--- a/sdk/loadtestservice/Azure.Developer.LoadTesting/samples/Sample2_UploadTestFile.md
+++ b/sdk/loadtestservice/Azure.Developer.LoadTesting/samples/Sample2_UploadTestFile.md
@@ -39,5 +39,3 @@ catch (Exception e)
     Console.WriteLine(String.Format("Error : ", e.Message));
 }
 ```
-To see the full example source files, see:
-* [Sample2_UploadTestFile.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/loadtestservice/Azure.Developer.LoadTesting/tests/Samples/Sample2_UploadTestFile.cs)

--- a/sdk/loadtestservice/Azure.Developer.LoadTesting/samples/Sample2_UploadTestFileAsync.md
+++ b/sdk/loadtestservice/Azure.Developer.LoadTesting/samples/Sample2_UploadTestFileAsync.md
@@ -39,5 +39,3 @@ catch (Exception e)
     Console.WriteLine(String.Format("Error : ", e.Message));
 }
 ```
-To see the full example source files, see:
-* [Sample2_UploadTestFileAsync.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/loadtestservice/Azure.Developer.LoadTesting/tests/Samples/Sample2_UploadTestFileAsync.cs)

--- a/sdk/loadtestservice/Azure.Developer.LoadTesting/samples/Sample3_CreateOrUpdateAppComponent.md
+++ b/sdk/loadtestservice/Azure.Developer.LoadTesting/samples/Sample3_CreateOrUpdateAppComponent.md
@@ -57,5 +57,3 @@ catch (Exception e)
     Console.WriteLine(String.Format("Error : ", e.Message));
 }
 ```
-To see the full example source files, see:
-* [Sample3_CreateOrUpdateAppComponent.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/loadtestservice/Azure.Developer.LoadTesting/tests/Samples/Sample3_CreateOrUpdateAppComponent.cs)

--- a/sdk/loadtestservice/Azure.Developer.LoadTesting/samples/Sample3_CreateOrUpdateAppComponentAsync.md
+++ b/sdk/loadtestservice/Azure.Developer.LoadTesting/samples/Sample3_CreateOrUpdateAppComponentAsync.md
@@ -57,5 +57,3 @@ catch (Exception e)
     Console.WriteLine(String.Format("Error : ", e.Message));
 }
 ```
-To see the full example source files, see:
-* [Sample3_CreateOrUpdateAppComponentAsync.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/loadtestservice/Azure.Developer.LoadTesting/tests/Samples/Sample3_CreateOrUpdateAppComponentAsync.cs)

--- a/sdk/loadtestservice/Azure.Developer.LoadTesting/samples/Sample4_CreateAndUpdateTest.md
+++ b/sdk/loadtestservice/Azure.Developer.LoadTesting/samples/Sample4_CreateAndUpdateTest.md
@@ -44,5 +44,3 @@ catch (Exception e)
     Console.WriteLine(String.Format("Error : ", e.Message));
 }
 ```
-To see the full example source files, see:
-* [Sample4_CreateAndUpdateTest.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/loadtestservice/Azure.Developer.LoadTesting/tests/Samples/Sample4_CreateAndUpdateTest.cs)

--- a/sdk/loadtestservice/Azure.Developer.LoadTesting/samples/Sample4_CreateAndUpdateTestAsync.md
+++ b/sdk/loadtestservice/Azure.Developer.LoadTesting/samples/Sample4_CreateAndUpdateTestAsync.md
@@ -44,5 +44,3 @@ catch (Exception e)
     Console.WriteLine(String.Format("Error : ", e.Message));
 }
 ```
-To see the full example source files, see:
-* [Sample4_CreateAndUpdateTestAsync.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/loadtestservice/Azure.Developer.LoadTesting/tests/Samples/Sample4_CreateAndUpdateTestAsync.cs)

--- a/sdk/loadtestservice/Azure.Developer.LoadTesting/tests/Samples/README.md
+++ b/sdk/loadtestservice/Azure.Developer.LoadTesting/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/loadtestservice/Azure.Developer.LoadTesting/samples) for more explanation about how to use this client library.

--- a/sdk/maps/Azure.Maps.Geolocation/tests/Samples/README.md
+++ b/sdk/maps/Azure.Maps.Geolocation/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/maps/Azure.Maps.Geolocation/samples) for more explanation about how to use this client library.

--- a/sdk/maps/Azure.Maps.Rendering/tests/Samples/README.md
+++ b/sdk/maps/Azure.Maps.Rendering/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/maps/Azure.Maps.Rendering/samples) for more explanation about how to use this client library.

--- a/sdk/maps/Azure.Maps.Routing/tests/Samples/README.md
+++ b/sdk/maps/Azure.Maps.Routing/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/maps/Azure.Maps.Routing/samples) for more explanation about how to use this client library.

--- a/sdk/maps/Azure.Maps.Search/tests/Samples/README.md
+++ b/sdk/maps/Azure.Maps.Search/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/maps/Azure.Maps.Search/samples) for more explanation about how to use this client library.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/README.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/samples) for more explanation about how to use this client library.

--- a/sdk/monitor/Azure.Monitor.Ingestion/samples/Sample1_LogData.md
+++ b/sdk/monitor/Azure.Monitor.Ingestion/samples/Sample1_LogData.md
@@ -50,5 +50,3 @@ BinaryData data = BinaryData.FromObjectAsJson(
 // Upload our logs
 Response response = client.Upload(ruleId, streamName, RequestContent.Create(data));
 ```
-
-To see the full example source files, see [LogData](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.Ingestion/tests/Samples/LogDataAndQuery.cs).

--- a/sdk/monitor/Azure.Monitor.Ingestion/samples/Sample1_LogDataAsync.md
+++ b/sdk/monitor/Azure.Monitor.Ingestion/samples/Sample1_LogDataAsync.md
@@ -52,5 +52,3 @@ Response response = await client.UploadAsync(
     streamName,
     RequestContent.Create(data)).ConfigureAwait(false);
 ```
-
-To see the full example source files, see [LogDataAsync](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.Ingestion/tests/Samples/LogDataAndQueryAsync.cs).

--- a/sdk/monitor/Azure.Monitor.Ingestion/samples/Sample2_VerifyLogs.md
+++ b/sdk/monitor/Azure.Monitor.Ingestion/samples/Sample2_VerifyLogs.md
@@ -4,7 +4,7 @@ To use these samples, you'll first need to set up resources. See [getting starte
 
 ## Verify logs
 
-You can verify that your data has been uploaded correctly by using the [Azure.Monitor.Query](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.Query/README.md#install-the-package) library. Run the [Upload custom logs](#upload-custom-logs) sample first before verifying the logs. 
+You can verify that your data has been uploaded correctly by using the [Azure.Monitor.Query](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.Query/README.md#install-the-package) library. Run the [Upload custom logs](#upload-custom-logs) sample first before verifying the logs.
 
 ```C# Snippet:VerifyLogs
 var workspaceId = "<log_analytics_workspace_id>";
@@ -26,5 +26,3 @@ Response<LogsBatchQueryResultCollection> queryResponse =
 Console.WriteLine("Table entry count: " +
     queryResponse.Value.GetResult<int>(countQueryId).Single());
 ```
-
-To see the full example source files, see [Query](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.Ingestion/tests/Samples/LogDataAndQuery.cs).

--- a/sdk/monitor/Azure.Monitor.Ingestion/samples/Sample2_VerifyLogsAsync.md
+++ b/sdk/monitor/Azure.Monitor.Ingestion/samples/Sample2_VerifyLogsAsync.md
@@ -4,7 +4,7 @@ To use these samples, you'll first need to set up resources. See [getting starte
 
 ## Verify logs asynchronously
 
-You can verify that your data has been uploaded correctly by using the [Azure.Monitor.Query](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.Query/README.md#install-the-package) library. Run the [Upload custom logs](#upload-custom-logs) sample first before verifying the logs. 
+You can verify that your data has been uploaded correctly by using the [Azure.Monitor.Query](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.Query/README.md#install-the-package) library. Run the [Upload custom logs](#upload-custom-logs) sample first before verifying the logs.
 
 ```C# Snippet:VerifyLogsAsync
 var workspaceId = "<log_analytics_workspace_id>";
@@ -26,5 +26,3 @@ Response<LogsBatchQueryResultCollection> queryResponse =
 Console.WriteLine("Table entry count: " +
     queryResponse.Value.GetResult<int>(countQueryId).Single());
 ```
-
-To see the full example source files, see [QueryAsync](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.Ingestion/tests/Samples/LogDataAndQueryAsync.cs).

--- a/sdk/monitor/Azure.Monitor.Ingestion/tests/Samples/README.md
+++ b/sdk/monitor/Azure.Monitor.Ingestion/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/monitor/Azure.Monitor.Ingestion/samples) for more explanation about how to use this client library.

--- a/sdk/network/Azure.ResourceManager.Network/tests/Samples/README.md
+++ b/sdk/network/Azure.ResourceManager.Network/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/network/Azure.ResourceManager.Network/samples) for more explanation about how to use this client library.

--- a/sdk/resourcemanager/Azure.ResourceManager/tests/Samples/README.md
+++ b/sdk/resourcemanager/Azure.ResourceManager/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/resourcemanager/Azure.ResourceManager/samples) for more explanation about how to use this client library.

--- a/sdk/resources/Azure.ResourceManager.Resources/tests/Samples/README.md
+++ b/sdk/resources/Azure.ResourceManager.Resources/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/resources/Azure.ResourceManager.Resources/samples) for more explanation about how to use this client library.

--- a/sdk/search/Azure.Search.Documents/tests/Samples/README.md
+++ b/sdk/search/Azure.Search.Documents/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/search/Azure.Search.Documents/samples) for more explanation about how to use this client library.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample00_AuthenticateClient.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample00_AuthenticateClient.md
@@ -57,9 +57,3 @@ var sasToken = $"SharedAccessSignature sr={url}&sig={sig}&se={exp}&skn={keyName}
 var credential = new AzureSasCredential(sasToken);
 await using var client = new ServiceBusClient(fullyQualifiedNamespace, credential);
 ```
-
-## Source
-
-To see the full example source, see:
-
-* [Sample00_AuthenticateClient.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample00_AuthenticateClient.cs)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_SendReceive.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_SendReceive.md
@@ -168,14 +168,8 @@ await sender.CancelScheduledMessageAsync(seq);
 
 ### Setting time to live
 
-Message time to live can be configured at the queue or subscription level. By default, it is 14 days. Once this time has passed, the message is considered "expired". You can configure what happens to expired messages at the queue or subscription level. By default, these messages are deleted, but they can also be configured to move to the dead letter queue. More information about message expiry can be found [here](https://docs.microsoft.com/azure/service-bus-messaging/message-expiration). If you want to have an individual message expire before the entity-level configured time, you can set the `TimeToLive` property on the message.  
+Message time to live can be configured at the queue or subscription level. By default, it is 14 days. Once this time has passed, the message is considered "expired". You can configure what happens to expired messages at the queue or subscription level. By default, these messages are deleted, but they can also be configured to move to the dead letter queue. More information about message expiry can be found [here](https://docs.microsoft.com/azure/service-bus-messaging/message-expiration). If you want to have an individual message expire before the entity-level configured time, you can set the `TimeToLive` property on the message.
 
 ```C# Snippet:ServiceBusMessageTimeToLive
 var message = new ServiceBusMessage("Hello world!") { TimeToLive = TimeSpan.FromMinutes(5) };
 ```
-
-## Source
-
-To see the full example source, see:
-
-* [Sample01_SendReceive.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample01_SendReceive.cs)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample02_MessageSettlement.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample02_MessageSettlement.md
@@ -1,6 +1,6 @@
 # Settling messages
 
-This sample demonstrates how to [settle](https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#settling-receive-operations) 
+This sample demonstrates how to [settle](https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#settling-receive-operations)
 received messages. Message settlement can only be used when using a receiver in [PeekLock](https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock)
  mode, which is the default behavior. In order for the settlement operation to be successful, the message must be locked. By default, received messages will be locked for 30 seconds. This can be configured via the portal or when creating the queue or subscription using the `ServiceBusAdministrationClient` or by using the [Azure Resource Manager library](https://www.nuget.org/packages/Azure.ResourceManager.ServiceBus). Additionally, it is possible to extend the lock for an already received message by using the `RenewMessageLockAsync` method.
 
@@ -90,9 +90,3 @@ await Task.Delay(TimeSpan.FromSeconds(10));
 // complete the message, thereby deleting it from the service
 await receiver.CompleteMessageAsync(receivedMessage);
 ```
-
-## Source
-
-To see the full example source, see:
-
-* [Sample02_MessageSettlement.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample02_MessageSettlement.cs)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample03_SendReceiveSessions.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample03_SendReceiveSessions.md
@@ -68,9 +68,3 @@ await Task.Delay(TimeSpan.FromSeconds(10));
 // complete the message, thereby deleting it from the service
 await receiver.CompleteMessageAsync(receivedMessage);
 ```
-
-## Source
-
-To see the full example source, see:
-
-* [Sample03_SendReceiveSessions.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample03_SendReceiveSessions.cs)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample04_Processor.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample04_Processor.md
@@ -69,9 +69,3 @@ await processor.StartProcessingAsync();
 // since the processing happens in the background, we add a Console.ReadKey to allow the processing to continue until a key is pressed.
 Console.ReadKey();
 ```
-
-## Source
-
-To see the full example source, see:
-
-* [Sample04_Processor.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample04_Processor.cs)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample05_SessionProcessor.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample05_SessionProcessor.md
@@ -87,9 +87,3 @@ await processor.StartProcessingAsync();
 // since the processing happens in the background, we add a Conole.ReadKey to allow the processing to continue until a key is pressed.
 Console.ReadKey();
 ```
-
-## Source
-
-To see the full example source, see:
-
-* [Sample05_SessionProcessor.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample05_SessionProcessor.cs)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample06_Transactions.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample06_Transactions.md
@@ -94,9 +94,3 @@ using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
     ts.Complete();
 }
 ```
-
-## Source
-
-To see the full example source, see:
-
-* [Sample06_Transactions.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample06_Transactions.cs)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample07_CrudOperations.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample07_CrudOperations.md
@@ -142,9 +142,3 @@ A topic can be deleted using the topic name. Deleting a topic will automatically
 ```C# Snippet:DeleteTopic
 await client.DeleteTopicAsync(topicName);
 ```
-
-## Source
-
-To see the full example source, see:
-
-* [Sample07_CrudOperations.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample07_CrudOperations.cs)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample08_Interop.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample08_Interop.md
@@ -44,9 +44,3 @@ string receivedJson = (string) deserializer.ReadObject(reader);
 // deserialize the JSON string into TestModel
 TestModel output = JsonSerializer.Deserialize<TestModel>(receivedJson);
 ```
-
-## Source
-
-To see the full example source, see:
-
-* [Sample08_Interop.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample08_Interop.cs)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample09_Extensibility.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample09_Extensibility.md
@@ -360,9 +360,3 @@ processor.ProcessErrorAsync += args =>
 await processor.StartProcessingAsync();
 Console.ReadKey();
 ```
-
-## Source
-
-To see the full example source, see:
-
-* [Sample09_Extensibility.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample09_Extensibility.cs)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample10_ClaimCheck.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample10_ClaimCheck.md
@@ -52,9 +52,3 @@ if (receivedMessage.ApplicationProperties.TryGetValue("blob-name", out object bl
     await blobClient.DeleteAsync();
 }
 ```
-
-## Source
-
-To see the full example source, see:
-
-* [Sample10_ClaimCheck.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample10_ClaimCheck.cs)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample11_CloudEvents.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample11_CloudEvents.md
@@ -46,9 +46,3 @@ Console.WriteLine(receivedEmployee.Age);
 // complete the message, thereby deleting it from the service
 await receiver.CompleteMessageAsync(receivedMessage);
 ```
-
-## Source
-
-To see the full example source, see:
-
-* [Sample11_CloudEvents.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample11_CloudEvents.cs)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample12_ManagingRules.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample12_ManagingRules.md
@@ -70,9 +70,3 @@ while (true)
     Console.WriteLine($"Brand: {receivedMessage.Subject}, Price: {receivedMessage.ApplicationProperties["Price"]}");
 }
 ```
-
-## Source
-
-To see the full example source, see:
-
-* [Sample12_ManagingRules.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample12_ManagingRules.cs)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample13_AdvancedConfiguration.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample13_AdvancedConfiguration.md
@@ -74,9 +74,3 @@ ServiceBusProcessor processor = client.CreateProcessor("<queue-name>", new Servi
     PrefetchCount = 10
 });
 ```
-
-## Source
-
-To see the full example source, see:
-
-* [Sample13_AdvancedConfiguration.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample13_AdvancedConfiguration.cs)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample14_AMQPMessage.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample14_AMQPMessage.md
@@ -79,9 +79,3 @@ string customFooterValue = (string)receivedAmqpMessage.Footer["custom-footer-pro
 string customMessageAnnotation = (string)receivedAmqpMessage.MessageAnnotations["custom-message-annotation"];
 string customDeliveryAnnotation = (string)receivedAmqpMessage.DeliveryAnnotations["custom-delivery-annotation"];
 ```
-
-## Source
-
-To see the full example source, see:
-
-* [Sample14_AMQPMessage.cs](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample14_AMQPMessage.cs)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples) for more explanation about how to use this client library.

--- a/sdk/servicebus/Azure.ResourceManager.ServiceBus/tests/Samples/README.md
+++ b/sdk/servicebus/Azure.ResourceManager.ServiceBus/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/servicebus/Azure.ResourceManager.ServiceBus/samples) for more explanation about how to use this client library.

--- a/sdk/sqlmanagement/Azure.ResourceManager.Sql/tests/Samples/README.md
+++ b/sdk/sqlmanagement/Azure.ResourceManager.Sql/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/sqlmanagement/Azure.ResourceManager.Sql/samples) for more explanation about how to use this client library.

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/Samples/README.md
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/storage/Azure.ResourceManager.Storage/samples) for more explanation about how to use this client library.

--- a/sdk/synapse/Azure.Analytics.Synapse.AccessControl/tests/samples/README.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.AccessControl/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/synapse/Azure.Analytics.Synapse.AccessControl/samples) for more explanation about how to use this client library.

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/samples/README.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/synapse/Azure.Analytics.Synapse.Artifacts/samples) for more explanation about how to use this client library.

--- a/sdk/synapse/Azure.Analytics.Synapse.ManagedPrivateEndpoints/tests/samples/README.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.ManagedPrivateEndpoints/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/synapse/Azure.Analytics.Synapse.ManagedPrivateEndpoints/samples) for more explanation about how to use this client library.

--- a/sdk/synapse/Azure.Analytics.Synapse.Monitoring/tests/samples/README.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.Monitoring/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/synapse/Azure.Analytics.Synapse.Monitoring/samples) for more explanation about how to use this client library.

--- a/sdk/synapse/Azure.Analytics.Synapse.Spark/tests/samples/README.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.Spark/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/synapse/Azure.Analytics.Synapse.Spark/samples) for more explanation about how to use this client library.

--- a/sdk/tables/Azure.Data.Tables/samples/Sample1CreateDeleteTables.md
+++ b/sdk/tables/Azure.Data.Tables/samples/Sample1CreateDeleteTables.md
@@ -97,9 +97,3 @@ catch (RequestFailedException e)
     Console.WriteLine(e.Message);
 }
 ```
-
----
-To see the full example source files, see:
-- [Synchronous CreateDeleteTable](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tables/Azure.Data.Tables/tests/samples/Sample1_CreateDeleteTable.cs)
-- [Asynchronous CreateDeleteTable](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tables/Azure.Data.Tables/tests/samples/Sample1_CreateDeleteTableAsync.cs)
-- [CreateDeleteTableErrors](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tables/Azure.Data.Tables/tests/samples/Sample1_CreateDeleteTableErrors.cs)

--- a/sdk/tables/Azure.Data.Tables/samples/Sample2CreateDeleteEntities.md
+++ b/sdk/tables/Azure.Data.Tables/samples/Sample2CreateDeleteEntities.md
@@ -96,8 +96,3 @@ To delete an entity, invoke `DeleteEntity` and pass in its partition and row key
 // Delete the entity given the partition and row key.
 tableClient.DeleteEntity(partitionKey, rowKey);
 ```
-
----
-To see the full example source files, see:
-- [Synchronous Create and Delete Entities](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tables/Azure.Data.Tables/tests/samples/Sample2_CreateDeleteEntities.cs)
-- [Asynchronous Create and Delete Entities](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tables/Azure.Data.Tables/tests/samples/Sample2_CreateDeleteEntitiesAsync.cs)

--- a/sdk/tables/Azure.Data.Tables/samples/Sample3QueryTables.md
+++ b/sdk/tables/Azure.Data.Tables/samples/Sample3QueryTables.md
@@ -34,8 +34,3 @@ foreach (TableItem table in queryTableResults)
     Console.WriteLine(table.Name);
 }
 ```
-
----
-To see the full example source files, see:
-- [Synchronous Query Tables](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tables/Azure.Data.Tables/tests/samples/Sample3_QueryTables.cs)
-- [Asynchronous Query Tables](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tables/Azure.Data.Tables/tests/samples/Sample3_QueryTablesAsync.cs)

--- a/sdk/tables/Azure.Data.Tables/samples/Sample4QueryEntities.md
+++ b/sdk/tables/Azure.Data.Tables/samples/Sample4QueryEntities.md
@@ -96,8 +96,3 @@ foreach (Page<TableEntity> page in queryResultsMaxPerPage.AsPages())
     }
 }
 ```
-
----
-To see the full example source files, see:
-- [Synchronous Query Entities](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tables/Azure.Data.Tables/tests/samples/Sample4_QueryEntities.cs)
-- [Asynchronous Query Entities](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tables/Azure.Data.Tables/tests/samples/Sample4_QueryEntitiesAsync.cs)

--- a/sdk/tables/Azure.Data.Tables/samples/Sample5UpdateUpsertEntities.md
+++ b/sdk/tables/Azure.Data.Tables/samples/Sample5UpdateUpsertEntities.md
@@ -25,7 +25,7 @@ If you are not familiar with creating tables, refer to the sample on [creating a
 
 ## Upsert an entity
 
-The upsert operation combines the capabilities of insert and update unconditionally. 
+The upsert operation combines the capabilities of insert and update unconditionally.
 
 ```C# Snippet:TablesSample5UpsertEntityAsync
 var entity = new TableEntity(partitionKey, rowKey)
@@ -64,8 +64,3 @@ TableEntity updatedEntity = await tableClient.GetEntityAsync<TableEntity>(partit
 Console.WriteLine($"'Price' before updating: ${entity.GetDouble("Price")}");
 Console.WriteLine($"'Price' after updating: ${updatedEntity.GetDouble("Price")}");
 ```
-
----
-To see the full example source files, see:
-- [Synchronous Update and Upsert Entities](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tables/Azure.Data.Tables/tests/samples/Sample5_UpdateUpsertEntities.cs)
-- [Asynchronous Update and Upsert Entities](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tables/Azure.Data.Tables/tests/samples/Sample5_UpdateUpsertEntitiesAsync.cs)

--- a/sdk/tables/Azure.Data.Tables/samples/Sample6TransactionalBatch.md
+++ b/sdk/tables/Azure.Data.Tables/samples/Sample6TransactionalBatch.md
@@ -129,7 +129,3 @@ foreach (TableEntity entityToDelete in entityList)
 // Submit the batch.
 await client.SubmitTransactionAsync(deleteEntitiesBatch).ConfigureAwait(false);
 ```
-
----
-To see the full example source files, see:
-- [Transactional batches](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tables/Azure.Data.Tables/tests/samples/Sample6_TransactionalBatchAsync.cs)

--- a/sdk/tables/Azure.Data.Tables/tests/samples/README.md
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/tables/Azure.Data.Tables/samples) for more explanation about how to use this client library.

--- a/sdk/template/Azure.Template/samples/Sample1.HelloWorldAsync.md
+++ b/sdk/template/Azure.Template/samples/Sample1.HelloWorldAsync.md
@@ -22,6 +22,3 @@ SecretBundle secret = await client.GetSecretValueAsync("TestSecret");
 
 Console.WriteLine(secret.Value);
 ```
-
-To see the full example source files, see:
-* [HelloWorldAsync](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/template/Azure.Template/tests/Samples/Sample1_HelloWorldAsync.cs)

--- a/sdk/template/Azure.Template/samples/Sample1_HelloWorld.md
+++ b/sdk/template/Azure.Template/samples/Sample1_HelloWorld.md
@@ -22,6 +22,3 @@ SecretBundle secret = client.GetSecretValue("TestSecret");
 
 Console.WriteLine(secret.Value);
 ```
-
-To see the full example source files, see:
-* [HelloWorld](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/template/Azure.Template/tests/Samples/Sample1_HelloWorld.cs)

--- a/sdk/template/Azure.Template/tests/Samples/README.md
+++ b/sdk/template/Azure.Template/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/template/Azure.Template/samples) for more explanation about how to use this client library.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample10_MultiLabelClassify.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample10_MultiLabelClassify.md
@@ -90,13 +90,6 @@ await foreach (AnalyzeActionsResult documentsInPage in operation.Value)
 }
 ```
 
-To see the full example source files, see:
-
-* [Synchronously Multi Label Classify](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample10_MultiLabelClassify.cs)
-* [Asynchronously Multi Label Classify](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample10_MultiLabelClassifyAsync.cs)
-* [Synchronously Multi Label Classify Convenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample10_MultiLabelClassifyConvenience.cs)
-* [Asynchronously Multi Label Classify Convenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample10_MultiLabelClassifyConvenienceAsync.cs)
-
 [train_model]: https://aka.ms/azsdk/textanalytics/customfunctionalities
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/README.md

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample1_DetectLanguage.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample1_DetectLanguage.md
@@ -187,14 +187,5 @@ Console.WriteLine($"  Invalid document count: {documentsLanguage.Statistics.Inva
 Console.WriteLine($"  Transaction count: {documentsLanguage.Statistics.TransactionCount}");
 ```
 
-To see the full example source files, see:
-
-* [Synchronous DetectLanguage](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics//tests/samples/Sample1_DetectLanguage.cs)
-* [Asynchronous DetectLanguage](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageAsync.cs)
-* [Synchronous DetectLanguageBatch](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatch.cs)
-* [Asynchronous DetectLanguageBatch](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatchAsync.cs)
-* [Synchronous DetectLanguageBatchConvenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatchConvenience.cs)
-* [Asynchronous DetectLanguageBatchConvenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatchConvenienceAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/README.md

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2.1_AnalyzeSentimentWithOpinionMining.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2.1_AnalyzeSentimentWithOpinionMining.md
@@ -38,7 +38,7 @@ string reviewB = @"The rooms were beautiful. The AC was good and quiet, which wa
                 Once we notified the staff, they came and cleaned it and left candles.";
 
 string reviewC = @"Nice rooms! I had a great unobstructed view of the Microsoft campus
-                but bathrooms were old and the toilet was dirty when we arrived. 
+                but bathrooms were old and the toilet was dirty when we arrived.
                 It was close to bus stops and groceries stores. If you want to be close to
                 campus I will recommend it, otherwise, might be better to stay in a cleaner one.";
 
@@ -99,11 +99,6 @@ private Dictionary<string, int> GetComplaints(AnalyzeSentimentResultCollection r
     return complaints;
 }
 ```
-
-
-To see the full example source files, see:
-* [Synchronous Analyze Sentiment with Opinion Mining](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics//tests/samples/Sample2.1_AnalyzeSentimentWithOpinionMining.cs)
-* [Asynchronous Analyze Sentiment with Opinion Mining](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics//tests/samples/Sample2.1_AnalyzeSentimentWithOpinionMiningAsync.cs)
 
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/README.md

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2_AnalyzeSentiment.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2_AnalyzeSentiment.md
@@ -206,14 +206,5 @@ Console.WriteLine($"  Invalid document count: {sentimentPerDocuments.Statistics.
 Console.WriteLine($"  Transaction count: {sentimentPerDocuments.Statistics.TransactionCount}");
 ```
 
-To see the full example source files, see:
-
-* [Synchronous AnalyzeSentiment](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentiment.cs)
-* [Asynchronous AnalyzeSentiment](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentAsync.cs)
-* [Synchronous AnalyzeSentimentBatch](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatch.cs)
-* [Asynchronous AnalyzeSentimentBatch](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchAsync.cs)
-* [Synchronous AnalyzeSentimentBatchConvenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenience.cs)
-* [Asynchronous AnalyzeSentimentBatchConvenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenienceAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/README.md

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md
@@ -61,7 +61,7 @@ string documentB = @"Last week we stayed at Hotel Foo to celebrate our anniversa
 
 string documentC = @"That was the best day of my life! We went on a 4 day trip where we stayed at Hotel Foo.
                     They had great amenities that included an indoor pool, a spa, and a bar.
-                    The spa offered couples massages which were really good. 
+                    The spa offered couples massages which were really good.
                     The spa was clean and felt very peaceful. Overall the whole experience was great.
                     We will definitely come back.";
 
@@ -123,7 +123,7 @@ string documentB = @"Nos hospedamos en el Hotel Foo la semana pasada por nuestro
 
 string documentC = @"That was the best day of my life! We went on a 4 day trip where we stayed at Hotel Foo.
                     They had great amenities that included an indoor pool, a spa, and a bar.
-                    The spa offered couples massages which were really good. 
+                    The spa offered couples massages which were really good.
                     The spa was clean and felt very peaceful. Overall the whole experience was great.
                     We will definitely come back.";
 
@@ -187,16 +187,6 @@ Console.WriteLine($"  Invalid document count: {keyPhrasesInDocuments.Statistics.
 Console.WriteLine($"  Transaction count: {keyPhrasesInDocuments.Statistics.TransactionCount}");
 Console.WriteLine("");
 ```
-
-To see the full example source files, see:
-
-* [Synchronous ExtractKeyPhrases](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrases.cs)
-* [Asynchronous ExtractKeyPhrases](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesAsync.cs)
-* [ExtractKeyPhrases with warnings](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesWithWarnings.cs)
-* [Synchronous ExtractKeyPhrasesBatch](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatch.cs)
-* [Asynchronous ExtractKeyPhrasesBatch](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchAsync.cs)
-* [Synchronous ExtractKeyPhrasesBatchConvenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchConvenience.cs)
-* [Asynchronous ExtractKeyPhrasesBatchConvenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchConvenienceAsync.cs)
 
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/README.md

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md
@@ -68,7 +68,7 @@ string documentB = @"Last week we stayed at Hotel Foo to celebrate our anniversa
 
 string documentC = @"That was the best day of my life! We went on a 4 day trip where we stayed at Hotel Foo.
                     They had great amenities that included an indoor pool, a spa, and a bar.
-                    The spa offered couples massages which were really good. 
+                    The spa offered couples massages which were really good.
                     The spa was clean and felt very peaceful. Overall the whole experience was great.
                     We will definitely come back.";
 
@@ -137,7 +137,7 @@ string documentB = @"Nos hospedamos en el Hotel Foo la semana pasada por nuestro
 
 string documentC = @"That was the best day of my life! We went on a 4 day trip where we stayed at Hotel Foo.
                     They had great amenities that included an indoor pool, a spa, and a bar.
-                    The spa offered couples massages which were really good. 
+                    The spa offered couples massages which were really good.
                     The spa was clean and felt very peaceful. Overall the whole experience was great.
                     We will definitely come back.";
 
@@ -208,15 +208,6 @@ Console.WriteLine($"  Invalid document count: {entitiesInDocuments.Statistics.In
 Console.WriteLine($"  Transaction count: {entitiesInDocuments.Statistics.TransactionCount}");
 Console.WriteLine("");
 ```
-
-To see the full example source files, see:
-
-* [Synchronously RecognizeEntities](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntities.cs)
-* [Asynchronously RecognizeEntities](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesAsync.cs)
-* [Synchronously RecognizeEntitiesBatch](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatch.cs)
-* [Asynchronously RecognizeEntitiesBatch](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchAsync.cs)
-* [Synchronously RecognizeEntitiesBatchConvenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenience.cs)
-* [Asynchronously RecognizeEntitiesBatchConvenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenienceAsync.cs)
 
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/README.md

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample5_RecognizePiiEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample5_RecognizePiiEntities.md
@@ -188,14 +188,5 @@ Console.WriteLine($"  Transaction count: {entititesPerDocuments.Statistics.Trans
 Console.WriteLine("");
 ```
 
-To see the full example source files, see:
-* [Recognize PII Entities with specific categories](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesWithCategoriesFilter.cs)
-* [Synchronous RecognizePiiEntities](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntities.cs)
-* [Asynchronous RecognizePiiEntities](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesAsync.cs)
-* [Synchronous RecognizePiiEntitiesBatch](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatch.cs)
-* [Asynchronous RecognizePiiEntitiesBatch](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchAsync.cs)
-* [Synchronous RecognizePiiEntitiesBatchConvenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchConvenience.cs)
-* [Asynchronous RecognizePiiEntitiesBatchConvenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchConvenienceAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/README.md

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
@@ -65,7 +65,7 @@ string documentA = @"Microsoft was founded by Bill Gates with some friends he me
                     Microsoft originally moved its headquarters to Bellevue, Washington in Januaray 1979, but is now
                     headquartered in Redmond";
 
-string documentB = @"Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975, to develop and 
+string documentB = @"Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975, to develop and
                     sell BASIC interpreters for the Altair 8800. During his career at Microsoft, Gates held
                     the positions of chairman chief executive officer, president and chief software architect
                     while also being the largest individual shareholder until May 2014.";
@@ -133,7 +133,7 @@ string documentA = @"Microsoft was founded by Bill Gates with some friends he me
 string documentB = @"El CEO de Microsoft es Satya Nadella, quien asumió esta posición en Febrero de 2014. Él
                     empezó como Ingeniero de Software en el año 1992.";
 
-string documentC = @"Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975, to develop and 
+string documentC = @"Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975, to develop and
                     sell BASIC interpreters for the Altair 8800. During his career at Microsoft, Gates held
                     the positions of chairman chief executive officer, president and chief software architect
                     while also being the largest individual shareholder until May 2014.";
@@ -209,15 +209,6 @@ Console.WriteLine($"  Invalid document count: {entitiesPerDocuments.Statistics.I
 Console.WriteLine($"  Transaction count: {entitiesPerDocuments.Statistics.TransactionCount}");
 Console.WriteLine("");
 ```
-
-To see the full example source files, see:
-
-* [Synchronous RecognizeLinkedEntities](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs)
-* [Asynchronous RecognizeLinkedEntities](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesAsync.cs)
-* [Synchronous RecognizeLinkedEntitiesBatch](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatch.cs)
-* [Asynchronous RecognizeLinkedEntitiesBatch](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchAsync.cs)
-* [Synchronous RecognizeLinkedEntitiesBatchConvenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenience.cs)
-* [Asynchronous RecognizeLinkedEntitiesBatchConvenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenienceAsync.cs)
 
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/README.md

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample7_AnalyzeHealthcareEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample7_AnalyzeHealthcareEntities.md
@@ -137,14 +137,5 @@ await foreach (AnalyzeHealthcareEntitiesResultCollection documentsInPage in heal
 }
 ```
 
-To see the full example source files, see:
-
-* [Synchronous AnalyzeHealthcareEntities](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntities.cs)
-* [Asynchronous AnalyzeHealthcareEntities](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntitiesAsync.cs)
-* [Synchronous AnalyzeHealthcareEntities Convenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntitiesConvenience.cs)
-* [Asynchronous AnalyzeHealthcareEntities Convenience ](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntitiesConvenienceAsync.cs)
-* [Synchronous AnalyzeHealthcareEntities Cancellation](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntities_Cancellation.cs)
-* [Asynchronous AnalyzeHealthcareEntitiesAsync Cancellation](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntitiesAsync_Cancellation.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/README.md

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample8_RecognizeCustomEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample8_RecognizeCustomEntities.md
@@ -101,13 +101,6 @@ await foreach (AnalyzeActionsResult documentsInPage in operation.Value)
 }
 ```
 
-To see the full example source files, see:
-
-* [Synchronously RecognizeCustomEntities](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample8_RecognizeCustomEntities.cs)
-* [Asynchronously RecognizeCustomEntities](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample8_RecognizeCustomEntitiesAsync.cs)
-* [Synchronously RecognizeCustomEntities Convenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample8_RecognizeCustomEntitiesConvenience.cs)
-* [Asynchronously RecognizeCustomEntities Convenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample8_RecognizeCustomEntitiesConvenienceAsync.cs)
-
 <!-- LINKS -->
 [train_model]: https://aka.ms/azsdk/textanalytics/customentityrecognition
 [azure_language_studio]: https://language.azure.com/

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample9_SingleLabelClassify.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample9_SingleLabelClassify.md
@@ -83,13 +83,6 @@ await foreach (AnalyzeActionsResult documentsInPage in operation.Value)
 }
 ```
 
-To see the full example source files, see:
-
-* [Synchronously Single Label Classify](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample9_SingleLabelClassify.cs)
-* [Asynchronously Single Label Classify](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample9_SingleLabelClassifyAsync.cs)
-* [Synchronously Single Label Classify Convenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample9_SingleLabelClassifyConvenience.cs)
-* [Asynchronously Single Label Classify Convenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample9_SingleLabelClassifyConvenienceAsync.cs)
-
 [train_model]: https://aka.ms/azsdk/textanalytics/customfunctionalities
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/README.md

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_AnalyzeActions.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_AnalyzeActions.md
@@ -112,12 +112,5 @@ To run multiple actions in multiple documents, call `StartAnalyzeActionsAsync` o
 }
 ```
 
-To see the full example source files, see:
-
-* [Synchronously StartAnalyzeActions ](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperation.cs)
-* [Asynchronously StartAnalyzeActions ](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationAsync.cs)
-* [Synchronously StartAnalyzeActions Convenience ](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationConvenience.cs)
-* [Asynchronously StartAnalyzeActions Convenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationConvenienceAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/README.md

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_LROPolling.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_LROPolling.md
@@ -91,11 +91,6 @@ while (true)
 Console.WriteLine($"AnalyzeHealthcareEntities operation was completed");
 ```
 
-To see the full example source files, see:
-
-* [Asynchronous AnalyzeHealthcareEntities Convenience](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntitiesConvenienceAsync.cs)
-* [Synchronous AnalyzeHealthcareEntities Convenience ](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntitiesConvenience.cs)
-
 [analyze-healthcare-entities]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample7_AnalyzeHealthcareEntities.md
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/README.md

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_MockClient.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_MockClient.md
@@ -1,6 +1,6 @@
 # Mock a client for testing using the Moq library
 
-This sample illustrates how to use [Moq][moq] to create a unit test that mocks the response from a `TextAnalyticsClient` method. For more examples of mocking, see [Moq samples][moq_samples].
+This sample illustrates how to use [Moq][moq] to create a unit test that mocks the response from a `TextAnalyticsClient` method.
 
 ## Define method that uses TextAnalyticsClient
 To show the usage of mocks, define a method that will be tested with mocked objects. For this case, we are going to create a method that will verify if a document is writen in Spanish.
@@ -40,4 +40,3 @@ Assert.IsTrue(result);
 ```
 
 [moq]: https://github.com/Moq/moq4/
-[moq_samples]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/SampleMoq.cs

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/textanalytics/Azure.AI.TextAnalytics/samples) for more explanation about how to use this client library.

--- a/sdk/translation/Azure.AI.Translation.Document/samples/Sample1_StartTranslation.md
+++ b/sdk/translation/Azure.AI.Translation.Document/samples/Sample1_StartTranslation.md
@@ -58,11 +58,6 @@ await foreach (DocumentStatusResult document in operation.Value)
 }
 ```
 
-To see the full example source files, see:
-
-* [Synchronously StartTranslation ](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_StartTranslation.cs)
-* [Asynchronously StartTranslation ](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_StartTranslationAsync.cs)
-
 [Sas_token_permissions]: https://aka.ms/azsdk/documenttranslation/sas-permissions
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/translation/Azure.AI.Translation.Document/README.md

--- a/sdk/translation/Azure.AI.Translation.Document/samples/Sample2_PollIndividualDocuments.md
+++ b/sdk/translation/Azure.AI.Translation.Document/samples/Sample2_PollIndividualDocuments.md
@@ -60,10 +60,5 @@ await foreach (DocumentStatusResult document in operation.GetDocumentStatusesAsy
 }
 ```
 
-To see the full example source files, see:
-
-* [Synchronously PollIndividualDocuments ](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocuments.cs)
-* [Asynchronously PollIndividualDocuments ](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocumentsAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/translation/Azure.AI.Translation.Document/README.md

--- a/sdk/translation/Azure.AI.Translation.Document/samples/Sample3_OperationsHistory.md
+++ b/sdk/translation/Azure.AI.Translation.Document/samples/Sample3_OperationsHistory.md
@@ -56,10 +56,5 @@ Console.WriteLine($"Failed Document: {docsFailed}");
 Console.WriteLine($"Canceled Documents: {docsCanceled}");
 ```
 
-To see the full example source files, see:
-
-* [Synchronously OperationsHistory ](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_OperationsHistory.cs)
-* [Asynchronously OperationsHistory ](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_OperationsHistoryAsync.cs)
-
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/translation/Azure.AI.Translation.Document/README.md

--- a/sdk/translation/Azure.AI.Translation.Document/samples/Sample4_MultipleInputs.md
+++ b/sdk/translation/Azure.AI.Translation.Document/samples/Sample4_MultipleInputs.md
@@ -67,11 +67,6 @@ await foreach (DocumentStatusResult document in operation.GetValuesAsync())
 }
 ```
 
-To see the full example source files, see:
-
-* [Synchronously MultipleInputs ](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_MultipleInputs.cs)
-* [Asynchronously MultipleInputs ](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_MultipleInputsAsync.cs)
-
 [Sas_token_permissions]: https://aka.ms/azsdk/documenttranslation/sas-permissions
 [DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/translation/Azure.AI.Translation.Document/README.md

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/README.md
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/translation/Azure.AI.Translation.Document/samples) for more explanation about how to use this client library.

--- a/sdk/videoanalyzer/Azure.Media.VideoAnalyzer.Edge/tests/Samples/README.md
+++ b/sdk/videoanalyzer/Azure.Media.VideoAnalyzer.Edge/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/videoanalyzer/Azure.Media.VideoAnalyzer.Edge/samples) for more explanation about how to use this client library.

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/tests/Samples/README.md
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/samples) for more explanation about how to use this client library.

--- a/sdk/webpubsub/Azure.ResourceManager.WebPubSub/tests/Samples/README.md
+++ b/sdk/webpubsub/Azure.ResourceManager.WebPubSub/tests/Samples/README.md
@@ -1,0 +1,3 @@
+Source files in this directory are written as tests from which samples are extracted.
+They are not intended to be viewed directly and help ensure our samples compile and work correctly.
+See our [list of samples](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/webpubsub/Azure.ResourceManager.WebPubSub/samples) for more explanation about how to use this client library.


### PR DESCRIPTION
Fixes #32267 by adding a README.md to each sample source directory redirecting back to the packages' _samples_ directory, if any. Also fixes #32264. There are a few left where the sample is less of a test and would be involved to replace with snippets.