### PR TITLE
Update azure-sdk-build-tools ref to test tools change

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -3,7 +3,7 @@ resources:
     - repository: azure-sdk-build-tools
       type: git
       name: internal/azure-sdk-build-tools
-      ref: refs/tags/azure-sdk-build-tools_20220920.1
+      ref: refs/heads/UpdateEsrpCodeSigningTask
 
 parameters:
 - name: Artifacts


### PR DESCRIPTION
This will not be checked in, I need to test updated changes to the ESRP signing task.