### PR TITLE
[Docs] Fixing broken links

### DIFF
--- a/sdk/eventgrid/README.md
+++ b/sdk/eventgrid/README.md
@@ -32,4 +32,4 @@ Use the following library to work with the Azure Event Grid resource provider:
 
 | Nuget Package | Reference |
 |--------------------------------------|---------------------------------------------------------------|
-| [Microsoft.Azure.Management.EventGrid](https://www.nuget.org/packages/Microsoft.Azure.Management.EventGrid)  | [API Reference for Microsoft.Azure.Management.EventGrid](https://docs.microsoft.com/dotnet/api/overview/azure/eventgrid/management?view=azure-dotnet)  |
+| [Microsoft.Azure.Management.EventGrid](https://www.nuget.org/packages/Microsoft.Azure.Management.EventGrid)  | [API Reference for Microsoft.Azure.Management.EventGrid](https://learn.microsoft.com/dotnet/api/overview/azure/eventgrid/management/management-eventgrid?view=azure-dotnet)  |

--- a/sdk/eventhub/README.md
+++ b/sdk/eventhub/README.md
@@ -34,4 +34,4 @@ Use the following library to work with the Azure Event Hubs resource provider:
 
 | Nuget Package | Reference |
 |--------------------------------------|---------------------------------------------------------------|
-| [Azure.ResourceManager.EventHubs](https://www.nuget.org/packages/Azure.ResourceManager.EventHubs)  | [API Reference for Azure.ResourceManager.EventHubs](https://docs.microsoft.com/dotnet/api/overview/azure/eventhubs/management?view=azure-dotnet)  |
+| [Azure.ResourceManager.EventHubs](https://www.nuget.org/packages/Azure.ResourceManager.EventHubs)  | [API Reference for Azure.ResourceManager.EventHubs](https://learn.microsoft.com/dotnet/api/overview/azure/resourcemanager.eventhubs-readme?view=azure-dotnet)  |

--- a/sdk/monitor/Azure.Monitor.Ingestion/src/Azure.Monitor.Ingestion.csproj
+++ b/sdk/monitor/Azure.Monitor.Ingestion/src/Azure.Monitor.Ingestion.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>Azure Monitor Ingestion client library</AssemblyTitle>
     <Version>1.0.0-beta.5</Version>
     <PackageTags>Azure Monitor Ingestion</PackageTags>
-    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(RequiredTargetFrameworks);net461</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1835</NoWarn> <!--TODO: Suppressing warning in shared source-->
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>

--- a/sdk/monitor/Azure.Monitor.Ingestion/src/Azure.Monitor.Ingestion.csproj
+++ b/sdk/monitor/Azure.Monitor.Ingestion/src/Azure.Monitor.Ingestion.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>Azure Monitor Ingestion client library</AssemblyTitle>
     <Version>1.0.0-beta.5</Version>
     <PackageTags>Azure Monitor Ingestion</PackageTags>
-    <TargetFrameworks>$(RequiredTargetFrameworks);net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1835</NoWarn> <!--TODO: Suppressing warning in shared source-->
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>

--- a/sdk/monitor/Azure.Monitor.Query/README.md
+++ b/sdk/monitor/Azure.Monitor.Query/README.md
@@ -527,7 +527,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct][coc]. For m
 [kusto_query_language]: https://learn.microsoft.com/azure/data-explorer/kusto/query/
 [migration_guide_app_insights]: https://aka.ms/azsdk/net/migrate/ai-monitor-query
 [migration_guide_opp_insights]: https://aka.ms/azsdk/net/migrate/monitor-query
-[msdocs_apiref]: https://learn.microsoft.com/dotnet/api/overview/azure/monitor/query?view=azure-dotnet
+[msdocs_apiref]: https://learn.microsoft.com/dotnet/api/overview/azure/monitor.query-readme?view=azure-dotnet
 [package]: https://www.nuget.org/packages/Azure.Monitor.Query
 [source]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.Query/src
 


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a set of broken links to the MS Docs resources which moved during their recent view reorganization.

# References and Resources

- [Link verification run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2005181&view=logs&j=d41e9505-d81b-5b3c-5b50-be71bc9b0ccb&t=2521f384-3a28-5bc9-41e5-2f3e6ef99ecd) _(Microsoft internal)_
