### PR TITLE
Remove the Arguments requirement in a SignalR message

### DIFF
--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/InternalSignalRMessage.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/InternalSignalRMessage.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.SignalR;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
+{
+    [JsonObject]
+    internal class InternalSignalRMessage
+    {
+        public string connectionId { get; set; }
+        public string userId { get; set; }
+        public string groupName { get; set; }
+        [JsonRequired]
+        public string target { get; set; }
+        public object[] arguments { get; set; }
+        public ServiceEndpoint[] endpoints { get; set; }
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/JTokenExtensions.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/JTokenExtensions.cs
@@ -1,17 +1,23 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
     internal static class JTokenExtensions
     {
+        public static readonly JsonSerializer JsonSerializers = JsonSerializer.Create(new JsonSerializerSettings
+        {
+            Converters = new JsonConverter[] { new ServiceEndpointJsonConverter(), new SignalRMessageConverter() }
+        });
+
         public static bool TryToObject<TOutput>(this JToken input, out TOutput output)
         {
             try
             {
-                output = input.ToObject<TOutput>(ServiceEndpointJsonConverter.JsonSerializer);
+                output = input.ToObject<TOutput>(JsonSerializers);
             }
             catch
             {

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/ServiceEndpointJsonConverter.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/ServiceEndpointJsonConverter.cs
@@ -9,10 +9,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
     internal class ServiceEndpointJsonConverter : JsonConverter<ServiceEndpoint>
     {
-        public static readonly JsonSerializer JsonSerializer = JsonSerializer.Create(new JsonSerializerSettings
-        {
-            Converters = new JsonConverter[] { new ServiceEndpointJsonConverter() }
-        });
         private const string FakeAccessKey = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
         public override ServiceEndpoint ReadJson(JsonReader reader, Type objectType, ServiceEndpoint existingValue, bool hasExistingValue, JsonSerializer serializer)

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRMessageConverter.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRMessageConverter.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
+{
+    /// <summary>
+    /// The <see cref="SignalRMessage.Arguments"/> shouldn't be required, but it's a breaking change to remove the <see cref="JsonRequiredAttribute"/> of the member. As a workaround, we have to use a converter to override the behaviour.
+    /// </summary>
+    internal class SignalRMessageConverter : JsonConverter<SignalRMessage>
+    {
+        public override SignalRMessage ReadJson(JsonReader reader, Type objectType, SignalRMessage existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var internalMessageObj = serializer.Deserialize<InternalSignalRMessage>(reader);
+            return new()
+            {
+                ConnectionId = internalMessageObj.connectionId,
+                UserId = internalMessageObj.userId,
+                GroupName = internalMessageObj.groupName,
+                Target = internalMessageObj.target,
+                Arguments = internalMessageObj.arguments,
+                Endpoints = internalMessageObj.endpoints,
+            };
+        }
+
+        public override void WriteJson(JsonWriter writer, SignalRMessage value, JsonSerializer serializer)
+        {
+            serializer.Serialize(writer, value);
+        }
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/SignalRConfigProvider.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/SignalRConfigProvider.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
                 .BindToInput(new NegotiationContextAsyncConverter(_serviceManagerStore));
 
             _ = context.AddBindingRule<SignalREndpointsAttribute>()
-                   .AddConverter<ServiceEndpoint[], JArray>(endpoints => JArray.FromObject(endpoints, ServiceEndpointJsonConverter.JsonSerializer))
+                   .AddConverter<ServiceEndpoint[], JArray>(endpoints => JArray.FromObject(endpoints, JTokenExtensions.JsonSerializers))
                    .BindToInput(new SignalREndpointsAsyncConverter(_serviceManagerStore));
 
             var signalRAttributeRule = context.AddBindingRule<SignalRAttribute>();

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Config/OptionsSetupFacts.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Config/OptionsSetupFacts.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Reflection;
 using Azure.Core.Serialization;
 using Microsoft.Azure.SignalR.Management;
 using Microsoft.Azure.WebJobs.Extensions.SignalRService;
@@ -81,7 +82,9 @@ namespace SignalRServiceExtension.Tests.Config
             var options = new ServiceManagerOptions();
             var setup = new OptionsSetup(configuration, SingletonAzureComponentFactory.Instance, "key");
             setup.Configure(options);
-            Assert.Equal(objectSerializerType, options.ObjectSerializer?.GetType());
+            // hack to access internal member
+            var serializer = typeof(ServiceManagerOptions).GetProperty("ObjectSerializer", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(options);
+            Assert.Equal(objectSerializerType, serializer?.GetType());
         }
     }
 }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/SignalROutputConverterTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/SignalROutputConverterTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using Microsoft.Azure.SignalR;
 using Microsoft.Azure.WebJobs.Extensions.SignalRService;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -31,18 +32,55 @@ namespace SignalRServiceExtension.Tests
             var converter = new SignalROutputConverter();
 
             var input = JObject.Parse(@"{
-              'userId': 'user1',
-              'target': 'newMessage',
-              'arguments': [
-                {
-                  'arg1': 'arg1',
-                  'agr2': 'arg2'
-                }
-              ]
+                'userId': 'user1',
+                'target': 'newMessage',
+                'arguments': [
+                    {
+                        'arg1': 'arg1',
+                        'agr2': 'arg2'
+                    }
+                ],
+                'endpoints': [
+                    {
+                        'endpointType': 'primary',
+                        'name': 'endpoint1',
+                        'endpoint': 'https://endpoint1',
+                        'online': 'true'
+                    },
+                    {
+                        'endpointType': 'primary',
+                        'name': 'endpoint2',
+                        'endpoint': 'https://endpoint2',
+                        'online': 'true'
+                    }
+                ]
             }");
 
             var converted = converter.ConvertToSignalROutput(input);
             Assert.Equal(typeof(SignalRMessage), converted.GetType());
+            var message = (SignalRMessage)converted;
+            Assert.Equal("newMessage", message.Target);
+            Assert.Equal("user1", message.UserId);
+            Assert.Equal(2, message.Endpoints.Length);
+            Assert.Equal(new ServiceEndpoint("Endpoint=https://endpoint1;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;Version=1.0;", name: "endpoint1"), message.Endpoints[0]);
+            Assert.Equal(new ServiceEndpoint("Endpoint=https://endpoint2;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;Version=1.0;", name: "endpoint2"), message.Endpoints[1]);
+        }
+
+        [Fact]
+        public void OutputConverter_SignalRMessage_ArgumentsNotRequired()
+        {
+            var converter = new SignalROutputConverter();
+
+            var input = JObject.Parse(@"{
+              'userId': 'user1',
+              'target': 'newMessage',
+            }");
+
+            var converted = converter.ConvertToSignalROutput(input);
+            Assert.Equal(typeof(SignalRMessage), converted.GetType());
+            var message = (SignalRMessage)converted;
+            Assert.Equal("newMessage", message.Target);
+            Assert.Equal("user1", message.UserId);
         }
 
         [Fact]


### PR DESCRIPTION
* Remove the Arguments requirement in a SignalR message. In isolated model, the arguments of a SignalR message are not required. However, it's required here. We cannot remove the `JsonRequired` attribute of the member as it's a breaking change and fails the build. We have to use a custom JSON converter to make it not required.
* Hack to access internal member `ServiceManagerOptions.ObjectSerializer`

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
