### PR TITLE
Update SB samples to target NET6.0

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -180,8 +180,10 @@
   <ItemGroup Condition="('$(IsTestProject)' == 'true') OR ('$(IsTestSupportProject)' == 'true') OR ('$(IsPerfProject)' == 'true') OR ('$(IsStressProject)' == 'true') OR ('$(IsSamplesProject)' == 'true')">
     <PackageReference Update="ApprovalTests" Version="3.0.22" />
     <PackageReference Update="ApprovalUtilities" Version="3.0.22" />
+    <PackageReference Update="Azure.Identity" Version="1.7.0" />  
     <PackageReference Update="Azure.Messaging.EventHubs" Version="5.2.0" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.0.0" />
+    <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.11.1" />  
     <PackageReference Update="Azure.ResourceManager.Compute" Version="1.0.0" />
     <PackageReference Update="Azure.ResourceManager.Network" Version="1.0.1" />
     <PackageReference Update="Azure.ResourceManager.Resources" Version="1.3.1" />

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/DeadLetterQueue/DeadLetterQueue.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/DeadLetterQueue/DeadLetterQueue.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
       <PackageReference Update="Azure.Identity" />
-      <ProjectReference Update="Azure.Messaging.ServiceBus" />
+      <PackageReference Update="Azure.Messaging.ServiceBus" />
       <PackageReference Update="System.CommandLine" />
     </ItemGroup>
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/DeadLetterQueue/DeadLetterQueue.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/DeadLetterQueue/DeadLetterQueue.csproj
@@ -11,4 +11,11 @@
     <PackageReference Include="System.CommandLine" VersionOverride="2.0.0-beta1.21216.1" />
   </ItemGroup>
 
+  <!-- Use decentralized package references when building outside https://github.com/Azure/azure-sdk-for-net -->
+  <ItemGroup Condition="'$(IsSamplesProject)' != 'true'">
+    <PackageReference Update="Azure.Identity" Version="1.7.0" />
+    <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.11.1" />
+    <PackageReference Update="System.CommandLine" Version="%(VersionOverride)" />
+  </ItemGroup>
+
 </Project>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/DeadLetterQueue/DeadLetterQueue.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/DeadLetterQueue/DeadLetterQueue.csproj
@@ -1,13 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Azure.Identity" Version="1.2.1" />
-<!--      Using project reference out until processor subqueue fix is released-->
-<!--      <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.2.0-beta.2" />-->
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
     </ItemGroup>
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/DeadLetterQueue/DeadLetterQueue.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/DeadLetterQueue/DeadLetterQueue.csproj
@@ -5,12 +5,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Azure.Identity" Version="1.2.1" />
-      <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\Azure.Messaging.ServiceBus.csproj" />
+      <PackageReference Update="Azure.Identity" />
+      <ProjectReference Update="Azure.Messaging.ServiceBus" />
+      <PackageReference Update="System.CommandLine" />
     </ItemGroup>
 
 </Project>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/DeadLetterQueue/DeadLetterQueue.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/DeadLetterQueue/DeadLetterQueue.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
-    </PropertyGroup>
+  
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Update="Azure.Identity" />
-      <PackageReference Update="Azure.Messaging.ServiceBus" />
-      <PackageReference Update="System.CommandLine" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" />
+    <PackageReference Include="System.CommandLine" VersionOverride="2.0.0-beta1.21216.1" />
+  </ItemGroup>
 
 </Project>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Directory.Build.props
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Directory.Build.props
@@ -1,9 +1,10 @@
 ﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- Signal that samples are building in the repo as opposed to a standalone download from Samples Browser -->
-    <IsSample>true</IsSample>
+    <IsSamplesProject>true</IsSamplesProject>
     <IsPackable>false</IsPackable>
     <ExcludeFromCodeCoverage>true</ExcludeFromCodeCoverage>
+    <ImportRepoCommonSettings>true</ImportRepoCommonSettings>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 
@@ -11,5 +12,6 @@
 
   <PropertyGroup>
     <InheritDocEnabled>false</InheritDocEnabled>
+    <IsShippingLibrary>false</IsShippingLibrary>
   </PropertyGroup>
 </Project>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Directory.Build.targets
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Directory.Build.targets
@@ -1,0 +1,14 @@
+<Project>
+
+  <PropertyGroup>
+    <TargetFrameworks Condition="'$(TargetFramework)' != ''">$(TargetFramework)</TargetFrameworks>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.targets))\Directory.Build.targets"
+          Condition="'$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.targets))' != ''" />
+
+  <!-- Disable targets not necessary for samples -->
+  <Target Name="ValidateTargetFrameworks" />
+  <Target Name="VerifyProjectReferencesReferences" />
+
+</Project>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/TopicFilters/TopicFilters.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/TopicFilters/TopicFilters.csproj
@@ -5,12 +5,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Azure.Identity" Version="1.2.1" />
-      <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
+      <PackageReference Update="Azure.Identity" />
+      <ProjectReference Update="Azure.Messaging.ServiceBus" />
+      <PackageReference Update="System.CommandLine" />
     </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\Azure.Messaging.ServiceBus.csproj" />
-    </ItemGroup>
-
+    
 </Project>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/TopicFilters/TopicFilters.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/TopicFilters/TopicFilters.csproj
@@ -10,5 +10,12 @@
     <PackageReference Include="Azure.Messaging.ServiceBus" />
     <PackageReference Include="System.CommandLine" VersionOverride="2.0.0-beta1.21216.1" />
   </ItemGroup>
+
+  <!-- Use decentralized package references when building outside https://github.com/Azure/azure-sdk-for-net -->
+  <ItemGroup Condition="'$(IsSamplesProject)' != 'true'">
+    <PackageReference Update="Azure.Identity" Version="1.7.0" />
+    <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.11.1" />
+    <PackageReference Update="System.CommandLine" Version="%(VersionOverride)" />
+  </ItemGroup>
     
 </Project>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/TopicFilters/TopicFilters.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/TopicFilters/TopicFilters.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
       <PackageReference Update="Azure.Identity" />
-      <ProjectReference Update="Azure.Messaging.ServiceBus" />
+      <PackageReference Update="Azure.Messaging.ServiceBus" />
       <PackageReference Update="System.CommandLine" />
     </ItemGroup>
     

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/TopicFilters/TopicFilters.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/TopicFilters/TopicFilters.csproj
@@ -1,13 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Azure.Identity" Version="1.2.1" />
-      <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.2.0-beta.2" />
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Azure.Messaging.ServiceBus.csproj" />
     </ItemGroup>
 
 </Project>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/TopicFilters/TopicFilters.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/TopicFilters/TopicFilters.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
-    </PropertyGroup>
+  
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Update="Azure.Identity" />
-      <PackageReference Update="Azure.Messaging.ServiceBus" />
-      <PackageReference Update="System.CommandLine" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" />
+    <PackageReference Include="System.CommandLine" VersionOverride="2.0.0-beta1.21216.1" />
+  </ItemGroup>
     
 </Project>


### PR DESCRIPTION
The repo update to use .NET 6 SDK (along with .NET 5 being EOL) is resulting in build errors for SB CI pipeline.