### PR TITLE
Refactor the build method of `ServiceManager` to remove internal dependency

### DIFF
--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/EmptyConfiguration.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/EmptyConfiguration.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Azure.SignalR.Management;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
+{
+    /// <summary>
+    /// This configuration does nothing but provides a reload token from a real <see cref="IConfiguration"/> object.
+    /// It aims to trigger a configuration reload of <see cref="ServiceHubContext"/> when the real configuration changes. As the <see cref="ServiceManagerBuilder"/> doesn't provide an API to inject an <see cref="IOptionsChangeTokenSource{ServiceManagerOptions}"/> and it has a different way to read configuration with function extensions, we have to inject an empty configuration via <see cref="ServiceManagerBuilder.WithConfiguration(IConfiguration)"/> to provide a reload token and does actual configuration parsing via <see cref="ServiceManagerBuilder.WithOptions(Action{ServiceManagerOptions})"/>.
+    /// </summary>
+    internal class EmptyConfiguration : IConfiguration
+    {
+        private static readonly IConfiguration EmptyImpl = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        private readonly IConfiguration _configuration;
+
+        public EmptyConfiguration(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public string this[string key] { get => null; set { } }
+
+        public IEnumerable<IConfigurationSection> GetChildren() => Array.Empty<IConfigurationSection>();
+
+        public IChangeToken GetReloadToken() => _configuration.GetReloadToken();
+
+        public IConfigurationSection GetSection(string key) => EmptyImpl.GetSection(key);
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/IInternalServiceHubContextStore.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/IInternalServiceHubContextStore.cs
@@ -3,14 +3,14 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.Azure.SignalR;
 using Microsoft.Azure.SignalR.Management;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
     internal interface IInternalServiceHubContextStore : IServiceHubContextStore, IAsyncDisposable, IDisposable
     {
-        AccessKey[] AccessKeys { get; }
+        IOptionsMonitor<SignatureValidationOptions> SignatureValidationOptions { get; }
 
         ValueTask<ServiceHubContext<T>> GetAsync<T>(string hubName) where T : class;
     }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/OptionsSetup.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/OptionsSetup.cs
@@ -7,18 +7,16 @@ using Microsoft.Azure.SignalR;
 using Microsoft.Azure.SignalR.Management;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
-    internal class OptionsSetup : IConfigureOptions<ServiceManagerOptions>, IOptionsChangeTokenSource<ServiceManagerOptions>
+    internal class OptionsSetup
     {
         private readonly IConfiguration _configuration;
-        private readonly AzureComponentFactory _azureComponentFactory;
-        private readonly string _connectionStringKey;
+        private readonly Action<ServiceManagerOptions> _configureServiceManagerOptions;
 
-        public OptionsSetup(IConfiguration configuration, AzureComponentFactory azureComponentFactory, string connectionStringKey)
+        public OptionsSetup(IConfiguration configuration, AzureComponentFactory azureComponentFactory, string connectionStringKey, SignalROptions optionsFromCode)
         {
             if (string.IsNullOrWhiteSpace(connectionStringKey))
             {
@@ -26,53 +24,49 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             }
 
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-            _azureComponentFactory = azureComponentFactory;
-            _connectionStringKey = connectionStringKey;
+            _configureServiceManagerOptions = options =>
+            {
+                // Apply options from code.
+                options.ServiceEndpoints = optionsFromCode.ServiceEndpoints?.ToArray();
+                options.ServiceTransportType = optionsFromCode.ServiceTransportType;
+                options.UseJsonObjectSerializer(optionsFromCode.JsonObjectSerializer);
+
+                // Apply options from configuration
+                if (_configuration.TryGetJsonObjectSerializer(out var serializer))
+                {
+                    options.UseJsonObjectSerializer(serializer);
+                }
+                if (_configuration.GetConnectionString(connectionStringKey) != null || _configuration[connectionStringKey] != null)
+                {
+                    options.ConnectionString = _configuration.GetConnectionString(connectionStringKey) ?? _configuration[connectionStringKey];
+                }
+                var endpoints = _configuration.GetSection(Constants.AzureSignalREndpoints).GetEndpoints(azureComponentFactory);
+
+                // when the configuration is in the style: AzureSignalRConnectionString:serviceUri = https://xxx.service.signalr.net , we see the endpoint as unnamed.
+                if (options.ConnectionString == null && _configuration.GetSection(connectionStringKey).TryGetEndpointFromIdentity(azureComponentFactory, out var endpoint, isNamed: false))
+                {
+                    endpoints = endpoints.Append(endpoint);
+                }
+                if (endpoints.Any())
+                {
+                    options.ServiceEndpoints = endpoints.ToArray();
+                }
+                var serviceTransportTypeStr = _configuration[Constants.ServiceTransportTypeName];
+                if (Enum.TryParse<ServiceTransportType>(serviceTransportTypeStr, out var transport))
+                {
+                    options.ServiceTransportType = transport;
+                }
+                else if (!string.IsNullOrWhiteSpace(serviceTransportTypeStr))
+                {
+                    throw new InvalidOperationException($"Invalid service transport type: {serviceTransportTypeStr}.");
+                }
+                //make connection more stable
+                options.ConnectionCount = 3;
+                options.ProductInfo = GetProductInfo();
+            };
         }
 
-        public string Name => Options.DefaultName;
-
-        public void Configure(ServiceManagerOptions options)
-        {
-            if (_configuration.TryGetJsonObjectSerializer(out var serializer))
-            {
-                options.UseJsonObjectSerializer(serializer);
-            }
-
-            if (_configuration.GetConnectionString(_connectionStringKey) != null || _configuration[_connectionStringKey] != null)
-            {
-                options.ConnectionString = _configuration.GetConnectionString(_connectionStringKey) ?? _configuration[_connectionStringKey];
-            }
-
-            var endpoints = _configuration.GetSection(Constants.AzureSignalREndpoints).GetEndpoints(_azureComponentFactory);
-
-            // when the configuration is in the style: AzureSignalRConnectionString:serviceUri = https://xxx.service.signalr.net , we see the endpoint as unnamed.
-            if (options.ConnectionString == null && _configuration.GetSection(_connectionStringKey).TryGetEndpointFromIdentity(_azureComponentFactory, out var endpoint, isNamed: false))
-            {
-                endpoints = endpoints.Append(endpoint);
-            }
-            if (endpoints.Any())
-            {
-                options.ServiceEndpoints = endpoints.ToArray();
-            }
-            var serviceTransportTypeStr = _configuration[Constants.ServiceTransportTypeName];
-            if (Enum.TryParse<ServiceTransportType>(serviceTransportTypeStr, out var transport))
-            {
-                options.ServiceTransportType = transport;
-            }
-            else if (!string.IsNullOrWhiteSpace(serviceTransportTypeStr))
-            {
-                throw new InvalidOperationException($"Invalid service transport type: {serviceTransportTypeStr}.");
-            }
-            //make connection more stable
-            options.ConnectionCount = 3;
-            options.ProductInfo = GetProductInfo();
-        }
-
-        public IChangeToken GetChangeToken()
-        {
-            return _configuration.GetReloadToken();
-        }
+        public Action<ServiceManagerOptions> Configure => _configureServiceManagerOptions;
 
         private string GetProductInfo()
         {

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/ServiceHubContextStore.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/ServiceHubContextStore.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.SignalR;
 using Microsoft.Azure.SignalR.Management;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
@@ -14,17 +14,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     {
         private readonly ConcurrentDictionary<string, (Lazy<Task<IServiceHubContext>> Lazy, IServiceHubContext Value)> _store = new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<string, Lazy<Task<object>>> _stronglyTypedStore = new(StringComparer.OrdinalIgnoreCase);
-        private readonly IServiceEndpointManager _endpointManager;
         private readonly ServiceManager _serviceManager;
-
-        public AccessKey[] AccessKeys => _endpointManager.Endpoints.Keys.Select(endpoint => endpoint.AccessKey).ToArray();
 
         public IServiceManager ServiceManager => _serviceManager as IServiceManager;
 
-        public ServiceHubContextStore(IServiceEndpointManager endpointManager, ServiceManager serviceManager)
+        public IOptionsMonitor<SignatureValidationOptions> SignatureValidationOptions { get; }
+
+        public ServiceHubContextStore(IOptionsMonitor<SignatureValidationOptions> signatureValidationOptions, ServiceManager serviceManager)
         {
+            SignatureValidationOptions = signatureValidationOptions;
             _serviceManager = serviceManager;
-            _endpointManager = endpointManager;
         }
 
         public async ValueTask<ServiceHubContext<T>> GetAsync<T>(string hubName) where T : class

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/SignatureValidationOptions.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/SignatureValidationOptions.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
+{
+    internal class SignatureValidationOptions
+    {
+        public List<string> AccessKeys { get; } = new List<string>();
+        public bool RequireValidation { get; set; } = true;
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/SignatureValidationOptionsSetup.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/SignatureValidationOptionsSetup.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Azure.SignalR;
+using Microsoft.Azure.SignalR.Management;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
+{
+    internal class SignatureValidationOptionsSetup : IConfigureOptions<SignatureValidationOptions>
+    {
+        private static readonly char[] PropertySeparator = { ';' };
+        private static readonly char[] KeyValueSeparator = { '=' };
+        private const string AccessKeyProperty = "AccessKey";
+
+        private readonly Action<ServiceManagerOptions> _configureServiceManagerOptions;
+
+        public SignatureValidationOptionsSetup(Action<ServiceManagerOptions> configureServiceManagerOptions)
+        {
+            _configureServiceManagerOptions = configureServiceManagerOptions;
+        }
+
+        /// <remarks>
+        /// We can't get the <see cref="ServiceManagerOptions"/> from <see cref="ServiceManager"/>, therefore we have to reuse the configuration action to build the options again.
+        /// </remarks>
+        public void Configure(SignatureValidationOptions options)
+        {
+            var serviceManagerOptions = new ServiceManagerOptions();
+            _configureServiceManagerOptions(serviceManagerOptions);
+            IEnumerable<ServiceEndpoint> endpoints = serviceManagerOptions.ServiceEndpoints ?? Array.Empty<ServiceEndpoint>();
+            if (serviceManagerOptions.ConnectionString != null)
+            {
+                endpoints = endpoints.Append(new ServiceEndpoint(serviceManagerOptions.ConnectionString));
+            }
+            foreach (var endpoint in endpoints)
+            {
+                if (endpoint.ConnectionString != null && TryGetAccessKey(endpoint.ConnectionString, out var accessKey))
+                {
+                    options.AccessKeys.Add(accessKey);
+                }
+                else
+                {
+                    // Once there is one connection string without access key, the validation is not required. Currently we don't have mechanism to validate identity-based connection.
+                    options.RequireValidation = false;
+                    // Validation isn't required therefore no need to continue to get the access keys.
+                    return;
+                }
+            }
+        }
+
+        private static bool TryGetAccessKey(string connectionString, out string accesskey)
+        {
+            foreach (var property in connectionString.Split(PropertySeparator, StringSplitOptions.RemoveEmptyEntries))
+            {
+                var kvp = property.Split(KeyValueSeparator, 2);
+                if (kvp.Length != 2)
+                {
+                    continue;
+                }
+                if (kvp[0].Trim().Equals(AccessKeyProperty, StringComparison.OrdinalIgnoreCase))
+                {
+                    accesskey = kvp[1].Trim();
+                    return true;
+                }
+            }
+            accesskey = null;
+            return false;
+        }
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/Executor/ExecutionContext.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/Executor/ExecutionContext.cs
@@ -1,15 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Azure.SignalR;
 using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
     internal class ExecutionContext
     {
         public ITriggeredFunctionExecutor Executor { get; set; }
-
-        public AccessKey[] AccessKeys { get; set; }
+        public IOptionsMonitor<SignatureValidationOptions> SignatureValidationOptions { get; set; }
     }
 }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/Executor/SignalRMethodExecutor.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/Executor/SignalRMethodExecutor.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         protected Task<FunctionResult> ExecuteWithAuthAsync(HttpRequestMessage request, ExecutionContext executor,
             InvocationContext context, TaskCompletionSource<object> tcs = null)
         {
-            if (!Resolver.ValidateSignature(request, executor.AccessKeys))
+            if (!Resolver.ValidateSignature(request, executor.SignatureValidationOptions))
             {
                 throw new SignalRTriggerAuthorizeFailedException();
             }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/Resolver/IRequestResolver.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/Resolver/IRequestResolver.cs
@@ -5,8 +5,8 @@ using System.Net.Http;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.SignalR.Protocol;
-using Microsoft.Azure.SignalR;
 using Microsoft.Azure.SignalR.Serverless.Protocols;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     {
         bool ValidateContentType(HttpRequestMessage request);
 
-        bool ValidateSignature(HttpRequestMessage request, AccessKey[] accessKeys);
+        bool ValidateSignature(HttpRequestMessage request, IOptionsMonitor<SignatureValidationOptions> signatureValidationOptions);
 
         bool TryGetInvocationContext(HttpRequestMessage request, out InvocationContext context);
 

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/SignalRTriggerBinding.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/SignalRTriggerBinding.cs
@@ -11,12 +11,12 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.SignalR;
 using Microsoft.Azure.SignalR.Management;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.Triggers;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
@@ -28,16 +28,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         private readonly ParameterInfo _parameterInfo;
         private readonly SignalRTriggerAttribute _attribute;
         private readonly ISignalRTriggerDispatcher _dispatcher;
-        private readonly AccessKey[] _accessKeys;
+        private readonly IOptionsMonitor<SignatureValidationOptions> _signatureValidationOptions;
         private readonly ServiceHubContext _hubContext;
 
-        public SignalRTriggerBinding(ParameterInfo parameterInfo, SignalRTriggerAttribute attribute, ISignalRTriggerDispatcher dispatcher, AccessKey[] accessKeys, ServiceHubContext hubContext)
+        public SignalRTriggerBinding(ParameterInfo parameterInfo, SignalRTriggerAttribute attribute, ISignalRTriggerDispatcher dispatcher, IOptionsMonitor<SignatureValidationOptions> signatureValidationOptions, ServiceHubContext hubContext)
         {
             _parameterInfo = parameterInfo ?? throw new ArgumentNullException(nameof(parameterInfo));
             _attribute = attribute ?? throw new ArgumentNullException(nameof(attribute));
             _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
-            _accessKeys = accessKeys ?? throw new ArgumentNullException(nameof(accessKeys));
-            _hubContext = hubContext;
+            _signatureValidationOptions = signatureValidationOptions ?? throw new ArgumentNullException(nameof(signatureValidationOptions));
+            _hubContext = hubContext ?? throw new ArgumentNullException(nameof(hubContext));
             BindingDataContract = CreateBindingContract(_attribute, _parameterInfo);
         }
 
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 
             // It's not a real listener, and it doesn't need a start or close.
             _dispatcher.Map((_attribute.HubName, _attribute.Category, _attribute.Event),
-                new ExecutionContext { Executor = context.Executor, AccessKeys = _accessKeys });
+                new ExecutionContext { Executor = context.Executor, SignatureValidationOptions = _signatureValidationOptions });
 
             return Task.FromResult<IListener>(new NullListener());
         }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/SignalRTriggerBindingProvider.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/SignalRTriggerBindingProvider.cs
@@ -52,11 +52,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             var resolvedAttribute = GetParameterResolvedAttribute(attribute, parameterInfo);
             ValidateSignalRTriggerAttributeBinding(resolvedAttribute);
 
-            var accessKeys = _managerStore.GetOrAddByConnectionStringKey(resolvedAttribute.ConnectionStringSetting).AccessKeys;
+            var hubContextStore = _managerStore.GetOrAddByConnectionStringKey(resolvedAttribute.ConnectionStringSetting);
 
-            var hubContext = await _managerStore.GetOrAddByConnectionStringKey(resolvedAttribute.ConnectionStringSetting).GetAsync(resolvedAttribute.HubName).ConfigureAwait(false);
+            var hubContext = await hubContextStore.GetAsync(resolvedAttribute.HubName).ConfigureAwait(false);
 
-            return new SignalRTriggerBinding(parameterInfo, resolvedAttribute, _dispatcher, accessKeys, hubContext as ServiceHubContext);
+            return new SignalRTriggerBinding(parameterInfo, resolvedAttribute, _dispatcher, hubContextStore.SignatureValidationOptions, hubContext as ServiceHubContext);
         }
 
         internal SignalRTriggerAttribute GetParameterResolvedAttribute(SignalRTriggerAttribute attribute, ParameterInfo parameterInfo)

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Config/OptionsSetupFacts.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Config/OptionsSetupFacts.cs
@@ -20,7 +20,7 @@ namespace SignalRServiceExtension.Tests.Config
             var sectionKey = "connection";
             var serviceUri = "http://localhost.signalr.com";
             configuration[$"{sectionKey}:serviceUri"] = serviceUri;
-            var optionsSetup = new OptionsSetup(configuration, SingletonAzureComponentFactory.Instance, sectionKey);
+            var optionsSetup = new OptionsSetup(configuration, SingletonAzureComponentFactory.Instance, sectionKey, new());
             var options = new ServiceManagerOptions();
             optionsSetup.Configure(options);
 
@@ -37,7 +37,7 @@ namespace SignalRServiceExtension.Tests.Config
             var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
             configuration[$"Azure:SignalR:Endpoints:{endpointNames[0]}:serviceUri"] = serviceUris[0];
             configuration[$"Azure:SignalR:Endpoints:{endpointNames[1]}:serviceUri"] = serviceUris[1];
-            var optionsSetup = new OptionsSetup(configuration, SingletonAzureComponentFactory.Instance, "does_not_matter");
+            var optionsSetup = new OptionsSetup(configuration, SingletonAzureComponentFactory.Instance, "does_not_matter", new());
             var options = new ServiceManagerOptions();
             optionsSetup.Configure(options);
 
@@ -59,7 +59,7 @@ namespace SignalRServiceExtension.Tests.Config
             configuration[$"Azure:SignalR:Endpoints:{endpointName}:serviceUri"] = serviceUris[0];
             configuration[$"{namelessEndpointKey}:serviceUri"] = serviceUris[1];
 
-            var optionsSetup = new OptionsSetup(configuration, SingletonAzureComponentFactory.Instance, namelessEndpointKey);
+            var optionsSetup = new OptionsSetup(configuration, SingletonAzureComponentFactory.Instance, namelessEndpointKey, new());
             var options = new ServiceManagerOptions();
             optionsSetup.Configure(options);
 
@@ -80,7 +80,7 @@ namespace SignalRServiceExtension.Tests.Config
             var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
             configuration[configKey] = configValue;
             var options = new ServiceManagerOptions();
-            var setup = new OptionsSetup(configuration, SingletonAzureComponentFactory.Instance, "key");
+            var setup = new OptionsSetup(configuration, SingletonAzureComponentFactory.Instance, "key", new());
             setup.Configure(options);
             // hack to access internal member
             var serializer = typeof(ServiceManagerOptions).GetProperty("ObjectSerializer", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(options);

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Config/ServiceManagerStoreTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Config/ServiceManagerStoreTests.cs
@@ -6,17 +6,21 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Azure.Core.Serialization;
+using Microsoft.Azure.SignalR;
 using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Management;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Azure.WebJobs.Extensions.SignalRService;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Moq;
 using Xunit;
+using Constants = Microsoft.Azure.WebJobs.Extensions.SignalRService.Constants;
 
 namespace SignalRServiceExtension.Tests
 {
@@ -44,15 +48,12 @@ namespace SignalRServiceExtension.Tests
             configuration[connectionStringKey] = connectionString;
             configuration[Constants.FunctionsWorkerRuntime] = Constants.DotnetWorker;
 
-            var productInfo = new ServiceCollection()
-                .AddSignalRServiceManager(new OptionsSetup(configuration, SingletonAzureComponentFactory.Instance, connectionStringKey))
-                .BuildServiceProvider()
-                .GetRequiredService<IOptions<ServiceManagerOptions>>()
-                .Value.ProductInfo;
-
-            Assert.NotNull(productInfo);
+            var setup = new OptionsSetup(configuration, SingletonAzureComponentFactory.Instance, connectionStringKey, new());
+            var options = new ServiceManagerOptions();
+            setup.Configure(options);
+            Assert.NotNull(options.ProductInfo);
             var reg = new Regex(@"\[(\w*)=(\w*)\]");
-            var match = reg.Match(productInfo);
+            var match = reg.Match(options.ProductInfo);
             Assert.Equal(Constants.FunctionsWorkerProductInfoKey, match.Groups[1].Value);
             Assert.Equal(Constants.DotnetWorker, match.Groups[2].Value);
         }
@@ -93,6 +94,30 @@ namespace SignalRServiceExtension.Tests
             Assert.Equal(3, resultOptions.ServiceEndpoints.Length);
             Assert.Equal(ServiceTransportType.Persistent, resultOptions.ServiceTransportType);
             Assert.IsType<NewtonsoftJsonObjectSerializer>(resultOptions.ObjectSerializer);
+        }
+
+        [Fact]
+        public async void TestConfigurationHotReload()
+        {
+            var mock = new Mock<IEndpointRouter>();
+            var connectionStrings = FakeEndpointUtils.GetFakeConnectionString(2).ToArray();
+            var configuration = new ConfigurationRoot(new List<IConfigurationProvider>() { new MemoryConfigurationProvider(new()) });
+            configuration[Constants.AzureSignalRConnectionStringName] = connectionStrings[0];
+            // Only persistent mode supports hot reload.
+            configuration[Constants.ServiceTransportTypeName] = "Persistent";
+            var managerStore = new ServiceManagerStore(configuration, NullLoggerFactory.Instance, SingletonAzureComponentFactory.Instance, Options.Create(new SignalROptions()), mock.Object);
+            var hubContextStore = managerStore.GetOrAddByConnectionStringKey(Constants.AzureSignalRConnectionStringName);
+            var hubContext = await hubContextStore.GetAsync("hub") as ServiceHubContext;
+            await hubContext.ClientManager.UserExistsAsync("a");
+
+            configuration[Constants.AzureSignalRConnectionStringName] = connectionStrings[1];
+            configuration.Reload();
+            await Task.Delay(3000);
+            await hubContext.ClientManager.UserExistsAsync("a");
+
+            Assert.Equal(2, mock.Invocations.Count);
+            // By design, the new endpoint is firstly appended to the original endpoint list instead of replacing the old endpoint.
+            Assert.Equal(2, (mock.Invocations.Last().Arguments[1] as IEnumerable<ServiceEndpoint>).Count());
         }
     }
 }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Config/SignatureValidationOptionsSetupTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Config/SignatureValidationOptionsSetupTests.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Azure.Identity;
+using Microsoft.Azure.SignalR;
+using Microsoft.Azure.SignalR.Management;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using SignalRServiceExtension.Tests;
+using Xunit;
+using static Microsoft.Azure.SignalR.Tests.Common.FakeEndpointUtils;
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
+{
+    public class SignatureValidationOptionsSetupTests
+    {
+        private static readonly string AccessKeyConnectionString = GetFakeConnectionString(1).Single();
+        private const string AadConnectionString = "Endpoint=http://localhost; AuthType=aad ;Version=1.0;";
+        public static IEnumerable<object[]> ConfigureTestData()
+        {
+            yield return new object[] { AccessKeyConnectionString, null, true, new string[] { FakeAccessKey } };
+            yield return new object[] { null, GetFakeEndpoint(2), true, Enumerable.Repeat(FakeAccessKey, 2) };
+            yield return new object[] { AccessKeyConnectionString, GetFakeEndpoint(2), true, Enumerable.Repeat(FakeAccessKey, 3) };
+
+            yield return new object[] { AadConnectionString, null, false, null };
+            yield return new object[] { AadConnectionString, new ServiceEndpoint[] { new ServiceEndpoint(new Uri("https://endpoint"), new DefaultAzureCredential()), new ServiceEndpoint(AadConnectionString) }, false, null };
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigureTestData))]
+        public void OptionsConfigureTest(string connectionString, IEnumerable<ServiceEndpoint> serviceEndpoints, bool expectedValidationRequirement, string[] expectedAccessKey)
+        {
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+            configuration[Constants.AzureSignalRConnectionStringName] = connectionString;
+            var signalROptions = new SignalROptions()
+            {
+                ServiceTransportType = ServiceTransportType.Persistent
+            };
+            foreach (var endpoint in serviceEndpoints ?? Array.Empty<ServiceEndpoint>())
+            {
+                signalROptions.ServiceEndpoints.Add(endpoint);
+            }
+            var serviceManagerStore = new ServiceManagerStore(configuration, NullLoggerFactory.Instance, SingletonAzureComponentFactory.Instance, Options.Create(signalROptions));
+            var hubContextStore = serviceManagerStore.GetOrAddByConnectionStringKey(Constants.AzureSignalRConnectionStringName);
+            var signatureValidationOptions = hubContextStore.SignatureValidationOptions.CurrentValue;
+            Assert.Equal(expectedValidationRequirement, signatureValidationOptions.RequireValidation);
+            if (expectedValidationRequirement)
+            {
+                Assert.True(expectedAccessKey.SequenceEqual(signatureValidationOptions.AccessKeys));
+            }
+        }
+
+        [Fact]
+        public void OptionsHotReloadTest()
+        {
+            var configuration = new ConfigurationRoot(new List<IConfigurationProvider>() { new MemoryConfigurationProvider(new()) });
+            configuration[Constants.AzureSignalRConnectionStringName] = AadConnectionString;
+            var serviceManagerStore = new ServiceManagerStore(configuration, NullLoggerFactory.Instance, SingletonAzureComponentFactory.Instance, Options.Create(new SignalROptions()));
+            var options = serviceManagerStore.GetOrAddByConnectionStringKey(Constants.AzureSignalRConnectionStringName).SignatureValidationOptions;
+            Assert.False(options.CurrentValue.RequireValidation);
+
+            configuration[Constants.AzureSignalRConnectionStringName] = AccessKeyConnectionString;
+            configuration.Reload();
+            Assert.True(options.CurrentValue.RequireValidation);
+            Assert.Equal(FakeAccessKey, options.CurrentValue.AccessKeys.Single());
+        }
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Trigger/SignalRMethodExecutorTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Trigger/SignalRMethodExecutorTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Azure.SignalR.Serverless.Protocols;
 using Microsoft.Azure.WebJobs.Extensions.SignalRService;
 using Microsoft.Azure.WebJobs.Extensions.SignalRService.Tests.Common;
 using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Extensions.Options;
 using Moq;
 using Newtonsoft.Json;
 using SignalRServiceExtension.Tests.Utils;
@@ -21,6 +22,7 @@ namespace SignalRServiceExtension.Tests.Trigger
 {
     public class SignalRMethodExecutorTests
     {
+        private static readonly IOptionsMonitor<SignatureValidationOptions> SignatureValidationOptions = Mock.Of<IOptionsMonitor<SignatureValidationOptions>>(o => o.CurrentValue == new SignatureValidationOptions() { RequireValidation = false });
         private readonly ITriggeredFunctionExecutor _triggeredFunctionExecutor;
         private readonly TaskCompletionSource<TriggeredFunctionData> _triggeredFunctionDataTcs;
 
@@ -41,8 +43,8 @@ namespace SignalRServiceExtension.Tests.Trigger
         [Fact]
         public async Task SignalRConnectMethodExecutorTest()
         {
-            var resolver = new SignalRRequestResolver(false);
-            var methodExecutor = new SignalRConnectMethodExecutor(resolver, new ExecutionContext { Executor = _triggeredFunctionExecutor });
+            var resolver = new SignalRRequestResolver();
+            var methodExecutor = new SignalRConnectMethodExecutor(resolver, new ExecutionContext { Executor = _triggeredFunctionExecutor, SignatureValidationOptions = SignatureValidationOptions });
             var hub = Guid.NewGuid().ToString();
             var category = Guid.NewGuid().ToString();
             var @event = Guid.NewGuid().ToString();
@@ -64,8 +66,8 @@ namespace SignalRServiceExtension.Tests.Trigger
         [Fact]
         public async Task SignalRDisconnectMethodExecutorTest()
         {
-            var resolver = new SignalRRequestResolver(false);
-            var methodExecutor = new SignalRDisconnectMethodExecutor(resolver, new ExecutionContext { Executor = _triggeredFunctionExecutor });
+            var resolver = new SignalRRequestResolver();
+            var methodExecutor = new SignalRDisconnectMethodExecutor(resolver, new ExecutionContext { Executor = _triggeredFunctionExecutor, SignatureValidationOptions = SignatureValidationOptions });
             var hub = Guid.NewGuid().ToString();
             var category = Guid.NewGuid().ToString();
             var @event = Guid.NewGuid().ToString();
@@ -91,8 +93,8 @@ namespace SignalRServiceExtension.Tests.Trigger
         [InlineData("messagepack")]
         public async Task SignalRInvocationMethodExecutorTest(string protocolName)
         {
-            var resolver = new SignalRRequestResolver(false);
-            var methodExecutor = new SignalRInvocationMethodExecutor(resolver, new ExecutionContext { Executor = _triggeredFunctionExecutor });
+            var resolver = new SignalRRequestResolver();
+            var methodExecutor = new SignalRInvocationMethodExecutor(resolver, new ExecutionContext { Executor = _triggeredFunctionExecutor, SignatureValidationOptions = SignatureValidationOptions });
             var hub = Guid.NewGuid().ToString();
             var category = Guid.NewGuid().ToString();
             var @event = Guid.NewGuid().ToString();

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Trigger/SignalRRequestResolverTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Trigger/SignalRRequestResolverTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Identity;
-using Microsoft.Azure.SignalR;
+using Microsoft.Extensions.Options;
+using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService.Tests
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService.Tests
         public void ValidateSignatureWithAadAccessKeyFact()
         {
             var resolver = new SignalRRequestResolver();
-            Assert.True(resolver.ValidateSignature(new(), new[] { new AadAccessKey(new("http://localhost"), new DefaultAzureCredential()) }));
+            Assert.True(resolver.ValidateSignature(new(), Mock.Of<IOptionsMonitor<SignatureValidationOptions>>(o => o.CurrentValue.RequireValidation == false)));
         }
     }
 }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Trigger/SignalRTriggerDispatcherTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Trigger/SignalRTriggerDispatcherTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Azure.SignalR;
 using Microsoft.Azure.SignalR.Serverless.Protocols;
 using Microsoft.Azure.WebJobs.Extensions.SignalRService;
 using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Extensions.Options;
 using Moq;
 using SignalRServiceExtension.Tests.Utils;
 using Xunit;
@@ -44,11 +45,11 @@ namespace SignalRServiceExtension.Tests
             var executor = executorMoc.Object;
             if (throwException)
             {
-                Assert.ThrowsAny<Exception>(() => dispatcher.Map(key, new ExecutionContext { Executor = executor, AccessKeys = null }));
+                Assert.ThrowsAny<Exception>(() => dispatcher.Map(key, new ExecutionContext { Executor = executor, SignatureValidationOptions = null }));
                 return;
             }
 
-            dispatcher.Map(key, new ExecutionContext { Executor = executor, AccessKeys = null });
+            dispatcher.Map(key, new ExecutionContext { Executor = executor, SignatureValidationOptions = null });
             var request = TestHelpers.CreateHttpRequestMessage(key.hub, key.category, key.@event, Guid.NewGuid().ToString());
             await dispatcher.ExecuteAsync(request);
             executorMoc.Verify(e => e.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>()), Times.Once);
@@ -75,7 +76,7 @@ namespace SignalRServiceExtension.Tests
             executorMoc.Setup(f => f.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new FunctionResult(true)));
             var executor = executorMoc.Object;
-            dispatcher.Map(key, new ExecutionContext { Executor = executor, AccessKeys = null });
+            dispatcher.Map(key, new ExecutionContext { Executor = executor, SignatureValidationOptions = null });
 
             // Test content type
             resolver.ValidateContentTypeResult = false;
@@ -109,7 +110,7 @@ namespace SignalRServiceExtension.Tests
 
             public bool ValidateContentType(HttpRequestMessage request) => ValidateContentTypeResult;
 
-            public bool ValidateSignature(HttpRequestMessage request, AccessKey[] accessKeys) => ValidateSignatureResult;
+            public bool ValidateSignature(HttpRequestMessage request, IOptionsMonitor<SignatureValidationOptions> signatureValidationOptions) => ValidateSignatureResult;
 
             public bool TryGetInvocationContext(HttpRequestMessage request, out InvocationContext context)
             {

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Trigger/SignalRTriggerTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Trigger/SignalRTriggerTests.cs
@@ -5,11 +5,12 @@ using System;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.SignalR;
+using Microsoft.Azure.SignalR.Management;
 using Microsoft.Azure.WebJobs.Extensions.SignalRService;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Protocols;
+using Microsoft.Extensions.Options;
 using Moq;
 using SignalRServiceExtension.Tests.Utils;
 using Xunit;
@@ -19,7 +20,7 @@ namespace SignalRServiceExtension.Tests
     public class SignalRTriggerTests
     {
         private const string ConnectionString = "Endpoint=http://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;Version=1.0;";
-        private static readonly AccessKey[] AccessKeys = new AccessKey[] { new ServiceEndpoint(ConnectionString).AccessKey };
+        private static readonly IOptionsMonitor<SignatureValidationOptions> SignatureValidationOptions = Mock.Of<IOptionsMonitor<SignatureValidationOptions>>(o => o.CurrentValue == new SignatureValidationOptions() { RequireValidation = false });
 
         [Fact]
         public async Task BindAsyncTest()
@@ -44,7 +45,7 @@ namespace SignalRServiceExtension.Tests
             var hub = Guid.NewGuid().ToString();
             var method = Guid.NewGuid().ToString();
             var category = Guid.NewGuid().ToString();
-            var binding = new SignalRTriggerBinding(parameterInfo, new SignalRTriggerAttribute(hub, category, method), dispatcher, AccessKeys, null);
+            var binding = new SignalRTriggerBinding(parameterInfo, new SignalRTriggerAttribute(hub, category, method), dispatcher, SignatureValidationOptions, Mock.Of<ServiceHubContext>());
             await binding.CreateListenerAsync(listenerFactoryContext);
             Assert.Equal(executor, dispatcher.Executors[(hub, category, method)].Executor);
         }
@@ -106,7 +107,7 @@ namespace SignalRServiceExtension.Tests
         {
             var parameterInfo = GetType().GetMethod(functionName, BindingFlags.Instance | BindingFlags.NonPublic).GetParameters()[0];
             var dispatcher = new TestTriggerDispatcher();
-            return new SignalRTriggerBinding(parameterInfo, new SignalRTriggerAttribute(string.Empty, string.Empty, string.Empty, parameterNames), dispatcher, AccessKeys, null);
+            return new SignalRTriggerBinding(parameterInfo, new SignalRTriggerAttribute(string.Empty, string.Empty, string.Empty, parameterNames), dispatcher, SignatureValidationOptions, Mock.Of<ServiceHubContext>());
         }
 
         internal void TestFunction(InvocationContext context)


### PR DESCRIPTION
# The core changes
* In `ServiceManagerStore.cs`, refactor the build method of `ServiceManager` to remove internal dependency. The original implementation builds the `ServiceManager` from a `ServiceCollection` directly, and inject `IConfigureOptions<ServiceManagerOptions>` and `IOptionsChangeTokenSource<ServiceManagerOptions>` to support hot reload. Without internal depdencies, we have to use the `ServiceManagerBuilder` to support hot-reload. The only way of `ServiceManagerBuilder` to support hot-reload is to inject a `IConfiguration` object which provides a change token. However, the SDK and function extensions have different ways to parse configuration, for example, SDK lacks the functionality to parse identity-based connection from configuration. Therefore, we have to pass the actual configuration action via `ServiceManagerBuilder.WithOptions`, and injects an `IConfiguration` object to provide change token. To avoid errors thrown by SDK when it parses the configuration, we wraps the real `IConfiguration` object to make it looks like empty configuration but provides the true change token.
* Remove the internal access of `AccessKey` and also fix the problem that access keys used in signature validation are not hot-reloadable. Without internal access, we have to pass the configuration again to get the access keys.

