### PR TITLE
[Text Analytics] Fix tests with outdated model version

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/ExtractSummaryTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/ExtractSummaryTests.cs
@@ -242,6 +242,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/32759")]
         public async Task AnalyzeOperationExtractSummaryWithAutoDetectedLanguageTest()
         {
             TextAnalyticsClient client = GetClient();

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeEntitiesTests.cs
@@ -88,15 +88,13 @@ namespace Azure.AI.TextAnalytics.Tests
         [RecordedTest]
         public async Task RecognizeEntitiesWithSubCategoryTest()
         {
-            TextAnalyticsRequestOptions options = new TextAnalyticsRequestOptions() { ModelVersion = "2020-04-01" };
             TextAnalyticsClient client = GetClient();
             string document = "I had a wonderful trip to Seattle last week.";
 
-            RecognizeEntitiesResultCollection result = await client.RecognizeEntitiesBatchAsync(new List<string>() { document }, options: options );
+            RecognizeEntitiesResultCollection result = await client.RecognizeEntitiesBatchAsync(new List<string>() { document });
 
-            var documentResult = result.FirstOrDefault();
+            RecognizeEntitiesResult documentResult = result.FirstOrDefault();
             Assert.IsFalse(documentResult.HasError);
-
             Assert.GreaterOrEqual(documentResult.Entities.Count, 3);
 
             foreach (CategorizedEntity entity in documentResult.Entities)
@@ -104,10 +102,6 @@ namespace Azure.AI.TextAnalytics.Tests
                 if (entity.Text == "last week")
                     Assert.AreEqual("DateRange", entity.SubCategory);
             }
-
-            // Assert the options classes since overloads were added and the original now instantiates a RecognizeEntitiesOptions.
-            Assert.IsFalse(options.IncludeStatistics);
-            Assert.AreEqual("2020-04-01", options.ModelVersion);
         }
 
         [RecordedTest]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithSubCategoryTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithSubCategoryTest.json
@@ -5,12 +5,12 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "218",
+        "Content-Length": "190",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-208148dd9259eae6a00678512c6b8800-d4e5671b50c2f1f4-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221014.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8c9e881051453c24379f2daf616d5617",
+        "traceparent": "00-0af83edad2b19c3728333a8989148c1d-e978b2a707f1229e-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "abf8bda06471eab06221f29b0fc9b957",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -24,22 +24,22 @@
           ]
         },
         "parameters": {
-          "stringIndexType": "Utf16CodeUnit",
-          "modelVersion": "2020-04-01"
+          "stringIndexType": "Utf16CodeUnit"
         },
         "kind": "EntityRecognition"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cd868cb3-4459-481b-b727-2209eae8fb87",
-        "Content-Length": "441",
+        "apim-request-id": "748452e0-c0ac-4d7c-93a7-ab2c1b59508e",
+        "Content-Length": "440",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 14 Oct 2022 22:22:39 GMT",
+        "Date": "Wed, 30 Nov 2022 03:42:34 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "219"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",
@@ -53,7 +53,7 @@
                   "category": "Event",
                   "offset": 18,
                   "length": 4,
-                  "confidenceScore": 0.61
+                  "confidenceScore": 0.74
                 },
                 {
                   "text": "Seattle",
@@ -61,7 +61,7 @@
                   "subcategory": "GPE",
                   "offset": 26,
                   "length": 7,
-                  "confidenceScore": 0.82
+                  "confidenceScore": 1.0
                 },
                 {
                   "text": "last week",
@@ -76,13 +76,13 @@
             }
           ],
           "errors": [],
-          "modelVersion": "2020-04-01"
+          "modelVersion": "2021-06-01"
         }
       }
     }
   ],
   "Variables": {
-    "RandomSeed": "1678391871",
+    "RandomSeed": "136851253",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithSubCategoryTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithSubCategoryTestAsync.json
@@ -5,12 +5,12 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "218",
+        "Content-Length": "190",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-80092ba0e1017d2f7e7a1805cdc27d9c-0966e61e0f92cdb6-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221014.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b043f7db5d90995fdacaac6d4a1f9f8d",
+        "traceparent": "00-1235f6bf6561b591512afef90653fa71-bb5cbb7dfedeb1e4-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ce65f0c67ff7d0b6235c4ea209094001",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -24,22 +24,22 @@
           ]
         },
         "parameters": {
-          "stringIndexType": "Utf16CodeUnit",
-          "modelVersion": "2020-04-01"
+          "stringIndexType": "Utf16CodeUnit"
         },
         "kind": "EntityRecognition"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "59001742-42b5-45b4-aac0-facdb4bf7c6b",
-        "Content-Length": "441",
+        "apim-request-id": "32474e3b-e1af-4820-a003-ad7ae24eb7ae",
+        "Content-Length": "440",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 14 Oct 2022 22:22:40 GMT",
+        "Date": "Wed, 30 Nov 2022 03:44:49 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "129"
+        "x-envoy-upstream-service-time": "31",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",
@@ -53,7 +53,7 @@
                   "category": "Event",
                   "offset": 18,
                   "length": 4,
-                  "confidenceScore": 0.61
+                  "confidenceScore": 0.74
                 },
                 {
                   "text": "Seattle",
@@ -61,7 +61,7 @@
                   "subcategory": "GPE",
                   "offset": 26,
                   "length": 7,
-                  "confidenceScore": 0.82
+                  "confidenceScore": 1.0
                 },
                 {
                   "text": "last week",
@@ -76,13 +76,13 @@
             }
           ],
           "errors": [],
-          "modelVersion": "2020-04-01"
+          "modelVersion": "2021-06-01"
         }
       }
     }
   ],
   "Variables": {
-    "RandomSeed": "112297458",
+    "RandomSeed": "623214473",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/EntitiesCategories.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/EntitiesCategories.json
@@ -5,12 +5,12 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "221",
+        "Content-Length": "193",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-354a962103af0dc023cb9ce3e121f465-b8abf57ffb86b1c4-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221014.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "38b6ee1319af79c54ba0c8b75b3f68db",
+        "traceparent": "00-828207dcd5ceec0938f8a6eceaee36ae-734454384fbc9e64-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "072c5c7c5c1fde5c678e54d48ceb3f0a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -24,22 +24,22 @@
           ]
         },
         "parameters": {
-          "stringIndexType": "Utf16CodeUnit",
-          "modelVersion": "2020-02-01"
+          "stringIndexType": "Utf16CodeUnit"
         },
         "kind": "EntityRecognition"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "77d35476-a51c-48ff-aa40-2a5257d211be",
+        "apim-request-id": "c76f98f2-0fcd-4f15-a707-cd8ccdd473ff",
         "Content-Length": "519",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 14 Oct 2022 22:25:31 GMT",
+        "Date": "Wed, 30 Nov 2022 03:44:51 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "97"
+        "x-envoy-upstream-service-time": "31",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",
@@ -53,14 +53,14 @@
                   "category": "Person",
                   "offset": 0,
                   "length": 10,
-                  "confidenceScore": 0.6
+                  "confidenceScore": 1.0
                 },
                 {
                   "text": "Microsoft",
                   "category": "Organization",
                   "offset": 13,
                   "length": 9,
-                  "confidenceScore": 0.85
+                  "confidenceScore": 0.99
                 },
                 {
                   "text": "New Mexico",
@@ -68,7 +68,7 @@
                   "subcategory": "GPE",
                   "offset": 25,
                   "length": 10,
-                  "confidenceScore": 0.56
+                  "confidenceScore": 0.96
                 },
                 {
                   "text": "127.0.0.1",
@@ -82,13 +82,13 @@
             }
           ],
           "errors": [],
-          "modelVersion": "2020-02-01"
+          "modelVersion": "2021-06-01"
         }
       }
     }
   ],
   "Variables": {
-    "RandomSeed": "513631017",
+    "RandomSeed": "1262912110",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/EntitiesCategoriesAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/EntitiesCategoriesAsync.json
@@ -5,12 +5,12 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "221",
+        "Content-Length": "193",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ec102f54355509fb35772fb72c5c2f10-03cbd49f1eb1f701-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221014.1 (.NET 6.0.10; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c6d200bc6ea4c173432cbb76f1349b25",
+        "traceparent": "00-dba4bb8aae5f173141599b6bab93c3cc-31942aa1926788f3-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.3.0-alpha.20221129.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "72cbe4005f3d5fa1645c28ceb41beb0f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -24,22 +24,22 @@
           ]
         },
         "parameters": {
-          "stringIndexType": "Utf16CodeUnit",
-          "modelVersion": "2020-02-01"
+          "stringIndexType": "Utf16CodeUnit"
         },
         "kind": "EntityRecognition"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0877b545-9805-4a5e-b5bf-dc5438b269fa",
+        "apim-request-id": "2bb7bbff-fb0b-4a74-aeaf-0c05d478d255",
         "Content-Length": "519",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 14 Oct 2022 22:25:31 GMT",
+        "Date": "Wed, 30 Nov 2022 03:38:53 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "88"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",
@@ -53,14 +53,14 @@
                   "category": "Person",
                   "offset": 0,
                   "length": 10,
-                  "confidenceScore": 0.6
+                  "confidenceScore": 1.0
                 },
                 {
                   "text": "Microsoft",
                   "category": "Organization",
                   "offset": 13,
                   "length": 9,
-                  "confidenceScore": 0.85
+                  "confidenceScore": 0.99
                 },
                 {
                   "text": "New Mexico",
@@ -68,7 +68,7 @@
                   "subcategory": "GPE",
                   "offset": 25,
                   "length": 10,
-                  "confidenceScore": 0.56
+                  "confidenceScore": 0.96
                 },
                 {
                   "text": "127.0.0.1",
@@ -82,13 +82,13 @@
             }
           ],
           "errors": [],
-          "modelVersion": "2020-02-01"
+          "modelVersion": "2021-06-01"
         }
       }
     }
   ],
   "Variables": {
-    "RandomSeed": "1550385538",
+    "RandomSeed": "897358379",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
     "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
   }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
@@ -67,17 +67,13 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             const string document = "Bill Gates | Microsoft | New Mexico | 127.0.0.1";
 
-            RecognizeEntitiesResultCollection response = await client.RecognizeEntitiesBatchAsync(new List<string>() { document }, "en", new TextAnalyticsRequestOptions() { ModelVersion = "2020-02-01" });
+            RecognizeEntitiesResultCollection response = await client.RecognizeEntitiesBatchAsync(new List<string>() { document }, "en");
             var entities = response.FirstOrDefault().Entities.ToList();
 
             Assert.AreEqual(4, entities.Count);
-
             Assert.AreEqual(EntityCategory.Person, entities[0].Category);
-
             Assert.AreEqual(EntityCategory.Organization, entities[1].Category);
-
             Assert.AreEqual(EntityCategory.Location, entities[2].Category);
-
             Assert.AreEqual(EntityCategory.IPAddress, entities[3].Category);
         }
 


### PR DESCRIPTION
Disabling test to avoid a regression in extractive summarization. Additionally, some outdated model versions were also deprecated, causing a couple of tests that had them hardcoded to fail.