### PR TITLE
[Communication] - PhoneNumbers - Fix `pageSizeHint` for retrieving purchased phone numbers.

### DIFF
--- a/sdk/communication/Azure.Communication.PhoneNumbers/src/PhoneNumbersClient.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/src/PhoneNumbersClient.cs
@@ -379,7 +379,7 @@ namespace Azure.Communication.PhoneNumbers
                 scope.Start();
                 try
                 {
-                    var response = RestClient.ListPhoneNumbers(skip: null, top: null, cancellationToken);
+                    var response = RestClient.ListPhoneNumbers(skip: null, top: pageSizeHint, cancellationToken);
                     return Page.FromValues(response.Value.PhoneNumbers, response.Value.NextLink, response.GetRawResponse());
                 }
                 catch (Exception e)

--- a/sdk/communication/Azure.Communication.PhoneNumbers/src/PhoneNumbersClient.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/src/PhoneNumbersClient.cs
@@ -342,7 +342,7 @@ namespace Azure.Communication.PhoneNumbers
                 scope.Start();
                 try
                 {
-                    var response = await RestClient.ListPhoneNumbersAsync(skip: null, top: null, cancellationToken).ConfigureAwait(false);
+                    var response = await RestClient.ListPhoneNumbersAsync(skip: null, top: pageSizeHint, cancellationToken).ConfigureAwait(false);
                     return Page.FromValues(response.Value.PhoneNumbers, response.Value.NextLink, response.GetRawResponse());
                 }
                 catch (Exception e)


### PR DESCRIPTION
Passes the value of `pageSizeHint` as `top` in the first page request. Subsequent requests do not need to use `pageSizeHint` as they rely on the `nextLink` value provided by the server.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
