### PR TITLE
Add Cloud property to CommunicationUserIdentifier

### DIFF
--- a/sdk/communication/Azure.Communication.Common/api/Azure.Communication.Common.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.Common/api/Azure.Communication.Common.netstandard2.0.cs
@@ -6,7 +6,10 @@ namespace Azure.Communication
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public CommunicationCloudEnvironment(string value) { throw null; }
+        public static Azure.Communication.CommunicationCloudEnvironment AirGap08 { get { throw null; } }
+        public static Azure.Communication.CommunicationCloudEnvironment AirGap09 { get { throw null; } }
         public static Azure.Communication.CommunicationCloudEnvironment Dod { get { throw null; } }
+        public static Azure.Communication.CommunicationCloudEnvironment Gallatin { get { throw null; } }
         public static Azure.Communication.CommunicationCloudEnvironment Gcch { get { throw null; } }
         public static Azure.Communication.CommunicationCloudEnvironment Public { get { throw null; } }
         public bool Equals(Azure.Communication.CommunicationCloudEnvironment other) { throw null; }
@@ -48,6 +51,8 @@ namespace Azure.Communication
     public partial class CommunicationUserIdentifier : Azure.Communication.CommunicationIdentifier
     {
         public CommunicationUserIdentifier(string id) { }
+        public CommunicationUserIdentifier(string id, Azure.Communication.CommunicationCloudEnvironment cloud) { }
+        public Azure.Communication.CommunicationCloudEnvironment Cloud { get { throw null; } }
         public string Id { get { throw null; } }
         public override string RawId { get { throw null; } }
         public override bool Equals(Azure.Communication.CommunicationIdentifier other) { throw null; }

--- a/sdk/communication/Azure.Communication.Common/api/Azure.Communication.Common.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.Common/api/Azure.Communication.Common.netstandard2.0.cs
@@ -6,10 +6,7 @@ namespace Azure.Communication
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public CommunicationCloudEnvironment(string value) { throw null; }
-        public static Azure.Communication.CommunicationCloudEnvironment AirGap08 { get { throw null; } }
-        public static Azure.Communication.CommunicationCloudEnvironment AirGap09 { get { throw null; } }
         public static Azure.Communication.CommunicationCloudEnvironment Dod { get { throw null; } }
-        public static Azure.Communication.CommunicationCloudEnvironment Gallatin { get { throw null; } }
         public static Azure.Communication.CommunicationCloudEnvironment Gcch { get { throw null; } }
         public static Azure.Communication.CommunicationCloudEnvironment Public { get { throw null; } }
         public bool Equals(Azure.Communication.CommunicationCloudEnvironment other) { throw null; }
@@ -51,7 +48,6 @@ namespace Azure.Communication
     public partial class CommunicationUserIdentifier : Azure.Communication.CommunicationIdentifier
     {
         public CommunicationUserIdentifier(string id) { }
-        public CommunicationUserIdentifier(string id, Azure.Communication.CommunicationCloudEnvironment cloud) { }
         public Azure.Communication.CommunicationCloudEnvironment Cloud { get { throw null; } }
         public string Id { get { throw null; } }
         public override string RawId { get { throw null; } }

--- a/sdk/communication/Azure.Communication.Common/src/CommunicationCloudEnvironment.cs
+++ b/sdk/communication/Azure.Communication.Common/src/CommunicationCloudEnvironment.cs
@@ -19,6 +19,9 @@ namespace Azure.Communication
         private const string PublicValue = "public";
         private const string DodValue = "dod";
         private const string GcchValue = "gcch";
+        private const string AirGap08Value = "airgap08";
+        private const string AirGap09Value = "airgap09";
+        private const string GallatinValue = "gallatin";
 
         /// <summary> public. </summary>
         public static CommunicationCloudEnvironment Public { get; } = new CommunicationCloudEnvironment(PublicValue);
@@ -26,6 +29,12 @@ namespace Azure.Communication
         public static CommunicationCloudEnvironment Dod { get; } = new CommunicationCloudEnvironment(DodValue);
         /// <summary> gcch. </summary>
         public static CommunicationCloudEnvironment Gcch { get; } = new CommunicationCloudEnvironment(GcchValue);
+        /// <summary> airgap08. </summary>
+        public static CommunicationCloudEnvironment AirGap08 { get; } = new CommunicationCloudEnvironment(AirGap08Value);
+        /// <summary> airgap09. </summary>
+        public static CommunicationCloudEnvironment AirGap09 { get; } = new CommunicationCloudEnvironment(AirGap09Value);
+        /// <summary> gallatin. </summary>
+        public static CommunicationCloudEnvironment Gallatin { get; } = new CommunicationCloudEnvironment(GallatinValue);
         /// <summary> Determines if two <see cref="CommunicationCloudEnvironment"/> values are the same. </summary>
         public static bool operator ==(CommunicationCloudEnvironment left, CommunicationCloudEnvironment right) => left.Equals(right);
         /// <summary> Determines if two <see cref="CommunicationCloudEnvironment"/> values are not the same. </summary>

--- a/sdk/communication/Azure.Communication.Common/src/CommunicationCloudEnvironment.cs
+++ b/sdk/communication/Azure.Communication.Common/src/CommunicationCloudEnvironment.cs
@@ -19,9 +19,6 @@ namespace Azure.Communication
         private const string PublicValue = "public";
         private const string DodValue = "dod";
         private const string GcchValue = "gcch";
-        private const string AirGap08Value = "airgap08";
-        private const string AirGap09Value = "airgap09";
-        private const string GallatinValue = "gallatin";
 
         /// <summary> public. </summary>
         public static CommunicationCloudEnvironment Public { get; } = new CommunicationCloudEnvironment(PublicValue);
@@ -29,12 +26,6 @@ namespace Azure.Communication
         public static CommunicationCloudEnvironment Dod { get; } = new CommunicationCloudEnvironment(DodValue);
         /// <summary> gcch. </summary>
         public static CommunicationCloudEnvironment Gcch { get; } = new CommunicationCloudEnvironment(GcchValue);
-        /// <summary> airgap08. </summary>
-        public static CommunicationCloudEnvironment AirGap08 { get; } = new CommunicationCloudEnvironment(AirGap08Value);
-        /// <summary> airgap09. </summary>
-        public static CommunicationCloudEnvironment AirGap09 { get; } = new CommunicationCloudEnvironment(AirGap09Value);
-        /// <summary> gallatin. </summary>
-        public static CommunicationCloudEnvironment Gallatin { get; } = new CommunicationCloudEnvironment(GallatinValue);
         /// <summary> Determines if two <see cref="CommunicationCloudEnvironment"/> values are the same. </summary>
         public static bool operator ==(CommunicationCloudEnvironment left, CommunicationCloudEnvironment right) => left.Equals(right);
         /// <summary> Determines if two <see cref="CommunicationCloudEnvironment"/> values are not the same. </summary>

--- a/sdk/communication/Azure.Communication.Common/src/CommunicationIdentifier.cs
+++ b/sdk/communication/Azure.Communication.Common/src/CommunicationIdentifier.cs
@@ -10,6 +10,18 @@ namespace Azure.Communication
     /// <summary>Represents an identifier in Azure Communication Services.</summary>
     public abstract class CommunicationIdentifier : IEquatable<CommunicationIdentifier>
     {
+        internal const string TEAMS_USER_VISITOR_PREFIX = "8:teamsvisitor:";
+        internal const string TEAMS_USER_ORGID_PREFIX = "8:orgid:";
+        internal const string TEAMS_USER_DOD_PREFIX = "8:dod:";
+        internal const string TEAMS_USER_GCCH_PREFIX = "8:gcch:";
+        internal const string ACS_USER_ACS_PREFIX = "8:acs:";
+        internal const string ACS_USER_SPOOL_PREFIX = "8:spool:";
+        internal const string ACS_USER_GCCH_PREFIX = "8:gcch-acs:";
+        internal const string ACS_USER_AIR_GAP_08_PREFIX = "8:ag08-acs:";
+        internal const string ACS_USER_AIR_GAP_09_PREFIX = "8:ag09-acs:";
+        internal const string ACS_GALLATIN_PREFIX = "8:gal-acs:";
+        internal const string ACS_USER_DOD_PREFIX = "8:dod-acs:";
+
         /// <summary>
         /// Returns the canonical string representation of the <see cref="CommunicationIdentifier"/>.
         /// You can use the <see cref="RawId"/> for encoding the identifier and then use it as a key in a database.
@@ -68,11 +80,16 @@ namespace Azure.Communication
 
             return prefix switch
             {
-                "8:teamsvisitor:" => new MicrosoftTeamsUserIdentifier(suffix, true),
-                "8:orgid:" => new MicrosoftTeamsUserIdentifier(suffix, false, CommunicationCloudEnvironment.Public),
-                "8:dod:" => new MicrosoftTeamsUserIdentifier(suffix, false, CommunicationCloudEnvironment.Dod),
-                "8:gcch:" => new MicrosoftTeamsUserIdentifier(suffix, false, CommunicationCloudEnvironment.Gcch),
-                "8:acs:" or "8:spool:" or "8:dod-acs:" or "8:gcch-acs:" => new CommunicationUserIdentifier(rawId),
+                TEAMS_USER_VISITOR_PREFIX => new MicrosoftTeamsUserIdentifier(suffix, true),
+                TEAMS_USER_ORGID_PREFIX => new MicrosoftTeamsUserIdentifier(suffix, false, CommunicationCloudEnvironment.Public),
+                TEAMS_USER_DOD_PREFIX => new MicrosoftTeamsUserIdentifier(suffix, false, CommunicationCloudEnvironment.Dod),
+                TEAMS_USER_GCCH_PREFIX => new MicrosoftTeamsUserIdentifier(suffix, false, CommunicationCloudEnvironment.Gcch),
+                ACS_USER_ACS_PREFIX or ACS_USER_SPOOL_PREFIX => new CommunicationUserIdentifier(rawId, CommunicationCloudEnvironment.Public),
+                ACS_USER_GCCH_PREFIX => new CommunicationUserIdentifier(rawId, CommunicationCloudEnvironment.Gcch),
+                ACS_USER_AIR_GAP_08_PREFIX => new CommunicationUserIdentifier(rawId, CommunicationCloudEnvironment.AirGap08),
+                ACS_USER_AIR_GAP_09_PREFIX => new CommunicationUserIdentifier(rawId, CommunicationCloudEnvironment.AirGap09),
+                ACS_GALLATIN_PREFIX => new CommunicationUserIdentifier(rawId, CommunicationCloudEnvironment.Gallatin),
+                ACS_USER_DOD_PREFIX => new CommunicationUserIdentifier(rawId),
                 _ => new UnknownIdentifier(rawId),
             };
         }

--- a/sdk/communication/Azure.Communication.Common/src/CommunicationIdentifier.cs
+++ b/sdk/communication/Azure.Communication.Common/src/CommunicationIdentifier.cs
@@ -17,9 +17,6 @@ namespace Azure.Communication
         internal const string ACS_USER_ACS_PREFIX = "8:acs:";
         internal const string ACS_USER_SPOOL_PREFIX = "8:spool:";
         internal const string ACS_USER_GCCH_PREFIX = "8:gcch-acs:";
-        internal const string ACS_USER_AIR_GAP_08_PREFIX = "8:ag08-acs:";
-        internal const string ACS_USER_AIR_GAP_09_PREFIX = "8:ag09-acs:";
-        internal const string ACS_GALLATIN_PREFIX = "8:gal-acs:";
         internal const string ACS_USER_DOD_PREFIX = "8:dod-acs:";
 
         /// <summary>
@@ -84,12 +81,12 @@ namespace Azure.Communication
                 TEAMS_USER_ORGID_PREFIX => new MicrosoftTeamsUserIdentifier(suffix, false, CommunicationCloudEnvironment.Public),
                 TEAMS_USER_DOD_PREFIX => new MicrosoftTeamsUserIdentifier(suffix, false, CommunicationCloudEnvironment.Dod),
                 TEAMS_USER_GCCH_PREFIX => new MicrosoftTeamsUserIdentifier(suffix, false, CommunicationCloudEnvironment.Gcch),
-                ACS_USER_ACS_PREFIX or ACS_USER_SPOOL_PREFIX => new CommunicationUserIdentifier(rawId, CommunicationCloudEnvironment.Public),
-                ACS_USER_GCCH_PREFIX => new CommunicationUserIdentifier(rawId, CommunicationCloudEnvironment.Gcch),
-                ACS_USER_AIR_GAP_08_PREFIX => new CommunicationUserIdentifier(rawId, CommunicationCloudEnvironment.AirGap08),
-                ACS_USER_AIR_GAP_09_PREFIX => new CommunicationUserIdentifier(rawId, CommunicationCloudEnvironment.AirGap09),
-                ACS_GALLATIN_PREFIX => new CommunicationUserIdentifier(rawId, CommunicationCloudEnvironment.Gallatin),
+
+                ACS_USER_ACS_PREFIX or
+                ACS_USER_SPOOL_PREFIX or
+                ACS_USER_GCCH_PREFIX or
                 ACS_USER_DOD_PREFIX => new CommunicationUserIdentifier(rawId),
+
                 _ => new UnknownIdentifier(rawId),
             };
         }

--- a/sdk/communication/Azure.Communication.Common/src/CommunicationUserIdentifier.cs
+++ b/sdk/communication/Azure.Communication.Common/src/CommunicationUserIdentifier.cs
@@ -11,7 +11,7 @@ namespace Azure.Communication
         /// <summary>The id of the communication user.</summary>
         public string Id { get; }
 
-        /// <summary> The cloud that the identifier belongs to.</summary>
+        /// <summary>The cloud environment that the identifier belongs to.</summary>
         public CommunicationCloudEnvironment Cloud { get; }
 
         /// <summary>
@@ -30,26 +30,11 @@ namespace Azure.Communication
         /// <exception cref="System.ArgumentException">
         /// Thrown when the <paramref name="id"/> is empty.
         /// </exception>
-        public CommunicationUserIdentifier(string id) : this(id, CommunicationCloudEnvironment.Public)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of <see cref="CommunicationUserIdentifier"/>.
-        /// </summary>
-        /// <param name="id">Id of the communication user.</param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown when the <paramref name="id"/> is null.
-        /// </exception>
-        /// <exception cref="System.ArgumentException">
-        /// Thrown when the <paramref name="id"/> is empty.
-        /// </exception>
-        /// <param name="cloud">The cloud that the ACS user belongs to.</param>
-        public CommunicationUserIdentifier(string id, CommunicationCloudEnvironment cloud)
+        public CommunicationUserIdentifier(string id)
         {
             Argument.AssertNotNullOrEmpty(id, nameof(id));
             Id = id;
-            Cloud = cloud;
+            Cloud = GetAcsCloudEnvironmentFromRawId(id);
         }
 
         /// <inheritdoc />
@@ -58,5 +43,24 @@ namespace Azure.Communication
         /// <inheritdoc />
         public override bool Equals(CommunicationIdentifier other)
             => other is CommunicationUserIdentifier otherId && otherId.RawId == RawId;
+
+        private static CommunicationCloudEnvironment GetAcsCloudEnvironmentFromRawId(string rawId)
+        {
+            var segments = rawId.Split(':');
+
+            if (segments.Length < 2)
+            {
+                return CommunicationCloudEnvironment.Public;
+            }
+
+            var cloudEnvironment = segments[1];
+
+            return cloudEnvironment switch
+            {
+                "acs" or "spool" => CommunicationCloudEnvironment.Public,
+                "gcch-acs" => CommunicationCloudEnvironment.Gcch,
+                _ => CommunicationCloudEnvironment.Public,
+            };
+        }
     }
 }

--- a/sdk/communication/Azure.Communication.Common/src/CommunicationUserIdentifier.cs
+++ b/sdk/communication/Azure.Communication.Common/src/CommunicationUserIdentifier.cs
@@ -11,6 +11,9 @@ namespace Azure.Communication
         /// <summary>The id of the communication user.</summary>
         public string Id { get; }
 
+        /// <summary> The cloud that the identifier belongs to.</summary>
+        public CommunicationCloudEnvironment Cloud { get; }
+
         /// <summary>
         /// Returns the canonical string representation of the <see cref="CommunicationUserIdentifier"/>.
         /// You can use the <see cref="RawId"/> for encoding the identifier and then use it as a key in a database.
@@ -27,10 +30,26 @@ namespace Azure.Communication
         /// <exception cref="System.ArgumentException">
         /// Thrown when the <paramref name="id"/> is empty.
         /// </exception>
-        public CommunicationUserIdentifier(string id)
+        public CommunicationUserIdentifier(string id) : this(id, CommunicationCloudEnvironment.Public)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="CommunicationUserIdentifier"/>.
+        /// </summary>
+        /// <param name="id">Id of the communication user.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when the <paramref name="id"/> is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when the <paramref name="id"/> is empty.
+        /// </exception>
+        /// <param name="cloud">The cloud that the ACS user belongs to.</param>
+        public CommunicationUserIdentifier(string id, CommunicationCloudEnvironment cloud)
         {
             Argument.AssertNotNullOrEmpty(id, nameof(id));
             Id = id;
+            Cloud = cloud;
         }
 
         /// <inheritdoc />

--- a/sdk/communication/Azure.Communication.Common/src/MicrosoftTeamsUserIdentifier.cs
+++ b/sdk/communication/Azure.Communication.Common/src/MicrosoftTeamsUserIdentifier.cs
@@ -22,19 +22,19 @@ namespace Azure.Communication
                 {
                     if (IsAnonymous)
                     {
-                        _rawId = $"8:teamsvisitor:{UserId}";
+                        _rawId = $"{TEAMS_USER_VISITOR_PREFIX}{UserId}";
                     }
                     else if (Cloud == CommunicationCloudEnvironment.Dod)
                     {
-                        _rawId = $"8:dod:{UserId}";
+                        _rawId = $"{TEAMS_USER_DOD_PREFIX}{UserId}";
                     }
                     else if (Cloud == CommunicationCloudEnvironment.Gcch)
                     {
-                        _rawId = $"8:gcch:{UserId}";
+                        _rawId = $"{TEAMS_USER_GCCH_PREFIX}{UserId}";
                     }
                     else
                     {
-                        _rawId = $"8:orgid:{UserId}";
+                        _rawId = $"{TEAMS_USER_ORGID_PREFIX}{UserId}";
                     }
                 }
                 return _rawId;

--- a/sdk/communication/Azure.Communication.Common/tests/CommunicationIdentifierTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/CommunicationIdentifierTest.cs
@@ -37,11 +37,8 @@ namespace Azure.Communication
         {
             Assert.AreEqual(CommunicationCloudEnvironment.Public, (CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130") as CommunicationUserIdentifier)?.Cloud);
             Assert.AreEqual(CommunicationCloudEnvironment.Public, (CommunicationIdentifier.FromRawId("8:spool:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130") as CommunicationUserIdentifier)?.Cloud);
-            Assert.AreEqual(CommunicationCloudEnvironment.Public, (CommunicationIdentifier.FromRawId("8:dod-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130") as CommunicationUserIdentifier)?.Cloud);
             Assert.AreEqual(CommunicationCloudEnvironment.Gcch, (CommunicationIdentifier.FromRawId("8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130") as CommunicationUserIdentifier)?.Cloud);
-            Assert.AreEqual(CommunicationCloudEnvironment.AirGap08, (CommunicationIdentifier.FromRawId("8:ag08-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130") as CommunicationUserIdentifier)?.Cloud);
-            Assert.AreEqual(CommunicationCloudEnvironment.AirGap09, (CommunicationIdentifier.FromRawId("8:ag09-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130") as CommunicationUserIdentifier)?.Cloud);
-            Assert.AreEqual(CommunicationCloudEnvironment.Gallatin, (CommunicationIdentifier.FromRawId("8:gal-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130") as CommunicationUserIdentifier)?.Cloud);
+            Assert.AreEqual(CommunicationCloudEnvironment.Public, (CommunicationIdentifier.FromRawId("8:dod-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130") as CommunicationUserIdentifier)?.Cloud);
         }
 
         [Test]

--- a/sdk/communication/Azure.Communication.Common/tests/CommunicationIdentifierTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/CommunicationIdentifierTest.cs
@@ -33,6 +33,18 @@ namespace Azure.Communication
             => Assert.AreEqual(CommunicationCloudEnvironment.Public, new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true, rawId: "Raw Id").Cloud);
 
         [Test]
+        public void RawIdDeserializesToCorrectAcsCloudType()
+        {
+            Assert.AreEqual(CommunicationCloudEnvironment.Public, (CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130") as CommunicationUserIdentifier)?.Cloud);
+            Assert.AreEqual(CommunicationCloudEnvironment.Public, (CommunicationIdentifier.FromRawId("8:spool:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130") as CommunicationUserIdentifier)?.Cloud);
+            Assert.AreEqual(CommunicationCloudEnvironment.Public, (CommunicationIdentifier.FromRawId("8:dod-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130") as CommunicationUserIdentifier)?.Cloud);
+            Assert.AreEqual(CommunicationCloudEnvironment.Gcch, (CommunicationIdentifier.FromRawId("8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130") as CommunicationUserIdentifier)?.Cloud);
+            Assert.AreEqual(CommunicationCloudEnvironment.AirGap08, (CommunicationIdentifier.FromRawId("8:ag08-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130") as CommunicationUserIdentifier)?.Cloud);
+            Assert.AreEqual(CommunicationCloudEnvironment.AirGap09, (CommunicationIdentifier.FromRawId("8:ag09-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130") as CommunicationUserIdentifier)?.Cloud);
+            Assert.AreEqual(CommunicationCloudEnvironment.Gallatin, (CommunicationIdentifier.FromRawId("8:gal-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130") as CommunicationUserIdentifier)?.Cloud);
+        }
+
+        [Test]
         public void GetRawIdOfIdentifier()
         {
             static void AssertRawId(CommunicationIdentifier identifier, string expectedRawId) => Assert.AreEqual(identifier.RawId, expectedRawId);


### PR DESCRIPTION
Added Cloud property to CommunicationUserIdentifier. ACS is (or will be) supported not only in public cloud, so it makes sense to explicitly surface the value. This will allow to identify the cloud without the need to parse MRI. Consumers won't need to keep their custom parsing logic - it will be part of common package.
