### PR TITLE
[Text Analytics] Add support for default language in automatic language detection

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -21,15 +21,22 @@
   - Added the following classes: `AgeResolution`, `AreaResolution`, `BaseResolution`, `BooleanResolution`, `CurrencyResolution`, `DateTimeResolution`, `InformationResolution`, `LengthResolution`, `NumberResolution`, `NumericRangeResolution`, `OrdinalResolution`, `SpeedResolution`, `TemperatureResolution`, `TemporalSpanResolution` `VolumeResolution`, and `WeightResolution`.
   - Added the following enums: `AgeUnit`, `AreaUnit`, `DateTimeSubKind`, `InformationUnit`,`LengthUnit`, `NumberKind`, `RangeKind`, `RelativeTo`, `SpeedUnit`, `TemperatureUnit`,`TemporalModifier`, `VolumeUnit`, and `WeightUnit`.
 - Added support for automatic language detection.
+  - Added the `AbstractSummaryOptions.AutoDetectionDefaultLanguage` property.
   - Added the `AbstractSummaryResult.DetectedLanguage` property.
+  - Added the `AnalyzeActionsOptions.AutoDetectionDefaultLanguage` property.
+  - Added the `AnalyzeHealthcareEntitiesOptions.AutoDetectionDefaultLanguage` property.
   - Added the `AnalyzeHealthcareEntitiesResult.DetectedLanguage` property.
   - Added the `AnalyzeSentimentResult.DetectedLanguage` property.
   - Added the `ClassifyDocumentResult.DetectedLanguage` property.
   - Added the `ExtractKeyPhrasesResult.DetectedLanguage` property.
+  - Added the `ExtractSummaryOptions.AutoDetectionDefaultLanguage` property.
   - Added the `ExtractSummaryResult.DetectedLanguage` property.
+  - Added the `MultiLabelClassifyOptions.AutoDetectionDefaultLanguage` property.
+  - Added the `RecognizeCustomEntitiesOptions.AutoDetectionDefaultLanguage` property.
   - Added the `RecognizeEntitiesResult.DetectedLanguage` property.
   - Added the `RecognizeLinkedEntitiesResult.DetectedLanguage` property.
   - Added the `RecognizePiiEntitiesResult.DetectedLanguage` property.
+  - Added the `SingleLabelClassifyOptions.AutoDetectionDefaultLanguage` property.
 - Added support for script detection.
   - Added the `DetectedLanguage.Script` property.
   - Added the `ScriptKind` enum.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
@@ -47,6 +47,7 @@ namespace Azure.AI.TextAnalytics
     public partial class AbstractSummaryOptions : Azure.AI.TextAnalytics.TextAnalyticsRequestOptions
     {
         public AbstractSummaryOptions() { }
+        public string AutoDetectionDefaultLanguage { get { throw null; } set { } }
         public string DisplayName { get { throw null; } set { } }
         public int? MaxSentenceCount { get { throw null; } set { } }
     }
@@ -121,6 +122,7 @@ namespace Azure.AI.TextAnalytics
     public partial class AnalyzeActionsOptions
     {
         public AnalyzeActionsOptions() { }
+        public string AutoDetectionDefaultLanguage { get { throw null; } set { } }
         public bool? IncludeStatistics { get { throw null; } set { } }
     }
     public partial class AnalyzeActionsResult
@@ -180,6 +182,7 @@ namespace Azure.AI.TextAnalytics
     public partial class AnalyzeHealthcareEntitiesOptions : Azure.AI.TextAnalytics.TextAnalyticsRequestOptions
     {
         public AnalyzeHealthcareEntitiesOptions() { }
+        public string AutoDetectionDefaultLanguage { get { throw null; } set { } }
         public string DisplayName { get { throw null; } set { } }
         public Azure.AI.TextAnalytics.HealthcareDocumentType? DocumentType { get { throw null; } set { } }
         public Azure.AI.TextAnalytics.WellKnownFhirVersion? FhirVersion { get { throw null; } set { } }
@@ -546,6 +549,7 @@ namespace Azure.AI.TextAnalytics
     public partial class ExtractSummaryOptions : Azure.AI.TextAnalytics.TextAnalyticsRequestOptions
     {
         public ExtractSummaryOptions() { }
+        public string AutoDetectionDefaultLanguage { get { throw null; } set { } }
         public string DisplayName { get { throw null; } set { } }
         public int? MaxSentenceCount { get { throw null; } set { } }
         public Azure.AI.TextAnalytics.SummarySentencesOrder? OrderBy { get { throw null; } set { } }
@@ -830,6 +834,7 @@ namespace Azure.AI.TextAnalytics
     public partial class MultiLabelClassifyOptions
     {
         public MultiLabelClassifyOptions() { }
+        public string AutoDetectionDefaultLanguage { get { throw null; } set { } }
         public bool? DisableServiceLogs { get { throw null; } set { } }
         public string DisplayName { get { throw null; } set { } }
         public bool? IncludeStatistics { get { throw null; } set { } }
@@ -1154,6 +1159,7 @@ namespace Azure.AI.TextAnalytics
     public partial class RecognizeCustomEntitiesOptions
     {
         public RecognizeCustomEntitiesOptions() { }
+        public string AutoDetectionDefaultLanguage { get { throw null; } set { } }
         public bool? DisableServiceLogs { get { throw null; } set { } }
         public string DisplayName { get { throw null; } set { } }
         public bool? IncludeStatistics { get { throw null; } set { } }
@@ -1327,6 +1333,7 @@ namespace Azure.AI.TextAnalytics
     public partial class SingleLabelClassifyOptions
     {
         public SingleLabelClassifyOptions() { }
+        public string AutoDetectionDefaultLanguage { get { throw null; } set { } }
         public bool? DisableServiceLogs { get { throw null; } set { } }
         public string DisplayName { get { throw null; } set { } }
         public bool? IncludeStatistics { get { throw null; } set { } }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AbstractSummaryOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AbstractSummaryOptions.cs
@@ -22,7 +22,8 @@ namespace Azure.AI.TextAnalytics
         public string DisplayName { get; set; }
 
         /// <summary>
-        /// The default language to consider during automatic language detection.
+        /// The two-letter ISO 639-1 representation of the default language to consider for automatic language
+        /// detection (for example, "en" for English or "fr" for French).
         /// </summary>
         public string AutoDetectionDefaultLanguage { get; set; }
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AbstractSummaryOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AbstractSummaryOptions.cs
@@ -22,6 +22,11 @@ namespace Azure.AI.TextAnalytics
         public string DisplayName { get; set; }
 
         /// <summary>
+        /// The default language to consider during automatic language detection.
+        /// </summary>
+        public string AutoDetectionDefaultLanguage { get; set; }
+
+        /// <summary>
         /// The maximum number of sentences that the resulting summaries can have. If not set, the service default is
         /// used.
         /// </summary>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsOptions.cs
@@ -17,8 +17,12 @@ namespace Azure.AI.TextAnalytics
         public bool? IncludeStatistics { get; set; }
 
         /// <summary>
-        /// The default language to consider during automatic language detection.
+        /// The two-letter ISO 639-1 representation of the default language to consider for automatic language
+        /// detection (for example, "en" for English or "fr" for French).
         /// </summary>
+        /// <remarks>
+        /// This property only applies for <see cref="TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview"/>, and newer.
+        /// </remarks>
         public string AutoDetectionDefaultLanguage { get; set; }
 
         /// <summary>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsOptions.cs
@@ -8,12 +8,28 @@ namespace Azure.AI.TextAnalytics
     /// is run and what information is returned from it by the service.
     /// <para>For example, whether to include statistics.</para>
     /// </summary>
-    public class AnalyzeActionsOptions
+    public class AnalyzeActionsOptions : IModelValidator
     {
         /// <summary>
         /// Gets or sets a value that, if set to true, indicates that the service
         /// should return statistics with the results of the operation.
         /// </summary>
         public bool? IncludeStatistics { get; set; }
+
+        /// <summary>
+        /// The default language to consider during automatic language detection.
+        /// </summary>
+        public string AutoDetectionDefaultLanguage { get; set; }
+
+        /// <summary>
+        /// Checks that the specified <see cref="TextAnalyticsClientOptions.ServiceVersion"/> supports all properties set within this model.
+        /// </summary>
+        /// <param name="current">The current <see cref="TextAnalyticsClientOptions.ServiceVersion"/> used by the <see cref="TextAnalyticsClient"/>.</param>
+        internal void CheckSupported(TextAnalyticsClientOptions.ServiceVersion current)
+        {
+            Validation.SupportsProperty(this, AutoDetectionDefaultLanguage, nameof(AutoDetectionDefaultLanguage), TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview, current);
+        }
+
+        void IModelValidator.CheckSupported(TextAnalyticsClientOptions.ServiceVersion current) => CheckSupported(current);
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeHealthcareEntitiesOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeHealthcareEntitiesOptions.cs
@@ -26,6 +26,14 @@ namespace Azure.AI.TextAnalytics
         public string DisplayName { get; set; }
 
         /// <summary>
+        /// The default language to consider during automatic language detection.
+        /// </summary>
+        /// <remarks>
+        /// This property only applies for <see cref="TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview"/>, and newer.
+        /// </remarks>
+        public string AutoDetectionDefaultLanguage { get; set; }
+
+        /// <summary>
         /// The version of the FHIR specification that will be used to format the <see cref="AnalyzeHealthcareEntitiesResult.FhirBundle"/>
         /// in the result. If not set, the <see cref="AnalyzeHealthcareEntitiesResult.FhirBundle"/> will not be produced. For additional information, see
         /// <see href="https://www.hl7.org/fhir/overview.html"/>.
@@ -52,6 +60,7 @@ namespace Azure.AI.TextAnalytics
             Validation.SupportsProperty(this, DisplayName, nameof(DisplayName), TextAnalyticsClientOptions.ServiceVersion.V2022_05_01, current);
             Validation.SupportsProperty(this, FhirVersion, nameof(FhirVersion), TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview, current);
             Validation.SupportsProperty(this, DocumentType, nameof(DocumentType), TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview, current);
+            Validation.SupportsProperty(this, AutoDetectionDefaultLanguage, nameof(AutoDetectionDefaultLanguage), TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview, current);
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeHealthcareEntitiesOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeHealthcareEntitiesOptions.cs
@@ -26,7 +26,8 @@ namespace Azure.AI.TextAnalytics
         public string DisplayName { get; set; }
 
         /// <summary>
-        /// The default language to consider during automatic language detection.
+        /// The two-letter ISO 639-1 representation of the default language to consider for automatic language
+        /// detection (for example, "en" for English or "fr" for French).
         /// </summary>
         /// <remarks>
         /// This property only applies for <see cref="TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview"/>, and newer.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractSummaryOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractSummaryOptions.cs
@@ -22,7 +22,8 @@ namespace Azure.AI.TextAnalytics
         public string DisplayName { get; set; }
 
         /// <summary>
-        /// The default language to consider during automatic language detection.
+        /// The two-letter ISO 639-1 representation of the default language to consider for automatic language
+        /// detection (for example, "en" for English or "fr" for French).
         /// </summary>
         public string AutoDetectionDefaultLanguage { get; set; }
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractSummaryOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractSummaryOptions.cs
@@ -22,6 +22,11 @@ namespace Azure.AI.TextAnalytics
         public string DisplayName { get; set; }
 
         /// <summary>
+        /// The default language to consider during automatic language detection.
+        /// </summary>
+        public string AutoDetectionDefaultLanguage { get; set; }
+
+        /// <summary>
         /// The maximum number of sentences to be returned in the result. If not set, the service default is used.
         /// </summary>
         public int? MaxSentenceCount { get; set; }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/MultiLabelClassifyOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/MultiLabelClassifyOptions.cs
@@ -7,7 +7,7 @@ namespace Azure.AI.TextAnalytics
     /// Options that allow callers to specify details about how the operation
     /// is run and what information is returned from it by the service.
     /// </summary>
-    public class MultiLabelClassifyOptions
+    public class MultiLabelClassifyOptions : IModelValidator
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MultiLabelClassifyOptions"/>
@@ -40,5 +40,21 @@ namespace Azure.AI.TextAnalytics
         /// Optional display name for the operation.
         /// </summary>
         public string DisplayName { get; set; }
+
+        /// <summary>
+        /// The default language to consider during automatic language detection.
+        /// </summary>
+        public string AutoDetectionDefaultLanguage { get; set; }
+
+        /// <summary>
+        /// Checks that the specified <see cref="TextAnalyticsClientOptions.ServiceVersion"/> supports all properties set within this model.
+        /// </summary>
+        /// <param name="current">The current <see cref="TextAnalyticsClientOptions.ServiceVersion"/> used by the <see cref="TextAnalyticsClient"/>.</param>
+        internal void CheckSupported(TextAnalyticsClientOptions.ServiceVersion current)
+        {
+            Validation.SupportsProperty(this, AutoDetectionDefaultLanguage, nameof(AutoDetectionDefaultLanguage), TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview, current);
+        }
+
+        void IModelValidator.CheckSupported(TextAnalyticsClientOptions.ServiceVersion current) => CheckSupported(current);
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/MultiLabelClassifyOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/MultiLabelClassifyOptions.cs
@@ -42,8 +42,12 @@ namespace Azure.AI.TextAnalytics
         public string DisplayName { get; set; }
 
         /// <summary>
-        /// The default language to consider during automatic language detection.
+        /// The two-letter ISO 639-1 representation of the default language to consider for automatic language
+        /// detection (for example, "en" for English or "fr" for French).
         /// </summary>
+        /// <remarks>
+        /// This property only applies for <see cref="TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview"/>, and newer.
+        /// </remarks>
         public string AutoDetectionDefaultLanguage { get; set; }
 
         /// <summary>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeCustomEntitiesOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeCustomEntitiesOptions.cs
@@ -7,7 +7,7 @@ namespace Azure.AI.TextAnalytics
     /// Options that allow callers to specify details about how the operation
     /// is run and what information is returned from it by the service.
     /// </summary>
-    public class RecognizeCustomEntitiesOptions
+    public class RecognizeCustomEntitiesOptions : IModelValidator
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RecognizeCustomEntitiesOptions"/>
@@ -40,5 +40,21 @@ namespace Azure.AI.TextAnalytics
         /// Optional display name for the operation.
         /// </summary>
         public string DisplayName { get; set; }
+
+        /// <summary>
+        /// The default language to consider during automatic language detection.
+        /// </summary>
+        public string AutoDetectionDefaultLanguage { get; set; }
+
+        /// <summary>
+        /// Checks that the specified <see cref="TextAnalyticsClientOptions.ServiceVersion"/> supports all properties set within this model.
+        /// </summary>
+        /// <param name="current">The current <see cref="TextAnalyticsClientOptions.ServiceVersion"/> used by the <see cref="TextAnalyticsClient"/>.</param>
+        internal void CheckSupported(TextAnalyticsClientOptions.ServiceVersion current)
+        {
+            Validation.SupportsProperty(this, AutoDetectionDefaultLanguage, nameof(AutoDetectionDefaultLanguage), TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview, current);
+        }
+
+        void IModelValidator.CheckSupported(TextAnalyticsClientOptions.ServiceVersion current) => CheckSupported(current);
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeCustomEntitiesOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeCustomEntitiesOptions.cs
@@ -42,8 +42,12 @@ namespace Azure.AI.TextAnalytics
         public string DisplayName { get; set; }
 
         /// <summary>
-        /// The default language to consider during automatic language detection.
+        /// The two-letter ISO 639-1 representation of the default language to consider for automatic language
+        /// detection (for example, "en" for English or "fr" for French).
         /// </summary>
+        /// <remarks>
+        /// This property only applies for <see cref="TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview"/>, and newer.
+        /// </remarks>
         public string AutoDetectionDefaultLanguage { get; set; }
 
         /// <summary>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LanguageServiceClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LanguageServiceClient.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Azure.AI.TextAnalytics.Models;
 using Azure.Core;
 using Azure.Core.Pipeline;
-using static System.Collections.Specialized.BitVector32;
 
 namespace Azure.AI.TextAnalytics.ServiceClients
 {
@@ -718,6 +717,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
                 AnalyzeTextJobsInput input = new(multiLanguageInput, new List<AnalyzeTextLROTask>() { CreateCustomEntitiesTask(projectName, deploymentName, options) })
                 {
                     DisplayName = options.DisplayName,
+                    DefaultLanguage = options.AutoDetectionDefaultLanguage
                 };
 
                 var response = _languageRestClient.AnalyzeBatchSubmitJob(input, cancellationToken);
@@ -747,6 +747,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
                 AnalyzeTextJobsInput input = new(multiLanguageInput, new List<AnalyzeTextLROTask>() { CreateCustomEntitiesTask(projectName, deploymentName, options) })
                 {
                     DisplayName = options.DisplayName,
+                    DefaultLanguage = options.AutoDetectionDefaultLanguage
                 };
 
                 var response = await _languageRestClient.AnalyzeBatchSubmitJobAsync(input, cancellationToken).ConfigureAwait(false);
@@ -1390,7 +1391,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             };
         }
 
-        private AnalyzeHealthcareEntitiesOperation StartAnalyzeHealthcareEntities(MultiLanguageAnalysisInput batchInput, AnalyzeHealthcareEntitiesOptions options, CancellationToken cancellationToken = default)
+        private AnalyzeHealthcareEntitiesOperation StartAnalyzeHealthcareEntities(MultiLanguageAnalysisInput multiLanguageInput, AnalyzeHealthcareEntitiesOptions options, CancellationToken cancellationToken = default)
         {
             options ??= new();
 
@@ -1399,16 +1400,17 @@ namespace Azure.AI.TextAnalytics.ServiceClients
 
             try
             {
-                AnalyzeTextJobsInput input = new(batchInput, new List<AnalyzeTextLROTask>() { CreateHealthcareTask(options) } )
+                AnalyzeTextJobsInput input = new(multiLanguageInput, new List<AnalyzeTextLROTask>() { CreateHealthcareTask(options) } )
                 {
                     DisplayName = options.DisplayName,
+                    DefaultLanguage = options.AutoDetectionDefaultLanguage
                 };
 
                 var response = _languageRestClient.AnalyzeBatchSubmitJob(input, cancellationToken);
 
                 string location = response.Headers.OperationLocation;
 
-                IDictionary<string, int> idToIndexMap = CreateIdToIndexMap(batchInput.Documents);
+                IDictionary<string, int> idToIndexMap = CreateIdToIndexMap(multiLanguageInput.Documents);
 
                 return new AnalyzeHealthcareEntitiesOperation(this, _clientDiagnostics, location, idToIndexMap, options.IncludeStatistics);
             }
@@ -1419,7 +1421,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             }
         }
 
-        private async Task<AnalyzeHealthcareEntitiesOperation> StartAnalyzeHealthcareEntitiesAsync(MultiLanguageAnalysisInput batchInput, AnalyzeHealthcareEntitiesOptions options, CancellationToken cancellationToken = default)
+        private async Task<AnalyzeHealthcareEntitiesOperation> StartAnalyzeHealthcareEntitiesAsync(MultiLanguageAnalysisInput multiLanguageInput, AnalyzeHealthcareEntitiesOptions options, CancellationToken cancellationToken = default)
         {
             options ??= new();
 
@@ -1428,16 +1430,17 @@ namespace Azure.AI.TextAnalytics.ServiceClients
 
             try
             {
-                AnalyzeTextJobsInput input = new(batchInput, new List<AnalyzeTextLROTask>() { CreateHealthcareTask(options) })
+                AnalyzeTextJobsInput input = new(multiLanguageInput, new List<AnalyzeTextLROTask>() { CreateHealthcareTask(options) })
                 {
                     DisplayName = options.DisplayName,
+                    DefaultLanguage = options.AutoDetectionDefaultLanguage
                 };
 
                 var response = await _languageRestClient.AnalyzeBatchSubmitJobAsync(input, cancellationToken).ConfigureAwait(false);
 
                 string location = response.Headers.OperationLocation;
 
-                IDictionary<string, int> idToIndexMap = CreateIdToIndexMap(batchInput.Documents);
+                IDictionary<string, int> idToIndexMap = CreateIdToIndexMap(multiLanguageInput.Documents);
 
                 return new AnalyzeHealthcareEntitiesOperation(this, _clientDiagnostics, location, idToIndexMap, options.IncludeStatistics);
             }
@@ -1725,7 +1728,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             }
         }
 
-        private AnalyzeActionsOperation StartAnalyzeActions(MultiLanguageAnalysisInput batchInput, TextAnalyticsActions actions, AnalyzeActionsOptions options = default, CancellationToken cancellationToken = default)
+        private AnalyzeActionsOperation StartAnalyzeActions(MultiLanguageAnalysisInput multiLanguageInput, TextAnalyticsActions actions, AnalyzeActionsOptions options = default, CancellationToken cancellationToken = default)
         {
             options ??= new();
 
@@ -1734,13 +1737,17 @@ namespace Azure.AI.TextAnalytics.ServiceClients
 
             try
             {
-                AnalyzeTextJobsInput input = new(batchInput, CreateTasks(actions)) { DisplayName = actions.DisplayName };
+                AnalyzeTextJobsInput input = new(multiLanguageInput, CreateTasks(actions))
+                {
+                    DisplayName = actions.DisplayName,
+                    DefaultLanguage = options.AutoDetectionDefaultLanguage
+                };
 
                 var response = _languageRestClient.AnalyzeBatchSubmitJob(input, cancellationToken);
 
                 string location = response.Headers.OperationLocation;
 
-                IDictionary<string, int> idToIndexMap = CreateIdToIndexMap(batchInput.Documents);
+                IDictionary<string, int> idToIndexMap = CreateIdToIndexMap(multiLanguageInput.Documents);
 
                 return new AnalyzeActionsOperation(this, _clientDiagnostics, location, idToIndexMap, options.IncludeStatistics);
             }
@@ -1751,7 +1758,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             }
         }
 
-        private async Task<AnalyzeActionsOperation> StartAnalyzeActionsAsync(MultiLanguageAnalysisInput batchInput, TextAnalyticsActions actions, AnalyzeActionsOptions options = default, CancellationToken cancellationToken = default)
+        private async Task<AnalyzeActionsOperation> StartAnalyzeActionsAsync(MultiLanguageAnalysisInput multiLanguageInput, TextAnalyticsActions actions, AnalyzeActionsOptions options = default, CancellationToken cancellationToken = default)
         {
             options ??= new();
 
@@ -1760,13 +1767,17 @@ namespace Azure.AI.TextAnalytics.ServiceClients
 
             try
             {
-                AnalyzeTextJobsInput input = new(batchInput, CreateTasks(actions)) { DisplayName = actions.DisplayName };
+                AnalyzeTextJobsInput input = new(multiLanguageInput, CreateTasks(actions))
+                {
+                    DisplayName = actions.DisplayName,
+                    DefaultLanguage = options.AutoDetectionDefaultLanguage
+                };
 
                 var response = await _languageRestClient.AnalyzeBatchSubmitJobAsync(input, cancellationToken).ConfigureAwait(false);
 
                 string location = response.Headers.OperationLocation;
 
-                IDictionary<string, int> idToIndexMap = CreateIdToIndexMap(batchInput.Documents);
+                IDictionary<string, int> idToIndexMap = CreateIdToIndexMap(multiLanguageInput.Documents);
 
                 return new AnalyzeActionsOperation(this, _clientDiagnostics, location, idToIndexMap, options.IncludeStatistics);
             }
@@ -1942,6 +1953,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
                 AnalyzeTextJobsInput input = new(multiLanguageInput, new List<AnalyzeTextLROTask>() { CreateCustomSingleLabelClassificationTask(projectName, deploymentName, options) })
                 {
                     DisplayName = options.DisplayName,
+                    DefaultLanguage = options.AutoDetectionDefaultLanguage
                 };
 
                 var response = _languageRestClient.AnalyzeBatchSubmitJob(input, cancellationToken);
@@ -1971,6 +1983,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
                 AnalyzeTextJobsInput input = new(multiLanguageInput, new List<AnalyzeTextLROTask>() { CreateCustomSingleLabelClassificationTask(projectName, deploymentName, options) })
                 {
                     DisplayName = options.DisplayName,
+                    DefaultLanguage = options.AutoDetectionDefaultLanguage
                 };
 
                 var response = await _languageRestClient.AnalyzeBatchSubmitJobAsync(input, cancellationToken).ConfigureAwait(false);
@@ -2047,6 +2060,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
                 AnalyzeTextJobsInput input = new(multiLanguageInput, new List<AnalyzeTextLROTask>() { CreateCustomMultiLabelClassificationTask(projectName, deploymentName, options) })
                 {
                     DisplayName = options.DisplayName,
+                    DefaultLanguage = options.AutoDetectionDefaultLanguage
                 };
 
                 var response = _languageRestClient.AnalyzeBatchSubmitJob(input, cancellationToken);
@@ -2076,6 +2090,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
                 AnalyzeTextJobsInput input = new(multiLanguageInput, new List<AnalyzeTextLROTask>() { CreateCustomMultiLabelClassificationTask(projectName, deploymentName, options) })
                 {
                     DisplayName = options.DisplayName,
+                    DefaultLanguage = options.AutoDetectionDefaultLanguage
                 };
 
                 var response = await _languageRestClient.AnalyzeBatchSubmitJobAsync(input, cancellationToken).ConfigureAwait(false);
@@ -2156,6 +2171,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
                 AnalyzeTextJobsInput input = new(multiLanguageInput, new List<AnalyzeTextLROTask>() { CreateExtractiveSummarizationTask(options) })
                 {
                     DisplayName = options.DisplayName,
+                    DefaultLanguage = options.AutoDetectionDefaultLanguage
                 };
 
                 var response = _languageRestClient.AnalyzeBatchSubmitJob(input, cancellationToken);
@@ -2183,6 +2199,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
                 AnalyzeTextJobsInput input = new(multiLanguageInput, new List<AnalyzeTextLROTask>() { CreateExtractiveSummarizationTask(options) })
                 {
                     DisplayName = options.DisplayName,
+                    DefaultLanguage = options.AutoDetectionDefaultLanguage
                 };
 
                 var response = await _languageRestClient.AnalyzeBatchSubmitJobAsync(input, cancellationToken).ConfigureAwait(false);
@@ -2259,6 +2276,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
                 AnalyzeTextJobsInput input = new(multiLanguageInput, new List<AnalyzeTextLROTask>() { CreateAbstractiveSummarizationTask(options) })
                 {
                     DisplayName = options.DisplayName,
+                    DefaultLanguage = options.AutoDetectionDefaultLanguage
                 };
 
                 var response = _languageRestClient.AnalyzeBatchSubmitJob(input, cancellationToken);
@@ -2286,6 +2304,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
                 AnalyzeTextJobsInput input = new(multiLanguageInput, new List<AnalyzeTextLROTask>() { CreateAbstractiveSummarizationTask(options) })
                 {
                     DisplayName = options.DisplayName,
+                    DefaultLanguage = options.AutoDetectionDefaultLanguage
                 };
 
                 var response = await _languageRestClient.AnalyzeBatchSubmitJobAsync(input, cancellationToken).ConfigureAwait(false);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/SingleLabelClassifyOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/SingleLabelClassifyOptions.cs
@@ -7,7 +7,7 @@ namespace Azure.AI.TextAnalytics
     /// Options that allow callers to specify details about how the operation
     /// is run and what information is returned from it by the service.
     /// </summary>
-    public class SingleLabelClassifyOptions
+    public class SingleLabelClassifyOptions : IModelValidator
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SingleLabelClassifyOptions"/>
@@ -40,5 +40,21 @@ namespace Azure.AI.TextAnalytics
         /// Optional display name for the operation.
         /// </summary>
         public string DisplayName { get; set; }
+
+        /// <summary>
+        /// The default language to consider during automatic language detection.
+        /// </summary>
+        public string AutoDetectionDefaultLanguage { get; set; }
+
+        /// <summary>
+        /// Checks that the specified <see cref="TextAnalyticsClientOptions.ServiceVersion"/> supports all properties set within this model.
+        /// </summary>
+        /// <param name="current">The current <see cref="TextAnalyticsClientOptions.ServiceVersion"/> used by the <see cref="TextAnalyticsClient"/>.</param>
+        internal void CheckSupported(TextAnalyticsClientOptions.ServiceVersion current)
+        {
+            Validation.SupportsProperty(this, AutoDetectionDefaultLanguage, nameof(AutoDetectionDefaultLanguage), TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview, current);
+        }
+
+        void IModelValidator.CheckSupported(TextAnalyticsClientOptions.ServiceVersion current) => CheckSupported(current);
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/SingleLabelClassifyOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/SingleLabelClassifyOptions.cs
@@ -42,8 +42,12 @@ namespace Azure.AI.TextAnalytics
         public string DisplayName { get; set; }
 
         /// <summary>
-        /// The default language to consider during automatic language detection.
+        /// The two-letter ISO 639-1 representation of the default language to consider for automatic language
+        /// detection (for example, "en" for English or "fr" for French).
         /// </summary>
+        /// <remarks>
+        /// This property only applies for <see cref="TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview"/>, and newer.
+        /// </remarks>
         public string AutoDetectionDefaultLanguage { get; set; }
 
         /// <summary>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsActions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsActions.cs
@@ -80,16 +80,25 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// The set of <see cref="AnalyzeHealthcareEntitiesAction"/> that will get executed on the input documents.
         /// </summary>
+        /// <remarks>
+        /// This property only applies for <see cref="TextAnalyticsClientOptions.ServiceVersion.V2022_05_01"/> and newer.
+        /// </remarks>
         public IReadOnlyCollection<AnalyzeHealthcareEntitiesAction> AnalyzeHealthcareEntitiesActions { get; set; }
 
         /// <summary>
         /// The set of <see cref="ExtractSummaryAction"/> that will get executed on the input documents.
         /// </summary>
+        /// <remarks>
+        /// This property only applies for <see cref="TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview"/> and newer.
+        /// </remarks>
         public IReadOnlyCollection<ExtractSummaryAction> ExtractSummaryActions { get; set; }
 
         /// <summary>
         /// The set of <see cref="AbstractSummaryAction"/> that will get executed on the input documents.
         /// </summary>
+        /// <remarks>
+        /// This property only applies for <see cref="TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview"/> and newer.
+        /// </remarks>
         public IReadOnlyCollection<AbstractSummaryAction> AbstractSummaryActions { get; set; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -1731,8 +1731,11 @@ namespace Azure.AI.TextAnalytics
             TextAnalyticsActions actions,
             string language = default,
             AnalyzeActionsOptions options = default,
-            CancellationToken cancellationToken = default) =>
-            await _serviceClient.StartAnalyzeActionsAsync(documents, actions, language, options, cancellationToken).ConfigureAwait(false);
+            CancellationToken cancellationToken = default)
+        {
+            options?.CheckSupported(ServiceVersion);
+            return await _serviceClient.StartAnalyzeActionsAsync(documents, actions, language, options, cancellationToken).ConfigureAwait(false);
+        }
 
         /// <summary>
         /// Performs one or more text analysis actions on a set of documents. The list of supported actions includes:
@@ -1775,8 +1778,11 @@ namespace Azure.AI.TextAnalytics
             TextAnalyticsActions actions,
             string language = default,
             AnalyzeActionsOptions options = default,
-            CancellationToken cancellationToken = default) =>
-            _serviceClient.StartAnalyzeActions(documents, actions, language, options, cancellationToken);
+            CancellationToken cancellationToken = default)
+        {
+            options?.CheckSupported(ServiceVersion);
+            return _serviceClient.StartAnalyzeActions(documents, actions, language, options, cancellationToken);
+        }
 
         /// <summary>
         /// Performs one or more text analysis actions on a set of documents. The list of supported actions includes:
@@ -1817,8 +1823,11 @@ namespace Azure.AI.TextAnalytics
             IEnumerable<TextDocumentInput> documents,
             TextAnalyticsActions actions,
             AnalyzeActionsOptions options = default,
-            CancellationToken cancellationToken = default) =>
-            _serviceClient.StartAnalyzeActions(documents, actions, options, cancellationToken);
+            CancellationToken cancellationToken = default)
+        {
+            options?.CheckSupported(ServiceVersion);
+            return _serviceClient.StartAnalyzeActions(documents, actions, options, cancellationToken);
+        }
 
         /// <summary>
         /// Performs one or more text analysis actions on a set of documents. The list of supported actions includes:
@@ -1859,8 +1868,11 @@ namespace Azure.AI.TextAnalytics
             IEnumerable<TextDocumentInput> documents,
             TextAnalyticsActions actions,
             AnalyzeActionsOptions options = default,
-            CancellationToken cancellationToken = default) =>
-            await _serviceClient.StartAnalyzeActionsAsync(documents, actions, options, cancellationToken).ConfigureAwait(false);
+            CancellationToken cancellationToken = default)
+        {
+            options?.CheckSupported(ServiceVersion);
+            return await _serviceClient.StartAnalyzeActionsAsync(documents, actions, options, cancellationToken).ConfigureAwait(false);
+        }
 
         #endregion
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -730,8 +730,17 @@ namespace Azure.AI.TextAnalytics
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
         /// <exception cref="NotSupportedException">This method is only supported in service API version 2022-05-01 and newer.</exception>
-        public virtual RecognizeCustomEntitiesOperation StartRecognizeCustomEntities(IEnumerable<string> documents, string projectName, string deploymentName, string language = default, RecognizeCustomEntitiesOptions options = default, CancellationToken cancellationToken = default) =>
-            _serviceClient.StartRecognizeCustomEntities(documents, projectName, deploymentName, language, options, cancellationToken);
+        public virtual RecognizeCustomEntitiesOperation StartRecognizeCustomEntities(
+            IEnumerable<string> documents,
+            string projectName,
+            string deploymentName,
+            string language = default,
+            RecognizeCustomEntitiesOptions options = default,
+            CancellationToken cancellationToken = default)
+        {
+            options?.CheckSupported(ServiceVersion);
+            return _serviceClient.StartRecognizeCustomEntities(documents, projectName, deploymentName, language, options, cancellationToken);
+        }
 
         /// <summary>
         /// Runs a predictive model to identify a collection of custom named entities
@@ -758,8 +767,16 @@ namespace Azure.AI.TextAnalytics
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
         /// <exception cref="NotSupportedException">This method is only supported in service API version 2022-05-01 and newer.</exception>
-        public virtual RecognizeCustomEntitiesOperation StartRecognizeCustomEntities(IEnumerable<TextDocumentInput> documents, string projectName, string deploymentName, RecognizeCustomEntitiesOptions options = default, CancellationToken cancellationToken = default) =>
-            _serviceClient.StartRecognizeCustomEntities(documents, projectName, deploymentName, options, cancellationToken);
+        public virtual RecognizeCustomEntitiesOperation StartRecognizeCustomEntities(
+            IEnumerable<TextDocumentInput> documents,
+            string projectName,
+            string deploymentName,
+            RecognizeCustomEntitiesOptions options = default,
+            CancellationToken cancellationToken = default)
+        {
+            options?.CheckSupported(ServiceVersion);
+            return _serviceClient.StartRecognizeCustomEntities(documents, projectName, deploymentName, options, cancellationToken);
+        }
 
         /// <summary>
         /// Runs a predictive model to identify a collection of custom named entities
@@ -791,8 +808,17 @@ namespace Azure.AI.TextAnalytics
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
         /// <exception cref="NotSupportedException">This method is only supported in service API version 2022-05-01 and newer.</exception>
-        public virtual async Task<RecognizeCustomEntitiesOperation> StartRecognizeCustomEntitiesAsync(IEnumerable<string> documents, string projectName, string deploymentName, string language = default, RecognizeCustomEntitiesOptions options = default, CancellationToken cancellationToken = default) =>
-            await _serviceClient.StartRecognizeCustomEntitiesAsync(documents, projectName, deploymentName, language, options, cancellationToken).ConfigureAwait(false);
+        public virtual async Task<RecognizeCustomEntitiesOperation> StartRecognizeCustomEntitiesAsync(
+            IEnumerable<string> documents,
+            string projectName,
+            string deploymentName,
+            string language = default,
+            RecognizeCustomEntitiesOptions options = default,
+            CancellationToken cancellationToken = default)
+        {
+            options?.CheckSupported(ServiceVersion);
+            return await _serviceClient.StartRecognizeCustomEntitiesAsync(documents, projectName, deploymentName, language, options, cancellationToken).ConfigureAwait(false);
+        }
 
         /// <summary>
         /// Runs a predictive model to identify a collection of custom named entities
@@ -819,8 +845,16 @@ namespace Azure.AI.TextAnalytics
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
         /// <exception cref="NotSupportedException">This method is only supported in service API version 2022-05-01 and newer.</exception>
-        public virtual async Task<RecognizeCustomEntitiesOperation> StartRecognizeCustomEntitiesAsync(IEnumerable<TextDocumentInput> documents, string projectName, string deploymentName, RecognizeCustomEntitiesOptions options = default, CancellationToken cancellationToken = default) =>
-            await _serviceClient.StartRecognizeCustomEntitiesAsync(documents, projectName, deploymentName, options, cancellationToken).ConfigureAwait(false);
+        public virtual async Task<RecognizeCustomEntitiesOperation> StartRecognizeCustomEntitiesAsync(
+            IEnumerable<TextDocumentInput> documents,
+            string projectName,
+            string deploymentName,
+            RecognizeCustomEntitiesOptions options = default,
+            CancellationToken cancellationToken = default)
+        {
+            options?.CheckSupported(ServiceVersion);
+            return await _serviceClient.StartRecognizeCustomEntitiesAsync(documents, projectName, deploymentName, options, cancellationToken).ConfigureAwait(false);
+        }
 
         #endregion
 
@@ -1864,8 +1898,17 @@ namespace Azure.AI.TextAnalytics
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
         /// <exception cref="NotSupportedException">This method is only supported in service API version 2022-05-01 and newer.</exception>
-        public virtual ClassifyDocumentOperation StartSingleLabelClassify(IEnumerable<string> documents, string projectName, string deploymentName, string language = default, SingleLabelClassifyOptions options = default, CancellationToken cancellationToken = default) =>
-            _serviceClient.StartSingleLabelClassify(documents, projectName, deploymentName, language, options, cancellationToken);
+        public virtual ClassifyDocumentOperation StartSingleLabelClassify(
+            IEnumerable<string> documents,
+            string projectName,
+            string deploymentName,
+            string language = default,
+            SingleLabelClassifyOptions options = default,
+            CancellationToken cancellationToken = default)
+        {
+            options?.CheckSupported(ServiceVersion);
+            return _serviceClient.StartSingleLabelClassify(documents, projectName, deploymentName, language, options, cancellationToken);
+        }
 
         /// <summary>
         /// Runs a predictive model to identify a classify each document with a single label
@@ -1894,8 +1937,16 @@ namespace Azure.AI.TextAnalytics
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
         /// <exception cref="NotSupportedException">This method is only supported in service API version 2022-05-01 and newer.</exception>
-        public virtual ClassifyDocumentOperation StartSingleLabelClassify(IEnumerable<TextDocumentInput> documents, string projectName, string deploymentName, SingleLabelClassifyOptions options = default, CancellationToken cancellationToken = default) =>
-            _serviceClient.StartSingleLabelClassify(documents, projectName, deploymentName, options, cancellationToken);
+        public virtual ClassifyDocumentOperation StartSingleLabelClassify(
+            IEnumerable<TextDocumentInput> documents,
+            string projectName,
+            string deploymentName,
+            SingleLabelClassifyOptions options = default,
+            CancellationToken cancellationToken = default)
+        {
+            options?.CheckSupported(ServiceVersion);
+            return _serviceClient.StartSingleLabelClassify(documents, projectName, deploymentName, options, cancellationToken);
+        }
 
         /// <summary>
         /// Runs a predictive model to identify a classify each document with a single label
@@ -1929,8 +1980,17 @@ namespace Azure.AI.TextAnalytics
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
         /// <exception cref="NotSupportedException">This method is only supported in service API version 2022-05-01 and newer.</exception>
-        public virtual async Task<ClassifyDocumentOperation> StartSingleLabelClassifyAsync(IEnumerable<string> documents, string projectName, string deploymentName, string language = default, SingleLabelClassifyOptions options = default, CancellationToken cancellationToken = default) =>
-            await _serviceClient.StartSingleLabelClassifyAsync(documents, projectName, deploymentName, language, options, cancellationToken).ConfigureAwait(false);
+        public virtual async Task<ClassifyDocumentOperation> StartSingleLabelClassifyAsync(
+            IEnumerable<string> documents,
+            string projectName,
+            string deploymentName,
+            string language = default,
+            SingleLabelClassifyOptions options = default,
+            CancellationToken cancellationToken = default)
+        {
+            options?.CheckSupported(ServiceVersion);
+            return await _serviceClient.StartSingleLabelClassifyAsync(documents, projectName, deploymentName, language, options, cancellationToken).ConfigureAwait(false);
+        }
 
         /// <summary>
         /// Runs a predictive model to identify a classify each document with a single label
@@ -1959,8 +2019,16 @@ namespace Azure.AI.TextAnalytics
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
         /// <exception cref="NotSupportedException">This method is only supported in service API version 2022-05-01 and newer.</exception>
-        public virtual async Task<ClassifyDocumentOperation> StartSingleLabelClassifyAsync(IEnumerable<TextDocumentInput> documents, string projectName, string deploymentName, SingleLabelClassifyOptions options = default, CancellationToken cancellationToken = default) =>
-            await _serviceClient.StartSingleLabelClassifyAsync(documents, projectName, deploymentName, options, cancellationToken).ConfigureAwait(false);
+        public virtual async Task<ClassifyDocumentOperation> StartSingleLabelClassifyAsync(
+            IEnumerable<TextDocumentInput> documents,
+            string projectName,
+            string deploymentName,
+            SingleLabelClassifyOptions options = default,
+            CancellationToken cancellationToken = default)
+        {
+            options?.CheckSupported(ServiceVersion);
+            return await _serviceClient.StartSingleLabelClassifyAsync(documents, projectName, deploymentName, options, cancellationToken).ConfigureAwait(false);
+        }
 
         #endregion
 
@@ -1998,8 +2066,17 @@ namespace Azure.AI.TextAnalytics
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
         /// <exception cref="NotSupportedException">This method is only supported in service API version 2022-05-01 and newer.</exception>
-        public virtual ClassifyDocumentOperation StartMultiLabelClassify(IEnumerable<string> documents, string projectName, string deploymentName, string language = default, MultiLabelClassifyOptions options = default, CancellationToken cancellationToken = default) =>
-            _serviceClient.StartMultiLabelClassify(documents, projectName, deploymentName, language, options, cancellationToken);
+        public virtual ClassifyDocumentOperation StartMultiLabelClassify(
+            IEnumerable<string> documents,
+            string projectName,
+            string deploymentName,
+            string language = default,
+            MultiLabelClassifyOptions options = default,
+            CancellationToken cancellationToken = default)
+        {
+            options?.CheckSupported(ServiceVersion);
+            return _serviceClient.StartMultiLabelClassify(documents, projectName, deploymentName, language, options, cancellationToken);
+        }
 
         /// <summary>
         /// Runs a predictive model to identify a classify each document with multiple labels
@@ -2028,8 +2105,16 @@ namespace Azure.AI.TextAnalytics
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
         /// <exception cref="NotSupportedException">This method is only supported in service API version 2022-05-01 and newer.</exception>
-        public virtual ClassifyDocumentOperation StartMultiLabelClassify(IEnumerable<TextDocumentInput> documents, string projectName, string deploymentName, MultiLabelClassifyOptions options = default, CancellationToken cancellationToken = default) =>
-            _serviceClient.StartMultiLabelClassify(documents, projectName, deploymentName, options, cancellationToken);
+        public virtual ClassifyDocumentOperation StartMultiLabelClassify(
+            IEnumerable<TextDocumentInput> documents,
+            string projectName,
+            string deploymentName,
+            MultiLabelClassifyOptions options = default,
+            CancellationToken cancellationToken = default)
+        {
+            options?.CheckSupported(ServiceVersion);
+            return _serviceClient.StartMultiLabelClassify(documents, projectName, deploymentName, options, cancellationToken);
+        }
 
         /// <summary>
         /// Runs a predictive model to identify a classify each document with multiple labels
@@ -2063,8 +2148,17 @@ namespace Azure.AI.TextAnalytics
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
         /// <exception cref="NotSupportedException">This method is only supported in service API version 2022-05-01 and newer.</exception>
-        public virtual async Task<ClassifyDocumentOperation> StartMultiLabelClassifyAsync(IEnumerable<string> documents, string projectName, string deploymentName, string language = default, MultiLabelClassifyOptions options = default, CancellationToken cancellationToken = default) =>
-            await _serviceClient.StartMultiLabelClassifyAsync(documents, projectName, deploymentName, language, options, cancellationToken).ConfigureAwait(false);
+        public virtual async Task<ClassifyDocumentOperation> StartMultiLabelClassifyAsync(
+            IEnumerable<string> documents,
+            string projectName,
+            string deploymentName,
+            string language = default,
+            MultiLabelClassifyOptions options = default,
+            CancellationToken cancellationToken = default)
+        {
+            options?.CheckSupported(ServiceVersion);
+            return await _serviceClient.StartMultiLabelClassifyAsync(documents, projectName, deploymentName, language, options, cancellationToken).ConfigureAwait(false);
+        }
 
         /// <summary>
         /// Runs a predictive model to identify a classify each document with multiple labels
@@ -2093,8 +2187,16 @@ namespace Azure.AI.TextAnalytics
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
         /// <exception cref="NotSupportedException">This method is only supported in service API version 2022-05-01 and newer.</exception>
-        public virtual async Task<ClassifyDocumentOperation> StartMultiLabelClassifyAsync(IEnumerable<TextDocumentInput> documents, string projectName, string deploymentName, MultiLabelClassifyOptions options = default, CancellationToken cancellationToken = default) =>
-            await _serviceClient.StartMultiLabelClassifyAsync(documents, projectName, deploymentName, options, cancellationToken).ConfigureAwait(false);
+        public virtual async Task<ClassifyDocumentOperation> StartMultiLabelClassifyAsync(
+            IEnumerable<TextDocumentInput> documents,
+            string projectName,
+            string deploymentName,
+            MultiLabelClassifyOptions options = default,
+            CancellationToken cancellationToken = default)
+        {
+            options?.CheckSupported(ServiceVersion);
+            return await _serviceClient.StartMultiLabelClassifyAsync(documents, projectName, deploymentName, options, cancellationToken).ConfigureAwait(false);
+        }
 
         #endregion
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AbstractSummaryTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AbstractSummaryTests.cs
@@ -199,6 +199,29 @@ namespace Azure.AI.TextAnalytics.Tests
 
         [RecordedTest]
         [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/32614")]
+        public async Task AbstractSummaryBatchConvenienceWithAutoDetectedLanguageTest()
+        {
+            TextAnalyticsClient client = GetClient();
+
+            AbstractSummaryOptions options = new()
+            {
+                AutoDetectionDefaultLanguage = "en"
+            };
+
+            AbstractSummaryOperation operation = await client.StartAbstractSummaryAsync(s_batchConvenienceDocuments, "en", options);
+            await operation.WaitForCompletionAsync();
+            ValidateOperationProperties(operation);
+
+            List<AbstractSummaryResultCollection> resultInPages = operation.Value.ToEnumerableAsync().Result;
+            Assert.AreEqual(1, resultInPages.Count);
+
+            // Take the first page.
+            AbstractSummaryResultCollection resultCollection = resultInPages.FirstOrDefault();
+            ValidateSummaryBatchResult(resultCollection, isLanguageAutoDetected: true);
+        }
+
+        [RecordedTest]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/32614")]
         public async Task AnalyzeOperationAbstractSummaryWithAutoDetectedLanguageTest()
         {
             TextAnalyticsClient client = GetClient();

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeHealthcareEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeHealthcareEntitiesTests.cs
@@ -517,6 +517,30 @@ namespace Azure.AI.TextAnalytics.Tests
 
         [RecordedTest]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
+        public async Task AnalyzeHealthcareEntitiesBatchConvenienceWithAutoDetectedLanguageTest()
+        {
+            TextAnalyticsClient client = GetClient();
+            AnalyzeHealthcareEntitiesOptions options = new()
+            {
+                AutoDetectionDefaultLanguage = "en"
+            };
+
+            AnalyzeHealthcareEntitiesOperation operation = await client.StartAnalyzeHealthcareEntitiesAsync(
+                s_batchConvenienceDocuments,
+                "auto",
+                options);
+
+            await operation.WaitForCompletionAsync();
+
+            ValidateOperationProperties(operation);
+
+            // Take the first page.
+            AnalyzeHealthcareEntitiesResultCollection resultCollection = operation.Value.ToEnumerableAsync().Result.FirstOrDefault();
+            ValidateBatchDocumentsResult(resultCollection, s_expectedBatchOutput, isLanguageAutoDetected: true);
+        }
+
+        [RecordedTest]
+        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeOperationAnalyzeHealthcareEntitiesWithAutoDetectedLanguageTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -538,6 +562,27 @@ namespace Azure.AI.TextAnalytics.Tests
 
             AnalyzeHealthcareEntitiesResultCollection results = actionResults.FirstOrDefault().DocumentsResults;
             ValidateBatchDocumentsResult(results, expectedOutput, isLanguageAutoDetected: true);
+        }
+
+        [RecordedTest]
+        [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
+        public void AnalyzeHealthcareEntitiesBatchWithDefaultLanguageThrows()
+        {
+            TestDiagnostics = false;
+
+            TextAnalyticsClient client = GetClient();
+            AnalyzeHealthcareEntitiesOptions options = new()
+            {
+                AutoDetectionDefaultLanguage = "en"
+            };
+
+            NotSupportedException ex = Assert.ThrowsAsync<NotSupportedException>(
+                async () => await client.StartAnalyzeHealthcareEntitiesAsync(
+                s_batchConvenienceDocuments,
+                "auto",
+                options));
+
+            Assert.That(ex.Message.EndsWith("Use service API version 2022-10-01-preview or newer."));
         }
 
         private void ValidateInDocumenResult(IReadOnlyCollection<HealthcareEntity> entities, List<string> minimumExpectedOutput)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationTests.cs
@@ -3,10 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.Design;
 using System.Linq;
-using System.Reflection.Metadata;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
@@ -989,6 +986,32 @@ namespace Azure.AI.TextAnalytics.Tests
             };
 
             NotSupportedException ex = Assert.ThrowsAsync<NotSupportedException>(async () => await client.StartAnalyzeActionsAsync(batchDocuments, batchActions));
+            Assert.That(ex.Message.EndsWith("Use service API version 2022-10-01-preview or newer."));
+        }
+
+        [RecordedTest]
+        [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
+        public void AnalyzeOperationWithDefaultLanguageThrows()
+        {
+            TestDiagnostics = false;
+
+            TextAnalyticsClient client = GetClient();
+            List<string> documents = new()
+            {
+                "The park was clean and pretty. The bathrooms and restaurant were not clean.",
+            };
+            AnalyzeActionsOptions options = new()
+            {
+                AutoDetectionDefaultLanguage = "en"
+            };
+            TextAnalyticsActions actions = new()
+            {
+                AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() }
+            };
+
+            NotSupportedException ex = Assert.ThrowsAsync<NotSupportedException>(
+                async () => await client.StartAnalyzeActionsAsync(documents, actions, "auto", options));
+
             Assert.That(ex.Message.EndsWith("Use service API version 2022-10-01-preview or newer."));
         }
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeSentimentTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeSentimentTests.cs
@@ -538,13 +538,16 @@ namespace Azure.AI.TextAnalytics.Tests
             {
                 "The park was clean and pretty. The bathrooms and restaurant were not clean.",
             };
+            AnalyzeActionsOptions options = new()
+            {
+                AutoDetectionDefaultLanguage = "en"
+            };
             TextAnalyticsActions actions = new()
             {
-                AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() },
-                DisplayName = "AnalyzeSentimentWithAutoDetectedLanguage",
+                AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() }
             };
 
-            AnalyzeActionsOperation operation = await client.StartAnalyzeActionsAsync(documents, actions, "auto");
+            AnalyzeActionsOperation operation = await client.StartAnalyzeActionsAsync(documents, actions, "auto", options);
             await operation.WaitForCompletionAsync();
 
             // Take the first page.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/ExtractKeyPhrasesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/ExtractKeyPhrasesTests.cs
@@ -262,13 +262,16 @@ namespace Azure.AI.TextAnalytics.Tests
         {
             TextAnalyticsClient client = GetClient();
             List<string> documents = batchConvenienceDocuments;
+            AnalyzeActionsOptions options = new()
+            {
+                AutoDetectionDefaultLanguage = "en"
+            };
             TextAnalyticsActions actions = new()
             {
-                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
-                DisplayName = "ExtractKeyPhrasesWithAutoDetectedLanguage",
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() }
             };
 
-            AnalyzeActionsOperation operation = await client.StartAnalyzeActionsAsync(documents, actions, "auto");
+            AnalyzeActionsOperation operation = await client.StartAnalyzeActionsAsync(documents, actions, "auto", options);
             await operation.WaitForCompletionAsync();
 
             // Take the first page.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/ExtractSummaryTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/ExtractSummaryTests.cs
@@ -223,6 +223,25 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/32759")]
+        public async Task ExtractSummaryBatchConvenienceWithAutoDetectedLanguageTest()
+        {
+            TextAnalyticsClient client = GetClient();
+            ExtractSummaryOptions options = new() { AutoDetectionDefaultLanguage = "en" };
+
+            ExtractSummaryOperation operation = await client.StartExtractSummaryAsync(s_extractSummaryBatchConvenienceDocuments, "auto", options);
+            await operation.WaitForCompletionAsync();
+            ValidateOperationProperties(operation);
+
+            List<ExtractSummaryResultCollection> resultInPages = operation.Value.ToEnumerableAsync().Result;
+            Assert.AreEqual(1, resultInPages.Count);
+
+            // Take the first page.
+            ExtractSummaryResultCollection resultCollection = resultInPages.FirstOrDefault();
+            ValidateSummaryBatchResult(resultCollection, SummarySentencesOrder.Offset, isLanguageAutoDetected: true);
+        }
+
+        [RecordedTest]
         public async Task AnalyzeOperationExtractSummaryWithAutoDetectedLanguageTest()
         {
             TextAnalyticsClient client = GetClient();

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeCustomEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeCustomEntitiesTests.cs
@@ -337,6 +337,30 @@ namespace Azure.AI.TextAnalytics.Tests
 
         [RecordedTest]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
+        public async Task RecognizeCustomEntitiesBatchConvenienceWithAutoDetectedLanguageTest()
+        {
+            TextAnalyticsClient client = GetClient(useStaticResource: true);
+            RecognizeCustomEntitiesOptions options = new()
+            {
+                AutoDetectionDefaultLanguage = "en"
+            };
+
+            RecognizeCustomEntitiesOperation operation = await client.StartRecognizeCustomEntitiesAsync(
+                s_englishBatchConvenienceDocuments,
+                TestEnvironment.RecognizeCustomEntitiesProjectName,
+                TestEnvironment.RecognizeCustomEntitiesDeploymentName,
+                "auto",
+                options);
+
+            await operation.WaitForCompletionAsync();
+
+            // Take the first page.
+            RecognizeCustomEntitiesResultCollection resultCollection = operation.Value.ToEnumerableAsync().Result.FirstOrDefault();
+            ValidateBatchDocumentsResult(resultCollection, s_englishExpectedBatchOutput, isLanguageAutoDetected: true);
+        }
+
+        [RecordedTest]
+        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeOperationRecognizeCustomEntitiesWithAutoDetectedLanguageTest()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -361,6 +385,29 @@ namespace Azure.AI.TextAnalytics.Tests
 
             RecognizeCustomEntitiesResultCollection results = actionResults.FirstOrDefault().DocumentsResults;
             ValidateBatchDocumentsResult(results, expectedOutput, isLanguageAutoDetected: true);
+        }
+
+        [RecordedTest]
+        [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
+        public void MultiLabelClassifyBatchWithDefaultLanguageThrows()
+        {
+            TestDiagnostics = false;
+
+            TextAnalyticsClient client = GetClient();
+            RecognizeCustomEntitiesOptions options = new()
+            {
+                AutoDetectionDefaultLanguage = "en"
+            };
+
+            NotSupportedException ex = Assert.ThrowsAsync<NotSupportedException>(
+                async () => await client.StartRecognizeCustomEntitiesAsync(
+                s_englishBatchConvenienceDocuments,
+                TestEnvironment.RecognizeCustomEntitiesProjectName,
+                TestEnvironment.RecognizeCustomEntitiesDeploymentName,
+                "auto",
+                options));
+
+            Assert.That(ex.Message.EndsWith("Use service API version 2022-10-01-preview or newer."));
         }
 
         private RecognizeCustomEntitiesResultCollection ExtractDocumentsResultsFromResponse(AnalyzeActionsOperation analyzeActionOperation)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeCustomEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeCustomEntitiesTests.cs
@@ -389,7 +389,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
         [RecordedTest]
         [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
-        public void MultiLabelClassifyBatchWithDefaultLanguageThrows()
+        public void RecognizeCustomEntitiesBatchWithDefaultLanguageThrows()
         {
             TestDiagnostics = false;
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeEntitiesTests.cs
@@ -481,13 +481,16 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             List<string> documents = s_batchConvenienceDocuments;
             Dictionary<string, List<string>> expectedOutput = s_expectedBatchOutput;
+            AnalyzeActionsOptions options = new()
+            {
+                AutoDetectionDefaultLanguage = "en"
+            };
             TextAnalyticsActions actions = new()
             {
                 RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { new RecognizeEntitiesAction() },
-                DisplayName = "RecognizeEntitiesWithAutoDetectedLanguage",
             };
 
-            AnalyzeActionsOperation operation = await client.StartAnalyzeActionsAsync(documents, actions, "auto");
+            AnalyzeActionsOperation operation = await client.StartAnalyzeActionsAsync(documents, actions, "auto", options);
             await operation.WaitForCompletionAsync();
 
             // Take the first page.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeLinkedEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeLinkedEntitiesTests.cs
@@ -278,13 +278,16 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             List<string> documents = s_batchConvenienceDocuments;
             Dictionary<string, List<string>> expectedOutput = s_expectedBatchOutput;
+            AnalyzeActionsOptions options = new()
+            {
+                AutoDetectionDefaultLanguage = "en"
+            };
             TextAnalyticsActions actions = new()
             {
                 RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { new RecognizeLinkedEntitiesAction() },
-                DisplayName = "RecognizeLinkedEntitiesWithAutoDetectedLanguage",
             };
 
-            AnalyzeActionsOperation operation = await client.StartAnalyzeActionsAsync(documents, actions, "auto");
+            AnalyzeActionsOperation operation = await client.StartAnalyzeActionsAsync(documents, actions, "auto", options);
             await operation.WaitForCompletionAsync();
 
             // Take the first page.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizePiiEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizePiiEntitiesTests.cs
@@ -278,13 +278,16 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             List<string> documents = s_batchConvenienceDocuments;
             Dictionary<string, List<string>> expectedOutput = s_expectedBatchOutput;
+            AnalyzeActionsOptions options = new()
+            {
+                AutoDetectionDefaultLanguage = "en"
+            };
             TextAnalyticsActions actions = new()
             {
                 RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() },
-                DisplayName = "RecognizePiiEntitiesWithAutoDetectedLanguage",
             };
 
-            AnalyzeActionsOperation operation = await client.StartAnalyzeActionsAsync(documents, actions, "auto");
+            AnalyzeActionsOperation operation = await client.StartAnalyzeActionsAsync(documents, actions, "auto", options);
             await operation.WaitForCompletionAsync();
 
             // Take the first page.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeHealthcareEntitiesTests/AnalyzeHealthcareEntitiesBatchConvenienceWithAutoDetectedLanguageTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeHealthcareEntitiesTests/AnalyzeHealthcareEntitiesBatchConvenienceWithAutoDetectedLanguageTest.json
@@ -1,0 +1,1181 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-10-01-preview",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "349",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-b1ed178d6834b8d12720c6becdd319c0-27b82275998df7a6-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "db6a0b50bec9a2ea9ee63bc83b479dde",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "defaultLanguage": "en",
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "0",
+              "text": "Subject is taking 100mg of ibuprofen twice daily",
+              "language": "auto"
+            },
+            {
+              "id": "1",
+              "text": "Can cause rapid or irregular heartbeat, delirium, panic, psychosis, and heart failure.",
+              "language": "auto"
+            }
+          ]
+        },
+        "tasks": [
+          {
+            "parameters": {
+              "stringIndexType": "Utf16CodeUnit"
+            },
+            "kind": "Healthcare"
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "2e21f9f1-6f18-4261-97cb-2552a81f018c",
+        "Content-Length": "0",
+        "Date": "Tue, 29 Nov 2022 20:36:55 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/9a2d0158-6b3b-4281-b8b7-6fbcd66f414f?api-version=2022-10-01-preview",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "272",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/9a2d0158-6b3b-4281-b8b7-6fbcd66f414f?api-version=2022-10-01-preview\u0026showStats=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "37d85828b95231662387df5d5ed45fe9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ceaae524-2445-48f9-815c-bc402bd64cc6",
+        "Content-Length": "283",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:36:55 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "177",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "9a2d0158-6b3b-4281-b8b7-6fbcd66f414f",
+        "lastUpdatedDateTime": "2022-11-29T20:36:55Z",
+        "createdDateTime": "2022-11-29T20:36:55Z",
+        "expirationDateTime": "2022-11-30T20:36:55Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/9a2d0158-6b3b-4281-b8b7-6fbcd66f414f?api-version=2022-10-01-preview\u0026showStats=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ad20d93411b96c41a89ec4bdb7833ab7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8ce1a94a-2621-4907-b701-592e0a814789",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:36:56 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "9a2d0158-6b3b-4281-b8b7-6fbcd66f414f",
+        "lastUpdatedDateTime": "2022-11-29T20:36:56Z",
+        "createdDateTime": "2022-11-29T20:36:55Z",
+        "expirationDateTime": "2022-11-30T20:36:55Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/9a2d0158-6b3b-4281-b8b7-6fbcd66f414f?api-version=2022-10-01-preview\u0026showStats=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a3b5c4a0e87197e6a539b741df8d43ca",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "591b20fb-47a9-4e6b-8426-a6423d5598c0",
+        "Content-Length": "10362",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:36:57 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "132",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "9a2d0158-6b3b-4281-b8b7-6fbcd66f414f",
+        "lastUpdatedDateTime": "2022-11-29T20:36:57Z",
+        "createdDateTime": "2022-11-29T20:36:55Z",
+        "expirationDateTime": "2022-11-30T20:36:55Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 1,
+          "items": [
+            {
+              "kind": "HealthcareLROResults",
+              "lastUpdateDateTime": "2022-11-29T20:36:57.8296784Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "offset": 18,
+                        "length": 5,
+                        "text": "100mg",
+                        "category": "Dosage",
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "offset": 27,
+                        "length": 9,
+                        "text": "ibuprofen",
+                        "category": "MedicationName",
+                        "confidenceScore": 1.0,
+                        "name": "ibuprofen",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0020740"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000019879"
+                          },
+                          {
+                            "dataSource": "ATC",
+                            "id": "M01AE01"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "0046165"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000006519"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "2270-2077"
+                          },
+                          {
+                            "dataSource": "DRUGBANK",
+                            "id": "DB01050"
+                          },
+                          {
+                            "dataSource": "GS",
+                            "id": "1611"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh97005926"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LP16165-0"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "40458"
+                          },
+                          {
+                            "dataSource": "MMSL",
+                            "id": "d00015"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D007052"
+                          },
+                          {
+                            "dataSource": "MTHSPL",
+                            "id": "WK2XYI10QM"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C561"
+                          },
+                          {
+                            "dataSource": "NCI_CTRP",
+                            "id": "C561"
+                          },
+                          {
+                            "dataSource": "NCI_DCP",
+                            "id": "00803"
+                          },
+                          {
+                            "dataSource": "NCI_DTP",
+                            "id": "NSC0256857"
+                          },
+                          {
+                            "dataSource": "NCI_FDA",
+                            "id": "WK2XYI10QM"
+                          },
+                          {
+                            "dataSource": "NCI_NCI-GLOSS",
+                            "id": "CDR0000613511"
+                          },
+                          {
+                            "dataSource": "NDDF",
+                            "id": "002377"
+                          },
+                          {
+                            "dataSource": "PDQ",
+                            "id": "CDR0000040475"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "x02MO"
+                          },
+                          {
+                            "dataSource": "RXNORM",
+                            "id": "5640"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "E-7772"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "C-603C0"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "387207008"
+                          },
+                          {
+                            "dataSource": "USP",
+                            "id": "m39860"
+                          },
+                          {
+                            "dataSource": "USPMG",
+                            "id": "MTHU000060"
+                          },
+                          {
+                            "dataSource": "VANDF",
+                            "id": "4017840"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 37,
+                        "length": 11,
+                        "text": "twice daily",
+                        "category": "Frequency",
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "relations": [
+                      {
+                        "confidenceScore": 1.0,
+                        "relationType": "DosageOfMedication",
+                        "entities": [
+                          {
+                            "ref": "#/results/documents/0/entities/0",
+                            "role": "Dosage"
+                          },
+                          {
+                            "ref": "#/results/documents/0/entities/1",
+                            "role": "Medication"
+                          }
+                        ]
+                      },
+                      {
+                        "confidenceScore": 1.0,
+                        "relationType": "FrequencyOfMedication",
+                        "entities": [
+                          {
+                            "ref": "#/results/documents/0/entities/1",
+                            "role": "Medication"
+                          },
+                          {
+                            "ref": "#/results/documents/0/entities/2",
+                            "role": "Frequency"
+                          }
+                        ]
+                      }
+                    ],
+                    "warnings": [],
+                    "detectedLanguage": "en",
+                    "isLanguageDefaulted": false
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "offset": 10,
+                        "length": 5,
+                        "text": "rapid",
+                        "category": "SymptomOrSign",
+                        "confidenceScore": 0.88,
+                        "name": "Rapid",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0456962"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000002744"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000034666"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LA24868-4"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C65069"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "X78xZ"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "255358001"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 19,
+                        "length": 19,
+                        "text": "irregular heartbeat",
+                        "category": "SymptomOrSign",
+                        "confidenceScore": 1.0,
+                        "name": "Cardiac Arrhythmia",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0003811"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000005346"
+                          },
+                          {
+                            "dataSource": "BI",
+                            "id": "BI00057"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "1017785"
+                          },
+                          {
+                            "dataSource": "CCS",
+                            "id": "7.2.9"
+                          },
+                          {
+                            "dataSource": "CCSR_10",
+                            "id": "CIR017"
+                          },
+                          {
+                            "dataSource": "CCSR_ICD10CM",
+                            "id": "CIR017"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000001440"
+                          },
+                          {
+                            "dataSource": "COSTAR",
+                            "id": "153"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "1393-3277"
+                          },
+                          {
+                            "dataSource": "CST",
+                            "id": "ARRHYTHMIA"
+                          },
+                          {
+                            "dataSource": "HPO",
+                            "id": "HP:0011675"
+                          },
+                          {
+                            "dataSource": "ICD10",
+                            "id": "I49.9"
+                          },
+                          {
+                            "dataSource": "ICD10AM",
+                            "id": "I49.9"
+                          },
+                          {
+                            "dataSource": "ICD10CM",
+                            "id": "I49.9"
+                          },
+                          {
+                            "dataSource": "ICD9CM",
+                            "id": "427.9"
+                          },
+                          {
+                            "dataSource": "ICPC",
+                            "id": "K80"
+                          },
+                          {
+                            "dataSource": "ICPC2EENG",
+                            "id": "K80"
+                          },
+                          {
+                            "dataSource": "ICPC2ICD10ENG",
+                            "id": "MTHU033639"
+                          },
+                          {
+                            "dataSource": "ICPC2P",
+                            "id": "K80012"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U000359"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85007430"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LA15419-7"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10003119"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "35851"
+                          },
+                          {
+                            "dataSource": "MEDLINEPLUS",
+                            "id": "147"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D001145"
+                          },
+                          {
+                            "dataSource": "MTH",
+                            "id": "153"
+                          },
+                          {
+                            "dataSource": "MTHICD9",
+                            "id": "427.9"
+                          },
+                          {
+                            "dataSource": "NANDA-I",
+                            "id": "00126"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C2881"
+                          },
+                          {
+                            "dataSource": "NCI_FDA",
+                            "id": "1721"
+                          },
+                          {
+                            "dataSource": "NCI_GDC",
+                            "id": "C2881"
+                          },
+                          {
+                            "dataSource": "NCI_NICHD",
+                            "id": "C2881"
+                          },
+                          {
+                            "dataSource": "NCI_caDSR",
+                            "id": "C2881"
+                          },
+                          {
+                            "dataSource": "NOC",
+                            "id": "040520"
+                          },
+                          {
+                            "dataSource": "OMIM",
+                            "id": "115000"
+                          },
+                          {
+                            "dataSource": "PSY",
+                            "id": "03790"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "X77BB"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "F-73102"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "D3-30010"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "698247007"
+                          },
+                          {
+                            "dataSource": "WHO",
+                            "id": "0433"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 40,
+                        "length": 8,
+                        "text": "delirium",
+                        "category": "Diagnosis",
+                        "confidenceScore": 0.98,
+                        "name": "Delirium",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0011206"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000004328"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "1017884"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000003670"
+                          },
+                          {
+                            "dataSource": "COSTAR",
+                            "id": "U000178"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "5003-0016"
+                          },
+                          {
+                            "dataSource": "CST",
+                            "id": "DELIRIUM"
+                          },
+                          {
+                            "dataSource": "DSM-5",
+                            "id": "780.09"
+                          },
+                          {
+                            "dataSource": "DXP",
+                            "id": "U000937"
+                          },
+                          {
+                            "dataSource": "HPO",
+                            "id": "HP:0031258"
+                          },
+                          {
+                            "dataSource": "ICD10",
+                            "id": "F05.9"
+                          },
+                          {
+                            "dataSource": "ICD10AM",
+                            "id": "F05.9"
+                          },
+                          {
+                            "dataSource": "ICD10CM",
+                            "id": "R41.0"
+                          },
+                          {
+                            "dataSource": "ICNP",
+                            "id": "10022091"
+                          },
+                          {
+                            "dataSource": "ICPC2ICD10ENG",
+                            "id": "MTHU022150"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U001289"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85036579"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LP89856-6"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10012218"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "677"
+                          },
+                          {
+                            "dataSource": "MEDLINEPLUS",
+                            "id": "5562"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D003693"
+                          },
+                          {
+                            "dataSource": "NANDA-I",
+                            "id": "02157"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C2981"
+                          },
+                          {
+                            "dataSource": "NCI_CTCAE",
+                            "id": "E12898"
+                          },
+                          {
+                            "dataSource": "NCI_CTRP",
+                            "id": "C2981"
+                          },
+                          {
+                            "dataSource": "NCI_NCI-GLOSS",
+                            "id": "CDR0000450100"
+                          },
+                          {
+                            "dataSource": "NCI_NICHD",
+                            "id": "C2981"
+                          },
+                          {
+                            "dataSource": "NCI_caDSR",
+                            "id": "C2981"
+                          },
+                          {
+                            "dataSource": "NOC",
+                            "id": "091213"
+                          },
+                          {
+                            "dataSource": "OMIM",
+                            "id": "MTHU035152"
+                          },
+                          {
+                            "dataSource": "PDQ",
+                            "id": "CDR0000042226"
+                          },
+                          {
+                            "dataSource": "PSY",
+                            "id": "13360"
+                          },
+                          {
+                            "dataSource": "QMR",
+                            "id": "Q0200089"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "XE1Xv"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "F-85720"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "D9-20100"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "2776000"
+                          },
+                          {
+                            "dataSource": "WHO",
+                            "id": "0099"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 50,
+                        "length": 5,
+                        "text": "panic",
+                        "category": "Diagnosis",
+                        "confidenceScore": 0.93,
+                        "name": "Panic",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0030318"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000023911"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000009234"
+                          },
+                          {
+                            "dataSource": "CST",
+                            "id": "AGITATION"
+                          },
+                          {
+                            "dataSource": "ICD10CM",
+                            "id": "F41.0"
+                          },
+                          {
+                            "dataSource": "ICPC2ICD10ENG",
+                            "id": "MTHU057222"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U003458"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85097438"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10033670"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D010200"
+                          },
+                          {
+                            "dataSource": "MTH",
+                            "id": "551"
+                          },
+                          {
+                            "dataSource": "MTHICD9",
+                            "id": "300.01"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C94438"
+                          },
+                          {
+                            "dataSource": "NCI_NCI-GLOSS",
+                            "id": "CDR0000454704"
+                          },
+                          {
+                            "dataSource": "NOC",
+                            "id": "121346"
+                          },
+                          {
+                            "dataSource": "PSY",
+                            "id": "36260"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "Xa3Vj"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "F-90880"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "F-92560"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "79823003"
+                          },
+                          {
+                            "dataSource": "WHO",
+                            "id": "0163"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 57,
+                        "length": 9,
+                        "text": "psychosis",
+                        "category": "Diagnosis",
+                        "confidenceScore": 0.99,
+                        "name": "Psychotic Disorders",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0033975"
+                          },
+                          {
+                            "dataSource": "AIR",
+                            "id": "PSYCH"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000004324"
+                          },
+                          {
+                            "dataSource": "BI",
+                            "id": "BI00688"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "1018204"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000010350"
+                          },
+                          {
+                            "dataSource": "COSTAR",
+                            "id": "089"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "2484-8182"
+                          },
+                          {
+                            "dataSource": "CST",
+                            "id": "PSYCHOSIS"
+                          },
+                          {
+                            "dataSource": "DXP",
+                            "id": "U003257"
+                          },
+                          {
+                            "dataSource": "HPO",
+                            "id": "HP:0000709"
+                          },
+                          {
+                            "dataSource": "ICD9CM",
+                            "id": "298.9"
+                          },
+                          {
+                            "dataSource": "ICPC2ICD10ENG",
+                            "id": "MTHU070382"
+                          },
+                          {
+                            "dataSource": "ICPC2P",
+                            "id": "P98004"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85108502"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LA7534-6"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10061920"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "364298"
+                          },
+                          {
+                            "dataSource": "MEDLINEPLUS",
+                            "id": "4180"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D011618"
+                          },
+                          {
+                            "dataSource": "MTH",
+                            "id": "089"
+                          },
+                          {
+                            "dataSource": "MTHICD9",
+                            "id": "298.9"
+                          },
+                          {
+                            "dataSource": "NANDA-I",
+                            "id": "03128"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C78576"
+                          },
+                          {
+                            "dataSource": "NCI_CELLOSAURUS",
+                            "id": "C78576"
+                          },
+                          {
+                            "dataSource": "NCI_CTCAE",
+                            "id": "E12954"
+                          },
+                          {
+                            "dataSource": "NCI_NCI-GLOSS",
+                            "id": "CDR0000450115"
+                          },
+                          {
+                            "dataSource": "NCI_NICHD",
+                            "id": "C78576"
+                          },
+                          {
+                            "dataSource": "NOC",
+                            "id": "061619"
+                          },
+                          {
+                            "dataSource": "OMIM",
+                            "id": "MTHU002910"
+                          },
+                          {
+                            "dataSource": "PSY",
+                            "id": "41910"
+                          },
+                          {
+                            "dataSource": "QMR",
+                            "id": "Q0200208"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "X00S6"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "D-9200"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "D9-72000"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "69322001"
+                          },
+                          {
+                            "dataSource": "WHO",
+                            "id": "0193"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 72,
+                        "length": 13,
+                        "text": "heart failure",
+                        "category": "Diagnosis",
+                        "confidenceScore": 1.0,
+                        "name": "Heart failure",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0018801"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000005308"
+                          },
+                          {
+                            "dataSource": "BI",
+                            "id": "BI00019"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "0017571"
+                          },
+                          {
+                            "dataSource": "CCS",
+                            "id": "7.2.11.2"
+                          },
+                          {
+                            "dataSource": "CCSR_10",
+                            "id": "CIR019"
+                          },
+                          {
+                            "dataSource": "CCSR_ICD10CM",
+                            "id": "CIR019"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000005877"
+                          },
+                          {
+                            "dataSource": "COSTAR",
+                            "id": "U000338"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "1393-3587"
+                          },
+                          {
+                            "dataSource": "CST",
+                            "id": "HEART FAIL"
+                          },
+                          {
+                            "dataSource": "HPO",
+                            "id": "HP:0001635"
+                          },
+                          {
+                            "dataSource": "ICD10",
+                            "id": "I50.9"
+                          },
+                          {
+                            "dataSource": "ICD10AM",
+                            "id": "I50.9"
+                          },
+                          {
+                            "dataSource": "ICD10CM",
+                            "id": "I50.9"
+                          },
+                          {
+                            "dataSource": "ICD9CM",
+                            "id": "428.9"
+                          },
+                          {
+                            "dataSource": "ICPC",
+                            "id": "K77"
+                          },
+                          {
+                            "dataSource": "ICPC2EENG",
+                            "id": "K77"
+                          },
+                          {
+                            "dataSource": "ICPC2ICD10ENG",
+                            "id": "MTHU027668"
+                          },
+                          {
+                            "dataSource": "ICPC2P",
+                            "id": "K77011"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U005616"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85059745"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LP269421-6"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10007554"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "95724"
+                          },
+                          {
+                            "dataSource": "MEDLINEPLUS",
+                            "id": "199"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D006333"
+                          },
+                          {
+                            "dataSource": "MTHICD9",
+                            "id": "428.9"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C50577"
+                          },
+                          {
+                            "dataSource": "NCI_CTCAE",
+                            "id": "E10124"
+                          },
+                          {
+                            "dataSource": "NCI_FDA",
+                            "id": "2206"
+                          },
+                          {
+                            "dataSource": "NCI_NICHD",
+                            "id": "C50577"
+                          },
+                          {
+                            "dataSource": "NCI_PCDC",
+                            "id": "C50577"
+                          },
+                          {
+                            "dataSource": "OMIM",
+                            "id": "MTHU009472"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "G58.."
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "D-7050"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "D3-16000"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "84114007"
+                          },
+                          {
+                            "dataSource": "WHO",
+                            "id": "0496"
+                          }
+                        ]
+                      }
+                    ],
+                    "relations": [],
+                    "warnings": [],
+                    "detectedLanguage": "en",
+                    "isLanguageDefaulted": false
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-03-01"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1065637097",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeHealthcareEntitiesTests/AnalyzeHealthcareEntitiesBatchConvenienceWithAutoDetectedLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeHealthcareEntitiesTests/AnalyzeHealthcareEntitiesBatchConvenienceWithAutoDetectedLanguageTestAsync.json
@@ -1,0 +1,1219 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-10-01-preview",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "349",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9afefa909a61df5b6b74fe0a54d380f9-8ca0a3361e7674ce-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d7b3f57a97c3c56c0d82076296522d9c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "defaultLanguage": "en",
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "0",
+              "text": "Subject is taking 100mg of ibuprofen twice daily",
+              "language": "auto"
+            },
+            {
+              "id": "1",
+              "text": "Can cause rapid or irregular heartbeat, delirium, panic, psychosis, and heart failure.",
+              "language": "auto"
+            }
+          ]
+        },
+        "tasks": [
+          {
+            "parameters": {
+              "stringIndexType": "Utf16CodeUnit"
+            },
+            "kind": "Healthcare"
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "dc9e8134-2d55-412a-a7e1-5202060ff91c",
+        "Content-Length": "0",
+        "Date": "Tue, 29 Nov 2022 20:36:58 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/61e55196-3fc0-40db-8aac-9d2678e5a5ba?api-version=2022-10-01-preview",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "253",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/61e55196-3fc0-40db-8aac-9d2678e5a5ba?api-version=2022-10-01-preview\u0026showStats=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8c85ef1bf1d902f94ce298657cad5e62",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "01ef2f15-a255-4839-97be-24e31972ed21",
+        "Content-Length": "283",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:36:58 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "61e55196-3fc0-40db-8aac-9d2678e5a5ba",
+        "lastUpdatedDateTime": "2022-11-29T20:36:58Z",
+        "createdDateTime": "2022-11-29T20:36:58Z",
+        "expirationDateTime": "2022-11-30T20:36:58Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/61e55196-3fc0-40db-8aac-9d2678e5a5ba?api-version=2022-10-01-preview\u0026showStats=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d3d29f11132442472d815cafef5d6bbf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c7967358-b92c-40ee-84dd-cde3f547371c",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:36:59 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "61e55196-3fc0-40db-8aac-9d2678e5a5ba",
+        "lastUpdatedDateTime": "2022-11-29T20:36:59Z",
+        "createdDateTime": "2022-11-29T20:36:58Z",
+        "expirationDateTime": "2022-11-30T20:36:58Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/61e55196-3fc0-40db-8aac-9d2678e5a5ba?api-version=2022-10-01-preview\u0026showStats=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "71c3d47daf698842fbb18ae1ff07485f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "74342bef-db95-4680-aee0-d12ae6e8b756",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:00 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "49",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "61e55196-3fc0-40db-8aac-9d2678e5a5ba",
+        "lastUpdatedDateTime": "2022-11-29T20:36:59Z",
+        "createdDateTime": "2022-11-29T20:36:58Z",
+        "expirationDateTime": "2022-11-30T20:36:58Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/61e55196-3fc0-40db-8aac-9d2678e5a5ba?api-version=2022-10-01-preview\u0026showStats=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f750a42459800778a7435f58954913ef",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5dc177a5-8652-404d-a35f-a2e8bbafc100",
+        "Content-Length": "10362",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:01 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "46",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "61e55196-3fc0-40db-8aac-9d2678e5a5ba",
+        "lastUpdatedDateTime": "2022-11-29T20:37:01Z",
+        "createdDateTime": "2022-11-29T20:36:58Z",
+        "expirationDateTime": "2022-11-30T20:36:58Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 1,
+          "items": [
+            {
+              "kind": "HealthcareLROResults",
+              "lastUpdateDateTime": "2022-11-29T20:37:01.3690388Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "offset": 18,
+                        "length": 5,
+                        "text": "100mg",
+                        "category": "Dosage",
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "offset": 27,
+                        "length": 9,
+                        "text": "ibuprofen",
+                        "category": "MedicationName",
+                        "confidenceScore": 1.0,
+                        "name": "ibuprofen",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0020740"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000019879"
+                          },
+                          {
+                            "dataSource": "ATC",
+                            "id": "M01AE01"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "0046165"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000006519"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "2270-2077"
+                          },
+                          {
+                            "dataSource": "DRUGBANK",
+                            "id": "DB01050"
+                          },
+                          {
+                            "dataSource": "GS",
+                            "id": "1611"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh97005926"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LP16165-0"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "40458"
+                          },
+                          {
+                            "dataSource": "MMSL",
+                            "id": "d00015"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D007052"
+                          },
+                          {
+                            "dataSource": "MTHSPL",
+                            "id": "WK2XYI10QM"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C561"
+                          },
+                          {
+                            "dataSource": "NCI_CTRP",
+                            "id": "C561"
+                          },
+                          {
+                            "dataSource": "NCI_DCP",
+                            "id": "00803"
+                          },
+                          {
+                            "dataSource": "NCI_DTP",
+                            "id": "NSC0256857"
+                          },
+                          {
+                            "dataSource": "NCI_FDA",
+                            "id": "WK2XYI10QM"
+                          },
+                          {
+                            "dataSource": "NCI_NCI-GLOSS",
+                            "id": "CDR0000613511"
+                          },
+                          {
+                            "dataSource": "NDDF",
+                            "id": "002377"
+                          },
+                          {
+                            "dataSource": "PDQ",
+                            "id": "CDR0000040475"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "x02MO"
+                          },
+                          {
+                            "dataSource": "RXNORM",
+                            "id": "5640"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "E-7772"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "C-603C0"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "387207008"
+                          },
+                          {
+                            "dataSource": "USP",
+                            "id": "m39860"
+                          },
+                          {
+                            "dataSource": "USPMG",
+                            "id": "MTHU000060"
+                          },
+                          {
+                            "dataSource": "VANDF",
+                            "id": "4017840"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 37,
+                        "length": 11,
+                        "text": "twice daily",
+                        "category": "Frequency",
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "relations": [
+                      {
+                        "confidenceScore": 1.0,
+                        "relationType": "DosageOfMedication",
+                        "entities": [
+                          {
+                            "ref": "#/results/documents/0/entities/0",
+                            "role": "Dosage"
+                          },
+                          {
+                            "ref": "#/results/documents/0/entities/1",
+                            "role": "Medication"
+                          }
+                        ]
+                      },
+                      {
+                        "confidenceScore": 1.0,
+                        "relationType": "FrequencyOfMedication",
+                        "entities": [
+                          {
+                            "ref": "#/results/documents/0/entities/1",
+                            "role": "Medication"
+                          },
+                          {
+                            "ref": "#/results/documents/0/entities/2",
+                            "role": "Frequency"
+                          }
+                        ]
+                      }
+                    ],
+                    "warnings": [],
+                    "detectedLanguage": "en",
+                    "isLanguageDefaulted": false
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "offset": 10,
+                        "length": 5,
+                        "text": "rapid",
+                        "category": "SymptomOrSign",
+                        "confidenceScore": 0.88,
+                        "name": "Rapid",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0456962"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000002744"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000034666"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LA24868-4"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C65069"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "X78xZ"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "255358001"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 19,
+                        "length": 19,
+                        "text": "irregular heartbeat",
+                        "category": "SymptomOrSign",
+                        "confidenceScore": 1.0,
+                        "name": "Cardiac Arrhythmia",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0003811"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000005346"
+                          },
+                          {
+                            "dataSource": "BI",
+                            "id": "BI00057"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "1017785"
+                          },
+                          {
+                            "dataSource": "CCS",
+                            "id": "7.2.9"
+                          },
+                          {
+                            "dataSource": "CCSR_10",
+                            "id": "CIR017"
+                          },
+                          {
+                            "dataSource": "CCSR_ICD10CM",
+                            "id": "CIR017"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000001440"
+                          },
+                          {
+                            "dataSource": "COSTAR",
+                            "id": "153"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "1393-3277"
+                          },
+                          {
+                            "dataSource": "CST",
+                            "id": "ARRHYTHMIA"
+                          },
+                          {
+                            "dataSource": "HPO",
+                            "id": "HP:0011675"
+                          },
+                          {
+                            "dataSource": "ICD10",
+                            "id": "I49.9"
+                          },
+                          {
+                            "dataSource": "ICD10AM",
+                            "id": "I49.9"
+                          },
+                          {
+                            "dataSource": "ICD10CM",
+                            "id": "I49.9"
+                          },
+                          {
+                            "dataSource": "ICD9CM",
+                            "id": "427.9"
+                          },
+                          {
+                            "dataSource": "ICPC",
+                            "id": "K80"
+                          },
+                          {
+                            "dataSource": "ICPC2EENG",
+                            "id": "K80"
+                          },
+                          {
+                            "dataSource": "ICPC2ICD10ENG",
+                            "id": "MTHU033639"
+                          },
+                          {
+                            "dataSource": "ICPC2P",
+                            "id": "K80012"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U000359"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85007430"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LA15419-7"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10003119"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "35851"
+                          },
+                          {
+                            "dataSource": "MEDLINEPLUS",
+                            "id": "147"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D001145"
+                          },
+                          {
+                            "dataSource": "MTH",
+                            "id": "153"
+                          },
+                          {
+                            "dataSource": "MTHICD9",
+                            "id": "427.9"
+                          },
+                          {
+                            "dataSource": "NANDA-I",
+                            "id": "00126"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C2881"
+                          },
+                          {
+                            "dataSource": "NCI_FDA",
+                            "id": "1721"
+                          },
+                          {
+                            "dataSource": "NCI_GDC",
+                            "id": "C2881"
+                          },
+                          {
+                            "dataSource": "NCI_NICHD",
+                            "id": "C2881"
+                          },
+                          {
+                            "dataSource": "NCI_caDSR",
+                            "id": "C2881"
+                          },
+                          {
+                            "dataSource": "NOC",
+                            "id": "040520"
+                          },
+                          {
+                            "dataSource": "OMIM",
+                            "id": "115000"
+                          },
+                          {
+                            "dataSource": "PSY",
+                            "id": "03790"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "X77BB"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "F-73102"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "D3-30010"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "698247007"
+                          },
+                          {
+                            "dataSource": "WHO",
+                            "id": "0433"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 40,
+                        "length": 8,
+                        "text": "delirium",
+                        "category": "Diagnosis",
+                        "confidenceScore": 0.98,
+                        "name": "Delirium",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0011206"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000004328"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "1017884"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000003670"
+                          },
+                          {
+                            "dataSource": "COSTAR",
+                            "id": "U000178"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "5003-0016"
+                          },
+                          {
+                            "dataSource": "CST",
+                            "id": "DELIRIUM"
+                          },
+                          {
+                            "dataSource": "DSM-5",
+                            "id": "780.09"
+                          },
+                          {
+                            "dataSource": "DXP",
+                            "id": "U000937"
+                          },
+                          {
+                            "dataSource": "HPO",
+                            "id": "HP:0031258"
+                          },
+                          {
+                            "dataSource": "ICD10",
+                            "id": "F05.9"
+                          },
+                          {
+                            "dataSource": "ICD10AM",
+                            "id": "F05.9"
+                          },
+                          {
+                            "dataSource": "ICD10CM",
+                            "id": "R41.0"
+                          },
+                          {
+                            "dataSource": "ICNP",
+                            "id": "10022091"
+                          },
+                          {
+                            "dataSource": "ICPC2ICD10ENG",
+                            "id": "MTHU022150"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U001289"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85036579"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LP89856-6"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10012218"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "677"
+                          },
+                          {
+                            "dataSource": "MEDLINEPLUS",
+                            "id": "5562"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D003693"
+                          },
+                          {
+                            "dataSource": "NANDA-I",
+                            "id": "02157"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C2981"
+                          },
+                          {
+                            "dataSource": "NCI_CTCAE",
+                            "id": "E12898"
+                          },
+                          {
+                            "dataSource": "NCI_CTRP",
+                            "id": "C2981"
+                          },
+                          {
+                            "dataSource": "NCI_NCI-GLOSS",
+                            "id": "CDR0000450100"
+                          },
+                          {
+                            "dataSource": "NCI_NICHD",
+                            "id": "C2981"
+                          },
+                          {
+                            "dataSource": "NCI_caDSR",
+                            "id": "C2981"
+                          },
+                          {
+                            "dataSource": "NOC",
+                            "id": "091213"
+                          },
+                          {
+                            "dataSource": "OMIM",
+                            "id": "MTHU035152"
+                          },
+                          {
+                            "dataSource": "PDQ",
+                            "id": "CDR0000042226"
+                          },
+                          {
+                            "dataSource": "PSY",
+                            "id": "13360"
+                          },
+                          {
+                            "dataSource": "QMR",
+                            "id": "Q0200089"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "XE1Xv"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "F-85720"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "D9-20100"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "2776000"
+                          },
+                          {
+                            "dataSource": "WHO",
+                            "id": "0099"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 50,
+                        "length": 5,
+                        "text": "panic",
+                        "category": "Diagnosis",
+                        "confidenceScore": 0.93,
+                        "name": "Panic",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0030318"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000023911"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000009234"
+                          },
+                          {
+                            "dataSource": "CST",
+                            "id": "AGITATION"
+                          },
+                          {
+                            "dataSource": "ICD10CM",
+                            "id": "F41.0"
+                          },
+                          {
+                            "dataSource": "ICPC2ICD10ENG",
+                            "id": "MTHU057222"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U003458"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85097438"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10033670"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D010200"
+                          },
+                          {
+                            "dataSource": "MTH",
+                            "id": "551"
+                          },
+                          {
+                            "dataSource": "MTHICD9",
+                            "id": "300.01"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C94438"
+                          },
+                          {
+                            "dataSource": "NCI_NCI-GLOSS",
+                            "id": "CDR0000454704"
+                          },
+                          {
+                            "dataSource": "NOC",
+                            "id": "121346"
+                          },
+                          {
+                            "dataSource": "PSY",
+                            "id": "36260"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "Xa3Vj"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "F-90880"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "F-92560"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "79823003"
+                          },
+                          {
+                            "dataSource": "WHO",
+                            "id": "0163"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 57,
+                        "length": 9,
+                        "text": "psychosis",
+                        "category": "Diagnosis",
+                        "confidenceScore": 0.99,
+                        "name": "Psychotic Disorders",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0033975"
+                          },
+                          {
+                            "dataSource": "AIR",
+                            "id": "PSYCH"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000004324"
+                          },
+                          {
+                            "dataSource": "BI",
+                            "id": "BI00688"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "1018204"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000010350"
+                          },
+                          {
+                            "dataSource": "COSTAR",
+                            "id": "089"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "2484-8182"
+                          },
+                          {
+                            "dataSource": "CST",
+                            "id": "PSYCHOSIS"
+                          },
+                          {
+                            "dataSource": "DXP",
+                            "id": "U003257"
+                          },
+                          {
+                            "dataSource": "HPO",
+                            "id": "HP:0000709"
+                          },
+                          {
+                            "dataSource": "ICD9CM",
+                            "id": "298.9"
+                          },
+                          {
+                            "dataSource": "ICPC2ICD10ENG",
+                            "id": "MTHU070382"
+                          },
+                          {
+                            "dataSource": "ICPC2P",
+                            "id": "P98004"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85108502"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LA7534-6"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10061920"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "364298"
+                          },
+                          {
+                            "dataSource": "MEDLINEPLUS",
+                            "id": "4180"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D011618"
+                          },
+                          {
+                            "dataSource": "MTH",
+                            "id": "089"
+                          },
+                          {
+                            "dataSource": "MTHICD9",
+                            "id": "298.9"
+                          },
+                          {
+                            "dataSource": "NANDA-I",
+                            "id": "03128"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C78576"
+                          },
+                          {
+                            "dataSource": "NCI_CELLOSAURUS",
+                            "id": "C78576"
+                          },
+                          {
+                            "dataSource": "NCI_CTCAE",
+                            "id": "E12954"
+                          },
+                          {
+                            "dataSource": "NCI_NCI-GLOSS",
+                            "id": "CDR0000450115"
+                          },
+                          {
+                            "dataSource": "NCI_NICHD",
+                            "id": "C78576"
+                          },
+                          {
+                            "dataSource": "NOC",
+                            "id": "061619"
+                          },
+                          {
+                            "dataSource": "OMIM",
+                            "id": "MTHU002910"
+                          },
+                          {
+                            "dataSource": "PSY",
+                            "id": "41910"
+                          },
+                          {
+                            "dataSource": "QMR",
+                            "id": "Q0200208"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "X00S6"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "D-9200"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "D9-72000"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "69322001"
+                          },
+                          {
+                            "dataSource": "WHO",
+                            "id": "0193"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 72,
+                        "length": 13,
+                        "text": "heart failure",
+                        "category": "Diagnosis",
+                        "confidenceScore": 1.0,
+                        "name": "Heart failure",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0018801"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000005308"
+                          },
+                          {
+                            "dataSource": "BI",
+                            "id": "BI00019"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "0017571"
+                          },
+                          {
+                            "dataSource": "CCS",
+                            "id": "7.2.11.2"
+                          },
+                          {
+                            "dataSource": "CCSR_10",
+                            "id": "CIR019"
+                          },
+                          {
+                            "dataSource": "CCSR_ICD10CM",
+                            "id": "CIR019"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000005877"
+                          },
+                          {
+                            "dataSource": "COSTAR",
+                            "id": "U000338"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "1393-3587"
+                          },
+                          {
+                            "dataSource": "CST",
+                            "id": "HEART FAIL"
+                          },
+                          {
+                            "dataSource": "HPO",
+                            "id": "HP:0001635"
+                          },
+                          {
+                            "dataSource": "ICD10",
+                            "id": "I50.9"
+                          },
+                          {
+                            "dataSource": "ICD10AM",
+                            "id": "I50.9"
+                          },
+                          {
+                            "dataSource": "ICD10CM",
+                            "id": "I50.9"
+                          },
+                          {
+                            "dataSource": "ICD9CM",
+                            "id": "428.9"
+                          },
+                          {
+                            "dataSource": "ICPC",
+                            "id": "K77"
+                          },
+                          {
+                            "dataSource": "ICPC2EENG",
+                            "id": "K77"
+                          },
+                          {
+                            "dataSource": "ICPC2ICD10ENG",
+                            "id": "MTHU027668"
+                          },
+                          {
+                            "dataSource": "ICPC2P",
+                            "id": "K77011"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U005616"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85059745"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LP269421-6"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10007554"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "95724"
+                          },
+                          {
+                            "dataSource": "MEDLINEPLUS",
+                            "id": "199"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D006333"
+                          },
+                          {
+                            "dataSource": "MTHICD9",
+                            "id": "428.9"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C50577"
+                          },
+                          {
+                            "dataSource": "NCI_CTCAE",
+                            "id": "E10124"
+                          },
+                          {
+                            "dataSource": "NCI_FDA",
+                            "id": "2206"
+                          },
+                          {
+                            "dataSource": "NCI_NICHD",
+                            "id": "C50577"
+                          },
+                          {
+                            "dataSource": "NCI_PCDC",
+                            "id": "C50577"
+                          },
+                          {
+                            "dataSource": "OMIM",
+                            "id": "MTHU009472"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "G58.."
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "D-7050"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "D3-16000"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "84114007"
+                          },
+                          {
+                            "dataSource": "WHO",
+                            "id": "0496"
+                          }
+                        ]
+                      }
+                    ],
+                    "relations": [],
+                    "warnings": [],
+                    "detectedLanguage": "en",
+                    "isLanguageDefaulted": false
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-03-01"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "115587743",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeOperationAnalyzeSentimentWithAutoDetectedLanguageTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeOperationAnalyzeSentimentWithAutoDetectedLanguageTest.json
@@ -5,16 +5,16 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "292",
+        "Content-Length": "258",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-816bbc74fd00606adcfc7b6656244ed0-a30416821ac8ad4b-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0f89325b4e959e224792debec7bf705a",
+        "traceparent": "00-55a30ced892c2445c87ebbdba47161f5-c1fc72fca741cdab-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2607f15a2c3e70d0de7796346c1ce803",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "displayName": "AnalyzeSentimentWithAutoDetectedLanguage",
+        "defaultLanguage": "en",
         "analysisInput": {
           "documents": [
             {
@@ -35,47 +35,46 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "fabe55da-333e-423f-98d1-6662ffb40358",
+        "apim-request-id": "42a7ece9-7c43-44df-8edb-a8943a4be7cd",
         "Content-Length": "0",
-        "Date": "Tue, 22 Nov 2022 08:08:01 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/0b04532d-5638-45c2-bd5a-05a013d614b1?api-version=2022-10-01-preview",
+        "Date": "Tue, 29 Nov 2022 20:37:03 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/259f13f8-50ef-406c-ad1d-1ab893f29660?api-version=2022-10-01-preview",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "83",
+        "x-envoy-upstream-service-time": "108",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/0b04532d-5638-45c2-bd5a-05a013d614b1?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/259f13f8-50ef-406c-ad1d-1ab893f29660?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7652d2fdb800146f711f8dd461b242dd",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c78a72cd0531348ef1a9dfd2338d1dbe",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6a4b52ea-bd4f-48cc-ab2d-f3a6e7c02f22",
-        "Content-Length": "339",
+        "apim-request-id": "e81345c1-39ac-44f6-a9fa-4e18d8f3073b",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 08:08:01 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9",
+        "x-envoy-upstream-service-time": "7",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "0b04532d-5638-45c2-bd5a-05a013d614b1",
-        "lastUpdateDateTime": "2022-11-22T08:08:02Z",
-        "createdDateTime": "2022-11-22T08:08:02Z",
-        "expirationDateTime": "2022-11-23T08:08:02Z",
+        "jobId": "259f13f8-50ef-406c-ad1d-1ab893f29660",
+        "lastUpdatedDateTime": "2022-11-29T20:37:04Z",
+        "createdDateTime": "2022-11-29T20:37:04Z",
+        "expirationDateTime": "2022-11-30T20:37:04Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "AnalyzeSentimentWithAutoDetectedLanguage",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -86,35 +85,34 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/0b04532d-5638-45c2-bd5a-05a013d614b1?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/259f13f8-50ef-406c-ad1d-1ab893f29660?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ee82a13551a3f882bfc99ea1eada97db",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d828d0c4fc48bcd58fb8cba0ea661ab4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6773fae1-5796-420d-8534-cca28000dbdd",
-        "Content-Length": "336",
+        "apim-request-id": "d09638d3-6716-4b64-a52d-747d89377e43",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 08:08:02 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8",
+        "x-envoy-upstream-service-time": "7",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "0b04532d-5638-45c2-bd5a-05a013d614b1",
-        "lastUpdateDateTime": "2022-11-22T08:08:02Z",
-        "createdDateTime": "2022-11-22T08:08:02Z",
-        "expirationDateTime": "2022-11-23T08:08:02Z",
+        "jobId": "259f13f8-50ef-406c-ad1d-1ab893f29660",
+        "lastUpdatedDateTime": "2022-11-29T20:37:04Z",
+        "createdDateTime": "2022-11-29T20:37:04Z",
+        "expirationDateTime": "2022-11-30T20:37:04Z",
         "status": "running",
         "errors": [],
-        "displayName": "AnalyzeSentimentWithAutoDetectedLanguage",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -125,35 +123,34 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/0b04532d-5638-45c2-bd5a-05a013d614b1?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/259f13f8-50ef-406c-ad1d-1ab893f29660?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b7e2f88e115da280c2759d75c04d3d94",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7afc4e73631b549d63d335944cfe3c50",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1f5ed32f-6926-45e7-ac6e-ade056b1b026",
-        "Content-Length": "1069",
+        "apim-request-id": "340a82fe-1336-461e-8ce0-337e04fbd3d6",
+        "Content-Length": "1012",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 08:08:03 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "138",
+        "x-envoy-upstream-service-time": "40",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "0b04532d-5638-45c2-bd5a-05a013d614b1",
-        "lastUpdateDateTime": "2022-11-22T08:08:04Z",
-        "createdDateTime": "2022-11-22T08:08:02Z",
-        "expirationDateTime": "2022-11-23T08:08:02Z",
+        "jobId": "259f13f8-50ef-406c-ad1d-1ab893f29660",
+        "lastUpdatedDateTime": "2022-11-29T20:37:06Z",
+        "createdDateTime": "2022-11-29T20:37:04Z",
+        "expirationDateTime": "2022-11-30T20:37:04Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "AnalyzeSentimentWithAutoDetectedLanguage",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -162,7 +159,7 @@
           "items": [
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-11-22T08:08:04.2928829Z",
+              "lastUpdateDateTime": "2022-11-29T20:37:06.640068Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -208,7 +205,7 @@
                   }
                 ],
                 "errors": [],
-                "modelVersion": "2022-10-01"
+                "modelVersion": "2022-11-01"
               }
             }
           ]
@@ -217,7 +214,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "969717578",
+    "RandomSeed": "903777041",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeOperationAnalyzeSentimentWithAutoDetectedLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeOperationAnalyzeSentimentWithAutoDetectedLanguageTestAsync.json
@@ -5,16 +5,16 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "292",
+        "Content-Length": "258",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-45973383ec47ee2ade5eb6f700bd410c-e2a3c0531cac5e30-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221121.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "bc260ea4f36d63b9b34092bcbc4742a1",
+        "traceparent": "00-292e1e1d85fb025539f531371fa58383-4a2d6a9a09f5f795-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "77369dec2ead067b16dd2649ee1d8132",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "displayName": "AnalyzeSentimentWithAutoDetectedLanguage",
+        "defaultLanguage": "en",
         "analysisInput": {
           "documents": [
             {
@@ -35,86 +35,84 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "cf5a487b-ea63-49a7-89e0-37e1eb7ca81e",
+        "apim-request-id": "51aa3a08-8a83-4c9b-8cb4-5324369aec8a",
         "Content-Length": "0",
-        "Date": "Tue, 22 Nov 2022 06:10:08 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/33ab8bf8-4aff-44c9-bef7-f73aed508b3f?api-version=2022-10-01-preview",
+        "Date": "Tue, 29 Nov 2022 20:37:07 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/690a1787-28c2-4ac9-937d-ac5c3002f379?api-version=2022-10-01-preview",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "144",
+        "x-envoy-upstream-service-time": "128",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/33ab8bf8-4aff-44c9-bef7-f73aed508b3f?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/690a1787-28c2-4ac9-937d-ac5c3002f379?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221121.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "075b3247d2ec409c7cb06c844324782f",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b119471510bf457c407ca1e3f56ad00d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "322a5b91-fe6e-48d0-9ceb-1519f41384e2",
-        "Content-Length": "339",
+        "apim-request-id": "c04157f5-fac7-4f32-9e3f-501617bc7201",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 06:10:08 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:07 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "690a1787-28c2-4ac9-937d-ac5c3002f379",
+        "lastUpdatedDateTime": "2022-11-29T20:37:07Z",
+        "createdDateTime": "2022-11-29T20:37:07Z",
+        "expirationDateTime": "2022-11-30T20:37:07Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/690a1787-28c2-4ac9-937d-ac5c3002f379?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4b9e1e31f12e5c186fb79c15097b6d50",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f4167957-e48c-443b-b329-a8fc7f98cf57",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "8",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "33ab8bf8-4aff-44c9-bef7-f73aed508b3f",
-        "lastUpdateDateTime": "2022-11-22T06:10:08Z",
-        "createdDateTime": "2022-11-22T06:10:08Z",
-        "expirationDateTime": "2022-11-23T06:10:08Z",
-        "status": "notStarted",
-        "errors": [],
-        "displayName": "AnalyzeSentimentWithAutoDetectedLanguage",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/33ab8bf8-4aff-44c9-bef7-f73aed508b3f?api-version=2022-10-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221121.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "16b7c54f1c0ea21a3a760c82042d4983",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "feda7f23-fa7b-4e64-97d6-d58986809b77",
-        "Content-Length": "336",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 06:10:09 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "11",
-        "x-ms-region": "West US 2"
-      },
-      "ResponseBody": {
-        "jobId": "33ab8bf8-4aff-44c9-bef7-f73aed508b3f",
-        "lastUpdateDateTime": "2022-11-22T06:10:09Z",
-        "createdDateTime": "2022-11-22T06:10:08Z",
-        "expirationDateTime": "2022-11-23T06:10:08Z",
+        "jobId": "690a1787-28c2-4ac9-937d-ac5c3002f379",
+        "lastUpdatedDateTime": "2022-11-29T20:37:08Z",
+        "createdDateTime": "2022-11-29T20:37:07Z",
+        "expirationDateTime": "2022-11-30T20:37:07Z",
         "status": "running",
         "errors": [],
-        "displayName": "AnalyzeSentimentWithAutoDetectedLanguage",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -125,35 +123,34 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/33ab8bf8-4aff-44c9-bef7-f73aed508b3f?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/690a1787-28c2-4ac9-937d-ac5c3002f379?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221121.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "75f6ecc7fc6dd23671e63fbd86351f8f",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0b97d1d20623dccc20f136308c9811ab",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a207c525-be8a-4a17-9041-304810ce21fa",
-        "Content-Length": "1069",
+        "apim-request-id": "aa29caae-77d8-4249-af29-b1862ac8d4f8",
+        "Content-Length": "1013",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 06:10:10 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "38",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "33ab8bf8-4aff-44c9-bef7-f73aed508b3f",
-        "lastUpdateDateTime": "2022-11-22T06:10:10Z",
-        "createdDateTime": "2022-11-22T06:10:08Z",
-        "expirationDateTime": "2022-11-23T06:10:08Z",
+        "jobId": "690a1787-28c2-4ac9-937d-ac5c3002f379",
+        "lastUpdatedDateTime": "2022-11-29T20:37:09Z",
+        "createdDateTime": "2022-11-29T20:37:07Z",
+        "expirationDateTime": "2022-11-30T20:37:07Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "AnalyzeSentimentWithAutoDetectedLanguage",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -162,7 +159,7 @@
           "items": [
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-11-22T06:10:10.6856195Z",
+              "lastUpdateDateTime": "2022-11-29T20:37:09.5968833Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -208,7 +205,7 @@
                   }
                 ],
                 "errors": [],
-                "modelVersion": "2022-10-01"
+                "modelVersion": "2022-11-01"
               }
             }
           ]
@@ -217,7 +214,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "1481973050",
+    "RandomSeed": "1984864932",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/AnalyzeOperationExtractKeyPhrasesWithAutoDetectedLanguageTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/AnalyzeOperationExtractKeyPhrasesWithAutoDetectedLanguageTest.json
@@ -5,16 +5,16 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "328",
+        "Content-Length": "293",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f0508f4d04b6af097c38a879ec42d43a-f5e680edbd6948c5-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "cc5f74ffd8f8a82b4f966e6aff8008e2",
+        "traceparent": "00-1db36e674040d17f18531cdb184cddb9-2f669c13fef8f0f8-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b26aa6dd3f5611d0cbf309a743c81a6c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "displayName": "ExtractKeyPhrasesWithAutoDetectedLanguage",
+        "defaultLanguage": "en",
         "analysisInput": {
           "documents": [
             {
@@ -38,47 +38,46 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "8e0d5537-61d7-4311-b4d0-8142341e29c5",
+        "apim-request-id": "b1d77b57-3fc9-46fe-990b-ed70484e8295",
         "Content-Length": "0",
-        "Date": "Tue, 22 Nov 2022 08:08:06 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/b028915a-2d55-4ebd-966f-c4ab7f24a9e6?api-version=2022-10-01-preview",
+        "Date": "Tue, 29 Nov 2022 20:37:11 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/06877bca-444a-419f-ae3d-a647dec4c4a4?api-version=2022-10-01-preview",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "180",
+        "x-envoy-upstream-service-time": "305",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/b028915a-2d55-4ebd-966f-c4ab7f24a9e6?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/06877bca-444a-419f-ae3d-a647dec4c4a4?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1ee104deb59a07b5a262c259ec15f437",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ea288c68d58bc1db8b1b1a6c597dd2ea",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f25ed752-fcc5-4aef-a396-cb35cfba86b7",
-        "Content-Length": "340",
+        "apim-request-id": "4a47debc-eff1-4668-a002-cd1d1fae48c1",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 08:08:06 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "7",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b028915a-2d55-4ebd-966f-c4ab7f24a9e6",
-        "lastUpdateDateTime": "2022-11-22T08:08:07Z",
-        "createdDateTime": "2022-11-22T08:08:06Z",
-        "expirationDateTime": "2022-11-23T08:08:06Z",
+        "jobId": "06877bca-444a-419f-ae3d-a647dec4c4a4",
+        "lastUpdatedDateTime": "2022-11-29T20:37:11Z",
+        "createdDateTime": "2022-11-29T20:37:11Z",
+        "expirationDateTime": "2022-11-30T20:37:11Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "ExtractKeyPhrasesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -89,35 +88,34 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/b028915a-2d55-4ebd-966f-c4ab7f24a9e6?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/06877bca-444a-419f-ae3d-a647dec4c4a4?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4107b40dd88705b918cd54d5af3ad150",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a5466d3b87590f14329a3b9addb93c73",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "449aea42-1d32-401e-a503-590f37b240a7",
-        "Content-Length": "337",
+        "apim-request-id": "f5059a9e-8e43-4cfd-a3b9-7a036687b9c9",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 08:08:07 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6",
+        "x-envoy-upstream-service-time": "7",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b028915a-2d55-4ebd-966f-c4ab7f24a9e6",
-        "lastUpdateDateTime": "2022-11-22T08:08:07Z",
-        "createdDateTime": "2022-11-22T08:08:06Z",
-        "expirationDateTime": "2022-11-23T08:08:06Z",
+        "jobId": "06877bca-444a-419f-ae3d-a647dec4c4a4",
+        "lastUpdatedDateTime": "2022-11-29T20:37:12Z",
+        "createdDateTime": "2022-11-29T20:37:11Z",
+        "expirationDateTime": "2022-11-30T20:37:11Z",
         "status": "running",
         "errors": [],
-        "displayName": "ExtractKeyPhrasesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -128,35 +126,72 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/b028915a-2d55-4ebd-966f-c4ab7f24a9e6?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/06877bca-444a-419f-ae3d-a647dec4c4a4?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "9a619ec214f44a8ebf582a9616d1bb3a",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a768db12ab9e071ccaa8263b2464b84e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "325b4989-067c-40d1-8c5d-84cbdf93b749",
-        "Content-Length": "879",
+        "apim-request-id": "6d85b27e-9fdd-4dcd-b7b4-7849a845101b",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 08:08:08 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:13 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "06877bca-444a-419f-ae3d-a647dec4c4a4",
+        "lastUpdatedDateTime": "2022-11-29T20:37:12Z",
+        "createdDateTime": "2022-11-29T20:37:11Z",
+        "expirationDateTime": "2022-11-30T20:37:11Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/06877bca-444a-419f-ae3d-a647dec4c4a4?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d66b1e207482e1137718b8f09941e4d2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f5a39dc6-9184-447c-92c2-b63933a94ae7",
+        "Content-Length": "822",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "65",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b028915a-2d55-4ebd-966f-c4ab7f24a9e6",
-        "lastUpdateDateTime": "2022-11-22T08:08:09Z",
-        "createdDateTime": "2022-11-22T08:08:06Z",
-        "expirationDateTime": "2022-11-23T08:08:06Z",
+        "jobId": "06877bca-444a-419f-ae3d-a647dec4c4a4",
+        "lastUpdatedDateTime": "2022-11-29T20:37:13Z",
+        "createdDateTime": "2022-11-29T20:37:11Z",
+        "expirationDateTime": "2022-11-30T20:37:11Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "ExtractKeyPhrasesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -165,7 +200,7 @@
           "items": [
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-11-22T08:08:09.1122978Z",
+              "lastUpdateDateTime": "2022-11-29T20:37:13.6192282Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -210,7 +245,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "1626671300",
+    "RandomSeed": "1520958114",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/AnalyzeOperationExtractKeyPhrasesWithAutoDetectedLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/AnalyzeOperationExtractKeyPhrasesWithAutoDetectedLanguageTestAsync.json
@@ -5,16 +5,16 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "328",
+        "Content-Length": "293",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ed68c5f32427d43dcf6907fa98c20b0f-c172a1ee2c798d17-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221121.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f8f49d42c2a9ba0b8f87f69d9a01f90b",
+        "traceparent": "00-c6c85eff04e798b14a5f4ecde9e9bec7-10f790d3d4ea3fb1-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "67fff4dc8bbd4f45bc7277381e951c3c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "displayName": "ExtractKeyPhrasesWithAutoDetectedLanguage",
+        "defaultLanguage": "en",
         "analysisInput": {
           "documents": [
             {
@@ -38,86 +38,122 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "1c801ede-2216-4ec9-938e-22ef3b3e4a5b",
+        "apim-request-id": "2a252158-41a5-43ea-b10c-c9dcd2df9815",
         "Content-Length": "0",
-        "Date": "Tue, 22 Nov 2022 06:21:47 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/9f9dae7a-d84c-4d44-88f9-b61a472e3383?api-version=2022-10-01-preview",
+        "Date": "Tue, 29 Nov 2022 20:37:14 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/154706a2-a9f4-43cf-bc2d-74ab4349306d?api-version=2022-10-01-preview",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "220",
+        "x-envoy-upstream-service-time": "258",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/9f9dae7a-d84c-4d44-88f9-b61a472e3383?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/154706a2-a9f4-43cf-bc2d-74ab4349306d?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221121.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "440d9a988fb77422423f094595b8e0e3",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9788fd5e266372d81cf9c3bb7b8cd2c3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "443a8705-b1dd-4305-8d1a-aa3b2048280c",
-        "Content-Length": "340",
+        "apim-request-id": "24964609-5965-463a-aede-186f57bda09f",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 06:21:47 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:14 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "154706a2-a9f4-43cf-bc2d-74ab4349306d",
+        "lastUpdatedDateTime": "2022-11-29T20:37:15Z",
+        "createdDateTime": "2022-11-29T20:37:14Z",
+        "expirationDateTime": "2022-11-30T20:37:14Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/154706a2-a9f4-43cf-bc2d-74ab4349306d?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a7caf97a82f400ffff2591868a7ab95b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9014872c-e09c-403d-8731-08eb3115346a",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:16 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "154706a2-a9f4-43cf-bc2d-74ab4349306d",
+        "lastUpdatedDateTime": "2022-11-29T20:37:16Z",
+        "createdDateTime": "2022-11-29T20:37:14Z",
+        "expirationDateTime": "2022-11-30T20:37:14Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/154706a2-a9f4-43cf-bc2d-74ab4349306d?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dfed67fccf5eb65c1c8c4ac4c789d42f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b0a9474e-e9c4-467e-aeb8-66f3a91179fb",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "7",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9f9dae7a-d84c-4d44-88f9-b61a472e3383",
-        "lastUpdateDateTime": "2022-11-22T06:21:48Z",
-        "createdDateTime": "2022-11-22T06:21:47Z",
-        "expirationDateTime": "2022-11-23T06:21:47Z",
-        "status": "notStarted",
-        "errors": [],
-        "displayName": "ExtractKeyPhrasesWithAutoDetectedLanguage",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/9f9dae7a-d84c-4d44-88f9-b61a472e3383?api-version=2022-10-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221121.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8509b81ece1be277372ec1aba37f165e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e9351aff-5c63-40fd-8074-ca4fe7c18f1c",
-        "Content-Length": "337",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 06:21:48 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "12",
-        "x-ms-region": "West US 2"
-      },
-      "ResponseBody": {
-        "jobId": "9f9dae7a-d84c-4d44-88f9-b61a472e3383",
-        "lastUpdateDateTime": "2022-11-22T06:21:48Z",
-        "createdDateTime": "2022-11-22T06:21:47Z",
-        "expirationDateTime": "2022-11-23T06:21:47Z",
+        "jobId": "154706a2-a9f4-43cf-bc2d-74ab4349306d",
+        "lastUpdatedDateTime": "2022-11-29T20:37:16Z",
+        "createdDateTime": "2022-11-29T20:37:14Z",
+        "expirationDateTime": "2022-11-30T20:37:14Z",
         "status": "running",
         "errors": [],
-        "displayName": "ExtractKeyPhrasesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -128,35 +164,34 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/9f9dae7a-d84c-4d44-88f9-b61a472e3383?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/154706a2-a9f4-43cf-bc2d-74ab4349306d?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221121.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "79af51c67ca2b2437a7fb569b8c525d6",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "25beb39f74cbdb47fd87973e9451e8a2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "51825377-a0b6-4206-b494-6b1a8c87c04b",
-        "Content-Length": "879",
+        "apim-request-id": "da188b0a-a962-490c-84ca-2d4fbebd2f6c",
+        "Content-Length": "822",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 06:21:49 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "35",
+        "x-envoy-upstream-service-time": "38",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9f9dae7a-d84c-4d44-88f9-b61a472e3383",
-        "lastUpdateDateTime": "2022-11-22T06:21:50Z",
-        "createdDateTime": "2022-11-22T06:21:47Z",
-        "expirationDateTime": "2022-11-23T06:21:47Z",
+        "jobId": "154706a2-a9f4-43cf-bc2d-74ab4349306d",
+        "lastUpdatedDateTime": "2022-11-29T20:37:17Z",
+        "createdDateTime": "2022-11-29T20:37:14Z",
+        "expirationDateTime": "2022-11-30T20:37:14Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "ExtractKeyPhrasesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -165,7 +200,7 @@
           "items": [
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-11-22T06:21:50.1087902Z",
+              "lastUpdateDateTime": "2022-11-29T20:37:17.7867348Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -210,7 +245,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "2065398393",
+    "RandomSeed": "1839027906",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiLabelClassifyTests/MultiLabelClassifyBatchConvenienceWithAutoDetectedLanguageTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiLabelClassifyTests/MultiLabelClassifyBatchConvenienceWithAutoDetectedLanguageTest.json
@@ -5,12 +5,12 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "324",
+        "Content-Length": "594",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ef7747656d95a1b42d30d22680eb5ee8-e313cf15c60d832e-00",
+        "traceparent": "00-7c5b769977a9067d44fbd13bd35b87e6-cec83e1f862d6574-00",
         "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b4a1e0eca79799b0e6c957c1b13014b1",
+        "x-ms-client-request-id": "a57f711907634fb46a67a6bccc73935a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -19,12 +19,12 @@
           "documents": [
             {
               "id": "0",
-              "text": "Microsoft was founded by Bill Gates and Paul Allen.",
+              "text": "I need a reservation for an indoor restaurant in China. Please don\u0027t stop the music. Play music and add it to my playlist",
               "language": "auto"
             },
             {
               "id": "1",
-              "text": "My cat and my dog might need to see a veterinarian.",
+              "text": "David Schmidt, senior vice president--Food Safety, International Food Information Council (IFIC), Washington, D.C., discussed the physical activity component.",
               "language": "auto"
             }
           ]
@@ -32,52 +32,53 @@
         "tasks": [
           {
             "parameters": {
-              "stringIndexType": "Utf16CodeUnit"
+              "projectName": "7cdace98-537b-494a-b69a-c19754718025",
+              "deploymentName": "7cdace98-537b-494a-b69a-c19754718025"
             },
-            "kind": "EntityRecognition"
+            "kind": "CustomMultiLabelClassification"
           }
         ]
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "e9d51000-c265-4031-a6cc-bc99cd486371",
+        "apim-request-id": "edf40892-887e-47f2-b9da-cedf5914c5cf",
         "Content-Length": "0",
-        "Date": "Tue, 29 Nov 2022 20:37:30 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/7e7f751b-19a8-4f97-9b73-aff6f253fc57?api-version=2022-10-01-preview",
+        "Date": "Tue, 29 Nov 2022 20:37:19 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/046853a8-12a2-411f-b540-bb10d068b727?api-version=2022-10-01-preview",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "188",
+        "x-envoy-upstream-service-time": "377",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/7e7f751b-19a8-4f97-9b73-aff6f253fc57?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/046853a8-12a2-411f-b540-bb10d068b727?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "78038c3d882987a689948a85e769abcb",
+        "x-ms-client-request-id": "2db3e33c939483a1220112329c67efbd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "eb49f55c-def5-4279-9b1c-943f51b6e232",
+        "apim-request-id": "82dcf4d6-54a6-49ba-9b5a-ef0bf72224bb",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Nov 2022 20:37:31 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "8",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "7e7f751b-19a8-4f97-9b73-aff6f253fc57",
-        "lastUpdatedDateTime": "2022-11-29T20:37:31Z",
-        "createdDateTime": "2022-11-29T20:37:31Z",
-        "expirationDateTime": "2022-11-30T20:37:31Z",
+        "jobId": "046853a8-12a2-411f-b540-bb10d068b727",
+        "lastUpdatedDateTime": "2022-11-29T20:37:19Z",
+        "createdDateTime": "2022-11-29T20:37:19Z",
+        "expirationDateTime": "2022-11-30T20:37:19Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -90,32 +91,32 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/7e7f751b-19a8-4f97-9b73-aff6f253fc57?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/046853a8-12a2-411f-b540-bb10d068b727?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "803c0f270ef9793b1303f4762d090f9d",
+        "x-ms-client-request-id": "a482a0e361957f3010df8dad58454d7f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e00abe98-f5b3-479e-84a6-91b709151df8",
+        "apim-request-id": "6fc5271a-4aa5-4815-a739-e03fae22f34d",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Nov 2022 20:37:32 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "6",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "7e7f751b-19a8-4f97-9b73-aff6f253fc57",
-        "lastUpdatedDateTime": "2022-11-29T20:37:32Z",
-        "createdDateTime": "2022-11-29T20:37:31Z",
-        "expirationDateTime": "2022-11-30T20:37:31Z",
+        "jobId": "046853a8-12a2-411f-b540-bb10d068b727",
+        "lastUpdatedDateTime": "2022-11-29T20:37:20Z",
+        "createdDateTime": "2022-11-29T20:37:19Z",
+        "expirationDateTime": "2022-11-30T20:37:19Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -128,32 +129,32 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/7e7f751b-19a8-4f97-9b73-aff6f253fc57?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/046853a8-12a2-411f-b540-bb10d068b727?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "68618531043b63be39192a031d2ab17c",
+        "x-ms-client-request-id": "58739ab3d53d855fcffc8362f481b303",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1d5557e8-6dd1-4156-8013-0ec7aee60678",
-        "Content-Length": "1112",
+        "apim-request-id": "2a577755-49d9-4f29-bad5-146e013aefab",
+        "Content-Length": "893",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Nov 2022 20:37:33 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "39",
+        "x-envoy-upstream-service-time": "141",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "7e7f751b-19a8-4f97-9b73-aff6f253fc57",
-        "lastUpdatedDateTime": "2022-11-29T20:37:33Z",
-        "createdDateTime": "2022-11-29T20:37:31Z",
-        "expirationDateTime": "2022-11-30T20:37:31Z",
+        "jobId": "046853a8-12a2-411f-b540-bb10d068b727",
+        "lastUpdatedDateTime": "2022-11-29T20:37:20Z",
+        "createdDateTime": "2022-11-29T20:37:19Z",
+        "expirationDateTime": "2022-11-30T20:37:19Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -163,66 +164,42 @@
           "total": 1,
           "items": [
             {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-11-29T20:37:33.5480247Z",
+              "kind": "CustomMultiLabelClassificationLROResults",
+              "lastUpdateDateTime": "2022-11-29T20:37:20.8647608Z",
               "status": "succeeded",
               "results": {
                 "documents": [
                   {
                     "id": "0",
-                    "entities": [
+                    "class": [
                       {
-                        "text": "Microsoft",
-                        "category": "Organization",
-                        "offset": 0,
-                        "length": 9,
-                        "confidenceScore": 1.0
-                      },
-                      {
-                        "text": "Bill Gates",
-                        "category": "Person",
-                        "offset": 25,
-                        "length": 10,
-                        "confidenceScore": 1.0
-                      },
-                      {
-                        "text": "Paul Allen",
-                        "category": "Person",
-                        "offset": 40,
-                        "length": 10,
-                        "confidenceScore": 1.0
+                        "category": "BookRestaurant",
+                        "confidenceScore": 0.97
                       }
                     ],
                     "warnings": [],
                     "detectedLanguage": {
                       "name": "English",
                       "iso6391Name": "en",
-                      "confidenceScore": 0.94
+                      "confidenceScore": 0.95
                     },
                     "isLanguageDefaulted": false
                   },
                   {
                     "id": "1",
-                    "entities": [
-                      {
-                        "text": "veterinarian",
-                        "category": "PersonType",
-                        "offset": 38,
-                        "length": 12,
-                        "confidenceScore": 1.0
-                      }
-                    ],
+                    "class": [],
                     "warnings": [],
                     "detectedLanguage": {
                       "name": "English",
                       "iso6391Name": "en",
-                      "confidenceScore": 0.96
+                      "confidenceScore": 0.95
                     },
                     "isLanguageDefaulted": false
                   }
                 ],
                 "errors": [],
-                "modelVersion": "2021-06-01"
+                "projectName": "7cdace98-537b-494a-b69a-c19754718025",
+                "deploymentName": "7cdace98-537b-494a-b69a-c19754718025"
               }
             }
           ]
@@ -231,8 +208,10 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "687223842",
-    "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
+    "RandomSeed": "1264134569",
+    "TEXTANALYTICS_MULTI_CATEGORY_CLASSIFY_DEPLOYMENT_NAME": "7cdace98-537b-494a-b69a-c19754718025",
+    "TEXTANALYTICS_MULTI_CATEGORY_CLASSIFY_PROJECT_NAME": "7cdace98-537b-494a-b69a-c19754718025",
+    "TEXT_ANALYTICS_STATIC_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_STATIC_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiLabelClassifyTests/MultiLabelClassifyBatchConvenienceWithAutoDetectedLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiLabelClassifyTests/MultiLabelClassifyBatchConvenienceWithAutoDetectedLanguageTestAsync.json
@@ -1,0 +1,179 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-10-01-preview",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "594",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a158dd442e63e33b53f21ae53ea6bba0-552f3f22d93da705-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cdf95b3b5c613a93cfd8f5b2376a8c1d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "defaultLanguage": "en",
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "0",
+              "text": "I need a reservation for an indoor restaurant in China. Please don\u0027t stop the music. Play music and add it to my playlist",
+              "language": "auto"
+            },
+            {
+              "id": "1",
+              "text": "David Schmidt, senior vice president--Food Safety, International Food Information Council (IFIC), Washington, D.C., discussed the physical activity component.",
+              "language": "auto"
+            }
+          ]
+        },
+        "tasks": [
+          {
+            "parameters": {
+              "projectName": "7cdace98-537b-494a-b69a-c19754718025",
+              "deploymentName": "7cdace98-537b-494a-b69a-c19754718025"
+            },
+            "kind": "CustomMultiLabelClassification"
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "a9fbaa65-1839-4747-b799-50f175a0de0e",
+        "Content-Length": "0",
+        "Date": "Tue, 29 Nov 2022 20:37:22 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/b55a4fa0-0f85-4ee8-a1cd-873da5ce9803?api-version=2022-10-01-preview",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "313",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/b55a4fa0-0f85-4ee8-a1cd-873da5ce9803?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a5ab0f429d1b35265d9ce8fba6c4088f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e01d6c24-ffa3-4534-a8ca-daf7156aa239",
+        "Content-Length": "283",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:22 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "b55a4fa0-0f85-4ee8-a1cd-873da5ce9803",
+        "lastUpdatedDateTime": "2022-11-29T20:37:22Z",
+        "createdDateTime": "2022-11-29T20:37:22Z",
+        "expirationDateTime": "2022-11-30T20:37:22Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/b55a4fa0-0f85-4ee8-a1cd-873da5ce9803?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7136479bf9f2888b989c193272bad8a9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "453e360d-f434-4b95-ae8f-3c88a274a885",
+        "Content-Length": "893",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:23 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "45",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "b55a4fa0-0f85-4ee8-a1cd-873da5ce9803",
+        "lastUpdatedDateTime": "2022-11-29T20:37:23Z",
+        "createdDateTime": "2022-11-29T20:37:22Z",
+        "expirationDateTime": "2022-11-30T20:37:22Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 1,
+          "items": [
+            {
+              "kind": "CustomMultiLabelClassificationLROResults",
+              "lastUpdateDateTime": "2022-11-29T20:37:23.2334104Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "class": [
+                      {
+                        "category": "BookRestaurant",
+                        "confidenceScore": 0.97
+                      }
+                    ],
+                    "warnings": [],
+                    "detectedLanguage": {
+                      "name": "English",
+                      "iso6391Name": "en",
+                      "confidenceScore": 0.95
+                    },
+                    "isLanguageDefaulted": false
+                  },
+                  {
+                    "id": "1",
+                    "class": [],
+                    "warnings": [],
+                    "detectedLanguage": {
+                      "name": "English",
+                      "iso6391Name": "en",
+                      "confidenceScore": 0.95
+                    },
+                    "isLanguageDefaulted": false
+                  }
+                ],
+                "errors": [],
+                "projectName": "7cdace98-537b-494a-b69a-c19754718025",
+                "deploymentName": "7cdace98-537b-494a-b69a-c19754718025"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "57288814",
+    "TEXTANALYTICS_MULTI_CATEGORY_CLASSIFY_DEPLOYMENT_NAME": "7cdace98-537b-494a-b69a-c19754718025",
+    "TEXTANALYTICS_MULTI_CATEGORY_CLASSIFY_PROJECT_NAME": "7cdace98-537b-494a-b69a-c19754718025",
+    "TEXT_ANALYTICS_STATIC_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_STATIC_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchConvenienceWithAutoDetectedLanguageTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchConvenienceWithAutoDetectedLanguageTest.json
@@ -1,0 +1,340 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-10-01-preview",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "469",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6645cbed2f3fb0ff56147e3b9680e45e-b04496334a784a47-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6c4e96711fd9d3338843fd8b9d8536da",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "defaultLanguage": "en",
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "0",
+              "text": "A recent report by the Government Accountability Office found a dramatic increase in oil.",
+              "language": "auto"
+            },
+            {
+              "id": "1",
+              "text": "Capital Call #20 for Berkshire Multifamily.",
+              "language": "auto"
+            }
+          ]
+        },
+        "tasks": [
+          {
+            "parameters": {
+              "stringIndexType": "Utf16CodeUnit",
+              "projectName": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
+              "deploymentName": "88ee0f78-fbca-444d-98e2-7c4c8631e494"
+            },
+            "kind": "CustomEntityRecognition"
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "dae81059-3f79-41e8-8233-429486735f14",
+        "Content-Length": "0",
+        "Date": "Tue, 29 Nov 2022 20:37:24 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/48f0e85f-137c-49d2-b073-2b1b333642ae?api-version=2022-10-01-preview",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "384",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/48f0e85f-137c-49d2-b073-2b1b333642ae?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "22230c4ebe70c120c7790afdc6d7a33c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "06aedf6b-ff0f-4d11-a332-fc5716fd16cf",
+        "Content-Length": "283",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:24 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "48f0e85f-137c-49d2-b073-2b1b333642ae",
+        "lastUpdatedDateTime": "2022-11-29T20:37:24Z",
+        "createdDateTime": "2022-11-29T20:37:24Z",
+        "expirationDateTime": "2022-11-30T20:37:24Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/48f0e85f-137c-49d2-b073-2b1b333642ae?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a452aba3b34d33f81136f8b217947f99",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8b9d73c3-417f-42eb-b489-e19f810c95c6",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "48f0e85f-137c-49d2-b073-2b1b333642ae",
+        "lastUpdatedDateTime": "2022-11-29T20:37:25Z",
+        "createdDateTime": "2022-11-29T20:37:24Z",
+        "expirationDateTime": "2022-11-30T20:37:24Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/48f0e85f-137c-49d2-b073-2b1b333642ae?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8efc0ba07744b31d758da46014360db0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9b8962f4-be28-4f81-be90-b6106e0e9f98",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:26 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "48f0e85f-137c-49d2-b073-2b1b333642ae",
+        "lastUpdatedDateTime": "2022-11-29T20:37:25Z",
+        "createdDateTime": "2022-11-29T20:37:24Z",
+        "expirationDateTime": "2022-11-30T20:37:24Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/48f0e85f-137c-49d2-b073-2b1b333642ae?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f1e8c1a091339b8d13f01039c56ea932",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d2e144fe-c081-4b55-940d-a61906d4d497",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:27 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "48f0e85f-137c-49d2-b073-2b1b333642ae",
+        "lastUpdatedDateTime": "2022-11-29T20:37:25Z",
+        "createdDateTime": "2022-11-29T20:37:24Z",
+        "expirationDateTime": "2022-11-30T20:37:24Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/48f0e85f-137c-49d2-b073-2b1b333642ae?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bb5d70fa15db2bf78e9f2fc00e981edb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3457f7d6-f37a-430a-8f09-37330f19794c",
+        "Content-Length": "1496",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:28 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "48f0e85f-137c-49d2-b073-2b1b333642ae",
+        "lastUpdatedDateTime": "2022-11-29T20:37:28Z",
+        "createdDateTime": "2022-11-29T20:37:24Z",
+        "expirationDateTime": "2022-11-30T20:37:24Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 1,
+          "items": [
+            {
+              "kind": "CustomEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-11-29T20:37:28.2170763Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "recent",
+                        "category": "object_select",
+                        "offset": 2,
+                        "length": 6,
+                        "confidenceScore": 0.08
+                      },
+                      {
+                        "text": "Government",
+                        "category": "restaurant_name",
+                        "offset": 23,
+                        "length": 10,
+                        "confidenceScore": 0.05
+                      },
+                      {
+                        "text": "Accountability",
+                        "category": "geographic_poi",
+                        "offset": 34,
+                        "length": 14,
+                        "confidenceScore": 0.07
+                      },
+                      {
+                        "text": "Office",
+                        "category": "restaurant_name",
+                        "offset": 49,
+                        "length": 6,
+                        "confidenceScore": 0.11
+                      },
+                      {
+                        "text": "dramatic",
+                        "category": "sort",
+                        "offset": 64,
+                        "length": 8,
+                        "confidenceScore": 0.03
+                      },
+                      {
+                        "text": "oil",
+                        "category": "music_item",
+                        "offset": 85,
+                        "length": 3,
+                        "confidenceScore": 0.06
+                      }
+                    ],
+                    "warnings": [],
+                    "detectedLanguage": {
+                      "name": "English",
+                      "iso6391Name": "en",
+                      "confidenceScore": 0.97
+                    },
+                    "isLanguageDefaulted": false
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Berkshire Multifamily",
+                        "category": "location_name",
+                        "offset": 21,
+                        "length": 21,
+                        "confidenceScore": 0.46
+                      }
+                    ],
+                    "warnings": [],
+                    "detectedLanguage": {
+                      "name": "English",
+                      "iso6391Name": "en",
+                      "confidenceScore": 0.75
+                    },
+                    "isLanguageDefaulted": false
+                  }
+                ],
+                "errors": [],
+                "projectName": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
+                "deploymentName": "88ee0f78-fbca-444d-98e2-7c4c8631e494"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "157892944",
+    "TEXTANALYTICS_CUSTOM_ENTITIES_DEPLOYMENT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
+    "TEXTANALYTICS_CUSTOM_ENTITIES_PROJECT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
+    "TEXT_ANALYTICS_STATIC_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_STATIC_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchConvenienceWithAutoDetectedLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchConvenienceWithAutoDetectedLanguageTestAsync.json
@@ -1,0 +1,226 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-10-01-preview",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "469",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-4475803fc2eae2f0acab5c27d3a7a3dd-0fd7ddfa77d54b3a-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7a26df01a0c1113d0ea17c57e489d854",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "defaultLanguage": "en",
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "0",
+              "text": "A recent report by the Government Accountability Office found a dramatic increase in oil.",
+              "language": "auto"
+            },
+            {
+              "id": "1",
+              "text": "Capital Call #20 for Berkshire Multifamily.",
+              "language": "auto"
+            }
+          ]
+        },
+        "tasks": [
+          {
+            "parameters": {
+              "stringIndexType": "Utf16CodeUnit",
+              "projectName": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
+              "deploymentName": "88ee0f78-fbca-444d-98e2-7c4c8631e494"
+            },
+            "kind": "CustomEntityRecognition"
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "bb260bc2-392d-4ed8-8a04-48f864238d94",
+        "Content-Length": "0",
+        "Date": "Tue, 29 Nov 2022 20:37:29 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/1e9ad1c5-1463-4da7-99c2-140b4ab88f27?api-version=2022-10-01-preview",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "199",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/1e9ad1c5-1463-4da7-99c2-140b4ab88f27?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d53bce08c6e0434cd90d3df122bbbc23",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c27fe009-f8e7-4156-839b-fc1e2295a033",
+        "Content-Length": "283",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:29 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "1e9ad1c5-1463-4da7-99c2-140b4ab88f27",
+        "lastUpdatedDateTime": "2022-11-29T20:37:29Z",
+        "createdDateTime": "2022-11-29T20:37:29Z",
+        "expirationDateTime": "2022-11-30T20:37:29Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/1e9ad1c5-1463-4da7-99c2-140b4ab88f27?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "32e5ebac0aa0e15834711ea4d6a2847b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "244e4073-ced2-4cb5-afc3-c05e49606e26",
+        "Content-Length": "1496",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:30 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "60",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "1e9ad1c5-1463-4da7-99c2-140b4ab88f27",
+        "lastUpdatedDateTime": "2022-11-29T20:37:30Z",
+        "createdDateTime": "2022-11-29T20:37:29Z",
+        "expirationDateTime": "2022-11-30T20:37:29Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 1,
+          "items": [
+            {
+              "kind": "CustomEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-11-29T20:37:30.6200087Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "recent",
+                        "category": "object_select",
+                        "offset": 2,
+                        "length": 6,
+                        "confidenceScore": 0.08
+                      },
+                      {
+                        "text": "Government",
+                        "category": "restaurant_name",
+                        "offset": 23,
+                        "length": 10,
+                        "confidenceScore": 0.05
+                      },
+                      {
+                        "text": "Accountability",
+                        "category": "geographic_poi",
+                        "offset": 34,
+                        "length": 14,
+                        "confidenceScore": 0.07
+                      },
+                      {
+                        "text": "Office",
+                        "category": "restaurant_name",
+                        "offset": 49,
+                        "length": 6,
+                        "confidenceScore": 0.11
+                      },
+                      {
+                        "text": "dramatic",
+                        "category": "sort",
+                        "offset": 64,
+                        "length": 8,
+                        "confidenceScore": 0.03
+                      },
+                      {
+                        "text": "oil",
+                        "category": "music_item",
+                        "offset": 85,
+                        "length": 3,
+                        "confidenceScore": 0.06
+                      }
+                    ],
+                    "warnings": [],
+                    "detectedLanguage": {
+                      "name": "English",
+                      "iso6391Name": "en",
+                      "confidenceScore": 0.97
+                    },
+                    "isLanguageDefaulted": false
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Berkshire Multifamily",
+                        "category": "location_name",
+                        "offset": 21,
+                        "length": 21,
+                        "confidenceScore": 0.46
+                      }
+                    ],
+                    "warnings": [],
+                    "detectedLanguage": {
+                      "name": "English",
+                      "iso6391Name": "en",
+                      "confidenceScore": 0.75
+                    },
+                    "isLanguageDefaulted": false
+                  }
+                ],
+                "errors": [],
+                "projectName": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
+                "deploymentName": "88ee0f78-fbca-444d-98e2-7c4c8631e494"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1839821045",
+    "TEXTANALYTICS_CUSTOM_ENTITIES_DEPLOYMENT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
+    "TEXTANALYTICS_CUSTOM_ENTITIES_PROJECT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
+    "TEXT_ANALYTICS_STATIC_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_STATIC_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/AnalyzeOperationRecognizeEntitiesWithAutoDetectedLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/AnalyzeOperationRecognizeEntitiesWithAutoDetectedLanguageTestAsync.json
@@ -5,16 +5,16 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "359",
+        "Content-Length": "324",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-43dc439669c8c98be89ffad7156a9095-327a8cc7ae7b6319-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "00951cece895a3073b8ef576f8acbe4e",
+        "traceparent": "00-c3ce2a1655c78a347b42ee1ac4f3c859-277263b825d98dc7-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dbe33ea6a588fa61cf0f29ecbca3bb5d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "displayName": "RecognizeEntitiesWithAutoDetectedLanguage",
+        "defaultLanguage": "en",
         "analysisInput": {
           "documents": [
             {
@@ -40,47 +40,46 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "31db9520-d0a0-4f51-9c44-ddbc6c6e86fa",
+        "apim-request-id": "2a070a61-c5df-4157-a56b-fb59d7651d66",
         "Content-Length": "0",
-        "Date": "Tue, 22 Nov 2022 08:08:27 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/d8e490dc-08ae-411b-87f9-9e135e712193?api-version=2022-10-01-preview",
+        "Date": "Tue, 29 Nov 2022 20:37:33 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/ec336c44-7d82-43d0-8e97-2ace4d94eb75?api-version=2022-10-01-preview",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "127",
+        "x-envoy-upstream-service-time": "211",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/d8e490dc-08ae-411b-87f9-9e135e712193?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/ec336c44-7d82-43d0-8e97-2ace4d94eb75?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6d1d7d91689ca6d78c86bbdce50cf33f",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ffa385ace697ccd72e1f24c5703ebedd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6d9554ed-8b45-420a-8c2e-511be71e01d3",
-        "Content-Length": "340",
+        "apim-request-id": "b8d7a8ac-c064-4db0-886e-f841490bf676",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 08:08:27 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7",
+        "x-envoy-upstream-service-time": "9",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d8e490dc-08ae-411b-87f9-9e135e712193",
-        "lastUpdateDateTime": "2022-11-22T08:08:27Z",
-        "createdDateTime": "2022-11-22T08:08:27Z",
-        "expirationDateTime": "2022-11-23T08:08:27Z",
+        "jobId": "ec336c44-7d82-43d0-8e97-2ace4d94eb75",
+        "lastUpdatedDateTime": "2022-11-29T20:37:34Z",
+        "createdDateTime": "2022-11-29T20:37:34Z",
+        "expirationDateTime": "2022-11-30T20:37:34Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "RecognizeEntitiesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -91,35 +90,34 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/d8e490dc-08ae-411b-87f9-9e135e712193?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/ec336c44-7d82-43d0-8e97-2ace4d94eb75?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "31e84209d71fa9ef5c27f0a0e148e326",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "54d9fab2c1553a62410321447e689d41",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b361b29d-f502-4198-90b1-d982adad88c1",
-        "Content-Length": "337",
+        "apim-request-id": "ec4f0690-c5af-402c-a29d-c3227d7be359",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 08:08:28 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7",
+        "x-envoy-upstream-service-time": "13",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d8e490dc-08ae-411b-87f9-9e135e712193",
-        "lastUpdateDateTime": "2022-11-22T08:08:28Z",
-        "createdDateTime": "2022-11-22T08:08:27Z",
-        "expirationDateTime": "2022-11-23T08:08:27Z",
+        "jobId": "ec336c44-7d82-43d0-8e97-2ace4d94eb75",
+        "lastUpdatedDateTime": "2022-11-29T20:37:35Z",
+        "createdDateTime": "2022-11-29T20:37:34Z",
+        "expirationDateTime": "2022-11-30T20:37:34Z",
         "status": "running",
         "errors": [],
-        "displayName": "RecognizeEntitiesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -130,35 +128,34 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/d8e490dc-08ae-411b-87f9-9e135e712193?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/ec336c44-7d82-43d0-8e97-2ace4d94eb75?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5c970e0f89c6830745ef740e2d2bbd2e",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2e2e4d223eedc0306616ad69819b8990",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "63291efb-d27e-470d-bd41-3187bcf7c0c2",
-        "Content-Length": "1169",
+        "apim-request-id": "ed2d8f5d-1649-4616-86f0-3e61b72863c6",
+        "Content-Length": "1112",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 08:08:29 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "47",
+        "x-envoy-upstream-service-time": "51",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d8e490dc-08ae-411b-87f9-9e135e712193",
-        "lastUpdateDateTime": "2022-11-22T08:08:29Z",
-        "createdDateTime": "2022-11-22T08:08:27Z",
-        "expirationDateTime": "2022-11-23T08:08:27Z",
+        "jobId": "ec336c44-7d82-43d0-8e97-2ace4d94eb75",
+        "lastUpdatedDateTime": "2022-11-29T20:37:36Z",
+        "createdDateTime": "2022-11-29T20:37:34Z",
+        "expirationDateTime": "2022-11-30T20:37:34Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "RecognizeEntitiesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -167,7 +164,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-11-22T08:08:29.6215927Z",
+              "lastUpdateDateTime": "2022-11-29T20:37:36.5664608Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -234,7 +231,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "137810266",
+    "RandomSeed": "210086513",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/AnalyzeOperationRecognizeLinkedEntitiesWithAutoDetectedLanguageTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/AnalyzeOperationRecognizeLinkedEntitiesWithAutoDetectedLanguageTest.json
@@ -5,16 +5,16 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "362",
+        "Content-Length": "321",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-18739bb58c59b5af43e59fa7b1dac803-4c4165413c37fd0b-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8b584ff93304b6548fc2d753e006590c",
+        "traceparent": "00-57ecf4eaed1c7a1788d8b43bcd48606c-6885c6a35129877d-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7507cc7b66bfe900e871445e7789789e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "displayName": "RecognizeLinkedEntitiesWithAutoDetectedLanguage",
+        "defaultLanguage": "en",
         "analysisInput": {
           "documents": [
             {
@@ -40,47 +40,46 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "b109e3bf-0f1a-4079-b0cc-edd4e6008c1c",
+        "apim-request-id": "9264786a-d70e-4a12-90c1-2af531511831",
         "Content-Length": "0",
-        "Date": "Tue, 22 Nov 2022 08:08:30 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/b6aaa59a-6b54-4799-81c2-fef173a41549?api-version=2022-10-01-preview",
+        "Date": "Tue, 29 Nov 2022 20:37:37 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/5cf50e6e-5eeb-46a7-b01b-badf669ab6c1?api-version=2022-10-01-preview",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "191",
+        "x-envoy-upstream-service-time": "220",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/b6aaa59a-6b54-4799-81c2-fef173a41549?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/5cf50e6e-5eeb-46a7-b01b-badf669ab6c1?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "9a2bfb52706660b24b652d9f360163e2",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4007c0a36842e197859af68c34618e15",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d8d7f37f-dfdb-44e4-9764-43296972aa8a",
-        "Content-Length": "346",
+        "apim-request-id": "a7fede20-59cb-4608-8322-bd13a080f309",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 08:08:30 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "7",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b6aaa59a-6b54-4799-81c2-fef173a41549",
-        "lastUpdateDateTime": "2022-11-22T08:08:30Z",
-        "createdDateTime": "2022-11-22T08:08:30Z",
-        "expirationDateTime": "2022-11-23T08:08:30Z",
+        "jobId": "5cf50e6e-5eeb-46a7-b01b-badf669ab6c1",
+        "lastUpdatedDateTime": "2022-11-29T20:37:37Z",
+        "createdDateTime": "2022-11-29T20:37:37Z",
+        "expirationDateTime": "2022-11-30T20:37:37Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "RecognizeLinkedEntitiesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -91,35 +90,34 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/b6aaa59a-6b54-4799-81c2-fef173a41549?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/5cf50e6e-5eeb-46a7-b01b-badf669ab6c1?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4052ca0e549f6c8ca574ce900329d0e0",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a02b95d41b7278e9f88a8f48709149cc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e9a69a34-8fe6-4b43-af2c-9fd710df08b8",
-        "Content-Length": "343",
+        "apim-request-id": "9931a883-6c2a-4784-8039-8325d9a7150d",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 08:08:31 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "7",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b6aaa59a-6b54-4799-81c2-fef173a41549",
-        "lastUpdateDateTime": "2022-11-22T08:08:31Z",
-        "createdDateTime": "2022-11-22T08:08:30Z",
-        "expirationDateTime": "2022-11-23T08:08:30Z",
+        "jobId": "5cf50e6e-5eeb-46a7-b01b-badf669ab6c1",
+        "lastUpdatedDateTime": "2022-11-29T20:37:37Z",
+        "createdDateTime": "2022-11-29T20:37:37Z",
+        "expirationDateTime": "2022-11-30T20:37:37Z",
         "status": "running",
         "errors": [],
-        "displayName": "RecognizeLinkedEntitiesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -130,35 +128,34 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/b6aaa59a-6b54-4799-81c2-fef173a41549?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/5cf50e6e-5eeb-46a7-b01b-badf669ab6c1?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "eed987c7bb90896a9cf83f9f06b5808e",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "78e5d67669a813823425f0257074b586",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aba5cc75-f0c1-415e-88a8-01904daccd3f",
-        "Content-Length": "2113",
+        "apim-request-id": "b6e5e847-83d8-4fd3-a565-6565f1faa805",
+        "Content-Length": "2050",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 08:08:32 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "52",
+        "x-envoy-upstream-service-time": "95",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b6aaa59a-6b54-4799-81c2-fef173a41549",
-        "lastUpdateDateTime": "2022-11-22T08:08:32Z",
-        "createdDateTime": "2022-11-22T08:08:30Z",
-        "expirationDateTime": "2022-11-23T08:08:30Z",
+        "jobId": "5cf50e6e-5eeb-46a7-b01b-badf669ab6c1",
+        "lastUpdatedDateTime": "2022-11-29T20:37:39Z",
+        "createdDateTime": "2022-11-29T20:37:37Z",
+        "expirationDateTime": "2022-11-30T20:37:37Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "RecognizeLinkedEntitiesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -167,7 +164,7 @@
           "items": [
             {
               "kind": "EntityLinkingLROResults",
-              "lastUpdateDateTime": "2022-11-22T08:08:32.7930853Z",
+              "lastUpdateDateTime": "2022-11-29T20:37:39.4997191Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -286,7 +283,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "42886521",
+    "RandomSeed": "860292371",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/AnalyzeOperationRecognizeLinkedEntitiesWithAutoDetectedLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/AnalyzeOperationRecognizeLinkedEntitiesWithAutoDetectedLanguageTestAsync.json
@@ -5,16 +5,16 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "362",
+        "Content-Length": "321",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-06a8bc64b10d7a456e364c80c13786a5-788afa720447f7f2-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221121.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2ec2c6e8881f4896cdc07ef0b7da758c",
+        "traceparent": "00-e9249a1f8f16ae562bb04a19bda08474-fe372427f771bcb2-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d2c2e38c9f9a6aedae852827a5a7d4c1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "displayName": "RecognizeLinkedEntitiesWithAutoDetectedLanguage",
+        "defaultLanguage": "en",
         "analysisInput": {
           "documents": [
             {
@@ -40,47 +40,46 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "471a6200-b6f2-4c5d-80b6-e680f25f1785",
+        "apim-request-id": "428b5f55-668e-47e8-8b85-7b15e980bac9",
         "Content-Length": "0",
-        "Date": "Tue, 22 Nov 2022 06:41:39 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/0ca06c48-db81-48c2-9526-c87ce803c9d5?api-version=2022-10-01-preview",
+        "Date": "Tue, 29 Nov 2022 20:37:40 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/52669a13-f703-4261-a3e7-ce1713335f49?api-version=2022-10-01-preview",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "114",
+        "x-envoy-upstream-service-time": "183",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/0ca06c48-db81-48c2-9526-c87ce803c9d5?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/52669a13-f703-4261-a3e7-ce1713335f49?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221121.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e9614c5a32b259cdec72d9f9f65992a3",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "08e135f8d7cfa8e8e3ff05f781a9d9a2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "77dd5988-9a73-4365-ac39-136f79f3b313",
-        "Content-Length": "346",
+        "apim-request-id": "db3b0cae-0e04-44ef-bbbc-76a42d7f03dd",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 06:41:39 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "19",
+        "x-envoy-upstream-service-time": "7",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "0ca06c48-db81-48c2-9526-c87ce803c9d5",
-        "lastUpdateDateTime": "2022-11-22T06:41:40Z",
-        "createdDateTime": "2022-11-22T06:41:39Z",
-        "expirationDateTime": "2022-11-23T06:41:39Z",
+        "jobId": "52669a13-f703-4261-a3e7-ce1713335f49",
+        "lastUpdatedDateTime": "2022-11-29T20:37:40Z",
+        "createdDateTime": "2022-11-29T20:37:40Z",
+        "expirationDateTime": "2022-11-30T20:37:40Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "RecognizeLinkedEntitiesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -91,35 +90,34 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/0ca06c48-db81-48c2-9526-c87ce803c9d5?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/52669a13-f703-4261-a3e7-ce1713335f49?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221121.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "06504b7d7fc994866613c6b87bd2cb5a",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "067b455fb40e81994ecae007489e7ed1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "afe18652-6f58-40b1-8017-cd1456e29b3b",
-        "Content-Length": "343",
+        "apim-request-id": "64237502-4c7a-45f2-8b0b-b12a499164f8",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 06:41:40 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "17",
+        "x-envoy-upstream-service-time": "7",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "0ca06c48-db81-48c2-9526-c87ce803c9d5",
-        "lastUpdateDateTime": "2022-11-22T06:41:40Z",
-        "createdDateTime": "2022-11-22T06:41:39Z",
-        "expirationDateTime": "2022-11-23T06:41:39Z",
+        "jobId": "52669a13-f703-4261-a3e7-ce1713335f49",
+        "lastUpdatedDateTime": "2022-11-29T20:37:41Z",
+        "createdDateTime": "2022-11-29T20:37:40Z",
+        "expirationDateTime": "2022-11-30T20:37:40Z",
         "status": "running",
         "errors": [],
-        "displayName": "RecognizeLinkedEntitiesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -130,35 +128,34 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/0ca06c48-db81-48c2-9526-c87ce803c9d5?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/52669a13-f703-4261-a3e7-ce1713335f49?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221121.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c7ea00267c47b6b6f86941adae9c5274",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dd81ffe8e6a8b536fb1aee9a9af6e904",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "709f6d2c-5914-4eef-b366-a0d5e71ca552",
-        "Content-Length": "343",
+        "apim-request-id": "bcbef91d-cfc7-4d49-af1e-4ba29aa47495",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 06:41:41 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "11",
+        "x-envoy-upstream-service-time": "6",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "0ca06c48-db81-48c2-9526-c87ce803c9d5",
-        "lastUpdateDateTime": "2022-11-22T06:41:40Z",
-        "createdDateTime": "2022-11-22T06:41:39Z",
-        "expirationDateTime": "2022-11-23T06:41:39Z",
+        "jobId": "52669a13-f703-4261-a3e7-ce1713335f49",
+        "lastUpdatedDateTime": "2022-11-29T20:37:41Z",
+        "createdDateTime": "2022-11-29T20:37:40Z",
+        "expirationDateTime": "2022-11-30T20:37:40Z",
         "status": "running",
         "errors": [],
-        "displayName": "RecognizeLinkedEntitiesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -169,35 +166,72 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/0ca06c48-db81-48c2-9526-c87ce803c9d5?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/52669a13-f703-4261-a3e7-ce1713335f49?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221121.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6b72da2d6e8adbc2c6cc839f6b15de19",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5fc885acce2b43b39b5fba04f7e05f45",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "09274a24-52d9-4599-8ed6-4040a20d05d9",
-        "Content-Length": "2113",
+        "apim-request-id": "372f1353-d129-4ac5-a425-7a1eaa5d79ca",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 06:41:42 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "48",
+        "x-envoy-upstream-service-time": "9",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "0ca06c48-db81-48c2-9526-c87ce803c9d5",
-        "lastUpdateDateTime": "2022-11-22T06:41:42Z",
-        "createdDateTime": "2022-11-22T06:41:39Z",
-        "expirationDateTime": "2022-11-23T06:41:39Z",
+        "jobId": "52669a13-f703-4261-a3e7-ce1713335f49",
+        "lastUpdatedDateTime": "2022-11-29T20:37:41Z",
+        "createdDateTime": "2022-11-29T20:37:40Z",
+        "expirationDateTime": "2022-11-30T20:37:40Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/52669a13-f703-4261-a3e7-ce1713335f49?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "810e3380fb2878fa0fc60af3c5fee657",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8ae61e2d-a2d9-4768-b0b9-084155824433",
+        "Content-Length": "2050",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:44 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "40",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "52669a13-f703-4261-a3e7-ce1713335f49",
+        "lastUpdatedDateTime": "2022-11-29T20:37:44Z",
+        "createdDateTime": "2022-11-29T20:37:40Z",
+        "expirationDateTime": "2022-11-30T20:37:40Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "RecognizeLinkedEntitiesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -206,7 +240,7 @@
           "items": [
             {
               "kind": "EntityLinkingLROResults",
-              "lastUpdateDateTime": "2022-11-22T06:41:42.7304213Z",
+              "lastUpdateDateTime": "2022-11-29T20:37:44.6450802Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -325,7 +359,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "473065312",
+    "RandomSeed": "733796862",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/AnalyzeOperationRecognizePiiEntitiesWithAutoDetectedLanguageTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/AnalyzeOperationRecognizePiiEntitiesWithAutoDetectedLanguageTest.json
@@ -5,16 +5,16 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "490",
+        "Content-Length": "452",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2b84cc110ed3d2f723381f1f20c7f48f-4cb4e2dea501dcca-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2394a987d823151cff54dde65f403eb9",
+        "traceparent": "00-5e6b28bc05b69a6df26239f0b8d1eb40-bc9f9fce5009ce7d-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0d7a1d4823cf9bbf64cd73a9bac69114",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "displayName": "RecognizePiiEntitiesWithAutoDetectedLanguage",
+        "defaultLanguage": "en",
         "analysisInput": {
           "documents": [
             {
@@ -40,86 +40,84 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "028cd0f3-a53f-4e41-9fa5-5e8f1ae65371",
+        "apim-request-id": "21f5f59c-17ba-47a6-8a81-e000eb1f0ed1",
         "Content-Length": "0",
-        "Date": "Tue, 22 Nov 2022 08:08:33 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/d2e13058-2129-4382-9fd7-0ba9f59ea9a4?api-version=2022-10-01-preview",
+        "Date": "Tue, 29 Nov 2022 20:37:44 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/734c6f52-ff67-4a19-8f99-dd075d4afab3?api-version=2022-10-01-preview",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "161",
+        "x-envoy-upstream-service-time": "208",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/d2e13058-2129-4382-9fd7-0ba9f59ea9a4?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/734c6f52-ff67-4a19-8f99-dd075d4afab3?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "aab1608d968c1231056ca5f2bdf061b7",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a0b43e91010742b44fc6ad835a7b976d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f7f762dd-a27d-4381-91cd-ce681c04e632",
-        "Content-Length": "343",
+        "apim-request-id": "3bb4b982-cdbf-4f9f-9068-dd060fd27475",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 08:08:33 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:44 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "734c6f52-ff67-4a19-8f99-dd075d4afab3",
+        "lastUpdatedDateTime": "2022-11-29T20:37:45Z",
+        "createdDateTime": "2022-11-29T20:37:45Z",
+        "expirationDateTime": "2022-11-30T20:37:45Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/734c6f52-ff67-4a19-8f99-dd075d4afab3?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9bb5405963a47aa0cad8cd4760d0b68e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3ba20f11-1cb0-4907-9374-a848bc9ec45b",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "7",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d2e13058-2129-4382-9fd7-0ba9f59ea9a4",
-        "lastUpdateDateTime": "2022-11-22T08:08:33Z",
-        "createdDateTime": "2022-11-22T08:08:33Z",
-        "expirationDateTime": "2022-11-23T08:08:33Z",
-        "status": "notStarted",
-        "errors": [],
-        "displayName": "RecognizePiiEntitiesWithAutoDetectedLanguage",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/d2e13058-2129-4382-9fd7-0ba9f59ea9a4?api-version=2022-10-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d927f4a20631b0657e2f5e520b36fc56",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "2745836c-06fe-424a-94ea-19fa006298f7",
-        "Content-Length": "340",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 08:08:34 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8",
-        "x-ms-region": "West US 2"
-      },
-      "ResponseBody": {
-        "jobId": "d2e13058-2129-4382-9fd7-0ba9f59ea9a4",
-        "lastUpdateDateTime": "2022-11-22T08:08:34Z",
-        "createdDateTime": "2022-11-22T08:08:33Z",
-        "expirationDateTime": "2022-11-23T08:08:33Z",
+        "jobId": "734c6f52-ff67-4a19-8f99-dd075d4afab3",
+        "lastUpdatedDateTime": "2022-11-29T20:37:45Z",
+        "createdDateTime": "2022-11-29T20:37:45Z",
+        "expirationDateTime": "2022-11-30T20:37:45Z",
         "status": "running",
         "errors": [],
-        "displayName": "RecognizePiiEntitiesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -130,35 +128,34 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/d2e13058-2129-4382-9fd7-0ba9f59ea9a4?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/734c6f52-ff67-4a19-8f99-dd075d4afab3?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221122.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5e482d31ceb8f11778821eb7332a570f",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ff05743bb03f46866938bd09763c41e8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5d211590-7e69-4ef7-b180-109176156ee1",
-        "Content-Length": "1752",
+        "apim-request-id": "da8e5a98-a205-4223-ac7b-a5ff7503047c",
+        "Content-Length": "1692",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 08:08:35 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "38",
+        "x-envoy-upstream-service-time": "42",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d2e13058-2129-4382-9fd7-0ba9f59ea9a4",
-        "lastUpdateDateTime": "2022-11-22T08:08:35Z",
-        "createdDateTime": "2022-11-22T08:08:33Z",
-        "expirationDateTime": "2022-11-23T08:08:33Z",
+        "jobId": "734c6f52-ff67-4a19-8f99-dd075d4afab3",
+        "lastUpdatedDateTime": "2022-11-29T20:37:47Z",
+        "createdDateTime": "2022-11-29T20:37:45Z",
+        "expirationDateTime": "2022-11-30T20:37:45Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "RecognizePiiEntitiesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -167,7 +164,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-11-22T08:08:35.7395768Z",
+              "lastUpdateDateTime": "2022-11-29T20:37:47.4264916Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -257,7 +254,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "110986835",
+    "RandomSeed": "2024190819",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/AnalyzeOperationRecognizePiiEntitiesWithAutoDetectedLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/AnalyzeOperationRecognizePiiEntitiesWithAutoDetectedLanguageTestAsync.json
@@ -5,16 +5,16 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "490",
+        "Content-Length": "452",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a9846346dcb05dbe397d0e423346f205-d5ecf86319cdc19d-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221121.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "069662b99d9dfd5dbdffa4bc9e8c66f0",
+        "traceparent": "00-ed8561e91dd3c64fe18ff2a9a8c305db-1f3d983eb0e62743-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "043b6aae5a1ca89b212d687bd29fb8d9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "displayName": "RecognizePiiEntitiesWithAutoDetectedLanguage",
+        "defaultLanguage": "en",
         "analysisInput": {
           "documents": [
             {
@@ -40,47 +40,46 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "5bf44baa-25aa-496d-9769-06777b49fdf3",
+        "apim-request-id": "58d6e823-5ac0-410d-8def-520be2c6c51f",
         "Content-Length": "0",
-        "Date": "Tue, 22 Nov 2022 06:33:39 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/b0f77d6b-1977-4e6e-b800-2e24e64ca7a7?api-version=2022-10-01-preview",
+        "Date": "Tue, 29 Nov 2022 20:37:47 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/3ec95d40-fe58-451d-90b9-98bedf2ccab1?api-version=2022-10-01-preview",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "311",
+        "x-envoy-upstream-service-time": "247",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/b0f77d6b-1977-4e6e-b800-2e24e64ca7a7?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/3ec95d40-fe58-451d-90b9-98bedf2ccab1?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221121.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "bea2a07458280d2c7125276de2b3eaf3",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a5da4086a0f391dbfd1a48722616a7ba",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "06a286c7-ca0e-4530-8581-36e66742c592",
-        "Content-Length": "343",
+        "apim-request-id": "f6fbb20d-d726-4a6a-9f7b-47a256b7f337",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 06:33:39 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "12",
+        "x-envoy-upstream-service-time": "7",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b0f77d6b-1977-4e6e-b800-2e24e64ca7a7",
-        "lastUpdateDateTime": "2022-11-22T06:33:40Z",
-        "createdDateTime": "2022-11-22T06:33:39Z",
-        "expirationDateTime": "2022-11-23T06:33:39Z",
+        "jobId": "3ec95d40-fe58-451d-90b9-98bedf2ccab1",
+        "lastUpdatedDateTime": "2022-11-29T20:37:48Z",
+        "createdDateTime": "2022-11-29T20:37:48Z",
+        "expirationDateTime": "2022-11-30T20:37:48Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "RecognizePiiEntitiesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -91,35 +90,34 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/b0f77d6b-1977-4e6e-b800-2e24e64ca7a7?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/3ec95d40-fe58-451d-90b9-98bedf2ccab1?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221121.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8f19c0208a4f4aba83c0224ae372e2e3",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "848416f57387311f7ff55987057742b9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e8686849-a8c0-41c4-9e2f-fb11c0a2f08d",
-        "Content-Length": "340",
+        "apim-request-id": "3b56e0e1-7219-4ec0-8b96-afe93c5d41a9",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 06:33:40 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "11",
+        "x-envoy-upstream-service-time": "8",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b0f77d6b-1977-4e6e-b800-2e24e64ca7a7",
-        "lastUpdateDateTime": "2022-11-22T06:33:40Z",
-        "createdDateTime": "2022-11-22T06:33:39Z",
-        "expirationDateTime": "2022-11-23T06:33:39Z",
+        "jobId": "3ec95d40-fe58-451d-90b9-98bedf2ccab1",
+        "lastUpdatedDateTime": "2022-11-29T20:37:48Z",
+        "createdDateTime": "2022-11-29T20:37:48Z",
+        "expirationDateTime": "2022-11-30T20:37:48Z",
         "status": "running",
         "errors": [],
-        "displayName": "RecognizePiiEntitiesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -130,35 +128,34 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/b0f77d6b-1977-4e6e-b800-2e24e64ca7a7?api-version=2022-10-01-preview",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/3ec95d40-fe58-451d-90b9-98bedf2ccab1?api-version=2022-10-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221121.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7be5db7f6b9961df3588957776ef1a0a",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bcedc3c910e30efb8fa906011229820b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c8c106f7-ea4f-4626-95a4-2b4eb4e36ca6",
-        "Content-Length": "1751",
+        "apim-request-id": "a7bc7654-599f-4959-96f3-16180e7d582a",
+        "Content-Length": "1692",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 22 Nov 2022 06:33:41 GMT",
+        "Date": "Tue, 29 Nov 2022 20:37:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "44",
+        "x-envoy-upstream-service-time": "37",
         "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b0f77d6b-1977-4e6e-b800-2e24e64ca7a7",
-        "lastUpdateDateTime": "2022-11-22T06:33:42Z",
-        "createdDateTime": "2022-11-22T06:33:39Z",
-        "expirationDateTime": "2022-11-23T06:33:39Z",
+        "jobId": "3ec95d40-fe58-451d-90b9-98bedf2ccab1",
+        "lastUpdatedDateTime": "2022-11-29T20:37:50Z",
+        "createdDateTime": "2022-11-29T20:37:48Z",
+        "expirationDateTime": "2022-11-30T20:37:48Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "RecognizePiiEntitiesWithAutoDetectedLanguage",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -167,7 +164,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-11-22T06:33:42.278884Z",
+              "lastUpdateDateTime": "2022-11-29T20:37:50.5327795Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -257,7 +254,7 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "1048735906",
+    "RandomSeed": "1574915753",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleLabelClassifyTests/SingleLabelClassifyBatchConvenienceWithAutoDetectedLanguageTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleLabelClassifyTests/SingleLabelClassifyBatchConvenienceWithAutoDetectedLanguageTest.json
@@ -1,0 +1,184 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-10-01-preview",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "595",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3abc217178bc471c2e692ff2bd340faa-391e23252c6f1611-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d16abf7a5ae5ec621d04d645afbee349",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "defaultLanguage": "en",
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "0",
+              "text": "I need a reservation for an indoor restaurant in China. Please don\u0027t stop the music. Play music and add it to my playlist",
+              "language": "auto"
+            },
+            {
+              "id": "1",
+              "text": "David Schmidt, senior vice president--Food Safety, International Food Information Council (IFIC), Washington, D.C., discussed the physical activity component.",
+              "language": "auto"
+            }
+          ]
+        },
+        "tasks": [
+          {
+            "parameters": {
+              "projectName": "659c1851-be0b-4142-b12a-087da9785926",
+              "deploymentName": "659c1851-be0b-4142-b12a-087da9785926"
+            },
+            "kind": "CustomSingleLabelClassification"
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "9a71be4c-c577-4743-a52e-b779515a9f89",
+        "Content-Length": "0",
+        "Date": "Tue, 29 Nov 2022 20:37:50 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/86066530-c7ca-4dcc-8c3b-ab7e061a0bc6?api-version=2022-10-01-preview",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "207",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/86066530-c7ca-4dcc-8c3b-ab7e061a0bc6?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d206c42c00a9c9f60dddfd7b1b9f4d6c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "840617e5-9d8b-4c92-a995-c3982cf4def5",
+        "Content-Length": "283",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:50 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "86066530-c7ca-4dcc-8c3b-ab7e061a0bc6",
+        "lastUpdatedDateTime": "2022-11-29T20:37:51Z",
+        "createdDateTime": "2022-11-29T20:37:51Z",
+        "expirationDateTime": "2022-11-30T20:37:51Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/86066530-c7ca-4dcc-8c3b-ab7e061a0bc6?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e945710ea0bb4acbc597e1e9918dd43f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9a38c2e2-0573-4386-8505-86d4f5e5d615",
+        "Content-Length": "939",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:51 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "41",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "86066530-c7ca-4dcc-8c3b-ab7e061a0bc6",
+        "lastUpdatedDateTime": "2022-11-29T20:37:52Z",
+        "createdDateTime": "2022-11-29T20:37:51Z",
+        "expirationDateTime": "2022-11-30T20:37:51Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 1,
+          "items": [
+            {
+              "kind": "CustomSingleLabelClassificationLROResults",
+              "lastUpdateDateTime": "2022-11-29T20:37:52.1264024Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "class": [
+                      {
+                        "category": "BookRestaurant",
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": [],
+                    "detectedLanguage": {
+                      "name": "English",
+                      "iso6391Name": "en",
+                      "confidenceScore": 0.95
+                    },
+                    "isLanguageDefaulted": false
+                  },
+                  {
+                    "id": "1",
+                    "class": [
+                      {
+                        "category": "RateBook",
+                        "confidenceScore": 0.57
+                      }
+                    ],
+                    "warnings": [],
+                    "detectedLanguage": {
+                      "name": "English",
+                      "iso6391Name": "en",
+                      "confidenceScore": 0.95
+                    },
+                    "isLanguageDefaulted": false
+                  }
+                ],
+                "errors": [],
+                "projectName": "659c1851-be0b-4142-b12a-087da9785926",
+                "deploymentName": "659c1851-be0b-4142-b12a-087da9785926"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "267826006",
+    "TEXTANALYTICS_SINGLE_CATEGORY_CLASSIFY_DEPLOYMENT_NAME": "659c1851-be0b-4142-b12a-087da9785926",
+    "TEXTANALYTICS_SINGLE_CATEGORY_CLASSIFY_PROJECT_NAME": "659c1851-be0b-4142-b12a-087da9785926",
+    "TEXT_ANALYTICS_STATIC_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_STATIC_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleLabelClassifyTests/SingleLabelClassifyBatchConvenienceWithAutoDetectedLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleLabelClassifyTests/SingleLabelClassifyBatchConvenienceWithAutoDetectedLanguageTestAsync.json
@@ -1,0 +1,184 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs?api-version=2022-10-01-preview",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "595",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-bff93caf3cd0dfa4b989625d171db584-c49f843b8ede077b-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2e2cf6422652fee70f0f1394df5659e3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "defaultLanguage": "en",
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "0",
+              "text": "I need a reservation for an indoor restaurant in China. Please don\u0027t stop the music. Play music and add it to my playlist",
+              "language": "auto"
+            },
+            {
+              "id": "1",
+              "text": "David Schmidt, senior vice president--Food Safety, International Food Information Council (IFIC), Washington, D.C., discussed the physical activity component.",
+              "language": "auto"
+            }
+          ]
+        },
+        "tasks": [
+          {
+            "parameters": {
+              "projectName": "659c1851-be0b-4142-b12a-087da9785926",
+              "deploymentName": "659c1851-be0b-4142-b12a-087da9785926"
+            },
+            "kind": "CustomSingleLabelClassification"
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "8df45c14-b5d7-4f0a-9ec3-f06d73fbeeac",
+        "Content-Length": "0",
+        "Date": "Tue, 29 Nov 2022 20:37:52 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/ab4b3420-4d16-4b34-96e2-7dcc91385910?api-version=2022-10-01-preview",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "165",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/ab4b3420-4d16-4b34-96e2-7dcc91385910?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2741f9b3426323b4fbc0f95e6e0d0222",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e3d8904c-e784-4493-8a89-339e16556d7d",
+        "Content-Length": "283",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:52 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "ab4b3420-4d16-4b34-96e2-7dcc91385910",
+        "lastUpdatedDateTime": "2022-11-29T20:37:53Z",
+        "createdDateTime": "2022-11-29T20:37:52Z",
+        "expirationDateTime": "2022-11-30T20:37:52Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/language/analyze-text/jobs/ab4b3420-4d16-4b34-96e2-7dcc91385910?api-version=2022-10-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a5e363d833591741671ebaa7dde68849",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a7ce2321-8f76-4e80-ac06-d28098bc3984",
+        "Content-Length": "939",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 29 Nov 2022 20:37:53 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "33",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "ab4b3420-4d16-4b34-96e2-7dcc91385910",
+        "lastUpdatedDateTime": "2022-11-29T20:37:53Z",
+        "createdDateTime": "2022-11-29T20:37:52Z",
+        "expirationDateTime": "2022-11-30T20:37:52Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 1,
+          "items": [
+            {
+              "kind": "CustomSingleLabelClassificationLROResults",
+              "lastUpdateDateTime": "2022-11-29T20:37:53.9864594Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "class": [
+                      {
+                        "category": "BookRestaurant",
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": [],
+                    "detectedLanguage": {
+                      "name": "English",
+                      "iso6391Name": "en",
+                      "confidenceScore": 0.95
+                    },
+                    "isLanguageDefaulted": false
+                  },
+                  {
+                    "id": "1",
+                    "class": [
+                      {
+                        "category": "RateBook",
+                        "confidenceScore": 0.57
+                      }
+                    ],
+                    "warnings": [],
+                    "detectedLanguage": {
+                      "name": "English",
+                      "iso6391Name": "en",
+                      "confidenceScore": 0.95
+                    },
+                    "isLanguageDefaulted": false
+                  }
+                ],
+                "errors": [],
+                "projectName": "659c1851-be0b-4142-b12a-087da9785926",
+                "deploymentName": "659c1851-be0b-4142-b12a-087da9785926"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "144359403",
+    "TEXTANALYTICS_SINGLE_CATEGORY_CLASSIFY_DEPLOYMENT_NAME": "659c1851-be0b-4142-b12a-087da9785926",
+    "TEXTANALYTICS_SINGLE_CATEGORY_CLASSIFY_PROJECT_NAME": "659c1851-be0b-4142-b12a-087da9785926",
+    "TEXT_ANALYTICS_STATIC_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_STATIC_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SingleLabelClassifyTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SingleLabelClassifyTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -289,6 +290,30 @@ namespace Azure.AI.TextAnalytics.Tests
 
         [RecordedTest]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
+        public async Task SingleLabelClassifyBatchConvenienceWithAutoDetectedLanguageTest()
+        {
+            TextAnalyticsClient client = GetClient(useStaticResource: true);
+            SingleLabelClassifyOptions options = new()
+            {
+                AutoDetectionDefaultLanguage = "en"
+            };
+
+            ClassifyDocumentOperation operation = await client.StartSingleLabelClassifyAsync(
+                s_singleLabelClassifyBatchConvenienceDocuments,
+                TestEnvironment.SingleClassificationProjectName,
+                TestEnvironment.SingleClassificationDeploymentName,
+                "auto",
+                options);
+
+            await operation.WaitForCompletionAsync();
+
+            // Take the first page.
+            ClassifyDocumentResultCollection resultCollection = operation.Value.ToEnumerableAsync().Result.FirstOrDefault();
+            ValidateSummaryBatchResult(resultCollection, isLanguageAutoDetected: true);
+        }
+
+        [RecordedTest]
+        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeOperationSingleLabelClassifyWithAutoDetectedLanguageTest()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -312,6 +337,29 @@ namespace Azure.AI.TextAnalytics.Tests
 
             ClassifyDocumentResultCollection results = actionResults.FirstOrDefault().DocumentsResults;
             ValidateSummaryBatchResult(results, isLanguageAutoDetected: true);
+        }
+
+        [RecordedTest]
+        [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
+        public void MultiLabelClassifyBatchWithDefaultLanguageThrows()
+        {
+            TestDiagnostics = false;
+
+            TextAnalyticsClient client = GetClient();
+            SingleLabelClassifyOptions options = new()
+            {
+                AutoDetectionDefaultLanguage = "en"
+            };
+
+            NotSupportedException ex = Assert.ThrowsAsync<NotSupportedException>(
+                async () => await client.StartSingleLabelClassifyAsync(
+                s_singleLabelClassifyBatchConvenienceDocuments,
+                TestEnvironment.SingleClassificationProjectName,
+                TestEnvironment.SingleClassificationDeploymentName,
+                "auto",
+                options));
+
+            Assert.That(ex.Message.EndsWith("Use service API version 2022-10-01-preview or newer."));
         }
 
         private void ValidateSummaryDocumentResult(ClassificationCategory? classification)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SingleLabelClassifyTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SingleLabelClassifyTests.cs
@@ -341,7 +341,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
         [RecordedTest]
         [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
-        public void MultiLabelClassifyBatchWithDefaultLanguageThrows()
+        public void SingleLabelClassifyBatchWithDefaultLanguageThrows()
         {
             TestDiagnostics = false;
 


### PR DESCRIPTION
Resolves: #32738 

- Added the `AbstractSummaryOptions.AutoDetectionDefaultLanguage` property.
- Added the `AnalyzeActionsOptions.AutoDetectionDefaultLanguage` property.
- Added the `AnalyzeHealthcareEntitiesOptions.AutoDetectionDefaultLanguage` property.y.
- Added the `ExtractSummaryOptions.AutoDetectionDefaultLanguage` property.
- Added the `MultiLabelClassifyOptions.AutoDetectionDefaultLanguage` property.
- Added the `RecognizeCustomEntitiesOptions.AutoDetectionDefaultLanguage` property.
- Added the `SingleLabelClassifyOptions.AutoDetectionDefaultLanguage` property.