### PR TITLE
Make typed property bag methods public

### DIFF
--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -470,7 +470,9 @@ namespace Azure.Core
         public void Dispose() { }
         public System.IO.Stream? ExtractResponseContent() { throw null; }
         public void SetProperty(string name, object value) { }
+        public void SetProperty(System.Type type, object value) { }
         public bool TryGetProperty(string name, out object? value) { throw null; }
+        public bool TryGetProperty(System.Type type, out object? value) { throw null; }
     }
     public enum HttpPipelinePosition
     {

--- a/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
@@ -470,7 +470,9 @@ namespace Azure.Core
         public void Dispose() { }
         public System.IO.Stream? ExtractResponseContent() { throw null; }
         public void SetProperty(string name, object value) { }
+        public void SetProperty(System.Type type, object value) { }
         public bool TryGetProperty(string name, out object? value) { throw null; }
+        public bool TryGetProperty(System.Type type, out object? value) { throw null; }
     }
     public enum HttpPipelinePosition
     {

--- a/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
@@ -470,7 +470,9 @@ namespace Azure.Core
         public void Dispose() { }
         public System.IO.Stream? ExtractResponseContent() { throw null; }
         public void SetProperty(string name, object value) { }
+        public void SetProperty(System.Type type, object value) { }
         public bool TryGetProperty(string name, out object? value) { throw null; }
+        public bool TryGetProperty(System.Type type, out object? value) { throw null; }
     }
     public enum HttpPipelinePosition
     {

--- a/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
@@ -470,7 +470,9 @@ namespace Azure.Core
         public void Dispose() { }
         public System.IO.Stream? ExtractResponseContent() { throw null; }
         public void SetProperty(string name, object value) { }
+        public void SetProperty(System.Type type, object value) { }
         public bool TryGetProperty(string name, out object? value) { throw null; }
+        public bool TryGetProperty(System.Type type, out object? value) { throw null; }
     }
     public enum HttpPipelinePosition
     {

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -470,7 +470,9 @@ namespace Azure.Core
         public void Dispose() { }
         public System.IO.Stream? ExtractResponseContent() { throw null; }
         public void SetProperty(string name, object value) { }
+        public void SetProperty(System.Type type, object value) { }
         public bool TryGetProperty(string name, out object? value) { throw null; }
+        public bool TryGetProperty(System.Type type, out object? value) { throw null; }
     }
     public enum HttpPipelinePosition
     {

--- a/sdk/core/Azure.Core/src/HttpMessage.cs
+++ b/sdk/core/Azure.Core/src/HttpMessage.cs
@@ -161,7 +161,7 @@ namespace Azure.Core
         /// <param name="type">The property type.</param>
         /// <param name="value">The property value.</param>
         /// <returns><c>true</c> if property exists, otherwise. <c>false</c>.</returns>
-        internal bool TryGetInternalProperty(Type type, out object? value)
+        public bool TryGetProperty(Type type, out object? value)
         {
             value = null;
             return _typeProperties?.TryGetValue(type, out value) == true;
@@ -173,7 +173,7 @@ namespace Azure.Core
         /// </summary>
         /// <param name="type">The key for the value.</param>
         /// <param name="value">The property value.</param>
-        internal void SetInternalProperty(Type type, object value)
+        public void SetProperty(Type type, object value)
         {
             _typeProperties ??= new Dictionary<Type, object>();
             _typeProperties[type] = value;

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/TelemetryPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/TelemetryPolicy.cs
@@ -14,7 +14,7 @@ namespace Azure.Core.Pipeline
 
         public override void OnSendingRequest(HttpMessage message)
         {
-            if (message.TryGetInternalProperty(typeof(UserAgentValueKey), out var userAgent))
+            if (message.TryGetProperty(typeof(UserAgentValueKey), out var userAgent))
             {
                 message.Request.Headers.Add(HttpHeader.Names.UserAgent, ((string)userAgent!));
             }

--- a/sdk/core/Azure.Core/src/TelemetryDetails.cs
+++ b/sdk/core/Azure.Core/src/TelemetryDetails.cs
@@ -53,7 +53,7 @@ namespace Azure.Core
         /// <param name="message">The <see cref="HttpMessage"/> that will use this <see cref="TelemetryDetails"/>.</param>
         public void Apply(HttpMessage message)
         {
-            message.SetInternalProperty(typeof(UserAgentValueKey), ToString());
+            message.SetProperty(typeof(UserAgentValueKey), ToString());
         }
 
         internal static string GenerateUserAgentString(Assembly clientAssembly, string? applicationId = null)

--- a/sdk/core/Azure.Core/tests/TelemetryDetailsTests.cs
+++ b/sdk/core/Azure.Core/tests/TelemetryDetailsTests.cs
@@ -57,7 +57,7 @@ namespace Azure.Core.Tests
 
             target.Apply(message);
 
-            message.TryGetInternalProperty(typeof(UserAgentValueKey), out var obj);
+            message.TryGetProperty(typeof(UserAgentValueKey), out var obj);
             string actualValue = obj as string;
 
             Assert.AreEqual(target.ToString(), actualValue);


### PR DESCRIPTION
This will allow custom policies to be able to ensure unique property keys.