### PR TITLE
Fix failing SIP Routing tests in Communication/PhoneNumbers 

### DIFF
--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/Azure.Communication.PhoneNumbers.Tests.csproj
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/Azure.Communication.PhoneNumbers.Tests.csproj
@@ -19,6 +19,7 @@
   <!-- Shared source from Azure.Core -->
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)ConnectionString.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" LinkBase="Shared" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\samples\Sample_SipRoutingClient.md" Link="samples\Sample_SipRoutingClient.md" />

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/Sample_SipRoutingClient/ManageSipConfiguration.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/Sample_SipRoutingClient/ManageSipConfiguration.json
@@ -8,10 +8,10 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "982bd2e65437394563c2fe5576c76456",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b732b6c61686b409e18f6ddd86f8771f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:05:02 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:47 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -21,13 +21,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:05:03 GMT",
-        "MS-CV": "pQakuGaj7EWt2V5NaD1InA.0",
+        "Date": "Tue, 13 Dec 2022 01:47:47 GMT",
+        "MS-CV": "jr6bbBFJmEmdWPI0VHX6Ag.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0LoeOYwAAAADB1XfP7QyySYRPcpy8KLxWUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0w9mXYwAAAABsR3Bt7\u002BaFTpPZr3zrmKNOUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "1219ms"
+        "X-Processing-Time": "253ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -40,10 +40,10 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "74e4fea0122359d97f00318a453c4694",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e0cc0ab9602305eb50dfdc4118e0e060",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:05:03 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:48 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -51,13 +51,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:05:03 GMT",
-        "MS-CV": "TNI54m3tQkar1mdrUO9W/Q.0",
+        "Date": "Tue, 13 Dec 2022 01:47:47 GMT",
+        "MS-CV": "YH5UdLwNTkuR7/oKjmxutg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0L4eOYwAAAAAajx4lFGTgRq/D2n\u002B\u002BtCngUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0xNmXYwAAAABshe9NGiNTQJhx4065rSZXUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
+        "X-Processing-Time": "110ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -70,17 +70,17 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "51",
+        "Content-Length": "88",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b3156574c2321d682e31ede572f2baf1",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "778b2fa53691e3fb811907598b9028a8",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:05:03 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:48 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
             "sipSignalingPort": 3333
           }
         }
@@ -89,17 +89,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:05:04 GMT",
-        "MS-CV": "VgVrlkXCb0uGd2dsG/ZD1g.0",
+        "Date": "Tue, 13 Dec 2022 01:47:48 GMT",
+        "MS-CV": "4rcyHoILVE6pE9qjjQuREw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0L4eOYwAAAADyXQLdxcR1RJ8KRQWFPYjxUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0xNmXYwAAAACVj74wqf\u002BYSZVPSHpqOegiUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "491ms"
+        "X-Processing-Time": "858ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -112,12 +112,12 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "148",
+        "Content-Length": "185",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e0bf29ae8736d300f8d2183723baf426",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4ec173501c57650fca2c66a739c79c00",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:05:04 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:49 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -127,7 +127,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.com"
+              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
             ]
           }
         ]
@@ -136,17 +136,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:05:04 GMT",
-        "MS-CV": "KGvepsll1UuIIeDCpWLlYw.0",
+        "Date": "Tue, 13 Dec 2022 01:47:49 GMT",
+        "MS-CV": "AOZiAvPQXkCJ7IGcOy4Usg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0MIeOYwAAAAASFp4EU1TrQ7OohyUSNRYrUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0xdmXYwAAAADc2tZL\u002BMBAT6GcHQN/jMyYUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "155ms"
+        "X-Processing-Time": "194ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -156,50 +156,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "10e06a7cb0b2de2496c745f225f3e78d",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:05:04 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:05:04 GMT",
-        "MS-CV": "QpwPjWM3FkKqEQ\u002BPIWFenA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0MIeOYwAAAACqzTDvZoybRYOPQkfb4w4yUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "newsbs.com": {
-            "sipSignalingPort": 3333
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle all numbers\u0027",
-            "name": "Alternative rule",
-            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
-            "trunks": [
-              "newsbs.com"
+              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
             ]
           }
         ]
@@ -211,10 +168,10 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1bdb3f45657ded5e6542ba60aa30f973",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "57380daeff6d838d0ee85e0959927ac0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:05:04 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:49 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -222,17 +179,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:05:04 GMT",
-        "MS-CV": "SmoXCOTzQEyynwwjXe0iMg.0",
+        "Date": "Tue, 13 Dec 2022 01:47:49 GMT",
+        "MS-CV": "/znGI2UUg0WUQwGPKLvELQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0MIeOYwAAAAACC2lUBl4OSJRPo7pA263WUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0xtmXYwAAAABfthXnGYYWQ7ni/SN4q7sJUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "95ms"
+        "X-Processing-Time": "98ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -242,7 +199,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.com"
+              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
             ]
           }
         ]
@@ -254,10 +211,10 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0869c63da912fd3f05e14a6f410dae04",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a4f133b6911e88081f25ac65cf54aaba",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:05:05 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:49 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -265,17 +222,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:05:05 GMT",
-        "MS-CV": "KLYdzOZKKUSN3Z4ZLKdrQw.0",
+        "Date": "Tue, 13 Dec 2022 01:47:50 GMT",
+        "MS-CV": "HenTsb0djEKIm7koOr40oQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0MYeOYwAAAAAD6ViHh\u002B/gS4Sa\u002B2M5JDc\u002BUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0xtmXYwAAAAA\u002Bu8873yhXRZx8gYIHhB/QUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "82ms"
+        "X-Processing-Time": "248ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -285,7 +242,50 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.com"
+              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7daa067dd158503be63e406ebd060b38",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:50 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:47:50 GMT",
+        "MS-CV": "uOmml15lNUiTsN2\u002BE1b\u002B\u002BQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0x9mXYwAAAABtpAKUHAnZSZXEpTVLL1NFUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "86ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle all numbers\u0027",
+            "name": "Alternative rule",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": [
+              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
             ]
           }
         ]
@@ -297,17 +297,17 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "51",
+        "Content-Length": "88",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e4f28bead8df16a90cf2ab70f6c43365",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "05f0a6b2f8d61ce204af38475328b3ba",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:05:05 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:50 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
             "sipSignalingPort": 9999
           }
         }
@@ -316,17 +316,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:05:05 GMT",
-        "MS-CV": "vTkPximNQEmyA6//Bgidvw.0",
+        "Date": "Tue, 13 Dec 2022 01:47:50 GMT",
+        "MS-CV": "UPwUPBexA0Sb8Ajcw5zKgg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0MYeOYwAAAADc7gguiNEsRLoHGt0hLeYwUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0x9mXYwAAAACtJ8ReTmNmT5x924ifKOOsUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "339ms"
+        "X-Processing-Time": "386ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -336,7 +336,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.com"
+              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
             ]
           }
         ]
@@ -348,17 +348,17 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "49",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5eb5d1cddf8a9b7affdd169c1aefac57",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "538ca43efce7e568f8a0bddf519aca18",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:05:05 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:51 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
             "sipSignalingPort": 1122
           }
         }
@@ -367,20 +367,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:05:06 GMT",
-        "MS-CV": "B/XMIKZOhU\u002BmSsRvg8WPHQ.0",
+        "Date": "Tue, 13 Dec 2022 01:47:51 GMT",
+        "MS-CV": "myVpKIaFmkWklj7r/wJF6g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0MYeOYwAAAAAFA9/NCrExQLc7Wy337w0cUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0x9mXYwAAAACnqXaL9yOnQJo2CKxB83LlUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "1038ms"
+        "X-Processing-Time": "845ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
             "sipSignalingPort": 9999
           },
-          "sbs1.com": {
+          "sbs1.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -390,7 +390,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.com"
+              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
             ]
           }
         ]
@@ -402,34 +402,34 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "28",
+        "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1e75b693153d64941d52fb1ffecf0741",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "29b27419a46484e3238e79a898f4fdbe",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:05:06 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": null
+          "sbs1.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:05:06 GMT",
-        "MS-CV": "ocRCK8LGNkus985\u002BbzjeoA.0",
+        "Date": "Tue, 13 Dec 2022 01:47:52 GMT",
+        "MS-CV": "2oQ1g1WLhE6PUy3Mb6xaOA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0MoeOYwAAAACY7ErwCRQZSodNJpC/L3eLUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0yNmXYwAAAAC\u002BO17CafxERql94GUkx\u002B4PUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "256ms"
+        "X-Processing-Time": "278ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -439,7 +439,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.com"
+              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
             ]
           }
         ]
@@ -451,10 +451,10 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6fa1e4ad50580b7a1057e401c20dfb1d",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "182f858ab87ab5503e0b0d353a02cb69",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:05:07 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -462,17 +462,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:05:07 GMT",
-        "MS-CV": "IcdwP2sHV0eFznuTguuWpQ.0",
+        "Date": "Tue, 13 Dec 2022 01:47:52 GMT",
+        "MS-CV": "AlRMryNRREOnI4EpKJxKfA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0M4eOYwAAAAAk/ZdZW1hmTZa/b5/6t9EWUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ydmXYwAAAAC/VhUwzbPSRrg3sOyeSY08UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "78ms"
+        "X-Processing-Time": "86ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -482,7 +482,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.com"
+              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
             ]
           }
         ]
@@ -494,10 +494,10 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3fdc5346154fb8283d504037e35a9c30",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "de2d1fe48a759956c1072f5982bf4c04",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:05:07 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -505,17 +505,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:05:08 GMT",
-        "MS-CV": "GY/J9FFdB0WD/6dw\u002Bq8N3w.0",
+        "Date": "Tue, 13 Dec 2022 01:47:52 GMT",
+        "MS-CV": "YvpNVBf\u002B20aheeD3xEt19A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0M4eOYwAAAADv\u002B//MTWsKSoHl2FbFPsy6UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ydmXYwAAAAASSqb0nPwvSLsUo2A63mhSUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "824ms"
+        "X-Processing-Time": "91ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -525,7 +525,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.com"
+              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
             ]
           }
         ]
@@ -534,6 +534,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "79362876"
+    "RandomSeed": "858719838"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/Sample_SipRoutingClient/ManageSipConfiguration.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/Sample_SipRoutingClient/ManageSipConfiguration.json
@@ -8,10 +8,10 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2780350f9673c3db9b77d922223c9eee",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "982bd2e65437394563c2fe5576c76456",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:30 GMT",
+        "x-ms-date": "Tue, 06 Dec 2022 00:05:02 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -21,20 +21,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:31 GMT",
-        "MS-CV": "G4wYBXzWYUq3VjlBna/Qlw.0",
+        "Date": "Tue, 06 Dec 2022 00:05:03 GMT",
+        "MS-CV": "pQakuGaj7EWt2V5NaD1InA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "069dDYwAAAADv3TVLZnScS7tfJq/w4JuDTE9OMjFFREdFMTgxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0LoeOYwAAAADB1XfP7QyySYRPcpy8KLxWUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "218ms"
+        "X-Processing-Time": "1219ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "newsbs.sipconfigtest.com": {
-            "sipSignalingPort": 9999
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -44,10 +40,10 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e0a8e323d7e9e77f8b7bec866e3c2cd9",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "74e4fea0122359d97f00318a453c4694",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:31 GMT",
+        "x-ms-date": "Tue, 06 Dec 2022 00:05:03 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -55,106 +51,231 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:32 GMT",
-        "MS-CV": "HYsubOi55UCY6sNMFLEmIg.0",
+        "Date": "Tue, 06 Dec 2022 00:05:03 GMT",
+        "MS-CV": "TNI54m3tQkar1mdrUO9W/Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07NdDYwAAAACJJdihb7YEQbSf27Pr5YH4TE9OMjFFREdFMTgxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0L4eOYwAAAAAajx4lFGTgRq/D2n\u002B\u002BtCngUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "89ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "51",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b3156574c2321d682e31ede572f2baf1",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 06 Dec 2022 00:05:03 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 06 Dec 2022 00:05:04 GMT",
+        "MS-CV": "VgVrlkXCb0uGd2dsG/ZD1g.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0L4eOYwAAAADyXQLdxcR1RJ8KRQWFPYjxUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "491ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "148",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e0bf29ae8736d300f8d2183723baf426",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 06 Dec 2022 00:05:04 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": [
+          {
+            "description": "Handle all numbers\u0027",
+            "name": "Alternative rule",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": [
+              "newsbs.com"
+            ]
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 06 Dec 2022 00:05:04 GMT",
+        "MS-CV": "KGvepsll1UuIIeDCpWLlYw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0MIeOYwAAAAASFp4EU1TrQ7OohyUSNRYrUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "155ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle all numbers\u0027",
+            "name": "Alternative rule",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": [
+              "newsbs.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "10e06a7cb0b2de2496c745f225f3e78d",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 06 Dec 2022 00:05:04 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 06 Dec 2022 00:05:04 GMT",
+        "MS-CV": "QpwPjWM3FkKqEQ\u002BPIWFenA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0MIeOYwAAAACqzTDvZoybRYOPQkfb4w4yUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "87ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle all numbers\u0027",
+            "name": "Alternative rule",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": [
+              "newsbs.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1bdb3f45657ded5e6542ba60aa30f973",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 06 Dec 2022 00:05:04 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 06 Dec 2022 00:05:04 GMT",
+        "MS-CV": "SmoXCOTzQEyynwwjXe0iMg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0MIeOYwAAAAACC2lUBl4OSJRPo7pA263WUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "95ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle all numbers\u0027",
+            "name": "Alternative rule",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": [
+              "newsbs.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0869c63da912fd3f05e14a6f410dae04",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 06 Dec 2022 00:05:05 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 06 Dec 2022 00:05:05 GMT",
+        "MS-CV": "KLYdzOZKKUSN3Z4ZLKdrQw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0MYeOYwAAAAAD6ViHh\u002B/gS4Sa\u002B2M5JDc\u002BUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "82ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
-            "sipSignalingPort": 9999
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "PATCH",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "65",
-        "Content-Type": "application/merge-patch\u002Bjson",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "bc6ee762ffcd21e356779edf6769c6d0",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:31 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "trunks": {
-          "newsbs.sipconfigtest.com": {
-            "sipSignalingPort": 3333
-          }
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:32 GMT",
-        "MS-CV": "99c8XqiNP0OeoB04boPvZA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07NdDYwAAAACjxmF/RQcJQ7fLXlyorvoPTE9OMjFFREdFMTgxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "358ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "newsbs.sipconfigtest.com": {
-            "sipSignalingPort": 3333
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "PATCH",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "162",
-        "Content-Type": "application/merge-patch\u002Bjson",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "42b07bba6f5738f7b5999bf7a955555e",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:32 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "routes": [
-          {
-            "description": "Handle all numbers\u0027",
-            "name": "Alternative rule",
-            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
-            "trunks": [
-              "newsbs.sipconfigtest.com"
-            ]
-          }
-        ]
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:32 GMT",
-        "MS-CV": "enr\u002BWliXzkWbytTGxnELiQ.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07NdDYwAAAAB\u002B9cy3YGPpQI44tmv\u002BDqGaTE9OMjFFREdFMTgxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "146ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -164,136 +285,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.sipconfigtest.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3abf004ae1cd2420ff87897239a07f22",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:32 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:33 GMT",
-        "MS-CV": "cuPj4bVuvEOtm0LCKyKJfQ.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07NdDYwAAAABU5659ZUnhQ4V5nIkSSpaGTE9OMjFFREdFMTgxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "276ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "newsbs.sipconfigtest.com": {
-            "sipSignalingPort": 3333
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle all numbers\u0027",
-            "name": "Alternative rule",
-            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
-            "trunks": [
-              "newsbs.sipconfigtest.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f2cb1cb5e98bf281ef36073463ec7701",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:32 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:33 GMT",
-        "MS-CV": "bE4KbwO\u002B1UuPEvKoqv1MZQ.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07ddDYwAAAABO/s/HNKTLSZgpd2bxVatuTE9OMjFFREdFMTgxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "71ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "newsbs.sipconfigtest.com": {
-            "sipSignalingPort": 3333
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle all numbers\u0027",
-            "name": "Alternative rule",
-            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
-            "trunks": [
-              "newsbs.sipconfigtest.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "67943f228ba9d9025b8c43d0e684ff14",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:32 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:33 GMT",
-        "MS-CV": "uajvYYjRyEGSjsFZe9TI8A.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07ddDYwAAAABwCo44h\u002BhIQZqvgRZ1TS8dTE9OMjFFREdFMTgxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "newsbs.sipconfigtest.com": {
-            "sipSignalingPort": 3333
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle all numbers\u0027",
-            "name": "Alternative rule",
-            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
-            "trunks": [
-              "newsbs.sipconfigtest.com"
+              "newsbs.com"
             ]
           }
         ]
@@ -305,17 +297,17 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "65",
+        "Content-Length": "51",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8d427919628960d27ecd4b97daebc113",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e4f28bead8df16a90cf2ab70f6c43365",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:33 GMT",
+        "x-ms-date": "Tue, 06 Dec 2022 00:05:05 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 9999
           }
         }
@@ -324,17 +316,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:34 GMT",
-        "MS-CV": "j1X\u002BHCDw80uES9/oW6o1zQ.0",
+        "Date": "Tue, 06 Dec 2022 00:05:05 GMT",
+        "MS-CV": "vTkPximNQEmyA6//Bgidvw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07ddDYwAAAACrIgLUiqaZQ6TVZsIG28ybTE9OMjFFREdFMTgxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0MYeOYwAAAADc7gguiNEsRLoHGt0hLeYwUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "279ms"
+        "X-Processing-Time": "339ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -344,7 +336,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.sipconfigtest.com"
+              "newsbs.com"
             ]
           }
         ]
@@ -356,17 +348,17 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "63",
+        "Content-Length": "49",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f950880f170b297819f297ffa6b10c6a",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5eb5d1cddf8a9b7affdd169c1aefac57",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:33 GMT",
+        "x-ms-date": "Tue, 06 Dec 2022 00:05:05 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           }
         }
@@ -375,20 +367,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:34 GMT",
-        "MS-CV": "JCjIXjfzo0uEv73TLfvxeg.0",
+        "Date": "Tue, 06 Dec 2022 00:05:06 GMT",
+        "MS-CV": "B/XMIKZOhU\u002BmSsRvg8WPHQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07tdDYwAAAABZn1IisTAVR7qptAKy3TJeTE9OMjFFREdFMTgxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0MYeOYwAAAAAFA9/NCrExQLc7Wy337w0cUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "610ms"
+        "X-Processing-Time": "1038ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 9999
           },
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -398,7 +390,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.sipconfigtest.com"
+              "newsbs.com"
             ]
           }
         ]
@@ -410,34 +402,34 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "42",
+        "Content-Length": "28",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e91bf236eaaabf776c33e9dc406afe6f",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1e75b693153d64941d52fb1ffecf0741",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:34 GMT",
+        "x-ms-date": "Tue, 06 Dec 2022 00:05:06 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": null
+          "sbs1.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:35 GMT",
-        "MS-CV": "H1RjR9R1tUKAgjF\u002BtFMQTw.0",
+        "Date": "Tue, 06 Dec 2022 00:05:06 GMT",
+        "MS-CV": "ocRCK8LGNkus985\u002BbzjeoA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07tdDYwAAAABnpuanVnEES4Xw\u002BZoIs5F0TE9OMjFFREdFMTgxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0MoeOYwAAAACY7ErwCRQZSodNJpC/L3eLUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "349ms"
+        "X-Processing-Time": "256ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -447,7 +439,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.sipconfigtest.com"
+              "newsbs.com"
             ]
           }
         ]
@@ -459,10 +451,10 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5dc030ca0534010800187397cbd3bacc",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6fa1e4ad50580b7a1057e401c20dfb1d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:34 GMT",
+        "x-ms-date": "Tue, 06 Dec 2022 00:05:07 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -470,17 +462,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:35 GMT",
-        "MS-CV": "qqVgq5yuJU2Hl81RGcnDUg.0",
+        "Date": "Tue, 06 Dec 2022 00:05:07 GMT",
+        "MS-CV": "IcdwP2sHV0eFznuTguuWpQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "079dDYwAAAAASaP88iHtOSZfJ71NGVvhmTE9OMjFFREdFMTgxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0M4eOYwAAAAAk/ZdZW1hmTZa/b5/6t9EWUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "86ms"
+        "X-Processing-Time": "78ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -490,7 +482,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.sipconfigtest.com"
+              "newsbs.com"
             ]
           }
         ]
@@ -502,10 +494,10 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e760e0c0d7d0256811918dd82e9ce8ae",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3fdc5346154fb8283d504037e35a9c30",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:34 GMT",
+        "x-ms-date": "Tue, 06 Dec 2022 00:05:07 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -513,17 +505,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:35 GMT",
-        "MS-CV": "Fd4KFpNYrkGU/3IDmgArQQ.0",
+        "Date": "Tue, 06 Dec 2022 00:05:08 GMT",
+        "MS-CV": "GY/J9FFdB0WD/6dw\u002Bq8N3w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "079dDYwAAAABryKnfJr27Tp3/Ao\u002Be2kJkTE9OMjFFREdFMTgxMwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0M4eOYwAAAADv\u002B//MTWsKSoHl2FbFPsy6UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "98ms"
+        "X-Processing-Time": "824ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -533,7 +525,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.sipconfigtest.com"
+              "newsbs.com"
             ]
           }
         ]
@@ -541,7 +533,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1892157264"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "79362876"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/Sample_SipRoutingClient/ManageSipConfiguration.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/Sample_SipRoutingClient/ManageSipConfiguration.json
@@ -9,9 +9,9 @@
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b732b6c61686b409e18f6ddd86f8771f",
+        "x-ms-client-request-id": "ac0fd841ddc5c6234867ec667bc8c0e5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:47 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:30 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -21,13 +21,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:47 GMT",
-        "MS-CV": "jr6bbBFJmEmdWPI0VHX6Ag.0",
+        "Date": "Tue, 13 Dec 2022 20:17:30 GMT",
+        "MS-CV": "lblHdbveq0WVturwvrc8PQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0w9mXYwAAAABsR3Bt7\u002BaFTpPZr3zrmKNOUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0292YYwAAAADmuFXEguYxQKwdSnGXGt3jUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "253ms"
+        "X-Processing-Time": "295ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,9 +41,9 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e0cc0ab9602305eb50dfdc4118e0e060",
+        "x-ms-client-request-id": "c2de0f6d69c4a4b7df08de908814bbc5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:48 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:30 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -51,13 +51,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:47 GMT",
-        "MS-CV": "YH5UdLwNTkuR7/oKjmxutg.0",
+        "Date": "Tue, 13 Dec 2022 20:17:31 GMT",
+        "MS-CV": "dttM3hFH\u002B0mUOn8GVaCFog.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0xNmXYwAAAABshe9NGiNTQJhx4065rSZXUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0292YYwAAAABorfrearR7Qb2L7TtIcWrdUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "110ms"
+        "X-Processing-Time": "100ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -73,14 +73,14 @@
         "Content-Length": "88",
         "Content-Type": "application/merge-patch\u002Bjson",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "778b2fa53691e3fb811907598b9028a8",
+        "x-ms-client-request-id": "44037e4b0876a70e547605838c7bdca1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:48 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:30 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
+          "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com": {
             "sipSignalingPort": 3333
           }
         }
@@ -89,17 +89,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:48 GMT",
-        "MS-CV": "4rcyHoILVE6pE9qjjQuREw.0",
+        "Date": "Tue, 13 Dec 2022 20:17:31 GMT",
+        "MS-CV": "1Fg1\u002BPKxhUerTXNMP386oQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0xNmXYwAAAACVj74wqf\u002BYSZVPSHpqOegiUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0292YYwAAAABcxk32oK3zTIPXN2SbPDLxUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "858ms"
+        "X-Processing-Time": "621ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
+          "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -115,9 +115,9 @@
         "Content-Length": "185",
         "Content-Type": "application/merge-patch\u002Bjson",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4ec173501c57650fca2c66a739c79c00",
+        "x-ms-client-request-id": "dcb4392c62c1d791206bccbcfe933e33",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:49 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:31 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -127,7 +127,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
+              "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com"
             ]
           }
         ]
@@ -136,17 +136,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:49 GMT",
-        "MS-CV": "AOZiAvPQXkCJ7IGcOy4Usg.0",
+        "Date": "Tue, 13 Dec 2022 20:17:32 GMT",
+        "MS-CV": "Al1dK3nWtkaikfhO75yESg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0xdmXYwAAAADc2tZL\u002BMBAT6GcHQN/jMyYUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "03N2YYwAAAADq3QHuuHA4Q5eX9uoVPv6KUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "194ms"
+        "X-Processing-Time": "185ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
+          "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -156,50 +156,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "57380daeff6d838d0ee85e0959927ac0",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:49 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:49 GMT",
-        "MS-CV": "/znGI2UUg0WUQwGPKLvELQ.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0xtmXYwAAAABfthXnGYYWQ7ni/SN4q7sJUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "98ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
-            "sipSignalingPort": 3333
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle all numbers\u0027",
-            "name": "Alternative rule",
-            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
-            "trunks": [
-              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
+              "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com"
             ]
           }
         ]
@@ -212,9 +169,9 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a4f133b6911e88081f25ac65cf54aaba",
+        "x-ms-client-request-id": "fc1b27ab7bc5646e01366d4e64341864",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:49 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:31 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -222,17 +179,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:50 GMT",
-        "MS-CV": "HenTsb0djEKIm7koOr40oQ.0",
+        "Date": "Tue, 13 Dec 2022 20:17:32 GMT",
+        "MS-CV": "WQUbmI0rvUigCYAyiUY/2A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0xtmXYwAAAAA\u002Bu8873yhXRZx8gYIHhB/QUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "03N2YYwAAAABcpGBSd5koSaSV0UHlHbdLUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "248ms"
+        "X-Processing-Time": "92ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
+          "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -242,7 +199,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
+              "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com"
             ]
           }
         ]
@@ -255,9 +212,9 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7daa067dd158503be63e406ebd060b38",
+        "x-ms-client-request-id": "4f643d2bdf5fe803ed2b230b3b51a8c1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:50 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:32 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -265,17 +222,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:50 GMT",
-        "MS-CV": "uOmml15lNUiTsN2\u002BE1b\u002B\u002BQ.0",
+        "Date": "Tue, 13 Dec 2022 20:17:32 GMT",
+        "MS-CV": "9O4jhy4TR06gEijWTFEP1A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0x9mXYwAAAABtpAKUHAnZSZXEpTVLL1NFUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "03d2YYwAAAACS3KhVMpLBSrTg0V0jft8JUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "86ms"
+        "X-Processing-Time": "101ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
+          "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -285,7 +242,50 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
+              "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "64d7d138e05fb0dcca4fda8bf54273ec",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:32 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:17:32 GMT",
+        "MS-CV": "AEdUfxKUPk6ZQl5\u002B94q9Ng.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "03d2YYwAAAABQNmdUzexLR4t3JtZj2CBgUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "88ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle all numbers\u0027",
+            "name": "Alternative rule",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": [
+              "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com"
             ]
           }
         ]
@@ -300,14 +300,14 @@
         "Content-Length": "88",
         "Content-Type": "application/merge-patch\u002Bjson",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "05f0a6b2f8d61ce204af38475328b3ba",
+        "x-ms-client-request-id": "c1906853ee2eccd423330e9a576329b0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:50 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:32 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
+          "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com": {
             "sipSignalingPort": 9999
           }
         }
@@ -316,17 +316,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:50 GMT",
-        "MS-CV": "UPwUPBexA0Sb8Ajcw5zKgg.0",
+        "Date": "Tue, 13 Dec 2022 20:17:33 GMT",
+        "MS-CV": "d15JtDO/0EqZz4oKQ68FWQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0x9mXYwAAAACtJ8ReTmNmT5x924ifKOOsUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "03d2YYwAAAADLy0QGB15hSoI9lfoTJYB6UFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "386ms"
+        "X-Processing-Time": "274ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
+          "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -336,7 +336,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
+              "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com"
             ]
           }
         ]
@@ -351,14 +351,14 @@
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "538ca43efce7e568f8a0bddf519aca18",
+        "x-ms-client-request-id": "9216ac8db35c4b0461b3840f0478f2ab",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:51 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:32 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
+          "sbs1.4d3c7885-78eb-58e1-6aec-1e22eca02556.com": {
             "sipSignalingPort": 1122
           }
         }
@@ -367,20 +367,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:51 GMT",
-        "MS-CV": "myVpKIaFmkWklj7r/wJF6g.0",
+        "Date": "Tue, 13 Dec 2022 20:17:33 GMT",
+        "MS-CV": "e2jNgSQ3mUiVshUGsi9WNg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0x9mXYwAAAACnqXaL9yOnQJo2CKxB83LlUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "03d2YYwAAAACQfO/i92m1QYBqy\u002BCcr2wOUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "845ms"
+        "X-Processing-Time": "619ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
+          "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com": {
             "sipSignalingPort": 9999
           },
-          "sbs1.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
+          "sbs1.4d3c7885-78eb-58e1-6aec-1e22eca02556.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -390,7 +390,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
+              "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com"
             ]
           }
         ]
@@ -405,31 +405,31 @@
         "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "29b27419a46484e3238e79a898f4fdbe",
+        "x-ms-client-request-id": "d2b837b7e7c04992fd0b412cd1425967",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:52 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:33 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": null
+          "sbs1.4d3c7885-78eb-58e1-6aec-1e22eca02556.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:52 GMT",
-        "MS-CV": "2oQ1g1WLhE6PUy3Mb6xaOA.0",
+        "Date": "Tue, 13 Dec 2022 20:17:34 GMT",
+        "MS-CV": "CS5kEDqdT0a0uMSazp\u002Bnlg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0yNmXYwAAAAC\u002BO17CafxERql94GUkx\u002B4PUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "03t2YYwAAAADFAZEJLknET5ntuAmX2BBhUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "278ms"
+        "X-Processing-Time": "270ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
+          "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -439,7 +439,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
+              "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com"
             ]
           }
         ]
@@ -452,9 +452,9 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "182f858ab87ab5503e0b0d353a02cb69",
+        "x-ms-client-request-id": "48fd2a26e12b9f906445607b6ac4c7ab",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:52 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:34 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -462,17 +462,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:52 GMT",
-        "MS-CV": "AlRMryNRREOnI4EpKJxKfA.0",
+        "Date": "Tue, 13 Dec 2022 20:17:34 GMT",
+        "MS-CV": "JB8II0Er40eQ7bBZ3oIHFw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ydmXYwAAAAC/VhUwzbPSRrg3sOyeSY08UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0392YYwAAAAAO5DtPu7fwTociTRV/O3HQUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "86ms"
+        "X-Processing-Time": "85ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
+          "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -482,7 +482,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
+              "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com"
             ]
           }
         ]
@@ -495,9 +495,9 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "de2d1fe48a759956c1072f5982bf4c04",
+        "x-ms-client-request-id": "20e2634056aba6ef1acd955171d7791e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:52 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:34 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -505,17 +505,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:52 GMT",
-        "MS-CV": "YvpNVBf\u002B20aheeD3xEt19A.0",
+        "Date": "Tue, 13 Dec 2022 20:17:34 GMT",
+        "MS-CV": "4FXBMR5Go0ujGaGTHt1NDg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ydmXYwAAAAASSqb0nPwvSLsUo2A63mhSUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0392YYwAAAAAam3WHvhD4QrGgTfDQBgzXUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "91ms"
+        "X-Processing-Time": "90ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
+          "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -525,7 +525,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com"
+              "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com"
             ]
           }
         ]
@@ -534,6 +534,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "858719838"
+    "RandomSeed": "1735814703"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/Sample_SipRoutingClient/ManageSipConfigurationAsyncAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/Sample_SipRoutingClient/ManageSipConfigurationAsyncAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-80fe640224edaa44426a65b5852359e1-0913dd0f1014e131-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "108d19657d0cfe25262919cf2ebef4e0",
+        "traceparent": "00-a9c8d6bc5be545ed54253759329591fb-35ea6e7bf443017b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7790ad4ced1ee224d88fa98a22b51181",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:04:32 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,16 +22,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:04:31 GMT",
-        "MS-CV": "Xrmnmj\u002BY8EuXxgCJ4/E7BQ.0",
+        "Date": "Tue, 13 Dec 2022 01:47:52 GMT",
+        "MS-CV": "/h3PSt0vIEuMLXADDjzroA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0EIeOYwAAAABORA7X\u002B2MGQ6PPa\u002B1YibZwUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ydmXYwAAAABK\u002BV5E1VmiT5z\u002BaHuC/kUkUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "189ms"
+        "X-Processing-Time": "174ms"
       },
       "ResponseBody": {
-        "trunks": {},
+        "trunks": {
+          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
+            "sipSignalingPort": 9999
+          }
+        },
         "routes": []
       }
     },
@@ -41,11 +45,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-983edf1088ec30ba94b7b93c10c12d0f-1ef342b08519afd1-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f0c3d2fc16654133b2419f03c7ad344f",
+        "traceparent": "00-107e0fa8a46221bbf655fdd040a926d9-3961c6c3dfbbfe0e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "49a3f6133287f0187833a4eba0255604",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:04:32 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,16 +57,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:04:32 GMT",
-        "MS-CV": "vSOrR/Wrrkuwn9jFX68LZA.0",
+        "Date": "Tue, 13 Dec 2022 01:47:53 GMT",
+        "MS-CV": "Sx25zXOjskGZdpDX8XtiAQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0EIeOYwAAAABiLEYGo/3qRqnSLSBo14YMUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ydmXYwAAAACCEKFqPdfwRphtah4dw7\u002BJUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "78ms"
+        "X-Processing-Time": "97ms"
       },
       "ResponseBody": {
-        "trunks": {},
+        "trunks": {
+          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
+            "sipSignalingPort": 9999
+          }
+        },
         "routes": []
       }
     },
@@ -72,37 +80,38 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "51",
+        "Content-Length": "143",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-983edf1088ec30ba94b7b93c10c12d0f-597e769e6aef39b5-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f8e5ce854a3ab94c54a9435dd5c0ad2b",
+        "traceparent": "00-107e0fa8a46221bbf655fdd040a926d9-8b4c07845ed2e530-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "07446a92dbebb9259f4045cdd1e988e9",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:04:32 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
             "sipSignalingPort": 3333
-          }
+          },
+          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:04:32 GMT",
-        "MS-CV": "gy/hycJCgkmBlVyh/J/NsA.0",
+        "Date": "Tue, 13 Dec 2022 01:47:54 GMT",
+        "MS-CV": "/ew\u002BqNFNlEWRdPtyIgihrA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0EIeOYwAAAAChJb9/2S85QJKFHoURRGXSUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ytmXYwAAAACMOSgZ2aigRYyF6H3S0zFOUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "628ms"
+        "X-Processing-Time": "797ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -115,13 +124,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "148",
+        "Content-Length": "185",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-23a838bec72f65c68cf6241a394c60b9-7d92f1c79a0ebca8-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0967d08e4af64eafe54b5dcbdd223779",
+        "traceparent": "00-e846a9302ca7cebce4339e3718ec2add-f1ddc93aa4e41776-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d136bb8f246f1a1494a0ffea483842b2",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:04:33 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:54 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -131,7 +140,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.com"
+              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
             ]
           }
         ]
@@ -140,17 +149,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:04:33 GMT",
-        "MS-CV": "MYrCt9uSd0W7MQT7jv8Tcw.0",
+        "Date": "Tue, 13 Dec 2022 01:47:54 GMT",
+        "MS-CV": "KIuibQX6fkSXkupDjXLY5Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0EYeOYwAAAADYtJqhhUjkTrVDhCcRcTEjUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0y9mXYwAAAACM/UbJUEv0QZC6B2Qo5WpdUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "987ms"
+        "X-Processing-Time": "191ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -160,51 +169,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-1f7b8bddecbee53993606f2117c38fd7-bc06cb67bdb70859-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5f49caf4fbd9b1a6860a9bbbd3d66cf2",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:04:34 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:04:35 GMT",
-        "MS-CV": "VAj5zPusKEuDSS8aUi57rA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0EoeOYwAAAADlZXM7fLmoQYrPDdUxoXi1UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "1757ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "newsbs.com": {
-            "sipSignalingPort": 3333
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle all numbers\u0027",
-            "name": "Alternative rule",
-            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
-            "trunks": [
-              "newsbs.com"
+              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
             ]
           }
         ]
@@ -216,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-8e2c159546249508991000b32b808af4-c691f8489cbc030f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f77574932a453a581f9612efed81db32",
+        "traceparent": "00-906bba27cd57e59e2f887d8d203c1f23-798881e1fc55007b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b7f7a5390a703796d0eaa946ec4b1f8e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:04:36 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:54 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -228,17 +193,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:04:35 GMT",
-        "MS-CV": "SJGwv4LtKUa8SLCmiQ/fpw.0",
+        "Date": "Tue, 13 Dec 2022 01:47:54 GMT",
+        "MS-CV": "cjj8vSVa3EyLGfKdXGIlNg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0FIeOYwAAAACFP0rwOVrHRbmxhixWP\u002B07UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0y9mXYwAAAACbUMJJoFmSTI4QEVippb1XUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "88ms"
+        "X-Processing-Time": "100ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -248,7 +213,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.com"
+              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
             ]
           }
         ]
@@ -260,11 +225,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-a08dd2cf0f8377ecca7aed88ec5341f7-2441a43a20429ec9-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0b68c9724e76925129b683ecaef47b0f",
+        "traceparent": "00-28072394a4bc744ed01b1454d993254b-7a42b875ce5f096a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e45bbbab84ef6e945529724bdb3b7067",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:04:36 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -272,17 +237,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:04:36 GMT",
-        "MS-CV": "s\u002Bn/3vWhCEisbWIolVAWxA.0",
+        "Date": "Tue, 13 Dec 2022 01:47:54 GMT",
+        "MS-CV": "YvVYQSYWHE\u002BCiMYByp0xTw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0FIeOYwAAAAA9k\u002B\u002BHwe3lS74kLYtmAY9wUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0y9mXYwAAAAByifp21B9VRJZgtgY/wRGUUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
+        "X-Processing-Time": "99ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -292,7 +257,51 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.com"
+              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-eaa127062a6777d9c9aca11fbd3d57a4-454cb9b5002dc274-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2b9493fed0f1857825fe00847ace2e49",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:55 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:47:55 GMT",
+        "MS-CV": "eHrEuRMmRUmXV7Zm\u002B90PTQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0y9mXYwAAAADE3MFhPpu1T4n0g6c8ffxmUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "101ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle all numbers\u0027",
+            "name": "Alternative rule",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": [
+              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
             ]
           }
         ]
@@ -304,18 +313,18 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "51",
+        "Content-Length": "88",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-374d50124be590cfd2d338d0496262cf-aee1f966c4eb82eb-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "68376bdf40adca33710e4043e8b7c405",
+        "traceparent": "00-0d0928b2659e1b06a0f628189f858539-1738578be4be3a8d-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8d3f70815dddb4c210886147984b5b95",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:04:37 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
             "sipSignalingPort": 9999
           }
         }
@@ -324,17 +333,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:04:36 GMT",
-        "MS-CV": "PfHVkzynYUS85LYwDN/Nsg.0",
+        "Date": "Tue, 13 Dec 2022 01:47:55 GMT",
+        "MS-CV": "YbNdQv2l5kyKUaGXH3WjbQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0FYeOYwAAAADGsy3JkdbfRYHrK6vmd9kLUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0y9mXYwAAAAC33E7oCFqkSpCo2JYRSAvQUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "250ms"
+        "X-Processing-Time": "470ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -344,7 +353,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.com"
+              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
             ]
           }
         ]
@@ -356,18 +365,18 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "49",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-df9e65f2dd5672d5a0dcd9caa3322fd6-f3997be8a62a8bec-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0948692e616d457b23e2cd8fa76c8b2a",
+        "traceparent": "00-1128d9b2933ccb7b2276d206cea4734f-de2ca5b9b8c9915a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5848427af3b7da9d43d6bff18410f487",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:04:37 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:56 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
             "sipSignalingPort": 1122
           }
         }
@@ -376,20 +385,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:04:37 GMT",
-        "MS-CV": "8DgpZejlhkGy\u002B0vgb6UZzA.0",
+        "Date": "Tue, 13 Dec 2022 01:47:56 GMT",
+        "MS-CV": "BkkUfBMj10aVvj/Px7m2uA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0FYeOYwAAAADCsnOpZD6tQLHp1nLjXyxhUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0zNmXYwAAAACQrkesFeuRTrhwrxDqG8lVUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "598ms"
+        "X-Processing-Time": "509ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
             "sipSignalingPort": 9999
           },
-          "sbs1.com": {
+          "sbs1.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -399,7 +408,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.com"
+              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
             ]
           }
         ]
@@ -411,35 +420,35 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "28",
+        "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-522a688790d475044ae3a2b46414e404-e4acd4686ec7fcd7-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "810f031b73493284969e9a680d0ea972",
+        "traceparent": "00-b3e09e1500ae0b7bbe02c0b009462e4c-eab95a6d2fd07c32-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6bca28fbe3fca18ad0df1a696f31edd9",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:04:38 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:56 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": null
+          "sbs1.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:04:38 GMT",
-        "MS-CV": "0GvVzsRYB0al3C8f5pEa3A.0",
+        "Date": "Tue, 13 Dec 2022 01:47:56 GMT",
+        "MS-CV": "bJBo\u002BmOlB0KyQpnb2vauUw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0FoeOYwAAAAAohf\u002BdtwgjQLNwysETl4lgUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0zdmXYwAAAACNvDBQkvwWRbvz\u002B58EQE1zUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "1380ms"
+        "X-Processing-Time": "306ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -449,7 +458,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.com"
+              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
             ]
           }
         ]
@@ -461,11 +470,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-913727469fe0415d3ef084816d66af08-f7a0f9892aa363a0-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "45bd7ef271ab7ea1eff245ca72a42304",
+        "traceparent": "00-3eda5c5d3cd391f8965c23b8b56b5ff7-704237f2ce2b3019-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "380a6ba2d5858d92d36549069dd12f00",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:04:39 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -473,17 +482,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:04:39 GMT",
-        "MS-CV": "g\u002BZRThGw9Uyq1TF87C/mVA.0",
+        "Date": "Tue, 13 Dec 2022 01:47:56 GMT",
+        "MS-CV": "S5IxfCsVSEWvaqdbtN6B8w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0F4eOYwAAAAA1VukzaZV3SYIbBnDfASMEUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0zdmXYwAAAACXtQQ3VweQRYWD0JH\u002BJ1A0UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "154ms"
+        "X-Processing-Time": "96ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -493,7 +502,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.com"
+              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
             ]
           }
         ]
@@ -505,11 +514,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-ae29ea21787d997a142032fcaf151cb6-3cb58b338b7b115f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e527158242a7bbbbe41673cfc7133815",
+        "traceparent": "00-faae1a83ac84f9d8c514ddc218a95c97-38a53f508a9b44cc-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6f4bda94f0819799b8a688d7d9336b12",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 06 Dec 2022 00:04:39 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -517,17 +526,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 06 Dec 2022 00:04:39 GMT",
-        "MS-CV": "C7Hw/gyPKECecJRDOSgZpA.0",
+        "Date": "Tue, 13 Dec 2022 01:47:58 GMT",
+        "MS-CV": "hlHqC9WxWUSZ0AdI8fhviw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0F4eOYwAAAACsFbqH4fF2QYfGPRzl/xvZUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0zdmXYwAAAADfJJ7IJkpYQblraF6knk/0UFJHMDFFREdFMDkwOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "209ms"
+        "X-Processing-Time": "212ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -537,7 +546,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.com"
+              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
             ]
           }
         ]
@@ -546,6 +555,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "570007183"
+    "RandomSeed": "1067311688"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/Sample_SipRoutingClient/ManageSipConfigurationAsyncAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/Sample_SipRoutingClient/ManageSipConfigurationAsyncAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-017fd6ab6f482a75ff2dd4d77408665e-0e0cb7792d374be4-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7eabc323c5b85ab5a28a4477024e33ad",
+        "traceparent": "00-80fe640224edaa44426a65b5852359e1-0913dd0f1014e131-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "108d19657d0cfe25262919cf2ebef4e0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:11 GMT",
+        "x-ms-date": "Tue, 06 Dec 2022 00:04:32 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,23 +22,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:12 GMT",
-        "MS-CV": "s/Cx4ve6h02JkzibtGGk0g.0",
+        "Date": "Tue, 06 Dec 2022 00:04:31 GMT",
+        "MS-CV": "Xrmnmj\u002BY8EuXxgCJ4/E7BQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02NdDYwAAAAD76auogjsxTbkw9OMDVU47TFRTRURHRTEyMjAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0EIeOYwAAAABORA7X\u002B2MGQ6PPa\u002B1YibZwUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "299ms"
+        "X-Processing-Time": "189ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.sipconfigtest.com": {
-            "sipSignalingPort": 9999
-          },
-          "sbs2.sipconfigtest.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -48,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-23f3d60dac3a71bc8cbaa015c835da54-06af6addd87dc920-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "db84e44fd75e4e6b8b978832923039cc",
+        "traceparent": "00-983edf1088ec30ba94b7b93c10c12d0f-1ef342b08519afd1-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f0c3d2fc16654133b2419f03c7ad344f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:12 GMT",
+        "x-ms-date": "Tue, 06 Dec 2022 00:04:32 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,23 +53,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:12 GMT",
-        "MS-CV": "Sw6j2O/3nkuREkwVJgGJiw.0",
+        "Date": "Tue, 06 Dec 2022 00:04:32 GMT",
+        "MS-CV": "vSOrR/Wrrkuwn9jFX68LZA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02NdDYwAAAADgiQhyXg9WRYLptN3bKKOATFRTRURHRTEyMjAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0EIeOYwAAAABiLEYGo/3qRqnSLSBo14YMUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "80ms"
+        "X-Processing-Time": "78ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.sipconfigtest.com": {
-            "sipSignalingPort": 9999
-          },
-          "sbs2.sipconfigtest.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -86,39 +72,37 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "125",
+        "Content-Length": "51",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-23f3d60dac3a71bc8cbaa015c835da54-7da50ec6bce2458e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a75bd8a3dd0ea68550d53b3d227a5e84",
+        "traceparent": "00-983edf1088ec30ba94b7b93c10c12d0f-597e769e6aef39b5-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f8e5ce854a3ab94c54a9435dd5c0ad2b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:12 GMT",
+        "x-ms-date": "Tue, 06 Dec 2022 00:04:32 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
-          },
-          "sbs1.sipconfigtest.com": null,
-          "sbs2.sipconfigtest.com": null
+          }
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:13 GMT",
-        "MS-CV": "IjfZUSTc4Ea6JlNSRv7Lvg.0",
+        "Date": "Tue, 06 Dec 2022 00:04:32 GMT",
+        "MS-CV": "gy/hycJCgkmBlVyh/J/NsA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02ddDYwAAAACUvZA1B3X6S7LuEYo/Xbx9TFRTRURHRTEyMjAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0EIeOYwAAAAChJb9/2S85QJKFHoURRGXSUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "796ms"
+        "X-Processing-Time": "628ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -131,13 +115,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "162",
+        "Content-Length": "148",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-84c8fc6fb83681ec9529d3ef0dd8deb8-44d3cb1565ef9f50-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "be36a83a40be4b92575cf2203c82c871",
+        "traceparent": "00-23a838bec72f65c68cf6241a394c60b9-7d92f1c79a0ebca8-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0967d08e4af64eafe54b5dcbdd223779",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:13 GMT",
+        "x-ms-date": "Tue, 06 Dec 2022 00:04:33 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -147,7 +131,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.sipconfigtest.com"
+              "newsbs.com"
             ]
           }
         ]
@@ -156,17 +140,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:14 GMT",
-        "MS-CV": "4lJcfWzAJkqeoXL5LE4vnw.0",
+        "Date": "Tue, 06 Dec 2022 00:04:33 GMT",
+        "MS-CV": "MYrCt9uSd0W7MQT7jv8Tcw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02tdDYwAAAABxpAQqAWrnQ6qWDUXmr3QHTFRTRURHRTEyMjAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0EYeOYwAAAADYtJqhhUjkTrVDhCcRcTEjUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "157ms"
+        "X-Processing-Time": "987ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -176,51 +160,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.sipconfigtest.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-59e5fdd2b1d1368546de97d686cf2737-392e640eba5f93dd-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2ad477518bf3719f5fde8b889c2e2b11",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:13 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:14 GMT",
-        "MS-CV": "9hNWU7iQhEqE04Tra9M96Q.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02tdDYwAAAAB6g/yqzpVTTYCuJ0\u002BXWvlbTFRTRURHRTEyMjAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "71ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "newsbs.sipconfigtest.com": {
-            "sipSignalingPort": 3333
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle all numbers\u0027",
-            "name": "Alternative rule",
-            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
-            "trunks": [
-              "newsbs.sipconfigtest.com"
+              "newsbs.com"
             ]
           }
         ]
@@ -232,11 +172,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-62cacbdb06791c2012db46af82228fc2-88ab8e120a99d04c-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e9f804397afa620e460f50b1eb6469cd",
+        "traceparent": "00-1f7b8bddecbee53993606f2117c38fd7-bc06cb67bdb70859-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5f49caf4fbd9b1a6860a9bbbd3d66cf2",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:13 GMT",
+        "x-ms-date": "Tue, 06 Dec 2022 00:04:34 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -244,17 +184,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:14 GMT",
-        "MS-CV": "jEjfvmeHSE6Mk1aiEBUfLw.0",
+        "Date": "Tue, 06 Dec 2022 00:04:35 GMT",
+        "MS-CV": "VAj5zPusKEuDSS8aUi57rA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02tdDYwAAAADYnfoWasHDTYMMNgAoCHE7TFRTRURHRTEyMjAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0EoeOYwAAAADlZXM7fLmoQYrPDdUxoXi1UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "72ms"
+        "X-Processing-Time": "1757ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -264,7 +204,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.sipconfigtest.com"
+              "newsbs.com"
             ]
           }
         ]
@@ -276,11 +216,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-1521b06fe9559916714349ad02dc1be5-2d883749f6804fb0-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "aaecca0d33a6ae9109c55fdfb509af28",
+        "traceparent": "00-8e2c159546249508991000b32b808af4-c691f8489cbc030f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f77574932a453a581f9612efed81db32",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:14 GMT",
+        "x-ms-date": "Tue, 06 Dec 2022 00:04:36 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -288,17 +228,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:14 GMT",
-        "MS-CV": "KwyCqjf5tEmec8lbuMT5Xg.0",
+        "Date": "Tue, 06 Dec 2022 00:04:35 GMT",
+        "MS-CV": "SJGwv4LtKUa8SLCmiQ/fpw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02tdDYwAAAAAuG0NJr0uwRpTPPhssUYy/TFRTRURHRTEyMjAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0FIeOYwAAAACFP0rwOVrHRbmxhixWP\u002B07UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "86ms"
+        "X-Processing-Time": "88ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -308,7 +248,51 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.sipconfigtest.com"
+              "newsbs.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a08dd2cf0f8377ecca7aed88ec5341f7-2441a43a20429ec9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0b68c9724e76925129b683ecaef47b0f",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 06 Dec 2022 00:04:36 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 06 Dec 2022 00:04:36 GMT",
+        "MS-CV": "s\u002Bn/3vWhCEisbWIolVAWxA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0FIeOYwAAAAA9k\u002B\u002BHwe3lS74kLYtmAY9wUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "89ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle all numbers\u0027",
+            "name": "Alternative rule",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": [
+              "newsbs.com"
             ]
           }
         ]
@@ -320,18 +304,18 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "65",
+        "Content-Length": "51",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-1cf39234cc4811781a2dcaf4796f68d7-578a98731e25ab1b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "38e6e131de8ad6776971e4e33aed85fa",
+        "traceparent": "00-374d50124be590cfd2d338d0496262cf-aee1f966c4eb82eb-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "68376bdf40adca33710e4043e8b7c405",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:14 GMT",
+        "x-ms-date": "Tue, 06 Dec 2022 00:04:37 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 9999
           }
         }
@@ -340,17 +324,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:15 GMT",
-        "MS-CV": "duXFY7OxjkKgJmPbgCZaLg.0",
+        "Date": "Tue, 06 Dec 2022 00:04:36 GMT",
+        "MS-CV": "PfHVkzynYUS85LYwDN/Nsg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02tdDYwAAAAACdK3i/PkYRp0ifucKIV04TFRTRURHRTEyMjAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0FYeOYwAAAADGsy3JkdbfRYHrK6vmd9kLUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "326ms"
+        "X-Processing-Time": "250ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -360,7 +344,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.sipconfigtest.com"
+              "newsbs.com"
             ]
           }
         ]
@@ -372,18 +356,18 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "63",
+        "Content-Length": "49",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-dbeba8302f92bc67ac87e3b96e1d5ece-29ad1213b82cbe3b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d17abd748042066a7249df341b2ead3c",
+        "traceparent": "00-df9e65f2dd5672d5a0dcd9caa3322fd6-f3997be8a62a8bec-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0948692e616d457b23e2cd8fa76c8b2a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:14 GMT",
+        "x-ms-date": "Tue, 06 Dec 2022 00:04:37 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           }
         }
@@ -392,20 +376,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:15 GMT",
-        "MS-CV": "mN3HKIOtVUiE2Sv9k1g7yg.0",
+        "Date": "Tue, 06 Dec 2022 00:04:37 GMT",
+        "MS-CV": "8DgpZejlhkGy\u002B0vgb6UZzA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "029dDYwAAAACyyGcWxyBdRp2KEdlOhuhXTFRTRURHRTEyMjAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0FYeOYwAAAADCsnOpZD6tQLHp1nLjXyxhUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "432ms"
+        "X-Processing-Time": "598ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 9999
           },
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -415,7 +399,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.sipconfigtest.com"
+              "newsbs.com"
             ]
           }
         ]
@@ -427,35 +411,35 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "42",
+        "Content-Length": "28",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-f22864ce7ce0a4d6eb6bc9d9a33dd511-5561b016fafa957f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0a802760317d2e43521541344fad731c",
+        "traceparent": "00-522a688790d475044ae3a2b46414e404-e4acd4686ec7fcd7-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "810f031b73493284969e9a680d0ea972",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:15 GMT",
+        "x-ms-date": "Tue, 06 Dec 2022 00:04:38 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": null
+          "sbs1.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:15 GMT",
-        "MS-CV": "mRl3cqZ8FECWuUvPZZ1hUA.0",
+        "Date": "Tue, 06 Dec 2022 00:04:38 GMT",
+        "MS-CV": "0GvVzsRYB0al3C8f5pEa3A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "029dDYwAAAACTGhGrTWWWRID7bo9tIuD9TFRTRURHRTEyMjAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0FoeOYwAAAAAohf\u002BdtwgjQLNwysETl4lgUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "255ms"
+        "X-Processing-Time": "1380ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -465,7 +449,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.sipconfigtest.com"
+              "newsbs.com"
             ]
           }
         ]
@@ -477,11 +461,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-192d07b1195384ffe362b757f6ed1fbc-4fcf986a460b70ec-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f76a6440de8eb0e676e0c540ff43bb3a",
+        "traceparent": "00-913727469fe0415d3ef084816d66af08-f7a0f9892aa363a0-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "45bd7ef271ab7ea1eff245ca72a42304",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:15 GMT",
+        "x-ms-date": "Tue, 06 Dec 2022 00:04:39 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -489,17 +473,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:16 GMT",
-        "MS-CV": "9ZnRjCZmDkKiJc6xVISfVQ.0",
+        "Date": "Tue, 06 Dec 2022 00:04:39 GMT",
+        "MS-CV": "g\u002BZRThGw9Uyq1TF87C/mVA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "03NdDYwAAAADE2YTKQBabSYJMowA4MaowTFRTRURHRTEyMjAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0F4eOYwAAAAA1VukzaZV3SYIbBnDfASMEUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "192ms"
+        "X-Processing-Time": "154ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -509,7 +493,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.sipconfigtest.com"
+              "newsbs.com"
             ]
           }
         ]
@@ -521,11 +505,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-cf3c30eb66be16a0f2fd59b327178200-0040169434e082be-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1383a7c37a6d437c7a4c7e2d3f36b7c4",
+        "traceparent": "00-ae29ea21787d997a142032fcaf151cb6-3cb58b338b7b115f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e527158242a7bbbbe41673cfc7133815",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:29:15 GMT",
+        "x-ms-date": "Tue, 06 Dec 2022 00:04:39 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -533,17 +517,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:29:16 GMT",
-        "MS-CV": "Njgw/FAOfEuO\u002BGoc15\u002Besg.0",
+        "Date": "Tue, 06 Dec 2022 00:04:39 GMT",
+        "MS-CV": "C7Hw/gyPKECecJRDOSgZpA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "03NdDYwAAAAD/MhBgxx6sTY\u002Br6WIz0GhiTE9OMjFFREdFMTcwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0F4eOYwAAAACsFbqH4fF2QYfGPRzl/xvZUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "176ms"
+        "X-Processing-Time": "209ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -553,7 +537,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.sipconfigtest.com"
+              "newsbs.com"
             ]
           }
         ]
@@ -561,7 +545,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1177580981"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "570007183"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/Sample_SipRoutingClient/ManageSipConfigurationAsyncAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/Sample_SipRoutingClient/ManageSipConfigurationAsyncAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-a9c8d6bc5be545ed54253759329591fb-35ea6e7bf443017b-00",
+        "traceparent": "00-d011e3ba49f654c3de8bc140ebeb1ce8-e633e2e5e9ba7f18-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7790ad4ced1ee224d88fa98a22b51181",
+        "x-ms-client-request-id": "de5d38a18c57fa428138dcaed104477b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:53 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:34 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,17 +22,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:52 GMT",
-        "MS-CV": "/h3PSt0vIEuMLXADDjzroA.0",
+        "Date": "Tue, 13 Dec 2022 20:17:35 GMT",
+        "MS-CV": "6/fqjv0Ms0qtuXa2IJk12w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ydmXYwAAAABK\u002BV5E1VmiT5z\u002BaHuC/kUkUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0392YYwAAAADX3kwBsk5cS6UhmHlIAA3rUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "174ms"
+        "X-Processing-Time": "186ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
+          "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -45,11 +45,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-107e0fa8a46221bbf655fdd040a926d9-3961c6c3dfbbfe0e-00",
+        "traceparent": "00-ef13900344b9fd3bd4dff52e3b414088-861deecfbf88d032-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "49a3f6133287f0187833a4eba0255604",
+        "x-ms-client-request-id": "4fb7889253d3083e7aa5f4bb76ae16ad",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:53 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:34 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -57,17 +57,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:53 GMT",
-        "MS-CV": "Sx25zXOjskGZdpDX8XtiAQ.0",
+        "Date": "Tue, 13 Dec 2022 20:17:35 GMT",
+        "MS-CV": "WbwgK1OovUSNi01CR6E5xg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ydmXYwAAAACCEKFqPdfwRphtah4dw7\u002BJUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0392YYwAAAABknhBp7/TIQq/l9/oSd0ElUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "97ms"
+        "X-Processing-Time": "90ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": {
+          "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -82,36 +82,36 @@
         "Authorization": "Sanitized",
         "Content-Length": "143",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-107e0fa8a46221bbf655fdd040a926d9-8b4c07845ed2e530-00",
+        "traceparent": "00-ef13900344b9fd3bd4dff52e3b414088-ed51a29bbdb58956-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "07446a92dbebb9259f4045cdd1e988e9",
+        "x-ms-client-request-id": "89546b2254a0b48eee6aacebf3e07e87",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:53 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:35 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
+          "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com": {
             "sipSignalingPort": 3333
           },
-          "newsbs.e8ce8af9-f8e8-af6d-a0c8-927b5924fd32.com": null
+          "newsbs.4d3c7885-78eb-58e1-6aec-1e22eca02556.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:54 GMT",
-        "MS-CV": "/ew\u002BqNFNlEWRdPtyIgihrA.0",
+        "Date": "Tue, 13 Dec 2022 20:17:36 GMT",
+        "MS-CV": "NzjHa2w2jUaG2D4GNH3HKA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ytmXYwAAAACMOSgZ2aigRYyF6H3S0zFOUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "04N2YYwAAAACftungqp18Rr2i0PSkzhP2UFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "797ms"
+        "X-Processing-Time": "570ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
+          "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -126,11 +126,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "185",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-e846a9302ca7cebce4339e3718ec2add-f1ddc93aa4e41776-00",
+        "traceparent": "00-9474665c64e3b62ad811724e4ca938a4-ebdf33242cc2fe14-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d136bb8f246f1a1494a0ffea483842b2",
+        "x-ms-client-request-id": "012a933079b24d43fa5563b2988683d2",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:54 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:35 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -140,7 +140,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
+              "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com"
             ]
           }
         ]
@@ -149,17 +149,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:54 GMT",
-        "MS-CV": "KIuibQX6fkSXkupDjXLY5Q.0",
+        "Date": "Tue, 13 Dec 2022 20:17:36 GMT",
+        "MS-CV": "cqbVVFvSYk6Bknx72Ae19A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0y9mXYwAAAACM/UbJUEv0QZC6B2Qo5WpdUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "04N2YYwAAAACKP/PgXeacSIXpldNB27WQUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "191ms"
+        "X-Processing-Time": "192ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
+          "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -169,51 +169,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-906bba27cd57e59e2f887d8d203c1f23-798881e1fc55007b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b7f7a5390a703796d0eaa946ec4b1f8e",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:54 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:54 GMT",
-        "MS-CV": "cjj8vSVa3EyLGfKdXGIlNg.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0y9mXYwAAAACbUMJJoFmSTI4QEVippb1XUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "100ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
-            "sipSignalingPort": 3333
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle all numbers\u0027",
-            "name": "Alternative rule",
-            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
-            "trunks": [
-              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
+              "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com"
             ]
           }
         ]
@@ -225,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-28072394a4bc744ed01b1454d993254b-7a42b875ce5f096a-00",
+        "traceparent": "00-8a8884f0fa0b08e211e173acd01415f5-de6b4f87af6d1688-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e45bbbab84ef6e945529724bdb3b7067",
+        "x-ms-client-request-id": "658c2e21bdaf3edafa036168a753149a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:55 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:36 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -237,17 +193,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:54 GMT",
-        "MS-CV": "YvVYQSYWHE\u002BCiMYByp0xTw.0",
+        "Date": "Tue, 13 Dec 2022 20:17:36 GMT",
+        "MS-CV": "aYtQRVfgWEGbLH2u9sh0qw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0y9mXYwAAAAByifp21B9VRJZgtgY/wRGUUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "04d2YYwAAAADxj3yw\u002B1X9S6IZorEQdh\u002BsUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "99ms"
+        "X-Processing-Time": "91ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
+          "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -257,7 +213,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
+              "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com"
             ]
           }
         ]
@@ -269,11 +225,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-eaa127062a6777d9c9aca11fbd3d57a4-454cb9b5002dc274-00",
+        "traceparent": "00-879a1561f64b9872013ea285c2d61b13-b8d2381e184c6912-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2b9493fed0f1857825fe00847ace2e49",
+        "x-ms-client-request-id": "e28a6c261584a8fa27068f4bf1db1b68",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:55 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:36 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -281,17 +237,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:55 GMT",
-        "MS-CV": "eHrEuRMmRUmXV7Zm\u002B90PTQ.0",
+        "Date": "Tue, 13 Dec 2022 20:17:36 GMT",
+        "MS-CV": "BQpJtxKLCkS4lypwAj/k1Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0y9mXYwAAAADE3MFhPpu1T4n0g6c8ffxmUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "04d2YYwAAAAAhp7q1mPwATaC1HFvk3JcQUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "101ms"
+        "X-Processing-Time": "102ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
+          "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -301,7 +257,51 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
+              "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b326ae4f3e2d7b2da34d8350588ebec4-9120d2cc344c654b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c5c9d9e6185473d8b9ec06af18daa6a7",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:36 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:17:36 GMT",
+        "MS-CV": "gw6YV\u002BbRDUaKxBVcFqdyaQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "04d2YYwAAAAC\u002BGu5R8vhnRrtSwWKJS59wUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "92ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle all numbers\u0027",
+            "name": "Alternative rule",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": [
+              "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com"
             ]
           }
         ]
@@ -315,16 +315,16 @@
         "Authorization": "Sanitized",
         "Content-Length": "88",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-0d0928b2659e1b06a0f628189f858539-1738578be4be3a8d-00",
+        "traceparent": "00-edcad9e2c7708933c0f770b9d791febd-579dc672948ed578-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8d3f70815dddb4c210886147984b5b95",
+        "x-ms-client-request-id": "2c8bc840a1fb0b4e33e33ea82e8f4c1e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:55 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:36 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
+          "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com": {
             "sipSignalingPort": 9999
           }
         }
@@ -333,17 +333,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:55 GMT",
-        "MS-CV": "YbNdQv2l5kyKUaGXH3WjbQ.0",
+        "Date": "Tue, 13 Dec 2022 20:17:37 GMT",
+        "MS-CV": "NKijmloBNE624jEuEdzWgw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0y9mXYwAAAAC33E7oCFqkSpCo2JYRSAvQUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "04d2YYwAAAACQdEtw6PAoRI/Tft3\u002BAbtnUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "470ms"
+        "X-Processing-Time": "242ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
+          "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -353,7 +353,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
+              "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com"
             ]
           }
         ]
@@ -367,16 +367,16 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-1128d9b2933ccb7b2276d206cea4734f-de2ca5b9b8c9915a-00",
+        "traceparent": "00-ced89c933b443232609ff3ec517ccaf5-a9a7d209b7f2469b-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5848427af3b7da9d43d6bff18410f487",
+        "x-ms-client-request-id": "cd82f9e74f890e46941729970e4b904c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:56 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:37 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
+          "sbs1.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com": {
             "sipSignalingPort": 1122
           }
         }
@@ -385,20 +385,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:56 GMT",
-        "MS-CV": "BkkUfBMj10aVvj/Px7m2uA.0",
+        "Date": "Tue, 13 Dec 2022 20:17:37 GMT",
+        "MS-CV": "DfqHcVRsUkukWovEhN6tpQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0zNmXYwAAAACQrkesFeuRTrhwrxDqG8lVUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "04t2YYwAAAACIPfEu1\u002BqJQqeOoAWffl0dUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "509ms"
+        "X-Processing-Time": "468ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
+          "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com": {
             "sipSignalingPort": 9999
           },
-          "sbs1.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
+          "sbs1.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -408,7 +408,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
+              "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com"
             ]
           }
         ]
@@ -422,33 +422,33 @@
         "Authorization": "Sanitized",
         "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-b3e09e1500ae0b7bbe02c0b009462e4c-eab95a6d2fd07c32-00",
+        "traceparent": "00-899e05496d01f93ae9f73c7693f3156e-4943ecc90bc5c6ca-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6bca28fbe3fca18ad0df1a696f31edd9",
+        "x-ms-client-request-id": "280ae75fef50456c8abd9170da2f4429",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:56 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:37 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": null
+          "sbs1.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:56 GMT",
-        "MS-CV": "bJBo\u002BmOlB0KyQpnb2vauUw.0",
+        "Date": "Tue, 13 Dec 2022 20:17:38 GMT",
+        "MS-CV": "VxAYFiLKX0G3NqE/kb8uMw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0zdmXYwAAAACNvDBQkvwWRbvz\u002B58EQE1zUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "04t2YYwAAAABFGpC4DgsjSosNpOXoLLhvUFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "306ms"
+        "X-Processing-Time": "267ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
+          "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -458,7 +458,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
+              "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com"
             ]
           }
         ]
@@ -470,11 +470,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-3eda5c5d3cd391f8965c23b8b56b5ff7-704237f2ce2b3019-00",
+        "traceparent": "00-fefcd6a21dabe7f524184c158e591a11-992566a053ffe11b-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "380a6ba2d5858d92d36549069dd12f00",
+        "x-ms-client-request-id": "1ec7e79fd958f11d827d97e377b7fde7",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:57 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:38 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -482,17 +482,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:56 GMT",
-        "MS-CV": "S5IxfCsVSEWvaqdbtN6B8w.0",
+        "Date": "Tue, 13 Dec 2022 20:17:38 GMT",
+        "MS-CV": "e3AVXlsaJ0KTkK8CRAw0SQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0zdmXYwAAAACXtQQ3VweQRYWD0JH\u002BJ1A0UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0492YYwAAAABoGnCa7k1HTrscKHmzbL/3UFJHMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "96ms"
+        "X-Processing-Time": "165ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
+          "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -502,7 +502,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
+              "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com"
             ]
           }
         ]
@@ -514,11 +514,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-faae1a83ac84f9d8c514ddc218a95c97-38a53f508a9b44cc-00",
+        "traceparent": "00-8f0a896d8715be963c779dc697ecb2e1-20f194ca7f8d63b0-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6f4bda94f0819799b8a688d7d9336b12",
+        "x-ms-client-request-id": "4648f1532384f7ce8c3c43cbbdd53465",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:57 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:38 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -526,17 +526,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:58 GMT",
-        "MS-CV": "hlHqC9WxWUSZ0AdI8fhviw.0",
+        "Date": "Tue, 13 Dec 2022 20:17:38 GMT",
+        "MS-CV": "uzDG\u002BEI7DkiVr9o1qNyO7Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0zdmXYwAAAADfJJ7IJkpYQblraF6knk/0UFJHMDFFREdFMDkwOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0492YYwAAAADNFSaTsNafRK6FrdhDRplPUFJHMDFFREdFMDkxMAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "212ms"
+        "X-Processing-Time": "109ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com": {
+          "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com": {
             "sipSignalingPort": 9999
           }
         },
@@ -546,7 +546,7 @@
             "name": "Alternative rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "newsbs.1e22c4a6-7a5c-ab73-9ea1-3c49c7136d9c.com"
+              "newsbs.2d643040-cf23-4f8f-8c78-0ebd8a6ac916.com"
             ]
           }
         ]
@@ -555,6 +555,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1067311688"
+    "RandomSeed": "510119102"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-0a74e6d060a20a0218b4885ac3974d63-44fb2fd585913621-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "41d65a22845b766dbaf308999bf2b912",
+        "traceparent": "00-b8088e92e202191f92bf9d5cfa2982e3-79750cb2e3e448a6-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e3d7c6bf461b8063c1d39ae098625e2c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:50:58 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:33 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:50:58 GMT",
-        "MS-CV": "Hi5ehuFjik6EKB0fdBgDTQ.0",
+        "Date": "Tue, 13 Dec 2022 01:18:34 GMT",
+        "MS-CV": "jMLeFeUoBUSkRQe9mDFtOg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "04oOOYwAAAADeP3bbLFpUQ69Dk518\u002BkPEUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "06dKXYwAAAAAZuQ33OLiURbx1r23oH6jvUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "298ms"
+        "X-Processing-Time": "335ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-306fb22dbfcff6d1719a2012b2941f14-4f609b95a08118a7-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "da9f5b9d62c38b316e29bb8c84a223ea",
+        "traceparent": "00-d555294ca7f2ab264db4bec7671febf1-5d6ddbcbffebd675-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "16e46e99c50fa95cee5ae5432c9fb4cc",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:50:59 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:34 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:50:58 GMT",
-        "MS-CV": "OO0ivXEA8023o8fHuh4jnA.0",
+        "Date": "Tue, 13 Dec 2022 01:18:34 GMT",
+        "MS-CV": "AYw9gawYF0Ol0wYhuJpalA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "044OOYwAAAABGemVVj9fsS7rypV8uQ\u002Bo5UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "06tKXYwAAAADmxS7TQjelSbycRXXXtuOrUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "94ms"
+        "X-Processing-Time": "95ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -72,21 +72,21 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "86",
+        "Content-Length": "236",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-306fb22dbfcff6d1719a2012b2941f14-e715490249fe47c8-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4d3bcbdcf261fc73b58b4c8dabcb175f",
+        "traceparent": "00-d555294ca7f2ab264db4bec7671febf1-91d1f6b618422b1b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b42aa392585da433ad82b186a981f1d7",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:50:59 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:34 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:50:59 GMT",
-        "MS-CV": "n4eIQfB0yEukhI5E/T4iBg.0",
+        "Date": "Tue, 13 Dec 2022 01:18:35 GMT",
+        "MS-CV": "4GdIYk63J0qjyrWrosfzpQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "044OOYwAAAACnz586o7s9RLjuUPahNmYoUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "069KXYwAAAADou8I6Y9o3Qp6x6HDg1JawUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "479ms"
+        "X-Processing-Time": "849ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -121,13 +121,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "164",
+        "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-2f72f63e1a611268836d8bc2daf4d51a-cfecf2787e553571-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "56675f3f3d56c026294bd232c8e1f117",
+        "traceparent": "00-05236ba15a799582b1aeb3b9ccd6743e-499000795e13679b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2d2167d94ab1fa22692ef5c061205321",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:00 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:35 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:50:59 GMT",
-        "MS-CV": "yrPPtJr7HU\u002Bu\u002BoIbzgahqQ.0",
+        "Date": "Tue, 13 Dec 2022 01:18:36 GMT",
+        "MS-CV": "dIJXEibgsUqkiIJurf5yeg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "05IOOYwAAAAC5OlN7p9grRrXAOVoyG2DTUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "069KXYwAAAAAcKcSIaK0wTLUXhaSYZ4rVUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "99ms"
+        "X-Processing-Time": "177ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com"
             ]
           }
         ]
@@ -181,18 +181,18 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "51",
+        "Content-Length": "88",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-16f421a4615a1b808703a31197905e40-8137506b86f3a4a7-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "cfbc1ed06bb7abb1e8a3243816a3dfa3",
+        "traceparent": "00-2bb2bde858ae5f37b6bf0e8d4e824535-310ba27b09cb66d1-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f54dcd1faa3841cf3b40688c13d5ff6d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:00 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:35 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 3333
           }
         }
@@ -201,23 +201,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:00 GMT",
-        "MS-CV": "1\u002B4BlxEMLk2JiYoQ45EBmQ.0",
+        "Date": "Tue, 13 Dec 2022 01:18:36 GMT",
+        "MS-CV": "g176PgZzvEKmsf3dcWSovQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "05IOOYwAAAAAzGRJOLWHUTZc34zfhQSfVUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07NKXYwAAAADaU4f87Gg2TJGO/UeAv1yUUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "263ms"
+        "X-Processing-Time": "492ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.com": {
+          "newsbs.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -227,7 +227,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com"
             ]
           }
         ]
@@ -239,11 +239,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-d388a9601bff18ca7315c780fd1d2747-27eaa91998e9d23c-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "244d5c11cc3a9f93a57a24151f4133d4",
+        "traceparent": "00-35eeabbe2831d8a804c9419703e369a4-91751a118013dad0-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c56a0d69867e481b812f4a2e6272438d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:00 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:36 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -251,23 +251,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:00 GMT",
-        "MS-CV": "L6hXxZEyGkulKmmaLU/W1A.0",
+        "Date": "Tue, 13 Dec 2022 01:18:36 GMT",
+        "MS-CV": "Abnb5oSGdEmAxLU\u002B4z6/ow.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "05IOOYwAAAACnD46QBQzuTpzoHxN1I8SBUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07NKXYwAAAADMv\u002BWJrGBjRZEvbkwwZz\u002BqUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "220ms"
+        "X-Processing-Time": "95ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.com": {
+          "newsbs.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -277,7 +277,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com"
             ]
           }
         ]
@@ -289,11 +289,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-0f6b01d4f878023af6a6aad6458707f5-3919828f81b79672-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8dbd3499480ed3a7aebc6eb319eea985",
+        "traceparent": "00-e0e57835f905d9be87725da4075b6a05-fedea2d4cab89ac1-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "db668f2ffb332f9f98dff271e195e794",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:01 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:36 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -301,23 +301,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:00 GMT",
-        "MS-CV": "YNWlHCkza06czsz\u002BXHvigA.0",
+        "Date": "Tue, 13 Dec 2022 01:18:37 GMT",
+        "MS-CV": "DhnIN2V000u0j6GQfqftKg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "05YOOYwAAAABkynBVNf8MSpZMvDHIbRLgUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07dKXYwAAAACLzsuwdmIqS79hah\u002BCorFZUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "97ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.com": {
+          "newsbs.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -327,7 +327,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com"
             ]
           }
         ]
@@ -341,11 +341,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-1cf7bbc5d244df6469e89740b20424f9-64be19d9dc3664c6-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6c202f6bcd9303dc8a1d293c479b8ba6",
+        "traceparent": "00-33eba4060deecb2751e29df7fa09a8a6-301804a0a1d839c1-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5357882f8eb599a3b20474095fa0dec9",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:01 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:36 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -355,23 +355,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:01 GMT",
-        "MS-CV": "iEmatKoWv0qpDz6ej6GkCw.0",
+        "Date": "Tue, 13 Dec 2022 01:18:37 GMT",
+        "MS-CV": "UohZb5EG7EGgI/jdbxraXw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "05YOOYwAAAAAOn3qWDoYfS5hfWVDIIhxeUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07dKXYwAAAAAjYH053Mi4TbMlejMwDVVHUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "268ms"
+        "X-Processing-Time": "175ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.com": {
+          "newsbs.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -384,11 +384,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-9681e9e93f04d0d8f67ded8bea29986d-5e621c57db903152-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e19e4f7052e6c994b479767e5ee085b7",
+        "traceparent": "00-bec3369a56c3929b921502ee2224ba22-f41c679061b6806e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "835ddbfc236e6d396e3a2c9e94aa67eb",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:01 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:37 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -396,23 +396,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:01 GMT",
-        "MS-CV": "cg0uAQqbGEeGu99x2hcTag.0",
+        "Date": "Tue, 13 Dec 2022 01:18:37 GMT",
+        "MS-CV": "7MOMYkLZiUCJeNmNn2OaAA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "05YOOYwAAAABVR64vsVKTRq5iFc6G07BuUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07dKXYwAAAAAyjg1xakJ8Qb3fnl5j4bdgUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "85ms"
+        "X-Processing-Time": "91ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.com": {
+          "newsbs.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -425,11 +425,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-a98db935a53c4f672ea235b983295a52-4b041aad5a0f78ca-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f0aa9ed0c620cc4057ba03f11e6b8b13",
+        "traceparent": "00-0ea7d71332aa9b2e41bee93fefd3a458-ba53be8ef6b4ead1-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "daffb647f01ba1d7ebcd282e8795cff7",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:02 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:37 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -437,23 +437,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:01 GMT",
-        "MS-CV": "fylZBLp3m0GyUSDwyCIXUA.0",
+        "Date": "Tue, 13 Dec 2022 01:18:37 GMT",
+        "MS-CV": "\u002BJDXIF6WFEWUWvI98DRcZw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "05oOOYwAAAACVlc0fumjrT7v5Z1QTfGJ8UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07dKXYwAAAAD1IsKu0dQfTIIrz/zZqlrRUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "84ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.com": {
+          "newsbs.730211eb-445a-8961-3a37-94bb9c966031.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -466,33 +466,33 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "62",
+        "Content-Length": "173",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-a98db935a53c4f672ea235b983295a52-44e56e7ee42f609e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c943c730c84f189f9a57b71a565ea4a9",
+        "traceparent": "00-0ea7d71332aa9b2e41bee93fefd3a458-49151dbfdd4e75b0-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0574280064370b254ee9e47a61050408",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:02 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:37 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": null,
-          "sbs2.com": null,
-          "newsbs.com": null
+          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": null,
+          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": null,
+          "newsbs.730211eb-445a-8961-3a37-94bb9c966031.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:02 GMT",
-        "MS-CV": "2ocyJMfKjkKVzKiswR6iRg.0",
+        "Date": "Tue, 13 Dec 2022 01:18:38 GMT",
+        "MS-CV": "NcjgV4hRZ0eRle/dg2Mnug.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "05oOOYwAAAAChEQWLrWIjSIfFLAm3ZjxlUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07dKXYwAAAACMpKDjcdwtS5QzR60otebwUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "522ms"
+        "X-Processing-Time": "352ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -502,6 +502,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "237458114"
+    "RandomSeed": "389862890"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-b8088e92e202191f92bf9d5cfa2982e3-79750cb2e3e448a6-00",
+        "traceparent": "00-e55f4b1768c4b2ad1aa12f7998f0e25d-41498e9cb8f9d721-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e3d7c6bf461b8063c1d39ae098625e2c",
+        "x-ms-client-request-id": "173126526ca602f3fe59b444084944b4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:33 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:21 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,16 +22,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:34 GMT",
-        "MS-CV": "jMLeFeUoBUSkRQe9mDFtOg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:22 GMT",
+        "MS-CV": "isGSA5etQkiZe4FQtvkwag.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "06dKXYwAAAAAZuQ33OLiURbx1r23oH6jvUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0lt2YYwAAAAAg9Tsjf7EQSKXNQOKWmjSaUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "335ms"
+        "X-Processing-Time": "340ms"
       },
       "ResponseBody": {
-        "trunks": {},
+        "trunks": {
+          "sbs1.577405d2-35b0-45f8-467d-57afd2ac5d12.com": {
+            "sipSignalingPort": 9999
+          },
+          "sbs2.577405d2-35b0-45f8-467d-57afd2ac5d12.com": {
+            "sipSignalingPort": 1123
+          }
+        },
         "routes": []
       }
     },
@@ -41,11 +48,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-d555294ca7f2ab264db4bec7671febf1-5d6ddbcbffebd675-00",
+        "traceparent": "00-632bfeed6413eec7d77847d69937b5b9-8eff1339d680112a-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "16e46e99c50fa95cee5ae5432c9fb4cc",
+        "x-ms-client-request-id": "1941af1e87ef7de901875b2a4186746b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:34 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:22 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,16 +60,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:34 GMT",
-        "MS-CV": "AYw9gawYF0Ol0wYhuJpalA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:22 GMT",
+        "MS-CV": "j4RXPWr6BE2/3WFYxzeNzA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "06tKXYwAAAADmxS7TQjelSbycRXXXtuOrUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0l92YYwAAAAA0eskBWlSORKPpgjhLggvBUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "95ms"
+        "X-Processing-Time": "75ms"
       },
       "ResponseBody": {
-        "trunks": {},
+        "trunks": {
+          "sbs1.577405d2-35b0-45f8-467d-57afd2ac5d12.com": {
+            "sipSignalingPort": 9999
+          },
+          "sbs2.577405d2-35b0-45f8-467d-57afd2ac5d12.com": {
+            "sipSignalingPort": 1123
+          }
+        },
         "routes": []
       }
     },
@@ -72,43 +86,45 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "236",
+        "Content-Length": "266",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d555294ca7f2ab264db4bec7671febf1-91d1f6b618422b1b-00",
+        "traceparent": "00-632bfeed6413eec7d77847d69937b5b9-1e55c31f495e02f7-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b42aa392585da433ad82b186a981f1d7",
+        "x-ms-client-request-id": "982b4d547d21c9af297603e78d37c70f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:34 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:22 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 1123
-          }
+          },
+          "sbs1.577405d2-35b0-45f8-467d-57afd2ac5d12.com": null,
+          "sbs2.577405d2-35b0-45f8-467d-57afd2ac5d12.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:35 GMT",
-        "MS-CV": "4GdIYk63J0qjyrWrosfzpQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:23 GMT",
+        "MS-CV": "et02JDDjB0SSTxyjisfKcA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "069KXYwAAAADou8I6Y9o3Qp6x6HDg1JawUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0l92YYwAAAAAXjZFhT9WyR4IzRt01/hmDUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "849ms"
+        "X-Processing-Time": "514ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +139,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-05236ba15a799582b1aeb3b9ccd6743e-499000795e13679b-00",
+        "traceparent": "00-d0fdfe5997755d8b6aba2b1020327921-12ec8b21f43db579-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2d2167d94ab1fa22692ef5c061205321",
+        "x-ms-client-request-id": "31a9498e2fbccb253cb3161e10c9c177",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:35 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:23 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +153,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com"
+              "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com"
             ]
           }
         ]
@@ -146,20 +162,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:36 GMT",
-        "MS-CV": "dIJXEibgsUqkiIJurf5yeg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:23 GMT",
+        "MS-CV": "v0By95XA\u002BkO6ni5W954lbA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "069KXYwAAAAAcKcSIaK0wTLUXhaSYZ4rVUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mN2YYwAAAAAJCBuKn/nOTImlJ6avAsfvUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "177ms"
+        "X-Processing-Time": "106ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +185,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com"
+              "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com"
             ]
           }
         ]
@@ -183,16 +199,16 @@
         "Authorization": "Sanitized",
         "Content-Length": "88",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-2bb2bde858ae5f37b6bf0e8d4e824535-310ba27b09cb66d1-00",
+        "traceparent": "00-70e7570cfbeaea280b8054722e367c42-786a495673cde885-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f54dcd1faa3841cf3b40688c13d5ff6d",
+        "x-ms-client-request-id": "bbf048e5ab1da1920078f0788302efc9",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:35 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:23 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "newsbs.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 3333
           }
         }
@@ -201,23 +217,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:36 GMT",
-        "MS-CV": "g176PgZzvEKmsf3dcWSovQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:24 GMT",
+        "MS-CV": "LG2sa3OWXEeHZCGbi4Y0jQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07NKXYwAAAADaU4f87Gg2TJGO/UeAv1yUUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mN2YYwAAAABB0r02TL36QKz6bjgnZYHdUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "492ms"
+        "X-Processing-Time": "450ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "newsbs.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -227,7 +243,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com"
+              "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com"
             ]
           }
         ]
@@ -239,11 +255,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-35eeabbe2831d8a804c9419703e369a4-91751a118013dad0-00",
+        "traceparent": "00-cf44da5e293f7f0f0a43a2ccddb8aab9-5efe5a4a663b045b-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c56a0d69867e481b812f4a2e6272438d",
+        "x-ms-client-request-id": "f89b4cc042dd25ae27605b6d6790b85f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:36 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:24 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -251,23 +267,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:36 GMT",
-        "MS-CV": "Abnb5oSGdEmAxLU\u002B4z6/ow.0",
+        "Date": "Tue, 13 Dec 2022 20:16:24 GMT",
+        "MS-CV": "4whjbdk8SEWVZOd26yHSng.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07NKXYwAAAADMv\u002BWJrGBjRZEvbkwwZz\u002BqUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0md2YYwAAAABV\u002B8iCHw/iSZYRqiRPPPpzUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "95ms"
+        "X-Processing-Time": "79ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "newsbs.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -277,7 +293,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com"
+              "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com"
             ]
           }
         ]
@@ -289,11 +305,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-e0e57835f905d9be87725da4075b6a05-fedea2d4cab89ac1-00",
+        "traceparent": "00-8c94ec0936c59f562f08739aad6632b5-aa0ebd510a9f993a-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "db668f2ffb332f9f98dff271e195e794",
+        "x-ms-client-request-id": "45028cb50b47e3f2b60731443eac483a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:36 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:24 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -301,23 +317,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:37 GMT",
-        "MS-CV": "DhnIN2V000u0j6GQfqftKg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:24 GMT",
+        "MS-CV": "dQOs\u002BCjlw06MgXpliMBB9A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07dKXYwAAAACLzsuwdmIqS79hah\u002BCorFZUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0md2YYwAAAADcWzy3FGmOS6PFaUbYWdT/UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "97ms"
+        "X-Processing-Time": "74ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "newsbs.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -327,7 +343,57 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com"
+              "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9a456f755e516874c14e63e6129f7a90-0c2c6748948dbb95-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c45d4cc4c82da39999cb93bd4f243a6f",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:24 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:16:24 GMT",
+        "MS-CV": "AAt7406U/ke2xwdr2ExY7Q.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0md2YYwAAAACC\u002Br6UvTxAQLgVJLYQeuUmUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "92ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+            "sipSignalingPort": 1123
+          },
+          "newsbs.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com"
             ]
           }
         ]
@@ -341,11 +407,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-33eba4060deecb2751e29df7fa09a8a6-301804a0a1d839c1-00",
+        "traceparent": "00-b8292a27fe83b3542f990ad8abb62d30-faf0a57f9bcc923e-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5357882f8eb599a3b20474095fa0dec9",
+        "x-ms-client-request-id": "f7c390bfaaffb58259b842d5106ae67b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:36 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:24 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -355,23 +421,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:37 GMT",
-        "MS-CV": "UohZb5EG7EGgI/jdbxraXw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:25 GMT",
+        "MS-CV": "7AS\u002BaWlEXUG4ssVjpOoTeQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07dKXYwAAAAAjYH053Mi4TbMlejMwDVVHUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0md2YYwAAAABq5H99dSZNQbHxqhMqZzA2UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "175ms"
+        "X-Processing-Time": "105ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "newsbs.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -384,11 +450,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-bec3369a56c3929b921502ee2224ba22-f41c679061b6806e-00",
+        "traceparent": "00-aa297ff73c306050667b18ecf429f53a-f19b566eec69236b-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "835ddbfc236e6d396e3a2c9e94aa67eb",
+        "x-ms-client-request-id": "1aa92117f432ec32f25fab7b77359391",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:37 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:24 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -396,64 +462,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:37 GMT",
-        "MS-CV": "7MOMYkLZiUCJeNmNn2OaAA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:25 GMT",
+        "MS-CV": "Sa/RwgoDp0i8daq7rbeNNg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07dKXYwAAAAAyjg1xakJ8Qb3fnl5j4bdgUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0md2YYwAAAACC1h6SlwOfSaQBUG2RoympUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "91ms"
+        "X-Processing-Time": "86ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.730211eb-445a-8961-3a37-94bb9c966031.com": {
-            "sipSignalingPort": 3333
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-0ea7d71332aa9b2e41bee93fefd3a458-ba53be8ef6b4ead1-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "daffb647f01ba1d7ebcd282e8795cff7",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:37 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:37 GMT",
-        "MS-CV": "\u002BJDXIF6WFEWUWvI98DRcZw.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07dKXYwAAAAD1IsKu0dQfTIIrz/zZqlrRUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": {
-            "sipSignalingPort": 1123
-          },
-          "newsbs.730211eb-445a-8961-3a37-94bb9c966031.com": {
+          "newsbs.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -468,31 +493,31 @@
         "Authorization": "Sanitized",
         "Content-Length": "173",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-0ea7d71332aa9b2e41bee93fefd3a458-49151dbfdd4e75b0-00",
+        "traceparent": "00-aa297ff73c306050667b18ecf429f53a-3afb60f2eaec0adc-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0574280064370b254ee9e47a61050408",
+        "x-ms-client-request-id": "ad84c2cd51e9193bcaa86a7586c4922f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:37 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:25 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.730211eb-445a-8961-3a37-94bb9c966031.com": null,
-          "sbs2.730211eb-445a-8961-3a37-94bb9c966031.com": null,
-          "newsbs.730211eb-445a-8961-3a37-94bb9c966031.com": null
+          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": null,
+          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": null,
+          "newsbs.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:38 GMT",
-        "MS-CV": "NcjgV4hRZ0eRle/dg2Mnug.0",
+        "Date": "Tue, 13 Dec 2022 20:16:25 GMT",
+        "MS-CV": "WEbqloA7HUWfpIMITctiJg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07dKXYwAAAACMpKDjcdwtS5QzR60otebwUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mt2YYwAAAADtBo7vXEd5RJ1CK3bWcDhZUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "352ms"
+        "X-Processing-Time": "166ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -502,6 +527,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "389862890"
+    "RandomSeed": "1229580860"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResource.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-9052904a9744c9f52a74c9a3e4140da7-ed8a49cbb036b181-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1ad74d5e27d7200d0979e680a2597640",
+        "traceparent": "00-8a519c8f2598c84cfa7a256ea2a7f63e-b58302363abec120-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0bcaa6bf203c34779b0347c6da11f132",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:09 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:43 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,37 +22,40 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:10 GMT",
-        "MS-CV": "mqqPvGrXcUSSMz4hTdaQmQ.0",
+        "Date": "Mon, 05 Dec 2022 22:48:43 GMT",
+        "MS-CV": "4tmtH/GAZUWGBTCA9JaomQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0qtZDYwAAAACNF4hWW\u002BgQQaQZHu9Pf6ndTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0S3WOYwAAAABcxZsE\u002B9WOQLIOKBqYzWtJUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "182ms"
+        "X-Processing-Time": "313ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
-            "sipSignalingPort": 5555
+          "sbs1.com": {
+            "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
+          },
+          "newsbs.com": {
+            "sipSignalingPort": 3333
           }
         },
         "routes": []
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-4ad82e3ee7274fc9a663f93e0e1fb099-a58c600c561ddebf-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ba5b7dcd474c87c1de62605764bdfc61",
+        "traceparent": "00-e05550911833bd905445321431885d8e-bdcedcd8f05b0eb2-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3ffe1db603a176c62ab83c2ebdfa093a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:10 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:44 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,69 +63,75 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:10 GMT",
-        "MS-CV": "cfwNOmlsbUOd3RZgw/pmwQ.0",
+        "Date": "Mon, 05 Dec 2022 22:48:44 GMT",
+        "MS-CV": "4j/\u002BKIa7VECGNIWXGLTA8A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0q9ZDYwAAAADP658xfVKMSq0VohZB8697TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0THWOYwAAAADCfZUIKVkZT75CZyNlHSNHUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "93ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
-            "sipSignalingPort": 5555
+          "sbs1.com": {
+            "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
+          },
+          "newsbs.com": {
+            "sipSignalingPort": 3333
           }
         },
         "routes": []
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "114",
+        "Content-Length": "136",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-4ad82e3ee7274fc9a663f93e0e1fb099-65f69031eccd4955-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "990b01fb521ccc35316b23dc8e0ac343",
+        "traceparent": "00-e05550911833bd905445321431885d8e-5b137d818107d29a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "92c9160753ac6481be85f24fd75bbe0b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:10 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:44 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
-          }
+          },
+          "sbs1.com": null,
+          "sbs2.com": null,
+          "newsbs.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:10 GMT",
-        "MS-CV": "ofMyWSKg8EK9GIKOHLcrlQ.0",
+        "Date": "Mon, 05 Dec 2022 22:48:44 GMT",
+        "MS-CV": "reC8QMV9\u002B0CFkDcfEHX1yw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0q9ZDYwAAAADsKLMeA5FERaR6TOEu1HxqTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0THWOYwAAAAAqulIAiLatSo8c1jUAyhPWUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "155ms"
+        "X-Processing-Time": "363ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -130,18 +139,18 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "178",
+        "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-c38e5af5002151682a8e1a5031602338-a7440d429ec06a7e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "703316bfba9e17098b4f3b75c6b5bc4b",
+        "traceparent": "00-28c46a687ef265e314d87ff5727f373a-17b6fdc5089c251c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "75a2e78bfd28bb39e054e184e44976a1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:11 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:45 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -151,7 +160,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -160,20 +169,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:11 GMT",
-        "MS-CV": "4MxXV2UCxkydS/Sgj5xrJA.0",
+        "Date": "Mon, 05 Dec 2022 22:48:44 GMT",
+        "MS-CV": "bTlmwKW0Ykymh5wuK23juQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0q9ZDYwAAAABAe7lhlFbASLE\u002B0VkRL7BNTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0TXWOYwAAAAAJsExf0HjxTYu5Cv3zhy2FUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "105ms"
+        "X-Processing-Time": "95ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -183,30 +192,30 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "65",
+        "Content-Length": "51",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-cef6d17a7faa526ffb989499b4d1705b-2bd8175c3881b8ee-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a085857cdd4e7b23488e89e023e5f9d3",
+        "traceparent": "00-cebd1746789ef9a1f6c8dcc8747609cf-1de6ae108918a87f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c4bf0dfa5e4862859b9a811c10769ece",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:11 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:45 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           }
         }
@@ -215,23 +224,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:11 GMT",
-        "MS-CV": "KUgwhaxY4Uu4DaRqzTMULg.0",
+        "Date": "Mon, 05 Dec 2022 22:48:45 GMT",
+        "MS-CV": "7AOdr5Lg1k2q\u002B/D8KQcijA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0q9ZDYwAAAAA8Zond1C9cRIxQJmZwpVnNTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0TXWOYwAAAACzrot9BYT3RbN4v06o5FgxUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "585ms"
+        "X-Processing-Time": "240ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -241,23 +250,23 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-36f103b04d994b5b5be275d2d49c443a-e94ed6398498853a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4e981d9f8b8941c2f8f40dcd16c0057c",
+        "traceparent": "00-8e91a3f85468b17aa1587e687c9617dd-31427c7ea743a512-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d6a231f993570a11dc0db25872fc8075",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:11 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:45 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -265,23 +274,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:12 GMT",
-        "MS-CV": "I1kME84noU2K0g7\u002BJ2soNw.0",
+        "Date": "Mon, 05 Dec 2022 22:48:45 GMT",
+        "MS-CV": "sZvrY4tkJU6Sksvc5WD1Ag.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rNZDYwAAAAAWGpzQZ7ZCSJ3fqZCFBwEKTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0TXWOYwAAAADvix19PjchSLTCKJhVcvogUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "239ms"
+        "X-Processing-Time": "75ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -291,7 +300,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -299,7 +308,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1464697617"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "15279217"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-8a519c8f2598c84cfa7a256ea2a7f63e-b58302363abec120-00",
+        "traceparent": "00-0a74e6d060a20a0218b4885ac3974d63-44fb2fd585913621-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0bcaa6bf203c34779b0347c6da11f132",
+        "x-ms-client-request-id": "41d65a22845b766dbaf308999bf2b912",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:43 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:50:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,26 +22,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:43 GMT",
-        "MS-CV": "4tmtH/GAZUWGBTCA9JaomQ.0",
+        "Date": "Mon, 05 Dec 2022 23:50:58 GMT",
+        "MS-CV": "Hi5ehuFjik6EKB0fdBgDTQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0S3WOYwAAAABcxZsE\u002B9WOQLIOKBqYzWtJUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "04oOOYwAAAADeP3bbLFpUQ69Dk518\u002BkPEUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "313ms"
+        "X-Processing-Time": "298ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          },
-          "newsbs.com": {
-            "sipSignalingPort": 3333
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -51,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-e05550911833bd905445321431885d8e-bdcedcd8f05b0eb2-00",
+        "traceparent": "00-306fb22dbfcff6d1719a2012b2941f14-4f609b95a08118a7-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3ffe1db603a176c62ab83c2ebdfa093a",
+        "x-ms-client-request-id": "da9f5b9d62c38b316e29bb8c84a223ea",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:44 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:50:59 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -63,26 +53,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:44 GMT",
-        "MS-CV": "4j/\u002BKIa7VECGNIWXGLTA8A.0",
+        "Date": "Mon, 05 Dec 2022 23:50:58 GMT",
+        "MS-CV": "OO0ivXEA8023o8fHuh4jnA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0THWOYwAAAADCfZUIKVkZT75CZyNlHSNHUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "044OOYwAAAABGemVVj9fsS7rypV8uQ\u002Bo5UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "93ms"
+        "X-Processing-Time": "94ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          },
-          "newsbs.com": {
-            "sipSignalingPort": 3333
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -92,13 +72,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "136",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-e05550911833bd905445321431885d8e-5b137d818107d29a-00",
+        "traceparent": "00-306fb22dbfcff6d1719a2012b2941f14-e715490249fe47c8-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "92c9160753ac6481be85f24fd75bbe0b",
+        "x-ms-client-request-id": "4d3bcbdcf261fc73b58b4c8dabcb175f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:44 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:50:59 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -108,23 +88,20 @@
           },
           "sbs2.com": {
             "sipSignalingPort": 1123
-          },
-          "sbs1.com": null,
-          "sbs2.com": null,
-          "newsbs.com": null
+          }
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:44 GMT",
-        "MS-CV": "reC8QMV9\u002B0CFkDcfEHX1yw.0",
+        "Date": "Mon, 05 Dec 2022 23:50:59 GMT",
+        "MS-CV": "n4eIQfB0yEukhI5E/T4iBg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0THWOYwAAAAAqulIAiLatSo8c1jUAyhPWUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "044OOYwAAAACnz586o7s9RLjuUPahNmYoUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "363ms"
+        "X-Processing-Time": "479ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -146,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-28c46a687ef265e314d87ff5727f373a-17b6fdc5089c251c-00",
+        "traceparent": "00-2f72f63e1a611268836d8bc2daf4d51a-cfecf2787e553571-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "75a2e78bfd28bb39e054e184e44976a1",
+        "x-ms-client-request-id": "56675f3f3d56c026294bd232c8e1f117",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:45 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:00 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -169,13 +146,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:44 GMT",
-        "MS-CV": "bTlmwKW0Ykymh5wuK23juQ.0",
+        "Date": "Mon, 05 Dec 2022 23:50:59 GMT",
+        "MS-CV": "yrPPtJr7HU\u002Bu\u002BoIbzgahqQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0TXWOYwAAAAAJsExf0HjxTYu5Cv3zhy2FUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "05IOOYwAAAAC5OlN7p9grRrXAOVoyG2DTUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "95ms"
+        "X-Processing-Time": "99ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -206,11 +183,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "51",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-cebd1746789ef9a1f6c8dcc8747609cf-1de6ae108918a87f-00",
+        "traceparent": "00-16f421a4615a1b808703a31197905e40-8137506b86f3a4a7-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c4bf0dfa5e4862859b9a811c10769ece",
+        "x-ms-client-request-id": "cfbc1ed06bb7abb1e8a3243816a3dfa3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:45 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:00 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -224,13 +201,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:45 GMT",
-        "MS-CV": "7AOdr5Lg1k2q\u002B/D8KQcijA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:00 GMT",
+        "MS-CV": "1\u002B4BlxEMLk2JiYoQ45EBmQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0TXWOYwAAAACzrot9BYT3RbN4v06o5FgxUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "05IOOYwAAAAAzGRJOLWHUTZc34zfhQSfVUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "240ms"
+        "X-Processing-Time": "263ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -262,11 +239,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-8e91a3f85468b17aa1587e687c9617dd-31427c7ea743a512-00",
+        "traceparent": "00-d388a9601bff18ca7315c780fd1d2747-27eaa91998e9d23c-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d6a231f993570a11dc0db25872fc8075",
+        "x-ms-client-request-id": "244d5c11cc3a9f93a57a24151f4133d4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:45 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:00 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -274,13 +251,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:45 GMT",
-        "MS-CV": "sZvrY4tkJU6Sksvc5WD1Ag.0",
+        "Date": "Mon, 05 Dec 2022 23:51:00 GMT",
+        "MS-CV": "L6hXxZEyGkulKmmaLU/W1A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0TXWOYwAAAADvix19PjchSLTCKJhVcvogUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "05IOOYwAAAACnD46QBQzuTpzoHxN1I8SBUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "75ms"
+        "X-Processing-Time": "220ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -305,10 +282,226 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0f6b01d4f878023af6a6aad6458707f5-3919828f81b79672-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8dbd3499480ed3a7aebc6eb319eea985",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:01 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:00 GMT",
+        "MS-CV": "YNWlHCkza06czsz\u002BXHvigA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "05YOOYwAAAABkynBVNf8MSpZMvDHIbRLgUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "97ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          },
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-1cf7bbc5d244df6469e89740b20424f9-64be19d9dc3664c6-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6c202f6bcd9303dc8a1d293c479b8ba6",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:01 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:01 GMT",
+        "MS-CV": "iEmatKoWv0qpDz6ej6GkCw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "05YOOYwAAAAAOn3qWDoYfS5hfWVDIIhxeUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "268ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          },
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9681e9e93f04d0d8f67ded8bea29986d-5e621c57db903152-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e19e4f7052e6c994b479767e5ee085b7",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:01 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:01 GMT",
+        "MS-CV": "cg0uAQqbGEeGu99x2hcTag.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "05YOOYwAAAABVR64vsVKTRq5iFc6G07BuUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "85ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          },
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a98db935a53c4f672ea235b983295a52-4b041aad5a0f78ca-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f0aa9ed0c620cc4057ba03f11e6b8b13",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:02 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:01 GMT",
+        "MS-CV": "fylZBLp3m0GyUSDwyCIXUA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "05oOOYwAAAACVlc0fumjrT7v5Z1QTfGJ8UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "84ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          },
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "62",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-a98db935a53c4f672ea235b983295a52-44e56e7ee42f609e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c943c730c84f189f9a57b71a565ea4a9",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:02 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.com": null,
+          "sbs2.com": null,
+          "newsbs.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:02 GMT",
+        "MS-CV": "2ocyJMfKjkKVzKiswR6iRg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "05oOOYwAAAAChEQWLrWIjSIfFLAm3ZjxlUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "522ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "15279217"
+    "RandomSeed": "237458114"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResource.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -67,7 +67,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -116,7 +116,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -176,7 +176,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -234,7 +234,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -284,7 +284,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -334,7 +334,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -379,7 +379,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -420,7 +420,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -461,7 +461,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -501,7 +501,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "237458114"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResourceAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-802cc663ae121bb0a79f4529663485f1-f4bdcc02c2e8f936-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "367c78b4eba1afd75a7d6ea6fd7eabe8",
+        "traceparent": "00-0f2ea9561e50dd8088f32883dae5c3e4-194f584c38657478-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cef39366dceec0aa5b1bea3ae51de0c9",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:23 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:09 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,20 +22,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:23 GMT",
-        "MS-CV": "E0AVuNpKoUG3XjONxFLimQ.0",
+        "Date": "Mon, 05 Dec 2022 22:49:09 GMT",
+        "MS-CV": "FLvVWYW11kaa1Grab7WxUQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0uNZDYwAAAADxlJh3h1OpS7MzVyL8FLVhTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0ZXWOYwAAAAALps812ZZcT6aiOa\u002BoALi\u002BUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "98ms"
+        "X-Processing-Time": "158ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -43,16 +43,16 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-56e9fbc5d29118b2e798c81af209d591-687e062ac076225a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7007985a2a073abeb57e6fd565a0fcda",
+        "traceparent": "00-7c938d059f2a77f838d1cfacc6a5c551-bfdfa7161cbaf129-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "baeb3f8d0a009b2b47dce12f4a059b72",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:24 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:10 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,20 +60,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:24 GMT",
-        "MS-CV": "IlwNL2T8vU\u002BIHbHlvNB07Q.0",
+        "Date": "Mon, 05 Dec 2022 22:49:10 GMT",
+        "MS-CV": "gWuP4Igq50muN0V9sMSB2A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0uNZDYwAAAAB3rJxzoGBpTa4Hio37kzGaTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0ZnWOYwAAAABs2h8RVT6AS5GkGmxYNsTxUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "68ms"
+        "X-Processing-Time": "82ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -81,48 +81,50 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "114",
+        "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-56e9fbc5d29118b2e798c81af209d591-fc594671b39c8b6a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7a79ec9d4167ab82bdb4187e32cd9e94",
+        "traceparent": "00-7c938d059f2a77f838d1cfacc6a5c551-2b46e0c4e65cf77e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7bd359b7ca5c1ec853aef42671ccc4fd",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:24 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:10 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
-          }
+          },
+          "sbs1.com": null,
+          "sbs2.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:24 GMT",
-        "MS-CV": "pZ1E1egbE0ugsc8MgTs5bA.0",
+        "Date": "Mon, 05 Dec 2022 22:49:10 GMT",
+        "MS-CV": "okl9UcSXdEKA2oWCkkTeUA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0uNZDYwAAAACadtv8o3L\u002BTbYGV7jRUzOvTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0ZnWOYwAAAAC7gqlx05CrSq21bzkMiRQuUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "144ms"
+        "X-Processing-Time": "285ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -130,18 +132,18 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "178",
+        "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-36f8296126d13011501cc2185e6001b0-afdc13ae104d64ea-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8373f128a5ce8a69ba4281237c0149b9",
+        "traceparent": "00-c519898d32c87effb595ed9d3a8e030d-36ca7d5183da00ee-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "81ecbb6dc5e45c8067578711fb7b7556",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:24 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:10 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -151,7 +153,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -160,20 +162,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:24 GMT",
-        "MS-CV": "EhV4FF8kQ0KPp8GyoLN2rA.0",
+        "Date": "Mon, 05 Dec 2022 22:49:10 GMT",
+        "MS-CV": "UI7bOpTTXk\u002BMh0di\u002BdiriA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0udZDYwAAAABMaha8DdahQZIm3e57y0ntTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0ZnWOYwAAAADalqar2S1YQpg50nSF9Er4UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
+        "X-Processing-Time": "114ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -183,30 +185,30 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "65",
+        "Content-Length": "51",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-250e6e22e6a8daf1c031533c125b9158-1dc902074753dbf9-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1008948131041881155bb353113f07e8",
+        "traceparent": "00-b9a2750b5732764d4805fb9e9d85d6a2-af796585e802d45f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8b82777f6549c36d76cd67521604297a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:24 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:11 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           }
         }
@@ -215,23 +217,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:24 GMT",
-        "MS-CV": "XcaQ\u002BHfEwUG7UwuFOe1XUA.0",
+        "Date": "Mon, 05 Dec 2022 22:49:11 GMT",
+        "MS-CV": "73oTy\u002BueiUKYYQehgkG8Bw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0udZDYwAAAAAnEjxu\u002BdcSS7KUvkKPmXpOTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0Z3WOYwAAAACBgFU7yWpeTJWggtAxKc79UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "334ms"
+        "X-Processing-Time": "286ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -241,23 +243,23 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f3c8e55d4cfaf852b4aaa1f8f1172d46-3ac6b3606be69332-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "73acdadf782df80c83efc024c05f2fbb",
+        "traceparent": "00-5bf131180090e405d171381cb25d80c3-14b69b8192e0d6bc-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8fc2e3181918f18ed877130442b723d8",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:25 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:11 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -265,23 +267,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:25 GMT",
-        "MS-CV": "CsBRiKkdSE2XH7GawoiMbA.0",
+        "Date": "Mon, 05 Dec 2022 22:49:11 GMT",
+        "MS-CV": "6xsl8W1LjUeYDkmijvu9Zg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0udZDYwAAAADtUcuh1kPTQ53rN4BZiSTcTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0Z3WOYwAAAAAP5Jw58krBRZLjnx1cFnN8UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "65ms"
+        "X-Processing-Time": "92ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -291,7 +293,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -299,7 +301,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1265487456"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "831381964"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-504f62cb6ae88ef04f8c387231d33df3-9b5fe452e0ce7607-00",
+        "traceparent": "00-342c77321c0bd864454bcec0075898a1-fac30f79457e6450-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "18d9ce2546a2d08261d419fe198f9cc6",
+        "x-ms-client-request-id": "d75047619487f1bf9de23352a366f0da",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:51 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:47 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:52 GMT",
-        "MS-CV": "ZgUCTX7AA0C4cVQrbBBS1Q.0",
+        "Date": "Tue, 13 Dec 2022 20:16:49 GMT",
+        "MS-CV": "RQLG0ZfRLEqAc0Ns5YkWiw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "06NeXYwAAAAB2wcdXESVHQ52ClsYaVcIGUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0sN2YYwAAAAARY2rBfeNNT51gCO5bXjF3UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "315ms"
+        "X-Processing-Time": "213ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-4eac4c737b3871f0faa9c3cd7c571a8c-892570ca34c49c07-00",
+        "traceparent": "00-86b9a3ab40c5ce7c66c62641eb23e233-77faff3ed026c710-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "330ee378de8fa90bb8371980814dfabf",
+        "x-ms-client-request-id": "7643d59fd16a3e3d1072b967b343d676",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:52 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:48 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:52 GMT",
-        "MS-CV": "ugECbjteDEuZfwECk83nlw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:49 GMT",
+        "MS-CV": "uafMFQaD/0aQH3bymeKEzw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "06deXYwAAAABH8DQ9mwHXSLj72lF0PAJHUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0sd2YYwAAAACE\u002BGGaXrhOQKaRIvh4V/QSUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "97ms"
+        "X-Processing-Time": "83ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-4eac4c737b3871f0faa9c3cd7c571a8c-744a452ba2f6d18c-00",
+        "traceparent": "00-86b9a3ab40c5ce7c66c62641eb23e233-ca255f8d2054c588-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7cd984c9ee496fca99c4058f0478035a",
+        "x-ms-client-request-id": "2bb4aa8373ba2ee5774bedcd29fe4222",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:53 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:48 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:53 GMT",
-        "MS-CV": "rOZtpGiIyU6NjfmS7rPNRw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:50 GMT",
+        "MS-CV": "JIBLv5f/20S1LmqL73Tcbw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "06deXYwAAAACBMYhwT9tJTINOxGIxdYg1UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0sd2YYwAAAACJR72w\u002B2SOTJdn9JkqDuVJUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "775ms"
+        "X-Processing-Time": "569ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-7cb3c14b32e5240983a20ee8f6256f94-b45cd9fd58db7665-00",
+        "traceparent": "00-e426e3a74dd8c549329247e476d67141-b57dc971935d6aad-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "98daed69305e4773c330606a2d014f14",
+        "x-ms-client-request-id": "ca4b734eb48190670a12c614da573e5a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:54 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:49 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com"
+              "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:53 GMT",
-        "MS-CV": "N5ZjzQ2bLkqbWxtM90g/zQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:50 GMT",
+        "MS-CV": "mcs7GLZ2g0yN8b1pByCo9g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "06teXYwAAAABiCkj22B7kQYgEKfcpNN71UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0st2YYwAAAAB8cJSH84rtQpqfb0gwj8irUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "178ms"
+        "X-Processing-Time": "188ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com"
+              "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com"
             ]
           }
         ]
@@ -183,16 +183,16 @@
         "Authorization": "Sanitized",
         "Content-Length": "88",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-263d8162333b51562ef842d09414bdb5-d7116c606a75d80b-00",
+        "traceparent": "00-d3c8a52d136f89c01511dad9226ba757-54e3191cc9b3b186-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "94355ad920b5897c199f99cbd87ba440",
+        "x-ms-client-request-id": "f8cebc0cc4b22c1fef14fe1fe3701412",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:54 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:49 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "newsbs.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 3333
           }
         }
@@ -201,23 +201,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:54 GMT",
-        "MS-CV": "5qfvX6WdikOSENHnPVuKUA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:50 GMT",
+        "MS-CV": "pQvsp9eDX0qpBD9Xi\u002Bn8Rg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "06teXYwAAAAC/5EviYm2tQJAD63Lu6IEnUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0st2YYwAAAAAu12gBZd5aTY4Yz6PukkHfUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "526ms"
+        "X-Processing-Time": "462ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "newsbs.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -227,7 +227,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com"
+              "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com"
             ]
           }
         ]
@@ -239,11 +239,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-671ca7428bb7f304377424dd50522136-1edf01e13b18c043-00",
+        "traceparent": "00-2dc2b3c26cc8504897e465f0792c7435-d416f68c91312753-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "9317bf33617298611191b8188e5f4297",
+        "x-ms-client-request-id": "3f18972f0bf7cef5432421a8acd0541f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:55 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:50 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -251,23 +251,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:54 GMT",
-        "MS-CV": "MKABz/O8kUepUod/AbGnZA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:51 GMT",
+        "MS-CV": "IY6olxxqoECfhkiNWOjmyQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "069eXYwAAAABkL0ladlHcTrs6S73H64N8UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0st2YYwAAAACHmM4rgdYGQqn7HbD/v27yUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "77ms"
+        "X-Processing-Time": "89ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "newsbs.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -277,7 +277,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com"
+              "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com"
             ]
           }
         ]
@@ -289,11 +289,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f81573cc589c8b00b2f4e7d7209a6ed4-81159aa906c3a819-00",
+        "traceparent": "00-344fd5a61eb6543a7af7c1e10b9c6395-3447ff00c42b9172-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "aab5f0746f4249a470507fbe96a76e47",
+        "x-ms-client-request-id": "6dc1930d4a2f8a70541fda6cb647ac9a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:55 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:50 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -301,23 +301,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:55 GMT",
-        "MS-CV": "4yuQR6PBqUmUKQni8\u002BPnqw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:51 GMT",
+        "MS-CV": "rF4h8\u002BGm1UiLc1nBExH8PA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "069eXYwAAAACCJY0tL5yCTbajo\u002BFWSVntUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0s92YYwAAAAAEYC68KVgpTLDY/0ipuJbDUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "79ms"
+        "X-Processing-Time": "88ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "newsbs.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -327,7 +327,57 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com"
+              "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-902f9193b1f7285f78b41fdcf06cab4e-d6f67e0edbea1ac4-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "43e4b4fdfe3e0062c700b58da3767f1f",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:50 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:16:51 GMT",
+        "MS-CV": "YMlXtHD\u002BOEmiDV6zgnzizw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0s92YYwAAAACTehzBi1/MTLVJm7afCWSOUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "90ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+            "sipSignalingPort": 1123
+          },
+          "newsbs.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com"
             ]
           }
         ]
@@ -341,11 +391,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-09f141cce37d3b7d140b6b20d9b7aaef-ec1ab55575fa8bf4-00",
+        "traceparent": "00-4db5d47083c378d19f0e1bb3fcb72a9b-75f0ef87ad5e8662-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6e37208bbbea78a1f99c82236764fbb9",
+        "x-ms-client-request-id": "4f12dec0a7aee5e2278eebd7318818fb",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:55 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:50 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -355,23 +405,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:55 GMT",
-        "MS-CV": "zSCHThz1dkugYfUx2UQA4g.0",
+        "Date": "Tue, 13 Dec 2022 20:16:51 GMT",
+        "MS-CV": "A\u002Be5IpXOEkuIQGC6zW4\u002BDw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07NeXYwAAAAAlHabNn9EiSprRvv6cFtRGUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0s92YYwAAAACVx0GXz0deQqmpaN4tXhtzUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "102ms"
+        "X-Processing-Time": "165ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "newsbs.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -384,11 +434,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-3cf26e6a3175d712e7f79a219fc71711-52db02c5e20ddfae-00",
+        "traceparent": "00-1af711e4107d257c2e3f690093638007-3e2ab3ae4bfa3003-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e856025dfac5c4fd1ace2322e1a20169",
+        "x-ms-client-request-id": "f8ab867710eb0ee131c0a62f94e2e6dd",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:55 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:50 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -396,64 +446,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:55 GMT",
-        "MS-CV": "qRpA2CKw1U\u002Bd20y5bKsfMg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:52 GMT",
+        "MS-CV": "4\u002Bwc1hJlY0S8AX5a9Q4dCg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07NeXYwAAAAA5ZXWqnP0uSotccNBDBQ\u002BOUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0s92YYwAAAAAzFhUNbCADR4u3loZSYRkMUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "85ms"
+        "X-Processing-Time": "92ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
-            "sipSignalingPort": 3333
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-1f0cb2fba698240904d22d9e93245d6c-95058b5634197036-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6e8d7023d428b9ac4f3db1a5ec80e10c",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:56 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:55 GMT",
-        "MS-CV": "guTI8EkwtkKcRYCm77Vikw.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07NeXYwAAAAAkhCs7dilsRbvLJJKU\u002BXrTUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "76ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
-            "sipSignalingPort": 1123
-          },
-          "newsbs.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
+          "newsbs.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -468,31 +477,31 @@
         "Authorization": "Sanitized",
         "Content-Length": "173",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-1f0cb2fba698240904d22d9e93245d6c-b477c40a562716c2-00",
+        "traceparent": "00-1af711e4107d257c2e3f690093638007-8963e2f8fe44239a-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "9461c555865091822272531c977e9656",
+        "x-ms-client-request-id": "d8acbba05d3456ebd1fe1cb0128bce3e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:56 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:51 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": null,
-          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": null,
-          "newsbs.66941bb5-1e63-1c77-e905-b3527c6c6403.com": null
+          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": null,
+          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": null,
+          "newsbs.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:56 GMT",
-        "MS-CV": "YaPqzcJ0mE6HtOALlBWrlQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:52 GMT",
+        "MS-CV": "uI7Z/a3dvkm8FT1Q9TSF6A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07NeXYwAAAABPoTsipIB\u002BQZI8xF0BRXESUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0tN2YYwAAAADD9omanUUERKF/ksBXMMpgUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "593ms"
+        "X-Processing-Time": "352ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -502,6 +511,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1698825589"
+    "RandomSeed": "2006928725"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResourceAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -67,7 +67,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -116,7 +116,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -176,7 +176,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -234,7 +234,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -284,7 +284,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -334,7 +334,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -379,7 +379,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -420,7 +420,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -461,7 +461,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -501,7 +501,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "657568539"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-0c41e98de4f13a541b784fb49c43a364-d1d8866643266930-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "bc6ba17686d0695d1c6589ee77b37ea9",
+        "traceparent": "00-504f62cb6ae88ef04f8c387231d33df3-9b5fe452e0ce7607-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "18d9ce2546a2d08261d419fe198f9cc6",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:30 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:51 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:29 GMT",
-        "MS-CV": "oNSeQHrqv0\u002BNnLpng3Qt/w.0",
+        "Date": "Tue, 13 Dec 2022 01:39:52 GMT",
+        "MS-CV": "ZgUCTX7AA0C4cVQrbBBS1Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0AoSOYwAAAADXc9eKKPHYTbdsSjZlVcDuUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "06NeXYwAAAAB2wcdXESVHQ52ClsYaVcIGUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "163ms"
+        "X-Processing-Time": "315ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-8df77c1c82dbf419c6043d5cc30abd3c-b123176bb8379f32-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5f23002acc497a77df96b680476b4075",
+        "traceparent": "00-4eac4c737b3871f0faa9c3cd7c571a8c-892570ca34c49c07-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "330ee378de8fa90bb8371980814dfabf",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:30 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:29 GMT",
-        "MS-CV": "l1Ro0tJNl0WCc6Iam\u002B2UFg.0",
+        "Date": "Tue, 13 Dec 2022 01:39:52 GMT",
+        "MS-CV": "ugECbjteDEuZfwECk83nlw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0AoSOYwAAAACGt3j0D9oKR5ggtxBFAUXSUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "06deXYwAAAABH8DQ9mwHXSLj72lF0PAJHUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "82ms"
+        "X-Processing-Time": "97ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -72,21 +72,21 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "86",
+        "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-8df77c1c82dbf419c6043d5cc30abd3c-6c3730f6fa0addb2-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c0de78757fd9784d08c14b600e53ad8a",
+        "traceparent": "00-4eac4c737b3871f0faa9c3cd7c571a8c-744a452ba2f6d18c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7cd984c9ee496fca99c4058f0478035a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:30 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:30 GMT",
-        "MS-CV": "JUEMLNssKE\u002BuJ220Zo\u002BAeQ.0",
+        "Date": "Tue, 13 Dec 2022 01:39:53 GMT",
+        "MS-CV": "rOZtpGiIyU6NjfmS7rPNRw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0AoSOYwAAAAA78TMuj/j5SrYTNpnLTO54UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "06deXYwAAAACBMYhwT9tJTINOxGIxdYg1UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "654ms"
+        "X-Processing-Time": "775ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -121,13 +121,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "164",
+        "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-115f75c9d2f9b7bc028cbc740e44206e-74c86db14f308012-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c4ee95a3bdc8a9de29f0dd3ad0dd21b1",
+        "traceparent": "00-7cb3c14b32e5240983a20ee8f6256f94-b45cd9fd58db7665-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "98daed69305e4773c330606a2d014f14",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:31 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:54 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:30 GMT",
-        "MS-CV": "AIDuGImYOEW\u002Bc0AN81HcEA.0",
+        "Date": "Tue, 13 Dec 2022 01:39:53 GMT",
+        "MS-CV": "N5ZjzQ2bLkqbWxtM90g/zQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0A4SOYwAAAAB6/dUUjmn2T62go4SqW4nIUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "06teXYwAAAABiCkj22B7kQYgEKfcpNN71UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "168ms"
+        "X-Processing-Time": "178ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com"
             ]
           }
         ]
@@ -181,18 +181,18 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "51",
+        "Content-Length": "88",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-38ef314fdfbc528e91e17ae4d67ae961-b5cf75cad1cf0d3b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "fe791325bed4abd0b2aa568780166c8c",
+        "traceparent": "00-263d8162333b51562ef842d09414bdb5-d7116c606a75d80b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "94355ad920b5897c199f99cbd87ba440",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:31 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:54 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 3333
           }
         }
@@ -201,23 +201,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:31 GMT",
-        "MS-CV": "hEHhGMEO1028ynxwSwyvrQ.0",
+        "Date": "Tue, 13 Dec 2022 01:39:54 GMT",
+        "MS-CV": "5qfvX6WdikOSENHnPVuKUA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0A4SOYwAAAACl\u002BiHRMJU2RKJnJ/DGEoYgUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "06teXYwAAAAC/5EviYm2tQJAD63Lu6IEnUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "632ms"
+        "X-Processing-Time": "526ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.com": {
+          "newsbs.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -227,7 +227,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com"
             ]
           }
         ]
@@ -239,11 +239,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-46a104ec1b049376b37882bd4ef3baf4-9e1256714778e008-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b2dc2ce87b7cb8ac9a3596e8a213a82b",
+        "traceparent": "00-671ca7428bb7f304377424dd50522136-1edf01e13b18c043-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9317bf33617298611191b8188e5f4297",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:32 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -251,23 +251,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:31 GMT",
-        "MS-CV": "l6Mk5aJ720OB3AojmyiWOQ.0",
+        "Date": "Tue, 13 Dec 2022 01:39:54 GMT",
+        "MS-CV": "MKABz/O8kUepUod/AbGnZA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0BISOYwAAAAB9\u002BcI2AtCvQ4zpkNTHNhXAUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "069eXYwAAAABkL0ladlHcTrs6S73H64N8UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "92ms"
+        "X-Processing-Time": "77ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.com": {
+          "newsbs.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -277,7 +277,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com"
             ]
           }
         ]
@@ -289,11 +289,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-77476579a830efed09189cb1c74f0633-fdcb5494ee3fb8fa-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "fa3b9aa0aed9e5b5c543121e67562812",
+        "traceparent": "00-f81573cc589c8b00b2f4e7d7209a6ed4-81159aa906c3a819-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "aab5f0746f4249a470507fbe96a76e47",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:32 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -301,23 +301,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:32 GMT",
-        "MS-CV": "lt66dB6AUk\u002BYwsY8IdDJJA.0",
+        "Date": "Tue, 13 Dec 2022 01:39:55 GMT",
+        "MS-CV": "4yuQR6PBqUmUKQni8\u002BPnqw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0BISOYwAAAAAMWpKthtY0S5f8rbvjTNh3UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "069eXYwAAAACCJY0tL5yCTbajo\u002BFWSVntUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "95ms"
+        "X-Processing-Time": "79ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.com": {
+          "newsbs.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -327,7 +327,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com"
             ]
           }
         ]
@@ -341,11 +341,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-934620f3ac24e95f6b8bd455ed908614-a357913754c828c3-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a45150846f00a93466c1649f27e8089f",
+        "traceparent": "00-09f141cce37d3b7d140b6b20d9b7aaef-ec1ab55575fa8bf4-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6e37208bbbea78a1f99c82236764fbb9",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:32 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -355,23 +355,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:32 GMT",
-        "MS-CV": "sO4as2xNKk2Fkmp/7gfmxA.0",
+        "Date": "Tue, 13 Dec 2022 01:39:55 GMT",
+        "MS-CV": "zSCHThz1dkugYfUx2UQA4g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0BISOYwAAAADjAbo8t3ugTIgn2hABsG9mUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07NeXYwAAAAAlHabNn9EiSprRvv6cFtRGUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "179ms"
+        "X-Processing-Time": "102ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.com": {
+          "newsbs.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -384,11 +384,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-6f5a40aeb7a77e2bac30a60a016f5af7-fa2c9f68087bde64-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e6e72a0171db3ab276f6ed38698e5043",
+        "traceparent": "00-3cf26e6a3175d712e7f79a219fc71711-52db02c5e20ddfae-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e856025dfac5c4fd1ace2322e1a20169",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:33 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -396,23 +396,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:32 GMT",
-        "MS-CV": "Q23PT3w0VUqXKoYvheEeOw.0",
+        "Date": "Tue, 13 Dec 2022 01:39:55 GMT",
+        "MS-CV": "qRpA2CKw1U\u002Bd20y5bKsfMg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0BYSOYwAAAAA\u002BfHTXkJLCT61Lk8ywaofsUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07NeXYwAAAAA5ZXWqnP0uSotccNBDBQ\u002BOUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
+        "X-Processing-Time": "85ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.com": {
+          "newsbs.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -425,11 +425,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-26f2e8b06246e887c7ad34bf00e1119f-3fe016e6f1e2a971-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5163830c03c1312a659194184915bedc",
+        "traceparent": "00-1f0cb2fba698240904d22d9e93245d6c-95058b5634197036-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6e8d7023d428b9ac4f3db1a5ec80e10c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:33 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:56 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -437,23 +437,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:32 GMT",
-        "MS-CV": "feSGtuWId0i/A8xOk2aizQ.0",
+        "Date": "Tue, 13 Dec 2022 01:39:55 GMT",
+        "MS-CV": "guTI8EkwtkKcRYCm77Vikw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0BYSOYwAAAAAbYfN1g5mVQZz495EuWBfVUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07NeXYwAAAAAkhCs7dilsRbvLJJKU\u002BXrTUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
+        "X-Processing-Time": "76ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.com": {
+          "newsbs.66941bb5-1e63-1c77-e905-b3527c6c6403.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -466,33 +466,33 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "62",
+        "Content-Length": "173",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-26f2e8b06246e887c7ad34bf00e1119f-ae0206a3ecf36524-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3c1c723b426e13379e172d0981fb40d8",
+        "traceparent": "00-1f0cb2fba698240904d22d9e93245d6c-b477c40a562716c2-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9461c555865091822272531c977e9656",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:33 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:56 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": null,
-          "sbs2.com": null,
-          "newsbs.com": null
+          "sbs1.66941bb5-1e63-1c77-e905-b3527c6c6403.com": null,
+          "sbs2.66941bb5-1e63-1c77-e905-b3527c6c6403.com": null,
+          "newsbs.66941bb5-1e63-1c77-e905-b3527c6c6403.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:33 GMT",
-        "MS-CV": "iN3vMaYcKESvR2euNGKIHQ.0",
+        "Date": "Tue, 13 Dec 2022 01:39:56 GMT",
+        "MS-CV": "YaPqzcJ0mE6HtOALlBWrlQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0BYSOYwAAAAB9AxNrVEaySI81kRTEGw7NUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07NeXYwAAAABPoTsipIB\u002BQZI8xF0BRXESUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "282ms"
+        "X-Processing-Time": "593ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -502,6 +502,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "657568539"
+    "RandomSeed": "1698825589"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-0f2ea9561e50dd8088f32883dae5c3e4-194f584c38657478-00",
+        "traceparent": "00-0c41e98de4f13a541b784fb49c43a364-d1d8866643266930-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "cef39366dceec0aa5b1bea3ae51de0c9",
+        "x-ms-client-request-id": "bc6ba17686d0695d1c6589ee77b37ea9",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:09 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:30 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,23 +22,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:09 GMT",
-        "MS-CV": "FLvVWYW11kaa1Grab7WxUQ.0",
+        "Date": "Mon, 05 Dec 2022 23:51:29 GMT",
+        "MS-CV": "oNSeQHrqv0\u002BNnLpng3Qt/w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ZXWOYwAAAAALps812ZZcT6aiOa\u002BoALi\u002BUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0AoSOYwAAAADXc9eKKPHYTbdsSjZlVcDuUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "158ms"
+        "X-Processing-Time": "163ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 9999
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -48,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-7c938d059f2a77f838d1cfacc6a5c551-bfdfa7161cbaf129-00",
+        "traceparent": "00-8df77c1c82dbf419c6043d5cc30abd3c-b123176bb8379f32-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "baeb3f8d0a009b2b47dce12f4a059b72",
+        "x-ms-client-request-id": "5f23002acc497a77df96b680476b4075",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:10 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:30 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,23 +53,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:10 GMT",
-        "MS-CV": "gWuP4Igq50muN0V9sMSB2A.0",
+        "Date": "Mon, 05 Dec 2022 23:51:29 GMT",
+        "MS-CV": "l1Ro0tJNl0WCc6Iam\u002B2UFg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ZnWOYwAAAABs2h8RVT6AS5GkGmxYNsTxUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0AoSOYwAAAACGt3j0D9oKR5ggtxBFAUXSUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "82ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 9999
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -86,13 +72,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "118",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-7c938d059f2a77f838d1cfacc6a5c551-2b46e0c4e65cf77e-00",
+        "traceparent": "00-8df77c1c82dbf419c6043d5cc30abd3c-6c3730f6fa0addb2-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7bd359b7ca5c1ec853aef42671ccc4fd",
+        "x-ms-client-request-id": "c0de78757fd9784d08c14b600e53ad8a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:10 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:30 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -102,22 +88,20 @@
           },
           "sbs2.com": {
             "sipSignalingPort": 1123
-          },
-          "sbs1.com": null,
-          "sbs2.com": null
+          }
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:10 GMT",
-        "MS-CV": "okl9UcSXdEKA2oWCkkTeUA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:30 GMT",
+        "MS-CV": "JUEMLNssKE\u002BuJ220Zo\u002BAeQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ZnWOYwAAAAC7gqlx05CrSq21bzkMiRQuUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0AoSOYwAAAAA78TMuj/j5SrYTNpnLTO54UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "285ms"
+        "X-Processing-Time": "654ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -139,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-c519898d32c87effb595ed9d3a8e030d-36ca7d5183da00ee-00",
+        "traceparent": "00-115f75c9d2f9b7bc028cbc740e44206e-74c86db14f308012-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "81ecbb6dc5e45c8067578711fb7b7556",
+        "x-ms-client-request-id": "c4ee95a3bdc8a9de29f0dd3ad0dd21b1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:10 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:31 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -162,13 +146,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:10 GMT",
-        "MS-CV": "UI7bOpTTXk\u002BMh0di\u002BdiriA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:30 GMT",
+        "MS-CV": "AIDuGImYOEW\u002Bc0AN81HcEA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ZnWOYwAAAADalqar2S1YQpg50nSF9Er4UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0A4SOYwAAAAB6/dUUjmn2T62go4SqW4nIUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "114ms"
+        "X-Processing-Time": "168ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -199,11 +183,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "51",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-b9a2750b5732764d4805fb9e9d85d6a2-af796585e802d45f-00",
+        "traceparent": "00-38ef314fdfbc528e91e17ae4d67ae961-b5cf75cad1cf0d3b-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8b82777f6549c36d76cd67521604297a",
+        "x-ms-client-request-id": "fe791325bed4abd0b2aa568780166c8c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:11 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:31 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -217,13 +201,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:11 GMT",
-        "MS-CV": "73oTy\u002BueiUKYYQehgkG8Bw.0",
+        "Date": "Mon, 05 Dec 2022 23:51:31 GMT",
+        "MS-CV": "hEHhGMEO1028ynxwSwyvrQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0Z3WOYwAAAACBgFU7yWpeTJWggtAxKc79UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0A4SOYwAAAACl\u002BiHRMJU2RKJnJ/DGEoYgUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "286ms"
+        "X-Processing-Time": "632ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -255,11 +239,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-5bf131180090e405d171381cb25d80c3-14b69b8192e0d6bc-00",
+        "traceparent": "00-46a104ec1b049376b37882bd4ef3baf4-9e1256714778e008-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8fc2e3181918f18ed877130442b723d8",
+        "x-ms-client-request-id": "b2dc2ce87b7cb8ac9a3596e8a213a82b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:11 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:32 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -267,11 +251,11 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:11 GMT",
-        "MS-CV": "6xsl8W1LjUeYDkmijvu9Zg.0",
+        "Date": "Mon, 05 Dec 2022 23:51:31 GMT",
+        "MS-CV": "l6Mk5aJ720OB3AojmyiWOQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0Z3WOYwAAAAAP5Jw58krBRZLjnx1cFnN8UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0BISOYwAAAAB9\u002BcI2AtCvQ4zpkNTHNhXAUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "92ms"
       },
@@ -298,10 +282,226 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-77476579a830efed09189cb1c74f0633-fdcb5494ee3fb8fa-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fa3b9aa0aed9e5b5c543121e67562812",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:32 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:32 GMT",
+        "MS-CV": "lt66dB6AUk\u002BYwsY8IdDJJA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0BISOYwAAAAAMWpKthtY0S5f8rbvjTNh3UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "95ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          },
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-934620f3ac24e95f6b8bd455ed908614-a357913754c828c3-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a45150846f00a93466c1649f27e8089f",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:32 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:32 GMT",
+        "MS-CV": "sO4as2xNKk2Fkmp/7gfmxA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0BISOYwAAAADjAbo8t3ugTIgn2hABsG9mUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "179ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          },
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6f5a40aeb7a77e2bac30a60a016f5af7-fa2c9f68087bde64-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e6e72a0171db3ab276f6ed38698e5043",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:33 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:32 GMT",
+        "MS-CV": "Q23PT3w0VUqXKoYvheEeOw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0BYSOYwAAAAA\u002BfHTXkJLCT61Lk8ywaofsUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "83ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          },
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-26f2e8b06246e887c7ad34bf00e1119f-3fe016e6f1e2a971-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5163830c03c1312a659194184915bedc",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:33 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:32 GMT",
+        "MS-CV": "feSGtuWId0i/A8xOk2aizQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0BYSOYwAAAAAbYfN1g5mVQZz495EuWBfVUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "87ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          },
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "62",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-26f2e8b06246e887c7ad34bf00e1119f-ae0206a3ecf36524-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3c1c723b426e13379e172d0981fb40d8",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:33 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.com": null,
+          "sbs2.com": null,
+          "newsbs.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:33 GMT",
+        "MS-CV": "iN3vMaYcKESvR2euNGKIHQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0BYSOYwAAAAB9AxNrVEaySI81kRTEGw7NUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "282ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "831381964"
+    "RandomSeed": "657568539"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-a3c569159ef36cc557168cfc4c43c23a-0335742b80710062-00",
+        "traceparent": "00-ecd8676b0cf68fc461d1ee5abdff9d49-453ac2c9dfe0467e-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c8db95a18cfff1ceb9efb5a91fdbc24a",
+        "x-ms-client-request-id": "ca27c411177a91b2218721d2e1013651",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:38 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:25 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:38 GMT",
-        "MS-CV": "RO1HUZfyOkSRIrySMruL2A.0",
+        "Date": "Tue, 13 Dec 2022 20:16:25 GMT",
+        "MS-CV": "Q59HWB1CCEmtvfjonLdLLg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07tKXYwAAAADH\u002Bst5bpn2SLP04DiXnUfDUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mt2YYwAAAAB0u\u002B1AJtyMTLVTmut0gAL8UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "157ms"
+        "X-Processing-Time": "110ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-c050906352534af97549fdf57c026f2b-167536e6df26b9ad-00",
+        "traceparent": "00-439fc691748828f70f99e98103872c95-62723fe1dd1a84e0-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "83e1701399c0eddefbf9e5ea0c0db7ff",
+        "x-ms-client-request-id": "aeda3a196ef692099133d8e40a92d393",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:38 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:25 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:38 GMT",
-        "MS-CV": "HTbw4lu/LkiDm\u002B30WGTg1Q.0",
+        "Date": "Tue, 13 Dec 2022 20:16:26 GMT",
+        "MS-CV": "a/TYlGhR0EuX0Z8BmaY1Bw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07tKXYwAAAAACrCYSXxx9RqsiHzFIVdiKUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mt2YYwAAAAAwR5yyZPkXTZEt\u002BePz0R6jUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "88ms"
+        "X-Processing-Time": "84ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-c050906352534af97549fdf57c026f2b-d92b70002bb7138d-00",
+        "traceparent": "00-439fc691748828f70f99e98103872c95-2679cca04d94ba97-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3c51c71a6427080f9a36078b4eacf310",
+        "x-ms-client-request-id": "7efe5a53d977ca15a748fdbd0b7f371a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:38 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:26 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
+          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
+          "sbs2.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:39 GMT",
-        "MS-CV": "MMImPtwMYUS5XfQD0r3Bxw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:26 GMT",
+        "MS-CV": "OOsNc7GyJEiQhBT60ydvnA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "079KXYwAAAAAdpqjbyyZFQJ9R8GdM5ZElUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mt2YYwAAAAACstsjel78TquKCWTj1TXuUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "490ms"
+        "X-Processing-Time": "372ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
+          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
+          "sbs2.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-2c04de3a07dfb86bbd23aedd02e95118-0b245c7c47ba6134-00",
+        "traceparent": "00-2709b252063f399ef48465143c63d306-31e50c63d69d0629-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "620dd0bdc2f208cdb6edcd06a7e4e5ab",
+        "x-ms-client-request-id": "5aabbde0ae56a3dbbb9438473fce868f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:39 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:26 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com"
+              "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:39 GMT",
-        "MS-CV": "h/wZhNJae06gtRu2RWwecA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:26 GMT",
+        "MS-CV": "HKIRQLsDSk2m1qi25pf\u002BWA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "079KXYwAAAADfzm2Eg5O0RpZwJMWTDFYVUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0m92YYwAAAAB7zECJRuYGQpjYkn/oAhEQUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "176ms"
+        "X-Processing-Time": "112ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
+          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
+          "sbs2.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com"
+              "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com"
             ]
           }
         ]
@@ -181,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f4e558ab02360cad073a27e1736d7267-6d37f9402dcfc536-00",
+        "traceparent": "00-247755a54a9c02e95e92fd8d6c4ff087-bf55b252c63c54a5-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "578eb637868aae2360d9e88a91539f4e",
+        "x-ms-client-request-id": "867f8db4b70340d9250f07ae704c8711",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:39 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:26 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -193,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:40 GMT",
-        "MS-CV": "gGfo/GHhOEOluiZXnyK9Ow.0",
+        "Date": "Tue, 13 Dec 2022 20:16:26 GMT",
+        "MS-CV": "3nKMQcU/NE6dRCTV19ExGg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "079KXYwAAAABsG\u002BEgxR4hTIE5m\u002BXSQL/pUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0m92YYwAAAABep0nKwE62QZmsASD1GOZGUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "93ms"
+        "X-Processing-Time": "84ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
+          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
+          "sbs2.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -216,7 +216,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com"
+              "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com"
             ]
           }
         ]
@@ -230,33 +230,33 @@
         "Authorization": "Sanitized",
         "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-13a9869fac5e14c5a706e364153997c6-ba6a2e95c817a115-00",
+        "traceparent": "00-a2dea3d009bdba86da6422123dc3e923-7cb70561b964b35d-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3b2cd40655ff580df9488639970960b6",
+        "x-ms-client-request-id": "4c03befc79e7a43c7f5ac3e2a0cd8bd8",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:39 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:26 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs2.c1276894-037a-1255-ec80-1b20d2d3458e.com": null
+          "sbs2.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:40 GMT",
-        "MS-CV": "MnZDTXCtbE\u002BTMLNiSLWqdg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:27 GMT",
+        "MS-CV": "/KefxJDSO0\u002B3YJV90oB03A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08NKXYwAAAAChTqPFkJ00SrIgCANdtfsyUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0m92YYwAAAAAS118LBEecToOT2\u002Bz4\u002Bh7LUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "266ms"
+        "X-Processing-Time": "111ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
+          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -266,7 +266,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com"
+              "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com"
             ]
           }
         ]
@@ -278,11 +278,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-70b78b3072ee629b4368961512114a30-4fc4b06675151599-00",
+        "traceparent": "00-0c479b98e73a36b2c8eb6aa3fc3b01b6-32bea5beff12658a-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "98545b509b1e3786ac5f0118d9437663",
+        "x-ms-client-request-id": "7d086ec2b1002816e36b3546a72d326f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:40 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:27 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -290,17 +290,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:40 GMT",
-        "MS-CV": "h7gFmVvvDUeai1yMv5jDEg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:27 GMT",
+        "MS-CV": "Byq0Pqyga02A1n0kEwGiwQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08NKXYwAAAAABUTy3mNoCSoBOy/NFb4LWUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nN2YYwAAAACeYscGS\u002BRhT7N0j1db0X19UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
+        "X-Processing-Time": "82ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
+          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -310,7 +310,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com"
+              "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com"
             ]
           }
         ]
@@ -322,11 +322,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-fabd564acd0117297454a9adba461387-17244c1095e9a26f-00",
+        "traceparent": "00-336412d2b77212f8739edc63c664c28a-9ddf14492884a359-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d2ff7e4da9b7e1aca9365d4200ea1756",
+        "x-ms-client-request-id": "814b270d39ca3aa851da06a8f4f79f57",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:40 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:27 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -334,17 +334,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:40 GMT",
-        "MS-CV": "8GgSCSI6Ok\u002BNnN8hWU9EMg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:27 GMT",
+        "MS-CV": "Bt/DWqQLBk64V1v8IUAAMQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08NKXYwAAAACcWv1u9r5yTpJ1sdXjunECUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nN2YYwAAAAAgFVU3PykqSrm/K7OkvMTAUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "81ms"
+        "X-Processing-Time": "85ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
+          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -354,7 +354,51 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com"
+              "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a44fc93a0438a332b8b76e77c861990f-caac85baf9fb992e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "02eb2f8409434a10a7db697b44f6fd52",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:27 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:16:27 GMT",
+        "MS-CV": "tdZDmT75/Uy0PmHlEbb4mw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0nN2YYwAAAABU3CU6RsCeTaCDg/3AkV/xUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "80ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
+            "sipSignalingPort": 1122
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com"
             ]
           }
         ]
@@ -368,11 +412,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-170565b0c5ce60acdd4dd4ae4c2f0803-7be8ffc477e255c5-00",
+        "traceparent": "00-3dfc0b9b6496c9c979ce882155daa1f8-d54d565d22de696e-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3539327807fe6a304df48fa053f47fb5",
+        "x-ms-client-request-id": "79d553280a82890dc6ce2c26aa6d33ec",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:40 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:27 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -382,17 +426,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:41 GMT",
-        "MS-CV": "9fdBgjjhQ0WpJeLk0izYzg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:27 GMT",
+        "MS-CV": "7cS/NTKzWUCC1VydB/BO8A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08NKXYwAAAABU7UkkV5HVSbfVE5zp9SFQUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nN2YYwAAAAB8bJlM0peGQIUZgxfmeV5xUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "171ms"
+        "X-Processing-Time": "96ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
+          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -405,11 +449,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-afd85329e021a77adca831e1ecdd6d65-27c8a7866a3460d2-00",
+        "traceparent": "00-f9948e91bc602d29acd83ae543819fd4-604c40d4af16bcf1-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "18eb22d18e0aa7feaf72efe83d4437c2",
+        "x-ms-client-request-id": "77c2ddcc3041032c1600d9efd02cf65b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:40 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:27 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -417,52 +461,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:41 GMT",
-        "MS-CV": "DBqXoDl55kOMccs3qt8Asg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:28 GMT",
+        "MS-CV": "MTpfvsSK4EWKxiPhiyb5Vg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08dKXYwAAAAAEyZ4I/PLRRI4FrNdbPhIPUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nN2YYwAAAAC3hAnS46zUSaxymrVSswgxUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "80ms"
+        "X-Processing-Time": "85ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
-            "sipSignalingPort": 1122
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-42d045ef151b2194d3043018a503bf30-c8f96e5ccc73fb7e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a6a0ab48400a46644d9485c21a0b8eb4",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:40 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:41 GMT",
-        "MS-CV": "Grc9I4zOUEm9dfkZE7Z1BQ.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08dKXYwAAAAAFBOAsZtmGRIlBq8\u002BIpy6dUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
+          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -477,29 +486,29 @@
         "Authorization": "Sanitized",
         "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-42d045ef151b2194d3043018a503bf30-d7bc451cb2cfa926-00",
+        "traceparent": "00-f9948e91bc602d29acd83ae543819fd4-a4b7b06c2ac691a1-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "dd70a7b6fefeea4c3492868c18482d09",
+        "x-ms-client-request-id": "a080b3dd25227ad421623b75ddeaa039",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:41 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:28 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": null
+          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:41 GMT",
-        "MS-CV": "cJpR0vwMWEWyWRuusHH/zA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:28 GMT",
+        "MS-CV": "RPNkgwdpfk\u002BEPfvKuuH5HQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08dKXYwAAAAAb9ViOeKaHQ7supWDBEk4ZUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nd2YYwAAAADL6nSW/rK8TocOBbHIICglUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "263ms"
+        "X-Processing-Time": "179ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -509,6 +518,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1044829664"
+    "RandomSeed": "1873022794"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResource.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-23649e1878cebeadb6fe313a735d78a0-cf4653a3bbcd4a99-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "fbc41308cb481a0dda93b99eeff4fed6",
+        "traceparent": "00-2bb1401db602295bf32cb8232befbb43-6cfb9c5040aea8ed-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4f13e78001cc311e0e032d713609c3dc",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:12 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:46 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,23 +22,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:12 GMT",
-        "MS-CV": "qZEiXr87K02ZwixkapwaAw.0",
+        "Date": "Mon, 05 Dec 2022 22:48:45 GMT",
+        "MS-CV": "nOz36mU\u002B/UuGYYu6sURZzw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rNZDYwAAAADVqnqqpnMrSrPJw7/tIc5iTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0TnWOYwAAAACdNIgiLB8XSpK5CZmJS5j6UFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "92ms"
+        "X-Processing-Time": "117ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -46,16 +46,16 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-de05747596d3ebc59337542cdab9a745-34fd5533213c8408-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1cf3a5aa84bf5b96bbf32ab7a4edcce3",
+        "traceparent": "00-74aaab6ec747fc4bdc4f3f47bc336bfb-03f285c1185026fb-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8dd63f35debfa130530b0f923f876849",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:12 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:46 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -63,23 +63,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:12 GMT",
-        "MS-CV": "2jbMOh1z0060ehC87kfJCQ.0",
+        "Date": "Mon, 05 Dec 2022 22:48:45 GMT",
+        "MS-CV": "mTet1KZZAkiqdkY08k699w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rdZDYwAAAAB5xVauqxNcSrpIXSBsMq9GTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0TnWOYwAAAAAdOp8sdp2YTa63cGsYEbN8UFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "71ms"
+        "X-Processing-Time": "79ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -87,49 +87,49 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "146",
+        "Content-Length": "104",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-de05747596d3ebc59337542cdab9a745-8792928a60e00295-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3513d256c803c27e8bc220d54338f8e6",
+        "traceparent": "00-74aaab6ec747fc4bdc4f3f47bc336bfb-72d38e0230bede68-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bd8c59c8cadc67fb7e7b14d4720ce6bb",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:12 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:46 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.sipconfigtest.com": null
+          "newsbs.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:12 GMT",
-        "MS-CV": "E15sV6rMqEmxsdHEAxDf7Q.0",
+        "Date": "Mon, 05 Dec 2022 22:48:46 GMT",
+        "MS-CV": "QtaRU4TgiEuhQXjzRBNp0w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rdZDYwAAAACn1RFz8hNpTY/tRguIDsiiTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0TnWOYwAAAADi6vhIfFpIQJqeHZhG0cQtUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "147ms"
+        "X-Processing-Time": "173ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -137,18 +137,18 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "178",
+        "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-1a01470ed7ebb281b8b183e2e20c5b4a-150d42eaf1b0b36e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8a727d7ab2d4836a7c684055a05575ec",
+        "traceparent": "00-7d98599b63b69ec55fa144b3c81e0a01-07b6e928ea83c928-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "564d50dcdc08a282b772fcc0f28bf187",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:13 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:47 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -158,7 +158,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -167,20 +167,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:12 GMT",
-        "MS-CV": "7njHrJwPQESkH02M7mtobQ.0",
+        "Date": "Mon, 05 Dec 2022 22:48:46 GMT",
+        "MS-CV": "cUUTKuf0G0O53o5JnapVdQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rdZDYwAAAADZGBCMi2AJRoGRymJ0nN0DTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0TnWOYwAAAAAv4IF\u002BHNPIS4ebGejvfL6yUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "104ms"
+        "X-Processing-Time": "127ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -190,23 +190,23 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-da56e1f8bf7bf04887f96676f7e25888-d45a1e0ff411f550-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1c48d6c6c9e0e2d2263191fc64c11882",
+        "traceparent": "00-7f8b4a7b5df158ca97d19c760e3fe8df-6cf4c12d37100bb7-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dca9e49a057c6bff436e0e44ca5b2e47",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:13 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:47 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -214,20 +214,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:13 GMT",
-        "MS-CV": "Y3mlHJ5mDEaOhwcbGkMSHQ.0",
+        "Date": "Mon, 05 Dec 2022 22:48:46 GMT",
+        "MS-CV": "Z3a4TnJv3EKYDE2s3GSnvQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rdZDYwAAAAD24RHDVgNnS7xeHSMve6riTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0T3WOYwAAAABDuE3O6GvWTKvtof0FV1eqUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "63ms"
+        "X-Processing-Time": "95ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -237,47 +237,47 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "42",
+        "Content-Length": "28",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-fb54602325df06073e78f809a31431cf-357577d4eae0a5af-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "273c43fa417ba30e6890b89b88292135",
+        "traceparent": "00-7b471634172e838444f8037772166c34-5f1fdc2ed94b254b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "eeb653251139eb40d6ea066ace3a74f2",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:13 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:47 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs2.sipconfigtest.com": null
+          "sbs2.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:13 GMT",
-        "MS-CV": "hpog7d/XpUqQF/TFzAjVDQ.0",
+        "Date": "Mon, 05 Dec 2022 22:48:46 GMT",
+        "MS-CV": "1roHnLwlwUWwpMgmH/lbYQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rdZDYwAAAABZygEdP/mHTKRvZEPuB9xQTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0T3WOYwAAAACHI0fN2auiQKCZ5FqXmuBUUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "210ms"
+        "X-Processing-Time": "157ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -287,23 +287,23 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-d4a9876f00a4fb5dcf1cb650ddfca08a-424bb4925ea9adcd-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6d0e334cdbefb105aa9064a3216d1fbb",
+        "traceparent": "00-7a0570c85e10c69311813b1211e596b6-f72c15d7ab0c2deb-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8d3a8d890a62d63e50e21399ce3ed75c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:13 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:47 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -311,17 +311,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:13 GMT",
-        "MS-CV": "wLiLBHaNLUS0nfojzzw\u002B/g.0",
+        "Date": "Mon, 05 Dec 2022 22:48:47 GMT",
+        "MS-CV": "lqWCxLavO02on3QWfxyCDA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rtZDYwAAAACeUqpp9ODhR7NlAnOwtniSTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0T3WOYwAAAAAIUXeGWGkATbM1iQzqralBUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "63ms"
+        "X-Processing-Time": "89ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -331,7 +331,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -339,7 +339,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "155334143"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "419120510"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResource.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -67,7 +67,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -116,7 +116,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -176,7 +176,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -223,7 +223,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -273,7 +273,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -317,7 +317,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -361,7 +361,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -400,7 +400,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -435,7 +435,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -470,7 +470,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -508,7 +508,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "507202009"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-85c59ddf37ae6f0e795e7e446f36f3bf-694df663b70b428d-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "051e48ce517214e52b903a643efa9b51",
+        "traceparent": "00-a3c569159ef36cc557168cfc4c43c23a-0335742b80710062-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c8db95a18cfff1ceb9efb5a91fdbc24a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:03 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:38 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:02 GMT",
-        "MS-CV": "fRi4rEmHAk\u002BFxaLYNJt4tg.0",
+        "Date": "Tue, 13 Dec 2022 01:18:38 GMT",
+        "MS-CV": "RO1HUZfyOkSRIrySMruL2A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "054OOYwAAAAAZogyqybVTT5hXb3B\u002B5pHzUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07tKXYwAAAADH\u002Bst5bpn2SLP04DiXnUfDUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "171ms"
+        "X-Processing-Time": "157ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-65045f179fa425ef74cf6882214f10a3-daf1ef4bb7125d66-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "021bd50d4c7f6e8e8e1eb9032a64227d",
+        "traceparent": "00-c050906352534af97549fdf57c026f2b-167536e6df26b9ad-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "83e1701399c0eddefbf9e5ea0c0db7ff",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:03 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:38 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:02 GMT",
-        "MS-CV": "OqfWg5r3VEym7BeNZimPAA.0",
+        "Date": "Tue, 13 Dec 2022 01:18:38 GMT",
+        "MS-CV": "HTbw4lu/LkiDm\u002B30WGTg1Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "054OOYwAAAACt9QZMFe/cTpS/ieSV9/cVUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07tKXYwAAAAACrCYSXxx9RqsiHzFIVdiKUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "94ms"
+        "X-Processing-Time": "88ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -72,21 +72,21 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "86",
+        "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-65045f179fa425ef74cf6882214f10a3-e932c7cc938b3496-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "90e5f10f6c74006e030b6c26f993437d",
+        "traceparent": "00-c050906352534af97549fdf57c026f2b-d92b70002bb7138d-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3c51c71a6427080f9a36078b4eacf310",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:03 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:38 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:03 GMT",
-        "MS-CV": "kcB2rgQQlUmy1Wrh4DEWFQ.0",
+        "Date": "Tue, 13 Dec 2022 01:18:39 GMT",
+        "MS-CV": "MMImPtwMYUS5XfQD0r3Bxw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "054OOYwAAAAABqX3/iEXXRJotNDN7PfaZUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "079KXYwAAAAAdpqjbyyZFQJ9R8GdM5ZElUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "712ms"
+        "X-Processing-Time": "490ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -121,13 +121,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "164",
+        "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-5cad9f7bf34969e800fbeff55051eb31-8cd632ec29b4d9e3-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8fe0852554b98110b9af775397e1eac7",
+        "traceparent": "00-2c04de3a07dfb86bbd23aedd02e95118-0b245c7c47ba6134-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "620dd0bdc2f208cdb6edcd06a7e4e5ab",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:04 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:39 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:04 GMT",
-        "MS-CV": "z7badOaG7keQOpmdF0orPw.0",
+        "Date": "Tue, 13 Dec 2022 01:18:39 GMT",
+        "MS-CV": "h/wZhNJae06gtRu2RWwecA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "06IOOYwAAAABpNcpYrFM9SJCq1AoLyEFZUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "079KXYwAAAADfzm2Eg5O0RpZwJMWTDFYVUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "252ms"
+        "X-Processing-Time": "176ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com"
             ]
           }
         ]
@@ -181,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-1de8d991933c2cf502a7f583ff09a2ce-a5b825de3a4feb13-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4d54bc6e0a15a0dd661aff74e06774fa",
+        "traceparent": "00-f4e558ab02360cad073a27e1736d7267-6d37f9402dcfc536-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "578eb637868aae2360d9e88a91539f4e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:04 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:39 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -193,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:04 GMT",
-        "MS-CV": "DdB02NckVkKuGCE/GSLJkg.0",
+        "Date": "Tue, 13 Dec 2022 01:18:40 GMT",
+        "MS-CV": "gGfo/GHhOEOluiZXnyK9Ow.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "06IOOYwAAAADW55EGuzNcT4gPJwg83XL/UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "079KXYwAAAABsG\u002BEgxR4hTIE5m\u002BXSQL/pUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
+        "X-Processing-Time": "93ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -216,7 +216,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com"
             ]
           }
         ]
@@ -228,35 +228,35 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "28",
+        "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-f928c77b98a27f9994ab9e9e5a174706-4c703d302846c47b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a4dd3cda9283bbc4e163d7c4f51a6821",
+        "traceparent": "00-13a9869fac5e14c5a706e364153997c6-ba6a2e95c817a115-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3b2cd40655ff580df9488639970960b6",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:04 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:39 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs2.com": null
+          "sbs2.c1276894-037a-1255-ec80-1b20d2d3458e.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:04 GMT",
-        "MS-CV": "eqdxEGHiLE2LpObcpRvWQg.0",
+        "Date": "Tue, 13 Dec 2022 01:18:40 GMT",
+        "MS-CV": "MnZDTXCtbE\u002BTMLNiSLWqdg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "06IOOYwAAAAB\u002Buh5KxuPOS6U2Wy13TIhwUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08NKXYwAAAAChTqPFkJ00SrIgCANdtfsyUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "404ms"
+        "X-Processing-Time": "266ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -266,7 +266,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com"
             ]
           }
         ]
@@ -278,11 +278,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-7fcb7773b5ea01d1f1fc19c4c3ad38d0-ba246cf0034929f8-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3db8a420f63f1b68a83f289e559ca151",
+        "traceparent": "00-70b78b3072ee629b4368961512114a30-4fc4b06675151599-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "98545b509b1e3786ac5f0118d9437663",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:05 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:40 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -290,17 +290,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:04 GMT",
-        "MS-CV": "0qxgiIRMGk6ko3UBEyKjBQ.0",
+        "Date": "Tue, 13 Dec 2022 01:18:40 GMT",
+        "MS-CV": "h7gFmVvvDUeai1yMv5jDEg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "06YOOYwAAAADX9t2jv4adRpd1cnfRwqlSUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08NKXYwAAAAABUTy3mNoCSoBOy/NFb4LWUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "82ms"
+        "X-Processing-Time": "87ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -310,7 +310,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com"
             ]
           }
         ]
@@ -322,11 +322,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-14ba2c290d0e6448bfc49eefac19a23e-2e31f1d860d69177-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5b787c3b4603db43f7996cb23318ab4b",
+        "traceparent": "00-fabd564acd0117297454a9adba461387-17244c1095e9a26f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d2ff7e4da9b7e1aca9365d4200ea1756",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:05 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:40 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -334,17 +334,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:05 GMT",
-        "MS-CV": "sbjI3XupnkyprcScUN3AKw.0",
+        "Date": "Tue, 13 Dec 2022 01:18:40 GMT",
+        "MS-CV": "8GgSCSI6Ok\u002BNnN8hWU9EMg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "06YOOYwAAAACUvbEqbhQhQbiGzMwgkkqcUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08NKXYwAAAACcWv1u9r5yTpJ1sdXjunECUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "90ms"
+        "X-Processing-Time": "81ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -354,7 +354,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com"
             ]
           }
         ]
@@ -368,11 +368,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-055c93b3a9b3c7e87ab8dad81ab416a7-a3cebff43f8bdbaa-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3c53ddb237afe4bbd3c2fb446a266644",
+        "traceparent": "00-170565b0c5ce60acdd4dd4ae4c2f0803-7be8ffc477e255c5-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3539327807fe6a304df48fa053f47fb5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:05 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:40 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -382,17 +382,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:05 GMT",
-        "MS-CV": "70kIr6GHzE22lqog1grr8Q.0",
+        "Date": "Tue, 13 Dec 2022 01:18:41 GMT",
+        "MS-CV": "9fdBgjjhQ0WpJeLk0izYzg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "06YOOYwAAAABbQYxgHCxySKnqXsk8xW5PUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08NKXYwAAAABU7UkkV5HVSbfVE5zp9SFQUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "174ms"
+        "X-Processing-Time": "171ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -405,11 +405,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-92882c5acc8985f057180722a30a5573-b2953d8330146452-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "798986c10ca1da1e60dc45a58ab6e790",
+        "traceparent": "00-afd85329e021a77adca831e1ecdd6d65-27c8a7866a3460d2-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "18eb22d18e0aa7feaf72efe83d4437c2",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:06 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:40 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -417,17 +417,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:05 GMT",
-        "MS-CV": "g\u002BGhV\u002BE5nUqvlIusEsxZTw.0",
+        "Date": "Tue, 13 Dec 2022 01:18:41 GMT",
+        "MS-CV": "DBqXoDl55kOMccs3qt8Asg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "06oOOYwAAAAAbl3Y\u002BXk/UQLYSdsG7ovdgUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08dKXYwAAAAAEyZ4I/PLRRI4FrNdbPhIPUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "80ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -440,11 +440,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-2a2ab70949ef19611db34bab0ee57ee9-7cf04df0b737ebf2-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "78ebdc94654803a1c09488404aff71d1",
+        "traceparent": "00-42d045ef151b2194d3043018a503bf30-c8f96e5ccc73fb7e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a6a0ab48400a46644d9485c21a0b8eb4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:06 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:40 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -452,17 +452,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:05 GMT",
-        "MS-CV": "FpjU7hvQw0es340oc7zUOA.0",
+        "Date": "Tue, 13 Dec 2022 01:18:41 GMT",
+        "MS-CV": "Grc9I4zOUEm9dfkZE7Z1BQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "06oOOYwAAAABitjtw7fnhTo0ivQbuvnIVUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08dKXYwAAAAAFBOAsZtmGRIlBq8\u002BIpy6dUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
+        "X-Processing-Time": "87ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -475,31 +475,31 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "28",
+        "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-2a2ab70949ef19611db34bab0ee57ee9-3a2df249fd1ebe4f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "adf02733318fa6aabe78dbd2f1155a1c",
+        "traceparent": "00-42d045ef151b2194d3043018a503bf30-d7bc451cb2cfa926-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dd70a7b6fefeea4c3492868c18482d09",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:06 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:41 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": null
+          "sbs1.c1276894-037a-1255-ec80-1b20d2d3458e.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:06 GMT",
-        "MS-CV": "6qvG8U/1gEuhQyhS15Gtsg.0",
+        "Date": "Tue, 13 Dec 2022 01:18:41 GMT",
+        "MS-CV": "cJpR0vwMWEWyWRuusHH/zA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "06oOOYwAAAAATfYJnutavToAUXpG/YwN5UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08dKXYwAAAAAb9ViOeKaHQ7supWDBEk4ZUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "266ms"
+        "X-Processing-Time": "263ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -509,6 +509,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "507202009"
+    "RandomSeed": "1044829664"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-2bb1401db602295bf32cb8232befbb43-6cfb9c5040aea8ed-00",
+        "traceparent": "00-85c59ddf37ae6f0e795e7e446f36f3bf-694df663b70b428d-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4f13e78001cc311e0e032d713609c3dc",
+        "x-ms-client-request-id": "051e48ce517214e52b903a643efa9b51",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:46 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:03 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,26 +22,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:45 GMT",
-        "MS-CV": "nOz36mU\u002B/UuGYYu6sURZzw.0",
+        "Date": "Mon, 05 Dec 2022 23:51:02 GMT",
+        "MS-CV": "fRi4rEmHAk\u002BFxaLYNJt4tg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0TnWOYwAAAACdNIgiLB8XSpK5CZmJS5j6UFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "054OOYwAAAAAZogyqybVTT5hXb3B\u002B5pHzUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "117ms"
+        "X-Processing-Time": "171ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          },
-          "newsbs.com": {
-            "sipSignalingPort": 3333
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -51,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-74aaab6ec747fc4bdc4f3f47bc336bfb-03f285c1185026fb-00",
+        "traceparent": "00-65045f179fa425ef74cf6882214f10a3-daf1ef4bb7125d66-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8dd63f35debfa130530b0f923f876849",
+        "x-ms-client-request-id": "021bd50d4c7f6e8e8e1eb9032a64227d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:46 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:03 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -63,26 +53,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:45 GMT",
-        "MS-CV": "mTet1KZZAkiqdkY08k699w.0",
+        "Date": "Mon, 05 Dec 2022 23:51:02 GMT",
+        "MS-CV": "OqfWg5r3VEym7BeNZimPAA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0TnWOYwAAAAAdOp8sdp2YTa63cGsYEbN8UFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "054OOYwAAAACt9QZMFe/cTpS/ieSV9/cVUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "79ms"
+        "X-Processing-Time": "94ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          },
-          "newsbs.com": {
-            "sipSignalingPort": 3333
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -92,13 +72,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "104",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-74aaab6ec747fc4bdc4f3f47bc336bfb-72d38e0230bede68-00",
+        "traceparent": "00-65045f179fa425ef74cf6882214f10a3-e932c7cc938b3496-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "bd8c59c8cadc67fb7e7b14d4720ce6bb",
+        "x-ms-client-request-id": "90e5f10f6c74006e030b6c26f993437d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:46 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:03 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -108,21 +88,20 @@
           },
           "sbs2.com": {
             "sipSignalingPort": 1123
-          },
-          "newsbs.com": null
+          }
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:46 GMT",
-        "MS-CV": "QtaRU4TgiEuhQXjzRBNp0w.0",
+        "Date": "Mon, 05 Dec 2022 23:51:03 GMT",
+        "MS-CV": "kcB2rgQQlUmy1Wrh4DEWFQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0TnWOYwAAAADi6vhIfFpIQJqeHZhG0cQtUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "054OOYwAAAAABqX3/iEXXRJotNDN7PfaZUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "173ms"
+        "X-Processing-Time": "712ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -144,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-7d98599b63b69ec55fa144b3c81e0a01-07b6e928ea83c928-00",
+        "traceparent": "00-5cad9f7bf34969e800fbeff55051eb31-8cd632ec29b4d9e3-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "564d50dcdc08a282b772fcc0f28bf187",
+        "x-ms-client-request-id": "8fe0852554b98110b9af775397e1eac7",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:47 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:04 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -167,13 +146,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:46 GMT",
-        "MS-CV": "cUUTKuf0G0O53o5JnapVdQ.0",
+        "Date": "Mon, 05 Dec 2022 23:51:04 GMT",
+        "MS-CV": "z7badOaG7keQOpmdF0orPw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0TnWOYwAAAAAv4IF\u002BHNPIS4ebGejvfL6yUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "06IOOYwAAAABpNcpYrFM9SJCq1AoLyEFZUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "127ms"
+        "X-Processing-Time": "252ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -202,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-7f8b4a7b5df158ca97d19c760e3fe8df-6cf4c12d37100bb7-00",
+        "traceparent": "00-1de8d991933c2cf502a7f583ff09a2ce-a5b825de3a4feb13-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "dca9e49a057c6bff436e0e44ca5b2e47",
+        "x-ms-client-request-id": "4d54bc6e0a15a0dd661aff74e06774fa",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:47 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:04 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -214,13 +193,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:46 GMT",
-        "MS-CV": "Z3a4TnJv3EKYDE2s3GSnvQ.0",
+        "Date": "Mon, 05 Dec 2022 23:51:04 GMT",
+        "MS-CV": "DdB02NckVkKuGCE/GSLJkg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0T3WOYwAAAABDuE3O6GvWTKvtof0FV1eqUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "06IOOYwAAAADW55EGuzNcT4gPJwg83XL/UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "95ms"
+        "X-Processing-Time": "84ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -251,11 +230,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "28",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-7b471634172e838444f8037772166c34-5f1fdc2ed94b254b-00",
+        "traceparent": "00-f928c77b98a27f9994ab9e9e5a174706-4c703d302846c47b-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "eeb653251139eb40d6ea066ace3a74f2",
+        "x-ms-client-request-id": "a4dd3cda9283bbc4e163d7c4f51a6821",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:47 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:04 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -267,13 +246,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:46 GMT",
-        "MS-CV": "1roHnLwlwUWwpMgmH/lbYQ.0",
+        "Date": "Mon, 05 Dec 2022 23:51:04 GMT",
+        "MS-CV": "eqdxEGHiLE2LpObcpRvWQg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0T3WOYwAAAACHI0fN2auiQKCZ5FqXmuBUUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "06IOOYwAAAAB\u002Buh5KxuPOS6U2Wy13TIhwUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "157ms"
+        "X-Processing-Time": "404ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -299,11 +278,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-7a0570c85e10c69311813b1211e596b6-f72c15d7ab0c2deb-00",
+        "traceparent": "00-7fcb7773b5ea01d1f1fc19c4c3ad38d0-ba246cf0034929f8-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8d3a8d890a62d63e50e21399ce3ed75c",
+        "x-ms-client-request-id": "3db8a420f63f1b68a83f289e559ca151",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:47 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:05 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -311,13 +290,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:47 GMT",
-        "MS-CV": "lqWCxLavO02on3QWfxyCDA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:04 GMT",
+        "MS-CV": "0qxgiIRMGk6ko3UBEyKjBQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0T3WOYwAAAAAIUXeGWGkATbM1iQzqralBUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "06YOOYwAAAADX9t2jv4adRpd1cnfRwqlSUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
+        "X-Processing-Time": "82ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -336,10 +315,200 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-14ba2c290d0e6448bfc49eefac19a23e-2e31f1d860d69177-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5b787c3b4603db43f7996cb23318ab4b",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:05 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:05 GMT",
+        "MS-CV": "sbjI3XupnkyprcScUN3AKw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "06YOOYwAAAACUvbEqbhQhQbiGzMwgkkqcUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "90ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-055c93b3a9b3c7e87ab8dad81ab416a7-a3cebff43f8bdbaa-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3c53ddb237afe4bbd3c2fb446a266644",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:05 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:05 GMT",
+        "MS-CV": "70kIr6GHzE22lqog1grr8Q.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "06YOOYwAAAABbQYxgHCxySKnqXsk8xW5PUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "174ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-92882c5acc8985f057180722a30a5573-b2953d8330146452-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "798986c10ca1da1e60dc45a58ab6e790",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:06 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:05 GMT",
+        "MS-CV": "g\u002BGhV\u002BE5nUqvlIusEsxZTw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "06oOOYwAAAAAbl3Y\u002BXk/UQLYSdsG7ovdgUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "80ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2a2ab70949ef19611db34bab0ee57ee9-7cf04df0b737ebf2-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "78ebdc94654803a1c09488404aff71d1",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:06 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:05 GMT",
+        "MS-CV": "FpjU7hvQw0es340oc7zUOA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "06oOOYwAAAABitjtw7fnhTo0ivQbuvnIVUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "83ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "28",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-2a2ab70949ef19611db34bab0ee57ee9-3a2df249fd1ebe4f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "adf02733318fa6aabe78dbd2f1155a1c",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:06 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:06 GMT",
+        "MS-CV": "6qvG8U/1gEuhQyhS15Gtsg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "06oOOYwAAAAATfYJnutavToAUXpG/YwN5UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "266ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "419120510"
+    "RandomSeed": "507202009"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-fd73add3a90ceb112e64ce30cdbc351c-d921799b898123e7-00",
+        "traceparent": "00-56651d5fc8818a0e26367187609d8e3f-eecee1c666cc3543-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c15e6ebceeeeb3df62fa31a771a535ac",
+        "x-ms-client-request-id": "13f4929dc77d7d502f1328e6fec5eab5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:38:49 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:51 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,20 +22,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:38:50 GMT",
-        "MS-CV": "4RP4uL9LqkS88On76YAKWQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:52 GMT",
+        "MS-CV": "Jmbl1BpOBkG4i8KzFM1ZKw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0qteXYwAAAAAX2gpay77oRLmofKLpgaacUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0tN2YYwAAAACQ2bREFksJRI4KYiONW5/AUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "312ms"
+        "X-Processing-Time": "162ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.3e828ecc-c7e2-3d5b-8280-b09e9bba6d74.com": {
-            "sipSignalingPort": 1122
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -45,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-c0409c7b6f930e04a6a640159e7c2a5e-fb4e461f90b2d6ca-00",
+        "traceparent": "00-5d9c1e809d52f06e9ed27bef89dea084-72b636e0fb0e78b5-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f460a5defa65c6a25fca31d7d6c515f4",
+        "x-ms-client-request-id": "ab4faa39e82ea884767446d90388cd43",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:38:50 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:51 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -57,20 +53,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:38:50 GMT",
-        "MS-CV": "n8CpRviRaEuvYmulWabiDA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:52 GMT",
+        "MS-CV": "wsmCY\u002BWue0m/ZCUJ4l5/QA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0q9eXYwAAAADB\u002B9V\u002BDne2QbIGL1UJZ1pZUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0tN2YYwAAAAC0zV9qaxxYSJJKvNlzj/wHUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
+        "X-Processing-Time": "83ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.3e828ecc-c7e2-3d5b-8280-b09e9bba6d74.com": {
-            "sipSignalingPort": 1122
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -80,44 +72,43 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "213",
+        "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-c0409c7b6f930e04a6a640159e7c2a5e-44d466203ec7a516-00",
+        "traceparent": "00-5d9c1e809d52f06e9ed27bef89dea084-0cb90039f04039d6-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "55a6caf41fc9fecde1411baed253d5a9",
+        "x-ms-client-request-id": "16bd5918d033d64815923eb96d4206fc",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:38:50 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+          "sbs2.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
             "sipSignalingPort": 1123
-          },
-          "sbs1.3e828ecc-c7e2-3d5b-8280-b09e9bba6d74.com": null
+          }
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:38:51 GMT",
-        "MS-CV": "NQN1NkbF8EGl/QpEOYlyzA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:53 GMT",
+        "MS-CV": "bNewb5vMh0C\u002BunEfNO/wHg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0q9eXYwAAAAAYzIZtynJfRrxaTC/IZBfsUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0tN2YYwAAAAC5GEgDA\u002BYpR5tA4CG56Ae4UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "996ms"
+        "X-Processing-Time": "527ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+          "sbs2.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -132,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-9042d09fad9bee41d055a6b1eb39c167-5581397c315f7fc9-00",
+        "traceparent": "00-7531417a329f3cf0970408e4b6f60813-c0d57ad78d92d8fb-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4dc2aa8f1edec2e3cb976123bc08dd9c",
+        "x-ms-client-request-id": "c9d36f10f701b4db0d4c9d09817679a6",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:38:51 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -146,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com"
+              "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com"
             ]
           }
         ]
@@ -155,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:38:52 GMT",
-        "MS-CV": "AlxJd6S9YEKgk43DcijTag.0",
+        "Date": "Tue, 13 Dec 2022 20:16:53 GMT",
+        "MS-CV": "zQLeJQwy1EG2Q18uz/ysiw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rNeXYwAAAADwWo8e3Xu\u002BRJarANUOydZLUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0td2YYwAAAACIKzPn/5e8SpKkvZxz4TuGUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "171ms"
+        "X-Processing-Time": "167ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+          "sbs2.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -178,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com"
+              "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com"
             ]
           }
         ]
@@ -190,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-856cc422c9a2d7b66d1f337757b2f1fd-b27d933c2f398bd4-00",
+        "traceparent": "00-84b59651436f79a4afb993786e39ed8e-7cc98d7454fccdac-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a7b23ce4dffebfe3d7621223def4f40b",
+        "x-ms-client-request-id": "a4cee545d40868816279959baaca3a33",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:38:52 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -202,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:38:52 GMT",
-        "MS-CV": "aVFA3a0wnESCHg15Op8gJQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:54 GMT",
+        "MS-CV": "/N/1R8wGIU2iqkTryMSIUw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rNeXYwAAAABjy62SG/z\u002BRZjsdFg/pUzlUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0td2YYwAAAABYDybfKXt/T71ljTh7rzzfUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "86ms"
+        "X-Processing-Time": "211ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+          "sbs2.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -225,7 +216,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com"
+              "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com"
             ]
           }
         ]
@@ -239,33 +230,33 @@
         "Authorization": "Sanitized",
         "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-4a7ea51674aa7ee3d836f4a59cc47d13-36a2d669ecd0f99d-00",
+        "traceparent": "00-68e808dbe39c6c0ce4433245ae280c75-1b0fedc8845bb5a0-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2b4788f5c802d515e6e48931beaa41d8",
+        "x-ms-client-request-id": "93c9496d04b521417e0808e7333e549f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:38:52 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs2.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": null
+          "sbs2.6e0f659d-96cc-0429-c2fb-250c7351a209.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:38:52 GMT",
-        "MS-CV": "BDDOpos2iEWaRY\u002BQRCFesw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:54 GMT",
+        "MS-CV": "jncZo58ySkGb6QrolAnnYA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rNeXYwAAAAAQvxzgujwFS4asgranHJbGUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0tt2YYwAAAAC8sBJoAONvQK/gQ9q90hJ0UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "388ms"
+        "X-Processing-Time": "261ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -275,7 +266,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com"
+              "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com"
             ]
           }
         ]
@@ -287,11 +278,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-7866485856ca94c838f38d5cc2157794-78ab80ab4492bba2-00",
+        "traceparent": "00-636fc5a9c310e5dd6b0fd76b08439566-a3f90dfc2a85ca64-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "95c97e632ea0afaac703757c0cbfe4d7",
+        "x-ms-client-request-id": "8874971861743bf4ed6a6688613f0a42",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:38:52 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -299,17 +290,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:38:53 GMT",
-        "MS-CV": "c7lgJraGBUSQ1oXJHdCR5Q.0",
+        "Date": "Tue, 13 Dec 2022 20:16:54 GMT",
+        "MS-CV": "4PP2zdntYUmVWnQTaQ1NWw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rdeXYwAAAADyy6Th0ADhSJHgUCw3eJxdUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0tt2YYwAAAABSFFcf19F6TL9Y1/FusFT6UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "94ms"
+        "X-Processing-Time": "161ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -319,7 +310,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com"
+              "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com"
             ]
           }
         ]
@@ -331,11 +322,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-7a41769adf6c457dd8b2d596fabe5a98-76fa5187615c3004-00",
+        "traceparent": "00-53d3d2ba6906bde53f2567f3a1e143cb-fb1e574648d16ee3-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "342e56a3b1c11c9a27ddc01a55b1012d",
+        "x-ms-client-request-id": "389c6a11e5ac40f1a3ac26ffcb9a3523",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:38:53 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -343,17 +334,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:38:53 GMT",
-        "MS-CV": "FHY9ctAf0EaZ0X4Z3CvIzQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:55 GMT",
+        "MS-CV": "6VxkoghTH0KCk/\u002BHG25QdQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rdeXYwAAAAAhIUgHw3c0SJgeVlFd3rxKUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0tt2YYwAAAAAyPnwznLIRSLVK1HWYlU/rUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "94ms"
+        "X-Processing-Time": "88ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -363,7 +354,51 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com"
+              "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a73fd8fc12eb35cdce3aa5e769044f20-4a755aac93053b9e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1283f625b2560bbf548ea64a9eb9bf3e",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:54 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:16:55 GMT",
+        "MS-CV": "mcv7IfYoeE\u002BjZzgQDhjEyA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0t92YYwAAAAAI/2I3xX3FQ75uRv5Vrn33UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "86ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
+            "sipSignalingPort": 1122
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com"
             ]
           }
         ]
@@ -377,11 +412,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-1d6a5402e93a1965603d08e74b194783-7769147be85f7246-00",
+        "traceparent": "00-4474e4b18bf0efe83d80c26a70bd4f05-3207f5b91f8f9d93-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5fc039215e2ac66ade9764fe5299c927",
+        "x-ms-client-request-id": "c9d5c5fe1ba232f2a634e4c73bf57053",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:38:53 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:54 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -391,17 +426,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:38:53 GMT",
-        "MS-CV": "X4WPqmFudkGJ622HZ4dn2Q.0",
+        "Date": "Tue, 13 Dec 2022 20:16:55 GMT",
+        "MS-CV": "8P9SwEdg2k6L2z0t/FxKVA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rdeXYwAAAAAZub1CBJtmTJRPmSU5XCwhUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0t92YYwAAAABwwSzeLnj0QIoncwDpghGSUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "160ms"
+        "X-Processing-Time": "176ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -414,11 +449,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-76398f43d5bf28ecdb93ea0577cc352d-89feb45616681865-00",
+        "traceparent": "00-fc04adbb81316ccd9caadfa570f308d8-c60f5fc4aee6bf73-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "678db2000d7bb217e4ad6ec36e905a15",
+        "x-ms-client-request-id": "6a634235f7bc5fecaa90e31e3fa6a2ea",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:38:53 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:54 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -426,52 +461,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:38:53 GMT",
-        "MS-CV": "5GrosLIkJEunm32EbdTcnA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:55 GMT",
+        "MS-CV": "exxBUVtqtUiJfAX\u002B6pNjJg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rteXYwAAAABRoT6a9Sy0RZ\u002BmjiODaoSpUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "86ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
-            "sipSignalingPort": 1122
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-99e59e4f6e8f1086dfd5ae34ba2003b0-78d5b5b9e1ebac5f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d25b480284ff45aceb68552a4d9cca8d",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:38:53 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:38:54 GMT",
-        "MS-CV": "aT/S2jc1b0OuiggyPkHc3Q.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rteXYwAAAABCUS232ef5TbjnO4NgpNIdUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0t92YYwAAAACmsVcA3dyFQ6abKwWbif\u002BEUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "83ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -486,29 +486,29 @@
         "Authorization": "Sanitized",
         "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-99e59e4f6e8f1086dfd5ae34ba2003b0-bd41cf9f1596c9d9-00",
+        "traceparent": "00-fc04adbb81316ccd9caadfa570f308d8-45ceefff4135397f-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a31a9813992414b2220d7a7defa7574e",
+        "x-ms-client-request-id": "0500e8ec6cc4098104506c22cdf8d05f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:38:53 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:54 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": null
+          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:38:54 GMT",
-        "MS-CV": "lDkEvB0pXE\u002BQ2hfNlvDiiQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:56 GMT",
+        "MS-CV": "2oJrekzXsEyOUgiS\u002BMTA\u002Bg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rteXYwAAAACsVEv/b0O2QowWMUhS6hgoUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0t92YYwAAAADp1KY8i0NdRYaI5oNni7lHUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "259ms"
+        "X-Processing-Time": "246ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -518,6 +518,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "890033175"
+    "RandomSeed": "464633339"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResourceAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-fba3db67121e6644e0abf5e495a684e5-8cc61461e8361ffc-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8a7d50d3ca737b66c928433a4ac590c5",
+        "traceparent": "00-d1078ec9f82fe5db981bf2c6afb108ca-b26e941126c14f1e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "40c7ebab7d4f627a7d6c78fc24095bf7",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:25 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:11 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,23 +22,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:25 GMT",
-        "MS-CV": "rs07qoxB7E687bWOljwqvA.0",
+        "Date": "Mon, 05 Dec 2022 22:49:11 GMT",
+        "MS-CV": "MQZfvZS6SUuDg\u002BeHKC1L6w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0udZDYwAAAAC39reqY17tQr9QeUK1JI9NTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0Z3WOYwAAAACYxavPfIpZQ5JG7cCaGjE3UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "91ms"
+        "X-Processing-Time": "200ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -46,16 +46,16 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-cea4f986366f71a78c73812143d2c486-21daac03130a654f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1b224fad215bff34ae3876f4525cd109",
+        "traceparent": "00-8814ef50617ed4a09e8e20e31fd31808-cdb4a045f6136a09-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "54533ba6b5d9624c70c2b4bc4788c491",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:25 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:12 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -63,23 +63,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:25 GMT",
-        "MS-CV": "Weox4VlzeE2u65ZiOMFUrw.0",
+        "Date": "Mon, 05 Dec 2022 22:49:12 GMT",
+        "MS-CV": "j9TiFM8b\u002BUuKyhA0XQAhDA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0utZDYwAAAAAVQD9MzmbXTaMsbp72daTkTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0aHWOYwAAAAALva6Sdl9ITqe7l5HTrNuKUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "66ms"
+        "X-Processing-Time": "90ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -87,49 +87,49 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "146",
+        "Content-Length": "104",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-cea4f986366f71a78c73812143d2c486-fb7ddb7725d2116f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f25241901ad8dffa136ba748b84c2c12",
+        "traceparent": "00-8814ef50617ed4a09e8e20e31fd31808-1e85eff26a360a7c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f1ac938bd0d5948834f1c742661fbc5a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:25 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:12 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.sipconfigtest.com": null
+          "newsbs.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:25 GMT",
-        "MS-CV": "4nIezYFLMU\u002Bh2JakJDKAoQ.0",
+        "Date": "Mon, 05 Dec 2022 22:49:12 GMT",
+        "MS-CV": "pS9YTnt3h0K2VsVApb\u002BsPw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0utZDYwAAAAAb8J7LZwtgSK0JSWXyn12WTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0aHWOYwAAAABbWYxfTTNRS7/4JReO1OG0UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "161ms"
+        "X-Processing-Time": "177ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -137,18 +137,18 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "178",
+        "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-9ec86023529c4634cb287c6900950fc7-aa64b36783c7e2f7-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "fa7170f830dcb1b31b7ddb3a5472296c",
+        "traceparent": "00-fb9bbf308c721759f02cd363ba5d7bf0-a2226dbb4b0bdabf-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4b5b18f2b0d4f5479f64d08dc9be1af4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:25 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:12 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -158,7 +158,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -167,20 +167,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:25 GMT",
-        "MS-CV": "7t7MtEKEQ0uZU49HTD7ThQ.0",
+        "Date": "Mon, 05 Dec 2022 22:49:12 GMT",
+        "MS-CV": "OzkhzmKYDEuGp4FWCXm\u002B4g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0utZDYwAAAAB0xt2GgVFgQr2QSCNDdE63TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0aHWOYwAAAADVNkqtMASUSJEy0GdeCuDuUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "88ms"
+        "X-Processing-Time": "114ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -190,23 +190,23 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-44df06300f8b2d5eb2db61db2399cb85-eb505e7a57eb98c4-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "08a939579e7393ec544307ef7aec4761",
+        "traceparent": "00-4361eb26986c4cc3574eddb5d515f9eb-054860c737194dfb-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9070e6a7695dd621b3bf1fe7ed0afc50",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:26 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:12 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -214,20 +214,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:26 GMT",
-        "MS-CV": "3BjctUPY50GFgpeWnDiWzw.0",
+        "Date": "Mon, 05 Dec 2022 22:49:12 GMT",
+        "MS-CV": "JRVvkbS9eUKIsF3CD4IPrw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0utZDYwAAAADbe8AXhx26RLM9SNmoFlpNTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0aHWOYwAAAAAiQ4YD2lNKTq/09mZeRgQXUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "77ms"
+        "X-Processing-Time": "89ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -237,47 +237,47 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "42",
+        "Content-Length": "28",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-20e739ca8381f27aa9dff4e184837e6a-115fc6f27d1b6dce-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e1fb640cd7eb602d8ea1d65b3ebf8aa0",
+        "traceparent": "00-fd53a68c69b197112865ad62f6e2d28c-1d27892d2bed585e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2fc95905792cdbbc4cb65271fffbcb76",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:26 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:13 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs2.sipconfigtest.com": null
+          "sbs2.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:26 GMT",
-        "MS-CV": "SwpZQ24oyEmUalWFBYIIGw.0",
+        "Date": "Mon, 05 Dec 2022 22:49:13 GMT",
+        "MS-CV": "8xgp/PGSWEqCCWU20Pwutw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0utZDYwAAAABCZWynRz\u002B9RYzvhwltSDfRTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0aXWOYwAAAACLBf06D0OLSpuscLHg/uDbUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "121ms"
+        "X-Processing-Time": "130ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -287,23 +287,23 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-9266c6060d0361dc999264a69c307703-1aa69a398c8b1ab1-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7ef03a4223a25a9f83dea59928c3362f",
+        "traceparent": "00-6c021a5008a2502ab1330b00a91696a4-c2b8c431e668e526-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "809ad3d72baf89fdf684971591600894",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:26 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:13 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -311,17 +311,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:26 GMT",
-        "MS-CV": "9zKnVYMpJ0WQh3qN3Aa3JA.0",
+        "Date": "Mon, 05 Dec 2022 22:49:13 GMT",
+        "MS-CV": "eR\u002B4yhyQEEaNPPJMuVOIVA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0u9ZDYwAAAACsBNmGa2AzQqfNuSIa95SZTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0aXWOYwAAAACsjgy6sw4cSb36Ge3P/NVRUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "68ms"
+        "X-Processing-Time": "83ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -331,7 +331,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -339,7 +339,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "596472393"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "164092641"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-fdadf696beea2ba888b644f88fecf6dc-f8c93dd9643618d1-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ac6926ca1add82ab045ee8bcef24ed36",
+        "traceparent": "00-fd73add3a90ceb112e64ce30cdbc351c-d921799b898123e7-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c15e6ebceeeeb3df62fa31a771a535ac",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:34 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:38:49 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,16 +22,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:33 GMT",
-        "MS-CV": "dXqRFb4l\u002Bk\u002B20tp9Z0PKBw.0",
+        "Date": "Tue, 13 Dec 2022 01:38:50 GMT",
+        "MS-CV": "4RP4uL9LqkS88On76YAKWQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0BoSOYwAAAAAxEfrXfCRgQrZVH1ygU5q\u002BUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0qteXYwAAAAAX2gpay77oRLmofKLpgaacUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "173ms"
+        "X-Processing-Time": "312ms"
       },
       "ResponseBody": {
-        "trunks": {},
+        "trunks": {
+          "sbs1.3e828ecc-c7e2-3d5b-8280-b09e9bba6d74.com": {
+            "sipSignalingPort": 1122
+          }
+        },
         "routes": []
       }
     },
@@ -41,11 +45,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-4c9dbdf81754f3098b82582eeda8e1d7-c58f9f6c2a14c045-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "60de94dca23f484c634da30194e9ea41",
+        "traceparent": "00-c0409c7b6f930e04a6a640159e7c2a5e-fb4e461f90b2d6ca-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f460a5defa65c6a25fca31d7d6c515f4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:34 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:38:50 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,160 +57,118 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:33 GMT",
-        "MS-CV": "W\u002B\u002B4/grlGEqNyYGrfzeuuQ.0",
+        "Date": "Tue, 13 Dec 2022 01:38:50 GMT",
+        "MS-CV": "n8CpRviRaEuvYmulWabiDA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0BoSOYwAAAABoo3gO\u002Bh5YRJScWRYVvT/NUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "85ms"
-      },
-      "ResponseBody": {
-        "trunks": {},
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "PATCH",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "86",
-        "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-4c9dbdf81754f3098b82582eeda8e1d7-11be3b2d7f599e36-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "10b0936726ce0cf4afaf8365983d994f",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:34 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:34 GMT",
-        "MS-CV": "L\u002BE4aGn4G0KiHcxQWnHYRA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0BoSOYwAAAADBSj42mJK0S6otMRZaN7M1UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "660ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "PATCH",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "164",
-        "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-a92a1177971ab99fb3ff488576d16f07-7e7b36943c4cb43b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2d86e457bbde2805d921498f77aaee1a",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:35 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.com"
-            ]
-          }
-        ]
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:34 GMT",
-        "MS-CV": "Jx\u002B2R3RmPUW4G\u002B\u002BmLJ52qw.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0B4SOYwAAAABbak32z/z1QJppYgh/\u002BWB6UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "176ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-72461a5d998c402b6d29eb7fd895055a-e21a55ca6f9f18e2-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5b54a674dd74b5679fd1b1901fe7af26",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:35 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:34 GMT",
-        "MS-CV": "NxAQS9gfAUWq6DbZ2JTfWA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0B4SOYwAAAADuNrLZWdOyTIymR3Pk6vX1UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0q9eXYwAAAADB\u002B9V\u002BDne2QbIGL1UJZ1pZUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "84ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.3e828ecc-c7e2-3d5b-8280-b09e9bba6d74.com": {
+            "sipSignalingPort": 1122
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "213",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-c0409c7b6f930e04a6a640159e7c2a5e-44d466203ec7a516-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "55a6caf41fc9fecde1411baed253d5a9",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:38:50 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+            "sipSignalingPort": 1123
+          },
+          "sbs1.3e828ecc-c7e2-3d5b-8280-b09e9bba6d74.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:38:51 GMT",
+        "MS-CV": "NQN1NkbF8EGl/QpEOYlyzA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0q9eXYwAAAAAYzIZtynJfRrxaTC/IZBfsUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "996ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "201",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-9042d09fad9bee41d055a6b1eb39c167-5581397c315f7fc9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4dc2aa8f1edec2e3cb976123bc08dd9c",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:38:51 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com"
+            ]
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:38:52 GMT",
+        "MS-CV": "AlxJd6S9YEKgk43DcijTag.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0rNeXYwAAAADwWo8e3Xu\u002BRJarANUOydZLUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "171ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -216,7 +178,54 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-856cc422c9a2d7b66d1f337757b2f1fd-b27d933c2f398bd4-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a7b23ce4dffebfe3d7621223def4f40b",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:38:52 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:38:52 GMT",
+        "MS-CV": "aVFA3a0wnESCHg15Op8gJQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0rNeXYwAAAABjy62SG/z\u002BRZjsdFg/pUzlUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "86ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com"
             ]
           }
         ]
@@ -228,35 +237,35 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "28",
+        "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-50c2de755074a10175d9c29cfa72c5d3-5b7a188adec3b85d-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "afa953b4bd63ac638d8737addd659404",
+        "traceparent": "00-4a7ea51674aa7ee3d836f4a59cc47d13-36a2d669ecd0f99d-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2b4788f5c802d515e6e48931beaa41d8",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:35 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:38:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs2.com": null
+          "sbs2.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:35 GMT",
-        "MS-CV": "si3bv38ThEe5jJOToXCy0Q.0",
+        "Date": "Tue, 13 Dec 2022 01:38:52 GMT",
+        "MS-CV": "BDDOpos2iEWaRY\u002BQRCFesw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0B4SOYwAAAAAaejnUEGbwRIqjrHDj6PI4UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0rNeXYwAAAAAQvxzgujwFS4asgranHJbGUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "308ms"
+        "X-Processing-Time": "388ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -266,7 +275,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com"
             ]
           }
         ]
@@ -278,11 +287,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-a74d56b142a200436027c7cd6110cf23-d1651c06421f775e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f2f168c13ee87adb7cd18d0d097509f2",
+        "traceparent": "00-7866485856ca94c838f38d5cc2157794-78ab80ab4492bba2-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "95c97e632ea0afaac703757c0cbfe4d7",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:36 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:38:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -290,17 +299,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:35 GMT",
-        "MS-CV": "YOtpiDSAJEyGyIG6onAHPA.0",
+        "Date": "Tue, 13 Dec 2022 01:38:53 GMT",
+        "MS-CV": "c7lgJraGBUSQ1oXJHdCR5Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0CISOYwAAAACaqkojEUJhRadBc9f6/BgvUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0rdeXYwAAAADyy6Th0ADhSJHgUCw3eJxdUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "92ms"
+        "X-Processing-Time": "94ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -310,7 +319,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com"
             ]
           }
         ]
@@ -322,11 +331,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-0952dc85a5886a6877d0ab4b9609fab9-b79a9b50f15b0be7-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "24db23723e01b7b743a7cdeca5bad73a",
+        "traceparent": "00-7a41769adf6c457dd8b2d596fabe5a98-76fa5187615c3004-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "342e56a3b1c11c9a27ddc01a55b1012d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:36 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:38:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -334,17 +343,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:35 GMT",
-        "MS-CV": "VSU2m0Ne6EyhPA7NEjrAtA.0",
+        "Date": "Tue, 13 Dec 2022 01:38:53 GMT",
+        "MS-CV": "FHY9ctAf0EaZ0X4Z3CvIzQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0CISOYwAAAAD1FcInDSUwSYwe\u002Bg5ktn/3UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0rdeXYwAAAAAhIUgHw3c0SJgeVlFd3rxKUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "88ms"
+        "X-Processing-Time": "94ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -354,7 +363,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com"
             ]
           }
         ]
@@ -368,11 +377,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-b713fc061fb6a351d8b338c1aaaf9fbd-a8dc21c595508a99-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b6cfad3cbcf6753d772e33912f56a218",
+        "traceparent": "00-1d6a5402e93a1965603d08e74b194783-7769147be85f7246-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5fc039215e2ac66ade9764fe5299c927",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:36 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:38:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -382,17 +391,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:35 GMT",
-        "MS-CV": "frHyIjdCUE64Ur3XxyIrLQ.0",
+        "Date": "Tue, 13 Dec 2022 01:38:53 GMT",
+        "MS-CV": "X4WPqmFudkGJ622HZ4dn2Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0CISOYwAAAABYJwIe19BpQoyGOCSeftwPUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0rdeXYwAAAAAZub1CBJtmTJRPmSU5XCwhUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "160ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -405,11 +414,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-47f8cdffe525ac2908f5450b0d86841c-8b0e32d5379ad180-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ba3a457d70898203b139af4071eed4c2",
+        "traceparent": "00-76398f43d5bf28ecdb93ea0577cc352d-89feb45616681865-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "678db2000d7bb217e4ad6ec36e905a15",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:36 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:38:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -417,52 +426,52 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:36 GMT",
-        "MS-CV": "f09xRdZ\u002Beky6sSV/ChV5Kg.0",
+        "Date": "Tue, 13 Dec 2022 01:38:53 GMT",
+        "MS-CV": "5GrosLIkJEunm32EbdTcnA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0CISOYwAAAACZ4DDMQjuhT4cAN9wcr2yyUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-7e903d4b7399b06d4691bc273f6ec799-9324293e4a99b165-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5cd053f953a6b5fbe565add20b2587ec",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:37 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:36 GMT",
-        "MS-CV": "3UUJd18an0yrP1tuKKU0bw.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0CYSOYwAAAAB\u002BAhFZvQ0JQqTb\u002BIbycYdWUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0rteXYwAAAABRoT6a9Sy0RZ\u002BmjiODaoSpUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "86ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
+            "sipSignalingPort": 1122
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-99e59e4f6e8f1086dfd5ae34ba2003b0-78d5b5b9e1ebac5f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d25b480284ff45aceb68552a4d9cca8d",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:38:53 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:38:54 GMT",
+        "MS-CV": "aT/S2jc1b0OuiggyPkHc3Q.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0rteXYwAAAABCUS232ef5TbjnO4NgpNIdUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "83ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -475,31 +484,31 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "28",
+        "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-7e903d4b7399b06d4691bc273f6ec799-7847bf4be7621208-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "606fb4041d7fccb0aa4c04bc0dfc0488",
+        "traceparent": "00-99e59e4f6e8f1086dfd5ae34ba2003b0-bd41cf9f1596c9d9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a31a9813992414b2220d7a7defa7574e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:37 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:38:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": null
+          "sbs1.7df4c1ec-04a8-47fb-4ec5-57a1f33f1348.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:36 GMT",
-        "MS-CV": "QRy5Yyc/SkO\u002BFBt\u002BjKWSYA.0",
+        "Date": "Tue, 13 Dec 2022 01:38:54 GMT",
+        "MS-CV": "lDkEvB0pXE\u002BQ2hfNlvDiiQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0CYSOYwAAAACCs8MT3\u002B1pQbYARkw6n4pUUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0rteXYwAAAACsVEv/b0O2QowWMUhS6hgoUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "280ms"
+        "X-Processing-Time": "259ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -509,6 +518,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "662952835"
+    "RandomSeed": "890033175"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResourceAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -67,7 +67,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -116,7 +116,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -176,7 +176,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -223,7 +223,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -273,7 +273,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -317,7 +317,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -361,7 +361,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -400,7 +400,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -435,7 +435,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -470,7 +470,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -508,7 +508,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "662952835"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d1078ec9f82fe5db981bf2c6afb108ca-b26e941126c14f1e-00",
+        "traceparent": "00-fdadf696beea2ba888b644f88fecf6dc-f8c93dd9643618d1-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "40c7ebab7d4f627a7d6c78fc24095bf7",
+        "x-ms-client-request-id": "ac6926ca1add82ab045ee8bcef24ed36",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:11 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:34 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,26 +22,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:11 GMT",
-        "MS-CV": "MQZfvZS6SUuDg\u002BeHKC1L6w.0",
+        "Date": "Mon, 05 Dec 2022 23:51:33 GMT",
+        "MS-CV": "dXqRFb4l\u002Bk\u002B20tp9Z0PKBw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0Z3WOYwAAAACYxavPfIpZQ5JG7cCaGjE3UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0BoSOYwAAAAAxEfrXfCRgQrZVH1ygU5q\u002BUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "200ms"
+        "X-Processing-Time": "173ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          },
-          "newsbs.com": {
-            "sipSignalingPort": 3333
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -51,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-8814ef50617ed4a09e8e20e31fd31808-cdb4a045f6136a09-00",
+        "traceparent": "00-4c9dbdf81754f3098b82582eeda8e1d7-c58f9f6c2a14c045-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "54533ba6b5d9624c70c2b4bc4788c491",
+        "x-ms-client-request-id": "60de94dca23f484c634da30194e9ea41",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:12 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:34 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -63,26 +53,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:12 GMT",
-        "MS-CV": "j9TiFM8b\u002BUuKyhA0XQAhDA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:33 GMT",
+        "MS-CV": "W\u002B\u002B4/grlGEqNyYGrfzeuuQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0aHWOYwAAAAALva6Sdl9ITqe7l5HTrNuKUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0BoSOYwAAAABoo3gO\u002Bh5YRJScWRYVvT/NUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "90ms"
+        "X-Processing-Time": "85ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          },
-          "newsbs.com": {
-            "sipSignalingPort": 3333
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -92,13 +72,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "104",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-8814ef50617ed4a09e8e20e31fd31808-1e85eff26a360a7c-00",
+        "traceparent": "00-4c9dbdf81754f3098b82582eeda8e1d7-11be3b2d7f599e36-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f1ac938bd0d5948834f1c742661fbc5a",
+        "x-ms-client-request-id": "10b0936726ce0cf4afaf8365983d994f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:12 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:34 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -108,21 +88,20 @@
           },
           "sbs2.com": {
             "sipSignalingPort": 1123
-          },
-          "newsbs.com": null
+          }
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:12 GMT",
-        "MS-CV": "pS9YTnt3h0K2VsVApb\u002BsPw.0",
+        "Date": "Mon, 05 Dec 2022 23:51:34 GMT",
+        "MS-CV": "L\u002BE4aGn4G0KiHcxQWnHYRA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0aHWOYwAAAABbWYxfTTNRS7/4JReO1OG0UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0BoSOYwAAAADBSj42mJK0S6otMRZaN7M1UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "177ms"
+        "X-Processing-Time": "660ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -144,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-fb9bbf308c721759f02cd363ba5d7bf0-a2226dbb4b0bdabf-00",
+        "traceparent": "00-a92a1177971ab99fb3ff488576d16f07-7e7b36943c4cb43b-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4b5b18f2b0d4f5479f64d08dc9be1af4",
+        "x-ms-client-request-id": "2d86e457bbde2805d921498f77aaee1a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:12 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:35 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -167,13 +146,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:12 GMT",
-        "MS-CV": "OzkhzmKYDEuGp4FWCXm\u002B4g.0",
+        "Date": "Mon, 05 Dec 2022 23:51:34 GMT",
+        "MS-CV": "Jx\u002B2R3RmPUW4G\u002B\u002BmLJ52qw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0aHWOYwAAAADVNkqtMASUSJEy0GdeCuDuUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0B4SOYwAAAABbak32z/z1QJppYgh/\u002BWB6UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "114ms"
+        "X-Processing-Time": "176ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -202,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-4361eb26986c4cc3574eddb5d515f9eb-054860c737194dfb-00",
+        "traceparent": "00-72461a5d998c402b6d29eb7fd895055a-e21a55ca6f9f18e2-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "9070e6a7695dd621b3bf1fe7ed0afc50",
+        "x-ms-client-request-id": "5b54a674dd74b5679fd1b1901fe7af26",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:12 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:35 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -214,13 +193,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:12 GMT",
-        "MS-CV": "JRVvkbS9eUKIsF3CD4IPrw.0",
+        "Date": "Mon, 05 Dec 2022 23:51:34 GMT",
+        "MS-CV": "NxAQS9gfAUWq6DbZ2JTfWA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0aHWOYwAAAAAiQ4YD2lNKTq/09mZeRgQXUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0B4SOYwAAAADuNrLZWdOyTIymR3Pk6vX1UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
+        "X-Processing-Time": "84ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -251,11 +230,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "28",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-fd53a68c69b197112865ad62f6e2d28c-1d27892d2bed585e-00",
+        "traceparent": "00-50c2de755074a10175d9c29cfa72c5d3-5b7a188adec3b85d-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2fc95905792cdbbc4cb65271fffbcb76",
+        "x-ms-client-request-id": "afa953b4bd63ac638d8737addd659404",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:13 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:35 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -267,13 +246,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:13 GMT",
-        "MS-CV": "8xgp/PGSWEqCCWU20Pwutw.0",
+        "Date": "Mon, 05 Dec 2022 23:51:35 GMT",
+        "MS-CV": "si3bv38ThEe5jJOToXCy0Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0aXWOYwAAAACLBf06D0OLSpuscLHg/uDbUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0B4SOYwAAAAAaejnUEGbwRIqjrHDj6PI4UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "130ms"
+        "X-Processing-Time": "308ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -299,11 +278,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-6c021a5008a2502ab1330b00a91696a4-c2b8c431e668e526-00",
+        "traceparent": "00-a74d56b142a200436027c7cd6110cf23-d1651c06421f775e-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "809ad3d72baf89fdf684971591600894",
+        "x-ms-client-request-id": "f2f168c13ee87adb7cd18d0d097509f2",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:13 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:36 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -311,13 +290,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:13 GMT",
-        "MS-CV": "eR\u002B4yhyQEEaNPPJMuVOIVA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:35 GMT",
+        "MS-CV": "YOtpiDSAJEyGyIG6onAHPA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0aXWOYwAAAACsjgy6sw4cSb36Ge3P/NVRUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0CISOYwAAAACaqkojEUJhRadBc9f6/BgvUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
+        "X-Processing-Time": "92ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -336,10 +315,200 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0952dc85a5886a6877d0ab4b9609fab9-b79a9b50f15b0be7-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "24db23723e01b7b743a7cdeca5bad73a",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:36 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:35 GMT",
+        "MS-CV": "VSU2m0Ne6EyhPA7NEjrAtA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0CISOYwAAAAD1FcInDSUwSYwe\u002Bg5ktn/3UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "88ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-b713fc061fb6a351d8b338c1aaaf9fbd-a8dc21c595508a99-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b6cfad3cbcf6753d772e33912f56a218",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:36 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:35 GMT",
+        "MS-CV": "frHyIjdCUE64Ur3XxyIrLQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0CISOYwAAAABYJwIe19BpQoyGOCSeftwPUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "160ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-47f8cdffe525ac2908f5450b0d86841c-8b0e32d5379ad180-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ba3a457d70898203b139af4071eed4c2",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:36 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:36 GMT",
+        "MS-CV": "f09xRdZ\u002Beky6sSV/ChV5Kg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0CISOYwAAAACZ4DDMQjuhT4cAN9wcr2yyUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "84ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7e903d4b7399b06d4691bc273f6ec799-9324293e4a99b165-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5cd053f953a6b5fbe565add20b2587ec",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:37 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:36 GMT",
+        "MS-CV": "3UUJd18an0yrP1tuKKU0bw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0CYSOYwAAAAB\u002BAhFZvQ0JQqTb\u002BIbycYdWUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "86ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "28",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-7e903d4b7399b06d4691bc273f6ec799-7847bf4be7621208-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "606fb4041d7fccb0aa4c04bc0dfc0488",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:37 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:36 GMT",
+        "MS-CV": "QRy5Yyc/SkO\u002BFBt\u002BjKWSYA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0CYSOYwAAAACCs8MT3\u002B1pQbYARkw6n4pUUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "280ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "164092641"
+    "RandomSeed": "662952835"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthentication.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthentication.json
@@ -6,9 +6,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-0c1a3da44bfc62b45fecc63727f18631-cc916d4a55de180a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5de667fc388ff32950e8c51231c930f5",
+        "traceparent": "00-5972f235b7555eac9e898a3e67f44c6d-2c24b911ee225fa6-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dcc3edecc2a07b5e056f4417ca3f6151",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -16,13 +16,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:07 GMT",
-        "MS-CV": "LpU7UemQ50KKyXxcCChdxQ.0",
+        "Date": "Tue, 13 Dec 2022 01:47:09 GMT",
+        "MS-CV": "Pxf9AVH8zEqZRHgef5PxMQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "064OOYwAAAAB8XBadYcqoRpZYu9FBeB4iUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nNmXYwAAAADAcWFlFJxvRr0ecX\u002BN\u002BK23UFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "124ms"
+        "X-Processing-Time": "389ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -35,11 +35,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f839e1dcf3997f21a54c5bdd59419617-2e2a663d10836581-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "21ce44df9df51d7cc97339c71850b9e4",
+        "traceparent": "00-50dfb9993e596f4fb89f6cdcf45da693-aae886813f1d8cf9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ccb38e3d36fa8b77f5b9b359ade21297",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:07 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:09 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -47,13 +47,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:07 GMT",
-        "MS-CV": "nvOy6ZPRpES/c10Scm0XCQ.0",
+        "Date": "Tue, 13 Dec 2022 01:47:09 GMT",
+        "MS-CV": "7ghiLWPq7EydluYb1GSLHQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "064OOYwAAAAC\u002BcfgrqGevT4k8xmwd7SH5UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ndmXYwAAAADr9yVWVBu3RYKaggl5TvAeUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
+        "X-Processing-Time": "117ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -66,11 +66,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-0282217a5b792bc42e5cab28752fcec5-30483c482d23629e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "77b2498c7a290ac930be304ff080bb62",
+        "traceparent": "00-fa7b9ee433daca0d5f4757110c2f4055-142eb36d44490ed5-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "380e579849448b5273d5e2efe637221d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:08 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:09 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -78,13 +78,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:07 GMT",
-        "MS-CV": "tIjHrIHPCEuTtoGXYKoPcQ.0",
+        "Date": "Tue, 13 Dec 2022 01:47:09 GMT",
+        "MS-CV": "RqIhRxGtG0mYtmPf51wXiw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07IOOYwAAAABkqmMxfEl3RLjkDerlicAAUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ndmXYwAAAAAqlLeVf\u002BlyQYt\u002B1iVrhqR\u002BUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
+        "X-Processing-Time": "106ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -94,6 +94,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1641633072"
+    "RandomSeed": "1901145341"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthentication.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthentication.json
@@ -6,9 +6,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f45212512674c83bf39dc5d894a5e503-7896cc550be3ae27-00",
+        "traceparent": "00-0c1a3da44bfc62b45fecc63727f18631-cc916d4a55de180a-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "04f3cf76621ecc5ee8378c21068afb56",
+        "x-ms-client-request-id": "5de667fc388ff32950e8c51231c930f5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -16,35 +16,84 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:48 GMT",
-        "MS-CV": "5QRaw\u002BlMrkGrai0\u002Bttlx8w.0",
+        "Date": "Mon, 05 Dec 2022 23:51:07 GMT",
+        "MS-CV": "LpU7UemQ50KKyXxcCChdxQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0UHWOYwAAAABJQ7dwT1G9Tbt45iCKOKoDUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "064OOYwAAAAB8XBadYcqoRpZYu9FBeB4iUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "212ms"
+        "X-Processing-Time": "124ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.com"
-            ]
-          }
-        ]
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f839e1dcf3997f21a54c5bdd59419617-2e2a663d10836581-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "21ce44df9df51d7cc97339c71850b9e4",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:07 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:07 GMT",
+        "MS-CV": "nvOy6ZPRpES/c10Scm0XCQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "064OOYwAAAAC\u002BcfgrqGevT4k8xmwd7SH5UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "89ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0282217a5b792bc42e5cab28752fcec5-30483c482d23629e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "77b2498c7a290ac930be304ff080bb62",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:08 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:07 GMT",
+        "MS-CV": "tIjHrIHPCEuTtoGXYKoPcQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "07IOOYwAAAABkqmMxfEl3RLjkDerlicAAUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "83ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
       }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1068373863"
+    "RandomSeed": "1641633072"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthentication.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthentication.json
@@ -6,9 +6,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-5972f235b7555eac9e898a3e67f44c6d-2c24b911ee225fa6-00",
+        "traceparent": "00-046124f47e00f063d81f382c40e50cb3-755a05a8912b712e-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "dcc3edecc2a07b5e056f4417ca3f6151",
+        "x-ms-client-request-id": "812b44d4418f87e2df72d1be7c59bc95",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -16,13 +16,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:09 GMT",
-        "MS-CV": "Pxf9AVH8zEqZRHgef5PxMQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:29 GMT",
+        "MS-CV": "R0nQn5Qk70WKXhIij4KCIA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0nNmXYwAAAADAcWFlFJxvRr0ecX\u002BN\u002BK23UFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nd2YYwAAAAABGIgtY9JPSLvt3BoZoCkHUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "389ms"
+        "X-Processing-Time": "140ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -35,11 +35,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-50dfb9993e596f4fb89f6cdcf45da693-aae886813f1d8cf9-00",
+        "traceparent": "00-e06676e4ef686d83c5ef2bdf080867cd-81f8182d57c53621-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ccb38e3d36fa8b77f5b9b359ade21297",
+        "x-ms-client-request-id": "b31b67e0fc45938318542a8a37ed75eb",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:09 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:29 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -47,13 +47,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:09 GMT",
-        "MS-CV": "7ghiLWPq7EydluYb1GSLHQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:29 GMT",
+        "MS-CV": "sQluWkTP2kq78lmXrsWKsA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ndmXYwAAAADr9yVWVBu3RYKaggl5TvAeUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nt2YYwAAAADqmWvYBWSzRaLgjvVARGRhUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "117ms"
+        "X-Processing-Time": "82ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -66,11 +66,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-fa7b9ee433daca0d5f4757110c2f4055-142eb36d44490ed5-00",
+        "traceparent": "00-032e30d90fc94812c4911fdfb4aa6496-80d336f7ce0fe21d-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "380e579849448b5273d5e2efe637221d",
+        "x-ms-client-request-id": "5b8f2781d720b925c5f6dca02c74b295",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:09 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:29 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -78,13 +78,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:09 GMT",
-        "MS-CV": "RqIhRxGtG0mYtmPf51wXiw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:29 GMT",
+        "MS-CV": "QJWvbAZk1E\u002BBTKQthsDBwA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ndmXYwAAAAAqlLeVf\u002BlyQYt\u002B1iVrhqR\u002BUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nt2YYwAAAADamdnJ1e60RJv5Teg/2hKCUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "106ms"
+        "X-Processing-Time": "73ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -94,6 +94,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1901145341"
+    "RandomSeed": "856007548"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthentication.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthentication.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -30,7 +30,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -61,7 +61,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -93,7 +93,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "1641633072"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthentication.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthentication.json
@@ -1,14 +1,14 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-c1463f77ed703cba576578f97026ce6c-23d6b48b589b1cd2-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a7bf7837bb30c24e5ba7602cd7c5d467",
+        "traceparent": "00-f45212512674c83bf39dc5d894a5e503-7896cc550be3ae27-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "04f3cf76621ecc5ee8378c21068afb56",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -16,17 +16,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:14 GMT",
-        "MS-CV": "KFVu2MUTUk\u002BRdVxfM\u002BHp0A.0",
+        "Date": "Mon, 05 Dec 2022 22:48:48 GMT",
+        "MS-CV": "5QRaw\u002BlMrkGrai0\u002Bttlx8w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rtZDYwAAAABcmkIIfhSPSrHypyxqz/IsTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0UHWOYwAAAABJQ7dwT1G9Tbt45iCKOKoDUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "725ms"
+        "X-Processing-Time": "212ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -36,7 +36,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -44,7 +44,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "57706373"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "1068373863"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthenticationAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthenticationAsync.json
@@ -6,9 +6,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-cd4da7188f107bd490319d6a4ca8108a-243e427937fc35f8-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "320dce5345d60e5f9db1d4d49f1aa408",
+        "traceparent": "00-b6380da6d40fe2d3d6a3830eefd297d8-1d9b8d8270cab1f4-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cdb40cf247a61cb2451d7387521a519f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -16,13 +16,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:36 GMT",
-        "MS-CV": "fUtfXc4X8E27c\u002BQ7d5LHDA.0",
+        "Date": "Tue, 13 Dec 2022 01:47:27 GMT",
+        "MS-CV": "4vH7rld9KEqqD\u002BwH8Rg9hA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0CYSOYwAAAAD4ulnjKTnKSLfgawjoX1GRUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0r9mXYwAAAABHirdZnHGTT5JEl\u002B9tUQyNUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "79ms"
+        "X-Processing-Time": "122ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -35,11 +35,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-25a45981a76f195334cb8516ff9efe5f-83306440b90b8272-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "42327535d991e8f4aa3276685007a32c",
+        "traceparent": "00-c5d4696290bd9d3083f83d8f743153ff-cab48302b010beb4-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6cccd4339daa7eba02e91251878f5ec8",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:37 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:27 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -47,13 +47,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:37 GMT",
-        "MS-CV": "M24tHAGVu0GwS/QXnef89g.0",
+        "Date": "Tue, 13 Dec 2022 01:47:27 GMT",
+        "MS-CV": "Xs8S2AbPSkSiVxZZB8fJ\u002BQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0CYSOYwAAAACf5KISMdqZRI8c/oxW59RaUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0r9mXYwAAAAC2TRVCG4p7Rbh99uwT5HRqUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
+        "X-Processing-Time": "80ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -66,11 +66,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-b9b4d4e73c36e4ec7c2b02c41e4e63a2-8c5ad624d2d3a8bd-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "096289b0d900a1117aed5bb48554d0fb",
+        "traceparent": "00-4053fcb32e5a1f8402d902cce0cb6b49-e3f83ed2ad5a84dd-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ad412154890d019617ad7874e49cedf1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:38 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:27 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -78,13 +78,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:37 GMT",
-        "MS-CV": "ynpn3GR24kaw83DGmIs4ZA.0",
+        "Date": "Tue, 13 Dec 2022 01:47:27 GMT",
+        "MS-CV": "id4q4XapiEOnBHjz4BbHuQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0CYSOYwAAAAB7Db3Ndh2JTKxLUImxJ0JMUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0sNmXYwAAAACEpsOAt\u002BWrQIq5QobGayysUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
+        "X-Processing-Time": "85ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -94,6 +94,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1653591537"
+    "RandomSeed": "1049629783"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthenticationAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthenticationAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -30,7 +30,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -61,7 +61,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -93,7 +93,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "1653591537"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthenticationAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthenticationAsync.json
@@ -6,9 +6,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-bdb9745b46fc87bf02a7ea2690a52577-84ff906d019970a6-00",
+        "traceparent": "00-cd4da7188f107bd490319d6a4ca8108a-243e427937fc35f8-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "dad5799ef4f4ae6533e074ed552a6f69",
+        "x-ms-client-request-id": "320dce5345d60e5f9db1d4d49f1aa408",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -16,35 +16,84 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:14 GMT",
-        "MS-CV": "dgR50o\u002BC4UKSMuXLJgwyuQ.0",
+        "Date": "Mon, 05 Dec 2022 23:51:36 GMT",
+        "MS-CV": "fUtfXc4X8E27c\u002BQ7d5LHDA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0anWOYwAAAAAu2IybNqT3QKAAj4SMEeFyUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0CYSOYwAAAAD4ulnjKTnKSLfgawjoX1GRUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "247ms"
+        "X-Processing-Time": "79ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.com"
-            ]
-          }
-        ]
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-25a45981a76f195334cb8516ff9efe5f-83306440b90b8272-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "42327535d991e8f4aa3276685007a32c",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:37 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:37 GMT",
+        "MS-CV": "M24tHAGVu0GwS/QXnef89g.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0CYSOYwAAAACf5KISMdqZRI8c/oxW59RaUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "87ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b9b4d4e73c36e4ec7c2b02c41e4e63a2-8c5ad624d2d3a8bd-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "096289b0d900a1117aed5bb48554d0fb",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:38 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:37 GMT",
+        "MS-CV": "ynpn3GR24kaw83DGmIs4ZA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0CYSOYwAAAAB7Db3Ndh2JTKxLUImxJ0JMUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "87ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
       }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1540054066"
+    "RandomSeed": "1653591537"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthenticationAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthenticationAsync.json
@@ -1,14 +1,14 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-1a6f587870b19c7f12fced67e171cd74-930ddd073d53d80f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7196b22c68f1a923a522dc6b8f5390c0",
+        "traceparent": "00-bdb9745b46fc87bf02a7ea2690a52577-84ff906d019970a6-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dad5799ef4f4ae6533e074ed552a6f69",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -16,17 +16,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:26 GMT",
-        "MS-CV": "PSHw\u002BAGgRE6YqUkq/4adJg.0",
+        "Date": "Mon, 05 Dec 2022 22:49:14 GMT",
+        "MS-CV": "dgR50o\u002BC4UKSMuXLJgwyuQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0u9ZDYwAAAAC6twW/Uhf5Q744saVJUgOVTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0anWOYwAAAAAu2IybNqT3QKAAj4SMEeFyUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "69ms"
+        "X-Processing-Time": "247ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -36,7 +36,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -44,7 +44,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "527535578"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "1540054066"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthenticationAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthenticationAsync.json
@@ -6,9 +6,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-b6380da6d40fe2d3d6a3830eefd297d8-1d9b8d8270cab1f4-00",
+        "traceparent": "00-6e294a10ab2e31200426c003fd4ee806-5b2486979a1b9e6a-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "cdb40cf247a61cb2451d7387521a519f",
+        "x-ms-client-request-id": "dbd749fb7c07c78ebe6a27a0d36cbc60",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -16,13 +16,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:27 GMT",
-        "MS-CV": "4vH7rld9KEqqD\u002BwH8Rg9hA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:56 GMT",
+        "MS-CV": "EWXvTtbjdUan2He0MLKIGw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0r9mXYwAAAABHirdZnHGTT5JEl\u002B9tUQyNUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0uN2YYwAAAAAleNMYAzc7QLTndTcZKiaiUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "122ms"
+        "X-Processing-Time": "126ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -35,11 +35,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-c5d4696290bd9d3083f83d8f743153ff-cab48302b010beb4-00",
+        "traceparent": "00-718a0e5198122621a9d5bc9d27b81e86-4cf64108460ead17-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6cccd4339daa7eba02e91251878f5ec8",
+        "x-ms-client-request-id": "7d9e8ebbcd4309dde0c759d97a2ecaa4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:27 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -47,13 +47,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:27 GMT",
-        "MS-CV": "Xs8S2AbPSkSiVxZZB8fJ\u002BQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:56 GMT",
+        "MS-CV": "ycCHUdio50aJvsNEtDhkPw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0r9mXYwAAAAC2TRVCG4p7Rbh99uwT5HRqUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0uN2YYwAAAAD5yPzM7WfdRp\u002BAIMMXGfDKUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "80ms"
+        "X-Processing-Time": "84ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -66,11 +66,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-4053fcb32e5a1f8402d902cce0cb6b49-e3f83ed2ad5a84dd-00",
+        "traceparent": "00-5ad605e629a69c2d0fdf25594c9b5c3f-fd8e8924b25577a3-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ad412154890d019617ad7874e49cedf1",
+        "x-ms-client-request-id": "0564900ace94af8dad4e1904f224d931",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:27 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -78,13 +78,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:27 GMT",
-        "MS-CV": "id4q4XapiEOnBHjz4BbHuQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:56 GMT",
+        "MS-CV": "lN/Kxuw0ZUaxavJwtf0dlA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sNmXYwAAAACEpsOAt\u002BWrQIq5QobGayysUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0uN2YYwAAAAD07PrFiHOVRb35fJPV2fGCUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "85ms"
+        "X-Processing-Time": "81ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -94,6 +94,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1049629783"
+    "RandomSeed": "375446389"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-23531ba35438d8d3104a274e5d03313d-76b037c253eadd39-00",
+        "traceparent": "00-8b2de766a10d6bf5b863ed1efc3be972-eb06dd6f93df1f3d-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f7de475cbd1306e790fc011dec768317",
+        "x-ms-client-request-id": "d420cbe4b6719d81822fbd071555c766",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:49 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:08 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,20 +22,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:48 GMT",
-        "MS-CV": "oWcpWpoWUkeNCoNPZqXOAg.0",
+        "Date": "Mon, 05 Dec 2022 23:51:07 GMT",
+        "MS-CV": "njlwwj3GLUKhzDUXe1vhqw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0UHWOYwAAAACrBHpcBU\u002BqSqV8vFpMrsrgUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07IOOYwAAAAAVvI5L6nwzQb3nBBgjOWBgUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "98ms"
+        "X-Processing-Time": "166ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -45,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-810a0f562649c14ffc3d9bf24187cb44-936758aae35527d6-00",
+        "traceparent": "00-5c0431954cf66f8fc797d43578bffe25-d36c9951bf1ce78e-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7eac759a47591778709433da92b9cebe",
+        "x-ms-client-request-id": "41489bcc310e12c538fc94f3ba8b4956",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:49 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:08 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -57,20 +53,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:48 GMT",
-        "MS-CV": "jvWWarVXB0uK29iYNAvI7w.0",
+        "Date": "Mon, 05 Dec 2022 23:51:08 GMT",
+        "MS-CV": "n5V0HmLdVkyrkg65HEcQ6Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0UXWOYwAAAACZRUaAL5WpSbxfBiq4wWF/UFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07IOOYwAAAACAdcxaipLqQ6Ns8LctsD4/UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "78ms"
+        "X-Processing-Time": "85ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -82,11 +74,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-810a0f562649c14ffc3d9bf24187cb44-4cb750e0fcd8af40-00",
+        "traceparent": "00-5c0431954cf66f8fc797d43578bffe25-b620caafab503b01-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3174ab2228cd862f2dc907d01dce1b0c",
+        "x-ms-client-request-id": "58ed736a239d40bb4762fc31b271e3d4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:49 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:08 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -103,13 +95,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:49 GMT",
-        "MS-CV": "KMB/klrOj0GJvXr2\u002BjPU2w.0",
+        "Date": "Mon, 05 Dec 2022 23:51:08 GMT",
+        "MS-CV": "0859fwQZPE2Rss2Vvp2Y9Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0UXWOYwAAAADrhhmP54fAQI/5nqBllEyCUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07IOOYwAAAAAtCsjH6IjmR5VtF7cCC3F7UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "327ms"
+        "X-Processing-Time": "596ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -131,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-038a8f5d39efbf6222981ee9844347f2-bcbf6e6e45ab5a36-00",
+        "traceparent": "00-09f9b6d9942d0b311c074e5bd0c72676-01748a9ae149a891-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0c950b4dd11e156acec7867f890d74d7",
+        "x-ms-client-request-id": "efdc4c2b5116b372060e9c74228ee3f7",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:49 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:09 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -154,13 +146,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:49 GMT",
-        "MS-CV": "/iOz9VpWEUuEsJ3tlsej1w.0",
+        "Date": "Mon, 05 Dec 2022 23:51:09 GMT",
+        "MS-CV": "rHBHv1Knmk2XcHxD5VEl9g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0UXWOYwAAAAA58XuYzDzBQ6z5E4Xba6tFUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07YOOYwAAAADCFXcF8pa9Q6\u002B3VIUyfKfaUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "162ms"
+        "X-Processing-Time": "176ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -189,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f57636e4c236d97d32c5e763ab36159a-6d5e201a0589ee0b-00",
+        "traceparent": "00-34dfb0057e77222bf6255a3d2f34eb87-292aa2322b0215d4-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "40fa432d5101714a4626508f3fa8f9a2",
+        "x-ms-client-request-id": "a29d67e66e67a8c9e008f9ab35945fc6",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:50 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:09 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -201,13 +193,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:49 GMT",
-        "MS-CV": "bF3W2Mf1E0Cz4Xg11AKcXA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:09 GMT",
+        "MS-CV": "AiaMofSQaEah5n4sdkV5bw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0UnWOYwAAAACWPxRDnNqYSI0BxNhBqm9lUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07YOOYwAAAAAZhb\u002BD7ghQT7XzOgeSQZMbUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "98ms"
+        "X-Processing-Time": "85ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -229,10 +221,213 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b2d1e3d9e7a8a08f952a004181c44e9d-b30c1f7b92aea2e8-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6dc8c0195aae193f013a528e87461db9",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:10 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:09 GMT",
+        "MS-CV": "Wy3yE14vDE6F94VN735jAw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "07YOOYwAAAACTeuJFrRYaQasSgrdrx2u6UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "87ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-405b94cd1401439620ea5692280273e8-810bb9ed294309fd-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4a4b047f41d3bc6c83340f0d57c67e72",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:10 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:09 GMT",
+        "MS-CV": "XMfrSm9C2kyWdS3M74WodA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "07oOOYwAAAABxYEVhPWciQIwZbKboq7VNUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "167ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2bc9a2ad9cc0c3aa32635bd482464cc9-963f3c50077e31c0-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "615bd5ae75c58b482883a02d1b3a2099",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:10 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:09 GMT",
+        "MS-CV": "9aIh2GWQJke1PAAYrpNGaA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "07oOOYwAAAAAMNA6G5lqVT6\u002BWrMd\u002BbcTnUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "83ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ac548d0158849b3e764ff8a79fe2a664-991c73e1bb396706-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "302b40ea1548d8f3540bea7a4b31c23a",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:10 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:10 GMT",
+        "MS-CV": "otnvx5zWZkWX95hKuLEX9g.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "07oOOYwAAAADmoYBkEwZDS79PhHr0ANpMUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "90ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "44",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-ac548d0158849b3e764ff8a79fe2a664-c5b6b88fe59849a5-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b1e0e0bcbceb0af4bbbf214fa03ea148",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:10 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.com": null,
+          "sbs2.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:10 GMT",
+        "MS-CV": "vjkcQ7AFkkWXM5iSNBPhpg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "07oOOYwAAAADYW4bhtQrsQKXwN3byT\u002Bu7UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "260ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1408275426"
+    "RandomSeed": "714417444"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-186711f1bded61c67df114e601e805f2-db0e684f1810ba3e-00",
+        "traceparent": "00-d978086615c24303484f5cef18778b50-1c4e97b06964db21-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3bd0c4ebd27242d7121cc2feae58f212",
+        "x-ms-client-request-id": "52a1abbd1078c30e9ed252391e40080f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:42 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:29 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:43 GMT",
-        "MS-CV": "QsMfD0\u002B90UqKe5FBUF0\u002BgA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:29 GMT",
+        "MS-CV": "2zCwmcHUs0izC3/FUPs09A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08tKXYwAAAABm21qp\u002BrnQTIXvSb379AHdUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nt2YYwAAAAD\u002BOvHzUqqrT7A2EZB4PV3IUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "221ms"
+        "X-Processing-Time": "118ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-a6341ac8bcbe10ba20c05dd32aa3e1ab-431d3cb3ae281cdd-00",
+        "traceparent": "00-dc529d0316d39b1f7137e77c3c42caeb-c6c3bc2768cd0f60-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1a809369b5b88074cf0bd3314ba7a366",
+        "x-ms-client-request-id": "902b6340b00ef7b7cc328e3360d8511d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:42 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:29 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:43 GMT",
-        "MS-CV": "sR88ZxjQs0yXjBIRL1HB6w.0",
+        "Date": "Tue, 13 Dec 2022 20:16:30 GMT",
+        "MS-CV": "ul6rof2Ua0Cy8X5VARRPcA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "089KXYwAAAADmAulgvwVMQZM4IVxfsjqjUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nt2YYwAAAADDAvEjniYcRZejih6kz3ZoUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
+        "X-Processing-Time": "91ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-a6341ac8bcbe10ba20c05dd32aa3e1ab-dbb89c2e7b89947b-00",
+        "traceparent": "00-dc529d0316d39b1f7137e77c3c42caeb-1e6b3dc18054ccf0-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "445224714f2d376e826180cd228e19ac",
+        "x-ms-client-request-id": "6198d92660b3bb4406021f738b46e114",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:43 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:30 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
+          "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
+          "sbs2.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:44 GMT",
-        "MS-CV": "8ZZjzKgk4kynvrM0lBgXiw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:30 GMT",
+        "MS-CV": "tkjd9dIbtkynYywDGVL22g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "089KXYwAAAADlnmi3hzMzSYJHUwMutoOwUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0n92YYwAAAAC18kfheGIuSJtafMYgQa4vUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "634ms"
+        "X-Processing-Time": "290ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
+          "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
+          "sbs2.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-aa79d89b4f8a1cf4f2e349cc142f22fd-853de9d24bb87c93-00",
+        "traceparent": "00-3f04ed82a725b3c37358264cfc4c0dfd-f5a761f144f84477-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b472e95d8f6635cd4f506b67ffa6f66a",
+        "x-ms-client-request-id": "97ecef25e36f0daaf4a9864681da62c5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:43 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:30 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com"
+              "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:44 GMT",
-        "MS-CV": "JI3ErVEAtUGvTHO73lJN3Q.0",
+        "Date": "Tue, 13 Dec 2022 20:16:30 GMT",
+        "MS-CV": "\u002BD7XFqsQ\u002B0\u002BGuWFCapQkqg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09NKXYwAAAAAF3QI1IpftQJYDzzxB3MTfUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0n92YYwAAAABivlLjF8CuSLJ4Tp\u002BhohXoUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "164ms"
+        "X-Processing-Time": "187ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
+          "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
+          "sbs2.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,54 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-d1752402d5500c302fc4cd8b8bc70961-db524ecdc584e8ba-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "898d5b79ad061ae52448975734a75d41",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:44 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:44 GMT",
-        "MS-CV": "8TzmMAEA2UKsqQgFwaF\u002BLw.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09NKXYwAAAACrNhZ0vMJ7Rokw4plrBg0ZUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "85ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com"
+              "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com"
             ]
           }
         ]
@@ -228,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-19d48f13b6c312941a1196fa199fa241-8334fbfb04811687-00",
+        "traceparent": "00-a72daec108003331706baf54002f1f9f-0ea09a027cbd546f-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "62d426f1ee34e200561cf4dce30638dc",
+        "x-ms-client-request-id": "44123480a7a8df5b1f6f8a0b91436c85",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:44 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:30 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -240,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:44 GMT",
-        "MS-CV": "rxh5KM1/ZkeiQ4E6SdJHJg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:30 GMT",
+        "MS-CV": "PoHi5f9Q7UeVwijgN9vaWA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09NKXYwAAAACpsE7ZpCLZQ6BMyJWJwcePUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0n92YYwAAAAAXusmdlp7rSovDxn7K11PKUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "90ms"
+        "X-Processing-Time": "95ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
+          "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
+          "sbs2.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,7 +216,101 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com"
+              "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-90067549e08f75c9f88aa1fcd4fe0e70-b92d3dded36b0f96-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "700e7a50b9ec43ae2f8b6d0ad9fe3a2b",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:30 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:16:31 GMT",
+        "MS-CV": "fI8LCMABVEuZl5Zi4ADhQQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0n92YYwAAAADRRdHHwX6jTqg00GPrIpnTUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "125ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fb8a5b5509c6b9ca7617e7b2dfe7d544-e49ff7ee1baa122b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "57f359a09d337e6b930c78ff589e7bb1",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:31 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:16:31 GMT",
+        "MS-CV": "qu05409XCUmyZ6rJn6PDSg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0oN2YYwAAAACmEY4aizfZS7bW09HYl0TZUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "96ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com"
             ]
           }
         ]
@@ -277,11 +324,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-6db383b8a56df187f4027a97363e3190-4bf268a703456681-00",
+        "traceparent": "00-6d1ee1b3b9c518cfff0e8353157947d0-b017d06d69c93d0e-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c653156a9001b0a50458901ef77601a8",
+        "x-ms-client-request-id": "07f5003df1ccc6d985cf141d39510621",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:44 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:31 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -291,20 +338,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:45 GMT",
-        "MS-CV": "K8tHp75SwEWHiDygiOWXaQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:31 GMT",
+        "MS-CV": "28m34CBT2UmpN1LslmqChg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09NKXYwAAAAAu07X9ZNtcTIuiNH2WMN/PUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0oN2YYwAAAADzC9rj2oaFQ4F9zEhgYE/vUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "186ms"
+        "X-Processing-Time": "103ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
+          "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
+          "sbs2.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -317,11 +364,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-d18f45c1a83e96220fa174700d22fee0-2d82c8390de7ca0f-00",
+        "traceparent": "00-10e5408e8f01a90ba31dde62b26bad6f-de9ffabc9cd7aabd-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d8762af293d28a365bab32eab808371d",
+        "x-ms-client-request-id": "386b5e351550b3520e8fdddf41afea90",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:44 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:31 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -329,58 +376,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:45 GMT",
-        "MS-CV": "0By3b2Bfs0qB6cGSnejLpA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:31 GMT",
+        "MS-CV": "ISag6QdM3UKOxmpj\u002BIf9zw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09dKXYwAAAAAo5\u002BGMhRq1QYWRxTueQK1vUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0oN2YYwAAAABsfpaLilzQR6094arJ2gBCUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "90ms"
+        "X-Processing-Time": "84ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
+          "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-22cec914157442402fe2178ef2e2c922-f2c86bc4ce968fcb-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1eecbb0f9753613f81245edc5ee1eae0",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:44 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:45 GMT",
-        "MS-CV": "ySYbULchp06BI3xkLRppJQ.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09dKXYwAAAAA64Rct1KalTo60fSLNfK/mUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "82ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
+          "sbs2.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -395,30 +404,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-22cec914157442402fe2178ef2e2c922-b77290ac49487fb3-00",
+        "traceparent": "00-10e5408e8f01a90ba31dde62b26bad6f-b38ac32337069a88-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b9e94c1a6090d60adfc96b565dbaf7fb",
+        "x-ms-client-request-id": "d8cdbc0f3208ae5f7f2cd163884e4442",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:45 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:31 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": null,
-          "sbs2.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": null
+          "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": null,
+          "sbs2.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:45 GMT",
-        "MS-CV": "UUhocOPN9EuEuz8K7BbUWA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:32 GMT",
+        "MS-CV": "\u002BBFC\u002Bg9uV0GNFCPz1iFx2g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09dKXYwAAAADbioGOKq2AR41KZal3JtusUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0oN2YYwAAAADzXCUOoG0dToZmQFJ1W87IUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "297ms"
+        "X-Processing-Time": "114ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -428,6 +437,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "675046886"
+    "RandomSeed": "221127128"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-8b2de766a10d6bf5b863ed1efc3be972-eb06dd6f93df1f3d-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d420cbe4b6719d81822fbd071555c766",
+        "traceparent": "00-186711f1bded61c67df114e601e805f2-db0e684f1810ba3e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3bd0c4ebd27242d7121cc2feae58f212",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:08 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:42 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:07 GMT",
-        "MS-CV": "njlwwj3GLUKhzDUXe1vhqw.0",
+        "Date": "Tue, 13 Dec 2022 01:18:43 GMT",
+        "MS-CV": "QsMfD0\u002B90UqKe5FBUF0\u002BgA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07IOOYwAAAAAVvI5L6nwzQb3nBBgjOWBgUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08tKXYwAAAABm21qp\u002BrnQTIXvSb379AHdUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "166ms"
+        "X-Processing-Time": "221ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-5c0431954cf66f8fc797d43578bffe25-d36c9951bf1ce78e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "41489bcc310e12c538fc94f3ba8b4956",
+        "traceparent": "00-a6341ac8bcbe10ba20c05dd32aa3e1ab-431d3cb3ae281cdd-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1a809369b5b88074cf0bd3314ba7a366",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:08 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:42 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:08 GMT",
-        "MS-CV": "n5V0HmLdVkyrkg65HEcQ6Q.0",
+        "Date": "Tue, 13 Dec 2022 01:18:43 GMT",
+        "MS-CV": "sR88ZxjQs0yXjBIRL1HB6w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07IOOYwAAAACAdcxaipLqQ6Ns8LctsD4/UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "089KXYwAAAADmAulgvwVMQZM4IVxfsjqjUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "85ms"
+        "X-Processing-Time": "87ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -72,21 +72,21 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "86",
+        "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-5c0431954cf66f8fc797d43578bffe25-b620caafab503b01-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "58ed736a239d40bb4762fc31b271e3d4",
+        "traceparent": "00-a6341ac8bcbe10ba20c05dd32aa3e1ab-dbb89c2e7b89947b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "445224714f2d376e826180cd228e19ac",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:08 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:43 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:08 GMT",
-        "MS-CV": "0859fwQZPE2Rss2Vvp2Y9Q.0",
+        "Date": "Tue, 13 Dec 2022 01:18:44 GMT",
+        "MS-CV": "8ZZjzKgk4kynvrM0lBgXiw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07IOOYwAAAAAtCsjH6IjmR5VtF7cCC3F7UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "089KXYwAAAADlnmi3hzMzSYJHUwMutoOwUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "596ms"
+        "X-Processing-Time": "634ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -121,13 +121,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "164",
+        "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-09f9b6d9942d0b311c074e5bd0c72676-01748a9ae149a891-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "efdc4c2b5116b372060e9c74228ee3f7",
+        "traceparent": "00-aa79d89b4f8a1cf4f2e349cc142f22fd-853de9d24bb87c93-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b472e95d8f6635cd4f506b67ffa6f66a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:09 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:43 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:09 GMT",
-        "MS-CV": "rHBHv1Knmk2XcHxD5VEl9g.0",
+        "Date": "Tue, 13 Dec 2022 01:18:44 GMT",
+        "MS-CV": "JI3ErVEAtUGvTHO73lJN3Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07YOOYwAAAADCFXcF8pa9Q6\u002B3VIUyfKfaUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09NKXYwAAAAAF3QI1IpftQJYDzzxB3MTfUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "176ms"
+        "X-Processing-Time": "164ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com"
             ]
           }
         ]
@@ -181,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-34dfb0057e77222bf6255a3d2f34eb87-292aa2322b0215d4-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a29d67e66e67a8c9e008f9ab35945fc6",
+        "traceparent": "00-d1752402d5500c302fc4cd8b8bc70961-db524ecdc584e8ba-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "898d5b79ad061ae52448975734a75d41",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:09 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:44 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -193,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:09 GMT",
-        "MS-CV": "AiaMofSQaEah5n4sdkV5bw.0",
+        "Date": "Tue, 13 Dec 2022 01:18:44 GMT",
+        "MS-CV": "8TzmMAEA2UKsqQgFwaF\u002BLw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07YOOYwAAAAAZhb\u002BD7ghQT7XzOgeSQZMbUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09NKXYwAAAACrNhZ0vMJ7Rokw4plrBg0ZUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "85ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -216,7 +216,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com"
             ]
           }
         ]
@@ -228,11 +228,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-b2d1e3d9e7a8a08f952a004181c44e9d-b30c1f7b92aea2e8-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6dc8c0195aae193f013a528e87461db9",
+        "traceparent": "00-19d48f13b6c312941a1196fa199fa241-8334fbfb04811687-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "62d426f1ee34e200561cf4dce30638dc",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:10 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:44 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -240,20 +240,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:09 GMT",
-        "MS-CV": "Wy3yE14vDE6F94VN735jAw.0",
+        "Date": "Tue, 13 Dec 2022 01:18:44 GMT",
+        "MS-CV": "rxh5KM1/ZkeiQ4E6SdJHJg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07YOOYwAAAACTeuJFrRYaQasSgrdrx2u6UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09NKXYwAAAACpsE7ZpCLZQ6BMyJWJwcePUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
+        "X-Processing-Time": "90ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,7 +263,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com"
             ]
           }
         ]
@@ -277,11 +277,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-405b94cd1401439620ea5692280273e8-810bb9ed294309fd-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4a4b047f41d3bc6c83340f0d57c67e72",
+        "traceparent": "00-6db383b8a56df187f4027a97363e3190-4bf268a703456681-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c653156a9001b0a50458901ef77601a8",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:10 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:44 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -291,20 +291,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:09 GMT",
-        "MS-CV": "XMfrSm9C2kyWdS3M74WodA.0",
+        "Date": "Tue, 13 Dec 2022 01:18:45 GMT",
+        "MS-CV": "K8tHp75SwEWHiDygiOWXaQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07oOOYwAAAABxYEVhPWciQIwZbKboq7VNUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09NKXYwAAAAAu07X9ZNtcTIuiNH2WMN/PUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "167ms"
+        "X-Processing-Time": "186ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -317,11 +317,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-2bc9a2ad9cc0c3aa32635bd482464cc9-963f3c50077e31c0-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "615bd5ae75c58b482883a02d1b3a2099",
+        "traceparent": "00-d18f45c1a83e96220fa174700d22fee0-2d82c8390de7ca0f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d8762af293d28a365bab32eab808371d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:10 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:44 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -329,58 +329,58 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:09 GMT",
-        "MS-CV": "9aIh2GWQJke1PAAYrpNGaA.0",
+        "Date": "Tue, 13 Dec 2022 01:18:45 GMT",
+        "MS-CV": "0By3b2Bfs0qB6cGSnejLpA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07oOOYwAAAAAMNA6G5lqVT6\u002BWrMd\u002BbcTnUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-ac548d0158849b3e764ff8a79fe2a664-991c73e1bb396706-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "302b40ea1548d8f3540bea7a4b31c23a",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:10 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:10 GMT",
-        "MS-CV": "otnvx5zWZkWX95hKuLEX9g.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07oOOYwAAAADmoYBkEwZDS79PhHr0ANpMUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09dKXYwAAAAAo5\u002BGMhRq1QYWRxTueQK1vUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "90ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-22cec914157442402fe2178ef2e2c922-f2c86bc4ce968fcb-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1eecbb0f9753613f81245edc5ee1eae0",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:44 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:18:45 GMT",
+        "MS-CV": "ySYbULchp06BI3xkLRppJQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "09dKXYwAAAAA64Rct1KalTo60fSLNfK/mUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "82ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -393,32 +393,32 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "44",
+        "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-ac548d0158849b3e764ff8a79fe2a664-c5b6b88fe59849a5-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b1e0e0bcbceb0af4bbbf214fa03ea148",
+        "traceparent": "00-22cec914157442402fe2178ef2e2c922-b77290ac49487fb3-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b9e94c1a6090d60adfc96b565dbaf7fb",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:10 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:45 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": null,
-          "sbs2.com": null
+          "sbs1.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": null,
+          "sbs2.93a35a0a-e4e9-c88d-054f-fbdc48e6aa86.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:10 GMT",
-        "MS-CV": "vjkcQ7AFkkWXM5iSNBPhpg.0",
+        "Date": "Tue, 13 Dec 2022 01:18:45 GMT",
+        "MS-CV": "UUhocOPN9EuEuz8K7BbUWA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07oOOYwAAAADYW4bhtQrsQKXwN3byT\u002Bu7UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09dKXYwAAAADbioGOKq2AR41KZal3JtusUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "260ms"
+        "X-Processing-Time": "297ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -428,6 +428,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "714417444"
+    "RandomSeed": "675046886"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResource.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-2bddc65b5e010c243e8f31c223bcedf4-b2c24ec922aa67d3-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "498efcaec8f2ac42eeb15c680e69021e",
+        "traceparent": "00-23531ba35438d8d3104a274e5d03313d-76b037c253eadd39-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f7de475cbd1306e790fc011dec768317",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:15 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:49 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,17 +22,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:15 GMT",
-        "MS-CV": "BDoYG8Zv10yDStJZfPW6Tg.0",
+        "Date": "Mon, 05 Dec 2022 22:48:48 GMT",
+        "MS-CV": "oWcpWpoWUkeNCoNPZqXOAg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0r9ZDYwAAAADDErq4oBptSIa1lx1nm6R1TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0UHWOYwAAAACrBHpcBU\u002BqSqV8vFpMrsrgUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "108ms"
+        "X-Processing-Time": "98ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -40,16 +40,16 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-c9dc542bdd038aa5be02ad738ff7f752-613ad32c2c3e69e1-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "022088b1ba3f0c37006bcf1b52acb67d",
+        "traceparent": "00-810a0f562649c14ffc3d9bf24187cb44-936758aae35527d6-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7eac759a47591778709433da92b9cebe",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:15 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:49 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -57,17 +57,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:15 GMT",
-        "MS-CV": "CIac8KzmUEiJ3GrhMq3FLg.0",
+        "Date": "Mon, 05 Dec 2022 22:48:48 GMT",
+        "MS-CV": "jvWWarVXB0uK29iYNAvI7w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sNZDYwAAAACL3BClxy3sS7PCszx\u002BJqM1TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0UXWOYwAAAACZRUaAL5WpSbxfBiq4wWF/UFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "66ms"
+        "X-Processing-Time": "78ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -75,26 +75,26 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "114",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-c9dc542bdd038aa5be02ad738ff7f752-264a6865c2dd0a1c-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8de5dbb97de01d195b91cfe24f3eaa1f",
+        "traceparent": "00-810a0f562649c14ffc3d9bf24187cb44-4cb750e0fcd8af40-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3174ab2228cd862f2dc907d01dce1b0c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:15 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:49 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -103,20 +103,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:15 GMT",
-        "MS-CV": "aJSLJ2nxmkefP68qoPWNuA.0",
+        "Date": "Mon, 05 Dec 2022 22:48:49 GMT",
+        "MS-CV": "KMB/klrOj0GJvXr2\u002BjPU2w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sNZDYwAAAABpkbiGiTo\u002BR5qrKCT6cGUDTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0UXWOYwAAAADrhhmP54fAQI/5nqBllEyCUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "204ms"
+        "X-Processing-Time": "327ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -124,18 +124,18 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "178",
+        "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-68e3a9c5572ad77a37eb7024780b128f-fa504d0a373d1444-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "451210924790f384c4814986f8275942",
+        "traceparent": "00-038a8f5d39efbf6222981ee9844347f2-bcbf6e6e45ab5a36-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0c950b4dd11e156acec7867f890d74d7",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:15 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:49 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -145,7 +145,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -154,20 +154,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:15 GMT",
-        "MS-CV": "es5oGTn9eESy9c7aEUIzbw.0",
+        "Date": "Mon, 05 Dec 2022 22:48:49 GMT",
+        "MS-CV": "/iOz9VpWEUuEsJ3tlsej1w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sNZDYwAAAAA1XiLgUhgTRbDg\u002BAK9p/q/TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0UXWOYwAAAAA58XuYzDzBQ6z5E4Xba6tFUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "122ms"
+        "X-Processing-Time": "162ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -177,23 +177,23 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-79f6f6e05922788874df6584e7ee83fe-12cba1e4e26367fd-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "32afdefa7583333d6e02a6aeea55bdc2",
+        "traceparent": "00-f57636e4c236d97d32c5e763ab36159a-6d5e201a0589ee0b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "40fa432d5101714a4626508f3fa8f9a2",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:16 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:50 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -201,20 +201,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:16 GMT",
-        "MS-CV": "Lq5Q9Idob0iIYWtp3RSc7A.0",
+        "Date": "Mon, 05 Dec 2022 22:48:49 GMT",
+        "MS-CV": "bF3W2Mf1E0Cz4Xg11AKcXA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sNZDYwAAAACR\u002BXnuEZ14RJfRDeXOoQbHTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0UnWOYwAAAACWPxRDnNqYSI0BxNhBqm9lUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "78ms"
+        "X-Processing-Time": "98ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -224,7 +224,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -232,7 +232,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1525743558"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "1408275426"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResource.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -67,7 +67,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -116,7 +116,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -176,7 +176,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -223,7 +223,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -270,7 +270,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -312,7 +312,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -350,7 +350,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -388,7 +388,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -427,7 +427,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "714417444"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResourceAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -67,7 +67,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -116,7 +116,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -176,7 +176,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -223,7 +223,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -270,7 +270,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -312,7 +312,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -350,7 +350,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -388,7 +388,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -427,7 +427,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "1711047334"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResourceAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-eceaa254494f30673ca0e014daa8fe91-f4d79b0057a59379-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "acbf10a350f261648d659b27c3173960",
+        "traceparent": "00-ecc720e5d2077b3449ae7f06c71907c3-b96c756385df414f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "aac8f96273026f3bb27a8602d216830e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:26 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:14 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,17 +22,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:26 GMT",
-        "MS-CV": "DPX3O71lQki7UUm8JVmX/g.0",
+        "Date": "Mon, 05 Dec 2022 22:49:14 GMT",
+        "MS-CV": "fa0Vqc\u002BoXE6z9p0Q2aWRFQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0u9ZDYwAAAAD1KPHrbmS2Rb9B2MkGfG9sTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0anWOYwAAAAAn8Djyoe6vS49PpoNw5g72UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "91ms"
+        "X-Processing-Time": "132ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -40,16 +40,16 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f409b998448743334f422faac744d801-6250e35a8c4db76e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1849d4dc2476d8d45754b28c97854b01",
+        "traceparent": "00-3eb55f6d00b3997094685922fca65430-9fc409462db505df-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d4e9e7377b6e1c26b1739d88bbc16a5f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:27 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:15 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -57,17 +57,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:27 GMT",
-        "MS-CV": "g/CCrs1\u002Bu0CwbY7kwONpLw.0",
+        "Date": "Mon, 05 Dec 2022 22:49:14 GMT",
+        "MS-CV": "\u002BuEFmKcQ1kKIJ03K3ajnoQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0u9ZDYwAAAAD8ZoI/jPywQqP8EUfBQ9tkTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0anWOYwAAAABTzJpt9\u002BVnRoTFoOU\u002BKcwBUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "67ms"
+        "X-Processing-Time": "97ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -75,26 +75,26 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "114",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-f409b998448743334f422faac744d801-ad512b479b1bc66e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c365851eea45efecc19fa6037efb7e6d",
+        "traceparent": "00-3eb55f6d00b3997094685922fca65430-c5441f190e97caba-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "021c02d0be90d54f025b354c99ee436f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:27 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:15 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -103,20 +103,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:27 GMT",
-        "MS-CV": "jz47usTpFkim1f8AZIHtBg.0",
+        "Date": "Mon, 05 Dec 2022 22:49:15 GMT",
+        "MS-CV": "nFVDiaAic0qTqafKyFktRw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0u9ZDYwAAAAD6NSOyGPr/SqZmQp0N4Y5zTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0a3WOYwAAAACS1SRGEEmHSIJLA1FCScBKUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "321ms"
+        "X-Processing-Time": "205ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -124,18 +124,18 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "178",
+        "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-a7077792155feec91c3769ce7f3103f6-0c588707c0f93bd9-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "03323a017feb7e123ce6559d9dd8c907",
+        "traceparent": "00-00cac0b09cb9e9a936e5c6e5275589d4-74b3b82784f9cbf5-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5e080ded5999e65fd2abf98ed5b3b4f1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:27 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:15 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -145,7 +145,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -154,20 +154,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:27 GMT",
-        "MS-CV": "xFkLsVlpFEqermk1f\u002BuNnw.0",
+        "Date": "Mon, 05 Dec 2022 22:49:15 GMT",
+        "MS-CV": "HEfxVhgBJEyp765Ufc\u002B8wA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vNZDYwAAAABalcEtxLikSaRJaezZJxU/TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0a3WOYwAAAAAV4X/gPpDgT5G9HLHoJ4DWUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "255ms"
+        "X-Processing-Time": "113ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -177,23 +177,23 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-4f34a39abbc6e6012ba24b9e7b3f4f38-45440dcd71cadbab-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3d09991a76b1f11be85a56d77ed05a5b",
+        "traceparent": "00-5bd9e5ffc91c2a0d4736ccbddb224b2d-e309c06147e0fe90-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cf31261081fa797e9813d21346da83c2",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:28 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:15 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -201,20 +201,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:28 GMT",
-        "MS-CV": "0W5pdw2\u002B6kqcYCWx2S0KzQ.0",
+        "Date": "Mon, 05 Dec 2022 22:49:15 GMT",
+        "MS-CV": "tdG0wFprgkOFOyHBl6kLSA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vNZDYwAAAABCUsvO45E/T7CcseWuiU0kTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0a3WOYwAAAABMs1oytAtkT5XJhXgsicRFUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "66ms"
+        "X-Processing-Time": "94ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -224,7 +224,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -232,7 +232,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1562048211"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "791594193"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d94057b57ac0c747b27b313baf4d3b31-a39a2e45261d28c4-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0e2896255b4efa08828b61ff3b1ac89e",
+        "traceparent": "00-de68bd4f85c50299bde65672f90d04c4-29f332372bc638d7-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cb0ac0db3f57df87e2340e85bb158496",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:38 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:37 GMT",
-        "MS-CV": "OC36FTt1jEKWeTsxnBMYjw.0",
+        "Date": "Tue, 13 Dec 2022 01:39:56 GMT",
+        "MS-CV": "tVWiWOaafUeTWyeVpc2pug.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0CoSOYwAAAAAQ7JAHwZseSoF7V3eyHxBGUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07deXYwAAAAANfHoGRL89TrhtcPrbWEyDUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "176ms"
+        "X-Processing-Time": "119ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-b7ecff4fdf5c8cc66d03f3a80615af90-55bbd64a7d84a811-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6155a0fcb324334a5d3b8ecaa1990344",
+        "traceparent": "00-e28fe42cd1638afb89b689b30c84c545-1e6d96a969da698a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5322b08c4def2955771113880b6860e3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:38 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:37 GMT",
-        "MS-CV": "O3zfuA9bNUyI3AJVpmHOyQ.0",
+        "Date": "Tue, 13 Dec 2022 01:39:56 GMT",
+        "MS-CV": "EBpQA\u002BYXMUGzSpPSJBSJOg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0CoSOYwAAAACOlyYyQVDQR7qXfVtYc9C6UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07deXYwAAAAAnA1OQhQ7rRYQNPKaSF4NrUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
+        "X-Processing-Time": "81ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -72,21 +72,21 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "86",
+        "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-b7ecff4fdf5c8cc66d03f3a80615af90-fa0864b2a20260be-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "375acc0badfe135279df3fb7506f7425",
+        "traceparent": "00-e28fe42cd1638afb89b689b30c84c545-ff91aa32c22da71f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a8c30419b7c31ca4664c0d38a73a69f5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:38 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:38 GMT",
-        "MS-CV": "hdiWmypwkkKLHcbX\u002B1OX0Q.0",
+        "Date": "Tue, 13 Dec 2022 01:39:57 GMT",
+        "MS-CV": "z2vCt9PhxECWHYrfk5UzCA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0CoSOYwAAAABSQzeg2krXSIXR5K2IpCHzUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07deXYwAAAAD5wIwnEkPUSY3uvZi8a1/aUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "651ms"
+        "X-Processing-Time": "394ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -121,13 +121,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "164",
+        "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-6f0f45184dbbdb549b5b87d9b0894adb-37a0302d31174c41-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b56d8c170d5272754bf4b112cd3e58e8",
+        "traceparent": "00-7cc342bd0a900f520a8a529889318e88-2cf011aec3a109c9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "739474e1626d8dd46be153452bfed47a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:39 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:38 GMT",
-        "MS-CV": "GJz7VHPdNEyrmBUbc6ERPA.0",
+        "Date": "Tue, 13 Dec 2022 01:39:57 GMT",
+        "MS-CV": "BbXa3XA7sEiTV9weCRaSuA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0C4SOYwAAAADy13FdqwRATYU6TdDOwlDdUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07teXYwAAAACs6DjskR3oR7O0EVSTQVcuUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "173ms"
+        "X-Processing-Time": "105ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,54 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-56f9e9e3b50e4fbad5aff189d4470787-942283e5a0ab3906-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6ef41c8891c04e9f4e41e7447393e2ed",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:39 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:39 GMT",
-        "MS-CV": "ZGPOcJehZEm9lw5DWWj0YA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0C4SOYwAAAADDN\u002BhUJn5PQ54IFmU9zPerUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.com"
+              "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com"
             ]
           }
         ]
@@ -228,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-402f816a808eb145eb84b88818ef663c-479c2d2f6976bd73-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "15b269c74e2bfdf157e7eb0afc3f463a",
+        "traceparent": "00-ddd2a59e4ccf0450cc05e4ac2c963c55-db113a2d3f8203db-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b66c2ad3db52d5d20b05eca3401c813c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:40 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -240,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:39 GMT",
-        "MS-CV": "lVY31kYDm0q6pZ0SVWwKcQ.0",
+        "Date": "Tue, 13 Dec 2022 01:39:58 GMT",
+        "MS-CV": "x7ksBRFSP0K3b2eocAtjfw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0DISOYwAAAADT2k70VsnARZckLhLBRfmiUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "07teXYwAAAAC0WczvJ\u002BTuRr8S\u002BqMUyh0WUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
+        "X-Processing-Time": "407ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,7 +216,54 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d7e6f09d06adccc8e7830bc2814ec3d1-0b6694a7262badf0-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "96a71ea7edd3b67630353de1645ff167",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:58 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:39:58 GMT",
+        "MS-CV": "Z3B9hVvY40eFf4Z\u002BDVZ9DA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "079eXYwAAAADjA1Lp1lGQTKGsDm0AwiJHUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "76ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com"
             ]
           }
         ]
@@ -277,11 +277,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-b86c41264b5cbde44c2694d9e120e4a3-311ff9a81f521f72-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "332f5686057b8664ec1f67112530ffb8",
+        "traceparent": "00-fad023198548192ee306812e31d7eec9-6265e7811df0d3e4-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7c659278b2ce05a2a2bf686876304c4e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:40 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -291,20 +291,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:39 GMT",
-        "MS-CV": "FCipXXvvWEW1Z5HZzRu\u002BFA.0",
+        "Date": "Tue, 13 Dec 2022 01:39:58 GMT",
+        "MS-CV": "CSUruQ/IUU2GyHgcEybM0Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0DISOYwAAAAAERNFwsWceQ4qDzOSGemVFUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "079eXYwAAAAC\u002BAxg7yclITKZvgte6W6MHUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "168ms"
+        "X-Processing-Time": "108ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -317,11 +317,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-38a4d500992ce1759e4756771248585b-f6a34165611f071c-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "644bc312428c39bd2bf617d8a595510e",
+        "traceparent": "00-69761b4665931a1a4afeca21e6f10d4e-7f6496a474eeb390-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0c9d16603d57e6a6b4b6861c9df170ac",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:40 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:59 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -329,20 +329,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:39 GMT",
-        "MS-CV": "HT8eXc9XE0G1M2lVXl6fzA.0",
+        "Date": "Tue, 13 Dec 2022 01:39:58 GMT",
+        "MS-CV": "NuWR4FZps0uyPt0RyNZkQw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0DISOYwAAAAB0T23f2ahKTaWWhJ3pvNg9UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "079eXYwAAAAAQ1msu8aC4Q7EaIxMWDsQWUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
+        "X-Processing-Time": "87ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -355,11 +355,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-a00c4e209ea11ef753fca32e29092439-d5721f633a9c37d0-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1cbdacfbae64c172042b290be7e0d826",
+        "traceparent": "00-80891bfefef2e3fe6a695e0ab43181d0-46d0e812a1805db7-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ad2a841305b6f56e7ca1f414840d3fff",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:40 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:59 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -367,20 +367,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:40 GMT",
-        "MS-CV": "yI\u002BWDc4Mt02f6Uss5bQXVg.0",
+        "Date": "Tue, 13 Dec 2022 01:39:58 GMT",
+        "MS-CV": "aR7gpY8ZAUWCh/2sKjONeg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0DISOYwAAAACbeJCG4IpkR5oZLRDVp1BvUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "079eXYwAAAABIiOyli3gdQYxlwhP4MM\u002BHUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "82ms"
+        "X-Processing-Time": "80ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -393,32 +393,32 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "44",
+        "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-a00c4e209ea11ef753fca32e29092439-6cb40ed1365bc964-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "38f733e8e1f444ae99f50884ee8ce156",
+        "traceparent": "00-80891bfefef2e3fe6a695e0ab43181d0-e6dacf72b326a587-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4d81efe8e5c13a10ec7fc7172c8567b0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:40 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:59 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": null,
-          "sbs2.com": null
+          "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": null,
+          "sbs2.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:40 GMT",
-        "MS-CV": "aaQQGtn8M0Gv0AamYQEXeQ.0",
+        "Date": "Tue, 13 Dec 2022 01:40:00 GMT",
+        "MS-CV": "NXCnaKE5ZE2phK9yfzP9Qw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0DISOYwAAAADIjQFKO2rERb5XY58yM/9JUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "079eXYwAAAACtmqYurU0zQLNNqTnbzz0KUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "283ms"
+        "X-Processing-Time": "138ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -428,6 +428,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1711047334"
+    "RandomSeed": "1680906862"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-de68bd4f85c50299bde65672f90d04c4-29f332372bc638d7-00",
+        "traceparent": "00-4bbf261ddfa39b7f33335f18584e87a8-26a27e5494b4a7b5-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "cb0ac0db3f57df87e2340e85bb158496",
+        "x-ms-client-request-id": "fdaa4d0d440446405fa368f0f67c0413",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:57 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:56 GMT",
-        "MS-CV": "tVWiWOaafUeTWyeVpc2pug.0",
+        "Date": "Tue, 13 Dec 2022 20:16:56 GMT",
+        "MS-CV": "E2o3Ko25fE6fDTYui9oTvA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07deXYwAAAAANfHoGRL89TrhtcPrbWEyDUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0uN2YYwAAAABqrQJ7LG0iR5flgRcYjLPvUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "119ms"
+        "X-Processing-Time": "156ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-e28fe42cd1638afb89b689b30c84c545-1e6d96a969da698a-00",
+        "traceparent": "00-389b5f203517f9784e31c5a2f5a552ef-54280e2c2045f77f-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5322b08c4def2955771113880b6860e3",
+        "x-ms-client-request-id": "3b1ad4ebcfd898bbab741618d8947dd9",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:57 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:56 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:56 GMT",
-        "MS-CV": "EBpQA\u002BYXMUGzSpPSJBSJOg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:57 GMT",
+        "MS-CV": "w03kaOmaWkSgXZXwDVH8eA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07deXYwAAAAAnA1OQhQ7rRYQNPKaSF4NrUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ud2YYwAAAAB8PmBrVid4QYz2Gbm9WNjVUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "81ms"
+        "X-Processing-Time": "112ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-e28fe42cd1638afb89b689b30c84c545-ff91aa32c22da71f-00",
+        "traceparent": "00-389b5f203517f9784e31c5a2f5a552ef-7b9d35fdc62988cc-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a8c30419b7c31ca4664c0d38a73a69f5",
+        "x-ms-client-request-id": "77033de64ec5668f99df45051a448490",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:57 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:56 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
+          "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
+          "sbs2.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:57 GMT",
-        "MS-CV": "z2vCt9PhxECWHYrfk5UzCA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:57 GMT",
+        "MS-CV": "fzor/KwQ/kKkt3Fnc4oHiQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07deXYwAAAAD5wIwnEkPUSY3uvZi8a1/aUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ud2YYwAAAADftLOQZrAeSYLG3c3Xa44oUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "394ms"
+        "X-Processing-Time": "616ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
+          "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
+          "sbs2.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-7cc342bd0a900f520a8a529889318e88-2cf011aec3a109c9-00",
+        "traceparent": "00-4c392b1bb2774d3d5e292d7e6db81da0-0e4c7323fa8d541e-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "739474e1626d8dd46be153452bfed47a",
+        "x-ms-client-request-id": "db6cdd25f4063e869211518f2d286dcb",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:58 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:56 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com"
+              "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:57 GMT",
-        "MS-CV": "BbXa3XA7sEiTV9weCRaSuA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:58 GMT",
+        "MS-CV": "uLrbXfFXQ0yM9sTCGFyHDQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07teXYwAAAACs6DjskR3oR7O0EVSTQVcuUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ud2YYwAAAAC4bMUthQfXSbtll/Vm3ZBoUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "105ms"
+        "X-Processing-Time": "157ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
+          "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
+          "sbs2.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,54 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-ddd2a59e4ccf0450cc05e4ac2c963c55-db113a2d3f8203db-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b66c2ad3db52d5d20b05eca3401c813c",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:58 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:58 GMT",
-        "MS-CV": "x7ksBRFSP0K3b2eocAtjfw.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "07teXYwAAAAC0WczvJ\u002BTuRr8S\u002BqMUyh0WUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "407ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com"
+              "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com"
             ]
           }
         ]
@@ -228,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-d7e6f09d06adccc8e7830bc2814ec3d1-0b6694a7262badf0-00",
+        "traceparent": "00-c8043a3ce8db925726a7de4f93577750-4dd5f12bef1d7215-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "96a71ea7edd3b67630353de1645ff167",
+        "x-ms-client-request-id": "b90a8f258c799d4e44b3a1f889b57d67",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:58 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -240,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:58 GMT",
-        "MS-CV": "Z3B9hVvY40eFf4Z\u002BDVZ9DA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:58 GMT",
+        "MS-CV": "ziGOQR1F2EiJnXwHl37znA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "079eXYwAAAADjA1Lp1lGQTKGsDm0AwiJHUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ut2YYwAAAAAxNThOao4DQLAaN94VVBbNUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "76ms"
+        "X-Processing-Time": "85ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
+          "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
+          "sbs2.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,7 +216,101 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com"
+              "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-da0c9f0030e9f145a1f3b5b49e4c82d1-ee4878933fb3ca3f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fbf286efa128f1d2b7c4e5b3fcff3871",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:57 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:16:58 GMT",
+        "MS-CV": "Gk3hp9cjwUK1\u002Brg7DsvMwA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0ut2YYwAAAABX\u002BtuBBDIkS7sfXTDzz/xuUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "96ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-eca4f3731e246c5d6f0579148fe20423-7972c5a5371bd924-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8be07a72cb3a99168fcf9752538db5dc",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:57 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:16:58 GMT",
+        "MS-CV": "gmnhCAFmM0yeK9YHLp/d7A.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0ut2YYwAAAACSVaeXbgTnSKf7J1aEqve\u002BUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "80ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com"
             ]
           }
         ]
@@ -277,11 +324,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-fad023198548192ee306812e31d7eec9-6265e7811df0d3e4-00",
+        "traceparent": "00-a58b701df903675ce678263538022080-1acc68bd5e3bf4e8-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7c659278b2ce05a2a2bf686876304c4e",
+        "x-ms-client-request-id": "a7a0ea93723683a3bc1801b5a69aa045",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:58 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -291,20 +338,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:58 GMT",
-        "MS-CV": "CSUruQ/IUU2GyHgcEybM0Q.0",
+        "Date": "Tue, 13 Dec 2022 20:16:59 GMT",
+        "MS-CV": "SdLa60jLMUiQ40h95fSzpQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "079eXYwAAAAC\u002BAxg7yclITKZvgte6W6MHUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ut2YYwAAAACg9UsYsvRNSYJ7qBkSfDIkUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "108ms"
+        "X-Processing-Time": "178ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
+          "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
+          "sbs2.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -317,11 +364,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-69761b4665931a1a4afeca21e6f10d4e-7f6496a474eeb390-00",
+        "traceparent": "00-aa27bdf42adce76999a68ceded75f162-65eb8b959f8f04d8-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0c9d16603d57e6a6b4b6861c9df170ac",
+        "x-ms-client-request-id": "0e86307af2d5232d70596b580a809e29",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:59 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -329,58 +376,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:58 GMT",
-        "MS-CV": "NuWR4FZps0uyPt0RyNZkQw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:59 GMT",
+        "MS-CV": "idTiDf9E/EGdRKNUNEpZvA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "079eXYwAAAAAQ1msu8aC4Q7EaIxMWDsQWUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0u92YYwAAAAAPSF8boeW2RIV88dOEPijVUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
+        "X-Processing-Time": "204ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
+          "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-80891bfefef2e3fe6a695e0ab43181d0-46d0e812a1805db7-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ad2a841305b6f56e7ca1f414840d3fff",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:59 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:39:58 GMT",
-        "MS-CV": "aR7gpY8ZAUWCh/2sKjONeg.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "079eXYwAAAABIiOyli3gdQYxlwhP4MM\u002BHUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "80ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": {
+          "sbs2.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -395,30 +404,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-80891bfefef2e3fe6a695e0ab43181d0-e6dacf72b326a587-00",
+        "traceparent": "00-aa27bdf42adce76999a68ceded75f162-e60d82eb4c229656-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4d81efe8e5c13a10ec7fc7172c8567b0",
+        "x-ms-client-request-id": "121f090f915eff3bd75cce21c961f2f5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:59 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": null,
-          "sbs2.f02cee5c-b56d-25c0-0a65-0b21238fb6c4.com": null
+          "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com": null,
+          "sbs2.a526daab-83a9-7b35-0d29-f158b0202f5e.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:00 GMT",
-        "MS-CV": "NXCnaKE5ZE2phK9yfzP9Qw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:59 GMT",
+        "MS-CV": "yOlHIYN/JUaUAMzJY63Ixw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "079eXYwAAAACtmqYurU0zQLNNqTnbzz0KUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0u92YYwAAAACvJLlAoc7AR714CN\u002BKeU0HUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "138ms"
+        "X-Processing-Time": "255ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -428,6 +437,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1680906862"
+    "RandomSeed": "1873134163"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-ecc720e5d2077b3449ae7f06c71907c3-b96c756385df414f-00",
+        "traceparent": "00-d94057b57ac0c747b27b313baf4d3b31-a39a2e45261d28c4-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "aac8f96273026f3bb27a8602d216830e",
+        "x-ms-client-request-id": "0e2896255b4efa08828b61ff3b1ac89e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:14 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:38 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,20 +22,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:14 GMT",
-        "MS-CV": "fa0Vqc\u002BoXE6z9p0Q2aWRFQ.0",
+        "Date": "Mon, 05 Dec 2022 23:51:37 GMT",
+        "MS-CV": "OC36FTt1jEKWeTsxnBMYjw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0anWOYwAAAAAn8Djyoe6vS49PpoNw5g72UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0CoSOYwAAAAAQ7JAHwZseSoF7V3eyHxBGUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "132ms"
+        "X-Processing-Time": "176ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -45,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-3eb55f6d00b3997094685922fca65430-9fc409462db505df-00",
+        "traceparent": "00-b7ecff4fdf5c8cc66d03f3a80615af90-55bbd64a7d84a811-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d4e9e7377b6e1c26b1739d88bbc16a5f",
+        "x-ms-client-request-id": "6155a0fcb324334a5d3b8ecaa1990344",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:15 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:38 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -57,20 +53,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:14 GMT",
-        "MS-CV": "\u002BuEFmKcQ1kKIJ03K3ajnoQ.0",
+        "Date": "Mon, 05 Dec 2022 23:51:37 GMT",
+        "MS-CV": "O3zfuA9bNUyI3AJVpmHOyQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0anWOYwAAAABTzJpt9\u002BVnRoTFoOU\u002BKcwBUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0CoSOYwAAAACOlyYyQVDQR7qXfVtYc9C6UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "97ms"
+        "X-Processing-Time": "87ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -82,11 +74,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-3eb55f6d00b3997094685922fca65430-c5441f190e97caba-00",
+        "traceparent": "00-b7ecff4fdf5c8cc66d03f3a80615af90-fa0864b2a20260be-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "021c02d0be90d54f025b354c99ee436f",
+        "x-ms-client-request-id": "375acc0badfe135279df3fb7506f7425",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:15 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:38 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -103,13 +95,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:15 GMT",
-        "MS-CV": "nFVDiaAic0qTqafKyFktRw.0",
+        "Date": "Mon, 05 Dec 2022 23:51:38 GMT",
+        "MS-CV": "hdiWmypwkkKLHcbX\u002B1OX0Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0a3WOYwAAAACS1SRGEEmHSIJLA1FCScBKUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0CoSOYwAAAABSQzeg2krXSIXR5K2IpCHzUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "205ms"
+        "X-Processing-Time": "651ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -131,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-00cac0b09cb9e9a936e5c6e5275589d4-74b3b82784f9cbf5-00",
+        "traceparent": "00-6f0f45184dbbdb549b5b87d9b0894adb-37a0302d31174c41-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5e080ded5999e65fd2abf98ed5b3b4f1",
+        "x-ms-client-request-id": "b56d8c170d5272754bf4b112cd3e58e8",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:15 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:39 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -154,13 +146,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:15 GMT",
-        "MS-CV": "HEfxVhgBJEyp765Ufc\u002B8wA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:38 GMT",
+        "MS-CV": "GJz7VHPdNEyrmBUbc6ERPA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0a3WOYwAAAAAV4X/gPpDgT5G9HLHoJ4DWUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0C4SOYwAAAADy13FdqwRATYU6TdDOwlDdUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "113ms"
+        "X-Processing-Time": "173ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -189,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-5bd9e5ffc91c2a0d4736ccbddb224b2d-e309c06147e0fe90-00",
+        "traceparent": "00-56f9e9e3b50e4fbad5aff189d4470787-942283e5a0ab3906-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "cf31261081fa797e9813d21346da83c2",
+        "x-ms-client-request-id": "6ef41c8891c04e9f4e41e7447393e2ed",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:15 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:39 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -201,13 +193,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:15 GMT",
-        "MS-CV": "tdG0wFprgkOFOyHBl6kLSA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:39 GMT",
+        "MS-CV": "ZGPOcJehZEm9lw5DWWj0YA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0a3WOYwAAAABMs1oytAtkT5XJhXgsicRFUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0C4SOYwAAAADDN\u002BhUJn5PQ54IFmU9zPerUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "94ms"
+        "X-Processing-Time": "89ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -229,10 +221,213 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-402f816a808eb145eb84b88818ef663c-479c2d2f6976bd73-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "15b269c74e2bfdf157e7eb0afc3f463a",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:40 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:39 GMT",
+        "MS-CV": "lVY31kYDm0q6pZ0SVWwKcQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0DISOYwAAAADT2k70VsnARZckLhLBRfmiUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "89ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-b86c41264b5cbde44c2694d9e120e4a3-311ff9a81f521f72-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "332f5686057b8664ec1f67112530ffb8",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:40 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:39 GMT",
+        "MS-CV": "FCipXXvvWEW1Z5HZzRu\u002BFA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0DISOYwAAAAAERNFwsWceQ4qDzOSGemVFUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "168ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-38a4d500992ce1759e4756771248585b-f6a34165611f071c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "644bc312428c39bd2bf617d8a595510e",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:40 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:39 GMT",
+        "MS-CV": "HT8eXc9XE0G1M2lVXl6fzA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0DISOYwAAAAB0T23f2ahKTaWWhJ3pvNg9UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "83ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a00c4e209ea11ef753fca32e29092439-d5721f633a9c37d0-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1cbdacfbae64c172042b290be7e0d826",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:40 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:40 GMT",
+        "MS-CV": "yI\u002BWDc4Mt02f6Uss5bQXVg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0DISOYwAAAACbeJCG4IpkR5oZLRDVp1BvUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "82ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "44",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-a00c4e209ea11ef753fca32e29092439-6cb40ed1365bc964-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "38f733e8e1f444ae99f50884ee8ce156",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:40 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.com": null,
+          "sbs2.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:40 GMT",
+        "MS-CV": "aaQQGtn8M0Gv0AamYQEXeQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0DISOYwAAAADIjQFKO2rERb5XY58yM/9JUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "283ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "791594193"
+    "RandomSeed": "1711047334"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d4e7893202a492e042d00e01cf24c0d4-494d149895309ed3-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1991d441444a4ad15502e548cf82b510",
+        "traceparent": "00-79b4797499f5b0ca9a29fbd393ba8d13-a831d69dd672a0b9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "930cdb6f2c24a10919d5da451b444ffa",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:11 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:45 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:10 GMT",
-        "MS-CV": "acZ\u002BRJvLA0uCTVNQNzxLVA.0",
+        "Date": "Tue, 13 Dec 2022 01:18:46 GMT",
+        "MS-CV": "yo3/hNbW8E\u002Bt3xcF/0TXqA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "074OOYwAAAADoI05pSVn\u002BQ7ys3Ce3iZAAUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09dKXYwAAAABTq9UtRoKcTaJhPbUsZ/c/UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "175ms"
+        "X-Processing-Time": "373ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-252ad34163489b42fd3c2ec75a71735c-31211d894665d4f1-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7840a1d6c5c48bbbf2d7b0c976b05434",
+        "traceparent": "00-0509c54c87ff9afe5a83511cf6b6a27c-9c52813732144617-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "de101f622e9e743acab5070f6ddb906e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:11 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:46 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:11 GMT",
-        "MS-CV": "udbrW55GAU2O4ACbC9\u002BkZw.0",
+        "Date": "Tue, 13 Dec 2022 01:18:46 GMT",
+        "MS-CV": "J6yGmuVADkyOiMSqhe3cZQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "074OOYwAAAAAjhrX4qBdDRYoTzwySai/nUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09tKXYwAAAACUKHF6l9U3ToWBDCEUs4oyUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
+        "X-Processing-Time": "81ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -72,21 +72,21 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "86",
+        "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-252ad34163489b42fd3c2ec75a71735c-662b8672d3d7d391-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a7aea71ef458ba868de517a6c87b3722",
+        "traceparent": "00-0509c54c87ff9afe5a83511cf6b6a27c-7483386b37740055-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c8ad042d28d01b0fe906d33e67b88e81",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:11 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:46 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:11 GMT",
-        "MS-CV": "IR3CQzcA70qeL\u002BimE7JgBA.0",
+        "Date": "Tue, 13 Dec 2022 01:18:47 GMT",
+        "MS-CV": "5v/G5XIjSEej7hix39u6Xw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "074OOYwAAAACQiL3IJ//qSLn3ZA1VKiRuUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09tKXYwAAAABZCpsv\u002BAm3TqzDAjzm3LTBUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "456ms"
+        "X-Processing-Time": "617ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -121,13 +121,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "164",
+        "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-df580c31269ad66fb7626e644a4eb45b-55407a8dc3c425ba-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "cb9f3394ffd87c24190526739308d3a4",
+        "traceparent": "00-11da6ba18c6c149b387176c05ad538eb-dfbc3ee0092d1552-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ae3ecab045aa40b4a098c96e25f9333d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:12 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:46 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:11 GMT",
-        "MS-CV": "1QLkR/BMmkaAXW51fyrgfQ.0",
+        "Date": "Tue, 13 Dec 2022 01:18:47 GMT",
+        "MS-CV": "OZVA/dSiNUO5icNJuvVHhQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08IOOYwAAAAAsb303SdvWRrqry1hE8d67UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "099KXYwAAAACAFSOASR4\u002BTLzWO6HcPlcMUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "169ms"
+        "X-Processing-Time": "158ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,54 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-148ce6523c79b05e96e11efdcebfc79c-a6b082b8d4ac5260-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2829b1ae0dd3e2b71a85ebdfad15c276",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:12 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:12 GMT",
-        "MS-CV": "9bITuPrGaU\u002BnyvhZHm2bUg.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08IOOYwAAAAASHk\u002BBsrL8RKXB4kQ41hJ5UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.com"
+              "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com"
             ]
           }
         ]
@@ -228,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-01ddf9ead95a9b6b21eb6efc1ff7f9f2-30e6959132481add-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "42358da088111f5b82328e52ce132685",
+        "traceparent": "00-9cc476e7f867b483f1f5507f49e95cee-4cdab06ac5e3aff8-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "17186b4487963a2a0ff5f4985bfc0d12",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:12 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:47 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -240,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:12 GMT",
-        "MS-CV": "c3j2xvRLPkKN1xFpqDf0XQ.0",
+        "Date": "Tue, 13 Dec 2022 01:18:47 GMT",
+        "MS-CV": "IP1hRRyNoUqrk2vhDYwu3A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08IOOYwAAAADN9puF2ICJRITXj3yIOHKCUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "099KXYwAAAABzMr7Nl/tXRoakePh796M2UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "80ms"
+        "X-Processing-Time": "98ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,7 +216,54 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-15d3c8d50a2b7831240140f60a21e151-d59a2b4a02e3fe8f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a25e8626e29de7c34f6c27385fa0f5f0",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:47 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:18:47 GMT",
+        "MS-CV": "604PFTg6Hkyewtoo9n9yJg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "099KXYwAAAACLYrjsvMQrTZnFkfDH8TQvUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "92ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com"
             ]
           }
         ]
@@ -277,11 +277,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-4d01ff16856355ca1e0f3f14413799f6-f6de00da35853f5b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "17f772110e52864f7bbcb0521445ce03",
+        "traceparent": "00-776d089231d6b96db9dd712976f0f07d-41170467f027d68c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fbf996d2779f29eaa0039eb4501be5a4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:13 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:47 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -291,20 +291,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:12 GMT",
-        "MS-CV": "rAKnUSMxOUW1IpqZQljbQw.0",
+        "Date": "Tue, 13 Dec 2022 01:18:48 GMT",
+        "MS-CV": "QCyJTQtaE0CoAWCpCz9A\u002BQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08IOOYwAAAADUar2UGfLnSI4q8WmA/19zUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BNKXYwAAAAAaHbCQnuTiSLG\u002BsfeUvVQAUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "163ms"
+        "X-Processing-Time": "295ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -317,11 +317,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-8032045f3b1c27bcdde4ef5ebb72540a-0b51d4fc76b97313-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "06d2af4291d22692550aa6a17e651307",
+        "traceparent": "00-d30c3ab17fd6d03bfce22021ad03e0b5-072e279a05daa95b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9e48b68b919a629fa831c72a5ff2db6e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:13 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:48 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -329,20 +329,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:12 GMT",
-        "MS-CV": "rHxfwj/tNEOauCcibJ6NUw.0",
+        "Date": "Tue, 13 Dec 2022 01:18:48 GMT",
+        "MS-CV": "TBKOHYo0z0\u002BKBtJ06KSsdw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08YOOYwAAAADBNgCNKqp2SrIteVQ1XarcUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BNKXYwAAAACaqeg/jeqJQ5aeiPtO44veUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "85ms"
+        "X-Processing-Time": "93ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -355,11 +355,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-022d8e7e10d9760631a82df2da8a2ad9-69655ca06b80fd55-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3bce665eab1e91243eafc754d7090a3d",
+        "traceparent": "00-70c9aa3b509ef9eb1593335b685d1ba4-80d61308e072987c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c4c604ff1103af729b350299440f9634",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:13 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:48 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -367,20 +367,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:12 GMT",
-        "MS-CV": "2zR125w/ZEejFRf5mc1MKA.0",
+        "Date": "Tue, 13 Dec 2022 01:18:49 GMT",
+        "MS-CV": "4n3jqtvAn0\u002Bw3uBjk\u002BrORw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08YOOYwAAAADTwj3INdhYRKuLgblV51uJUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BNKXYwAAAADY3EGIooxCR7vAKbB2BHf8UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
+        "X-Processing-Time": "100ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -393,32 +393,32 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "44",
+        "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-022d8e7e10d9760631a82df2da8a2ad9-7fc890e2427a9082-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1e108b64204080b2dfd0c24867ad0716",
+        "traceparent": "00-70c9aa3b509ef9eb1593335b685d1ba4-3ac0b66ee9829446-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a8ad838757584155f697536eb0c0c9ae",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:13 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:48 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": null,
-          "sbs2.com": null
+          "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": null,
+          "sbs2.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:13 GMT",
-        "MS-CV": "wX7\u002BArgyYkapb6aHDqpMjQ.0",
+        "Date": "Tue, 13 Dec 2022 01:18:49 GMT",
+        "MS-CV": "HCyntrmba0mE9/9tNhV1Nw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08YOOYwAAAAC0Y6sBahoXQblJ5eajfBPiUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BdKXYwAAAAAzQKpmrCPLT68SRk99343AUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "262ms"
+        "X-Processing-Time": "133ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -428,6 +428,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1257491746"
+    "RandomSeed": "1544761984"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-79b4797499f5b0ca9a29fbd393ba8d13-a831d69dd672a0b9-00",
+        "traceparent": "00-bfd086659febf8eac2ebd3011a072d1b-3ea9c2de858e03e4-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "930cdb6f2c24a10919d5da451b444ffa",
+        "x-ms-client-request-id": "8f9314266dc90d4cf1b1794e591389f8",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:45 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:32 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:46 GMT",
-        "MS-CV": "yo3/hNbW8E\u002Bt3xcF/0TXqA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:32 GMT",
+        "MS-CV": "7UrOJbhaeUSRfdmjpMZm1g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09dKXYwAAAABTq9UtRoKcTaJhPbUsZ/c/UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0oN2YYwAAAAC3pZFD9m7cTLK/ryozkoC\u002BUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "373ms"
+        "X-Processing-Time": "102ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-0509c54c87ff9afe5a83511cf6b6a27c-9c52813732144617-00",
+        "traceparent": "00-bc17eec21fa30c9d99c84d16cad2dda8-064208caefa09aff-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "de101f622e9e743acab5070f6ddb906e",
+        "x-ms-client-request-id": "063ea9c83fbc4261b17c7d3a2d68679c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:46 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:32 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:46 GMT",
-        "MS-CV": "J6yGmuVADkyOiMSqhe3cZQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:32 GMT",
+        "MS-CV": "CjfEgOYe30uFlNWo\u002Brb2aQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09tKXYwAAAACUKHF6l9U3ToWBDCEUs4oyUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0od2YYwAAAABtoGnxGlk0SKLM/assgh\u002B2UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "81ms"
+        "X-Processing-Time": "83ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-0509c54c87ff9afe5a83511cf6b6a27c-7483386b37740055-00",
+        "traceparent": "00-bc17eec21fa30c9d99c84d16cad2dda8-804518f929707f37-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c8ad042d28d01b0fe906d33e67b88e81",
+        "x-ms-client-request-id": "94473eeed19ecdd49330fcef08dcbfb7",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:46 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:32 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
+          "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
+          "sbs2.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:47 GMT",
-        "MS-CV": "5v/G5XIjSEej7hix39u6Xw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:32 GMT",
+        "MS-CV": "yt4Ixh4pAU6HTp80ukNiVQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09tKXYwAAAABZCpsv\u002BAm3TqzDAjzm3LTBUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0od2YYwAAAADUqzWXjNICSrlNto8FZ0MfUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "617ms"
+        "X-Processing-Time": "276ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
+          "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
+          "sbs2.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-11da6ba18c6c149b387176c05ad538eb-dfbc3ee0092d1552-00",
+        "traceparent": "00-736a19d63496396f2e7fd1fcdc7e2ee0-e70eaf52cf2f4cf5-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ae3ecab045aa40b4a098c96e25f9333d",
+        "x-ms-client-request-id": "b7f62182ef7ce663b351dd4cef12df89",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:46 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:32 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com"
+              "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:47 GMT",
-        "MS-CV": "OZVA/dSiNUO5icNJuvVHhQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:33 GMT",
+        "MS-CV": "B6EuFPeQLEqOhrTWVEkRuw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "099KXYwAAAACAFSOASR4\u002BTLzWO6HcPlcMUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0od2YYwAAAAAu\u002BExW2w/eR4H9O2rmD7aiUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "158ms"
+        "X-Processing-Time": "111ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
+          "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
+          "sbs2.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com"
+              "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com"
             ]
           }
         ]
@@ -181,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-9cc476e7f867b483f1f5507f49e95cee-4cdab06ac5e3aff8-00",
+        "traceparent": "00-09bf73ebe0deeb5d985d8bc91fcb1e6a-512904c0cfda9846-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "17186b4487963a2a0ff5f4985bfc0d12",
+        "x-ms-client-request-id": "1b60dc4af4ccf75ad570728c437139d5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:47 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:33 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -193,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:47 GMT",
-        "MS-CV": "IP1hRRyNoUqrk2vhDYwu3A.0",
+        "Date": "Tue, 13 Dec 2022 20:16:33 GMT",
+        "MS-CV": "OvpPuRwGeEaI8jrgeto1jA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "099KXYwAAAABzMr7Nl/tXRoakePh796M2UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0od2YYwAAAAARX5felHGqT4GW3d8jaqFJUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "98ms"
+        "X-Processing-Time": "77ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
+          "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
+          "sbs2.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -216,7 +216,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com"
+              "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com"
             ]
           }
         ]
@@ -228,11 +228,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-15d3c8d50a2b7831240140f60a21e151-d59a2b4a02e3fe8f-00",
+        "traceparent": "00-20e442c5a772f1717c3a980aae95777a-8b0f49a8b7a0799d-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a25e8626e29de7c34f6c27385fa0f5f0",
+        "x-ms-client-request-id": "0cb8c5bdb072fe20da61e14df387de81",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:47 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:33 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -240,20 +240,67 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:47 GMT",
-        "MS-CV": "604PFTg6Hkyewtoo9n9yJg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:33 GMT",
+        "MS-CV": "pmPyIBPr2k\u002B5oFgEmd1YEg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "099KXYwAAAACLYrjsvMQrTZnFkfDH8TQvUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ot2YYwAAAAA7HnF5KQ98TK\u002B8Utm/y5BgUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "74ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e9fe3e2867be775f82930c74cc611159-7a4838785f89414a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2ba57350a37c8eebc6fee10b7dd7a342",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:33 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:16:33 GMT",
+        "MS-CV": "aQ2Oz4UM1EKTmSTreSNRZg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0ot2YYwAAAAAy/HPm6H/NTbQzy7nKm8tdUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "92ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
+          "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
+          "sbs2.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,7 +310,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com"
+              "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com"
             ]
           }
         ]
@@ -277,11 +324,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-776d089231d6b96db9dd712976f0f07d-41170467f027d68c-00",
+        "traceparent": "00-72ea3f39963efc74367323e7666b7926-d459a2031e7ba3c3-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "fbf996d2779f29eaa0039eb4501be5a4",
+        "x-ms-client-request-id": "298f0817d3599a16bc61406a120d034d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:47 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:33 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -291,20 +338,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:48 GMT",
-        "MS-CV": "QCyJTQtaE0CoAWCpCz9A\u002BQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:33 GMT",
+        "MS-CV": "RpAahZajFkSur8ffL10yGw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BNKXYwAAAAAaHbCQnuTiSLG\u002BsfeUvVQAUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ot2YYwAAAAAqIZDcYpDfRY6U/NeeMpdPUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "295ms"
+        "X-Processing-Time": "105ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
+          "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
+          "sbs2.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -317,11 +364,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-d30c3ab17fd6d03bfce22021ad03e0b5-072e279a05daa95b-00",
+        "traceparent": "00-df6fea0e7c832d617fe84b3b045b2f20-9680d4ea7604b1ac-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "9e48b68b919a629fa831c72a5ff2db6e",
+        "x-ms-client-request-id": "cf3bf0920dcb1958da294573ce148103",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:48 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:33 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -329,58 +376,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:48 GMT",
-        "MS-CV": "TBKOHYo0z0\u002BKBtJ06KSsdw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:33 GMT",
+        "MS-CV": "7n1HuuhrbUebGubmR5GQeA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BNKXYwAAAACaqeg/jeqJQ5aeiPtO44veUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ot2YYwAAAAB1WMBglruLT7OPivwJZOcWUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "93ms"
+        "X-Processing-Time": "79ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
+          "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-70c9aa3b509ef9eb1593335b685d1ba4-80d61308e072987c-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c4c604ff1103af729b350299440f9634",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:48 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:49 GMT",
-        "MS-CV": "4n3jqtvAn0\u002Bw3uBjk\u002BrORw.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BNKXYwAAAADY3EGIooxCR7vAKbB2BHf8UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "100ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": {
+          "sbs2.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -395,30 +404,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-70c9aa3b509ef9eb1593335b685d1ba4-3ac0b66ee9829446-00",
+        "traceparent": "00-df6fea0e7c832d617fe84b3b045b2f20-f646da051be7a9c1-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a8ad838757584155f697536eb0c0c9ae",
+        "x-ms-client-request-id": "eb359fbeb4f87c275d0a6f1a63807bb8",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:48 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:33 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": null,
-          "sbs2.eca7f247-4114-a9fe-c500-c5a0cdbb2452.com": null
+          "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": null,
+          "sbs2.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:49 GMT",
-        "MS-CV": "HCyntrmba0mE9/9tNhV1Nw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:34 GMT",
+        "MS-CV": "GuSdPoGehUS1dV8gN1OPZg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BdKXYwAAAAAzQKpmrCPLT68SRk99343AUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ot2YYwAAAAAt0sFmwkEhSZ6A4KOUPLFYUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "133ms"
+        "X-Processing-Time": "122ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -428,6 +437,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1544761984"
+    "RandomSeed": "199239815"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-8d124da8a9e8a994e9be048196f6996d-30133d82c34521f9-00",
+        "traceparent": "00-d4e7893202a492e042d00e01cf24c0d4-494d149895309ed3-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "daf9f847f6e480152642e5feb94246b5",
+        "x-ms-client-request-id": "1991d441444a4ad15502e548cf82b510",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:50 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:11 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,23 +22,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:49 GMT",
-        "MS-CV": "S7DsazrPNEuR5/X7Y5ZMvA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:10 GMT",
+        "MS-CV": "acZ\u002BRJvLA0uCTVNQNzxLVA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0UnWOYwAAAABtGVqi98ptTLSj73DE027RUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "074OOYwAAAADoI05pSVn\u002BQ7ys3Ce3iZAAUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "294ms"
+        "X-Processing-Time": "175ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -48,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-1c15d735f581efcfb386a293d78c3a54-f1e34370fee7f2f1-00",
+        "traceparent": "00-252ad34163489b42fd3c2ec75a71735c-31211d894665d4f1-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0382ef9a722cce316ae8a609f346e8ed",
+        "x-ms-client-request-id": "7840a1d6c5c48bbbf2d7b0c976b05434",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:50 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:11 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,23 +53,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:50 GMT",
-        "MS-CV": "lEfSUAyF6UKwEX1lwAlm9g.0",
+        "Date": "Mon, 05 Dec 2022 23:51:11 GMT",
+        "MS-CV": "udbrW55GAU2O4ACbC9\u002BkZw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0UnWOYwAAAADKE5\u002Bjb\u002Bq2SZyC2IM7Y09VUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "074OOYwAAAAAjhrX4qBdDRYoTzwySai/nUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "86ms"
+        "X-Processing-Time": "89ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -88,11 +74,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-1c15d735f581efcfb386a293d78c3a54-51a3e3ffacdad57c-00",
+        "traceparent": "00-252ad34163489b42fd3c2ec75a71735c-662b8672d3d7d391-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ac374702657d6ef50902ce1bc717d702",
+        "x-ms-client-request-id": "a7aea71ef458ba868de517a6c87b3722",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:50 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:11 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -109,13 +95,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:50 GMT",
-        "MS-CV": "mladsOEn4UizZqdOmN9oOg.0",
+        "Date": "Mon, 05 Dec 2022 23:51:11 GMT",
+        "MS-CV": "IR3CQzcA70qeL\u002BimE7JgBA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0UnWOYwAAAAAzmBIoayJPQ73YBJBh0JuMUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "074OOYwAAAACQiL3IJ//qSLn3ZA1VKiRuUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "416ms"
+        "X-Processing-Time": "456ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -137,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-423646da25b535d7d8f2d12212a5c43c-eb0f2542a4ce4d4e-00",
+        "traceparent": "00-df580c31269ad66fb7626e644a4eb45b-55407a8dc3c425ba-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1d22d34c0df4d49ac72a70fb4f0b8ce0",
+        "x-ms-client-request-id": "cb9f3394ffd87c24190526739308d3a4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:51 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:12 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -160,13 +146,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:51 GMT",
-        "MS-CV": "gB6mhzAFoEikVpzV\u002BtoadA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:11 GMT",
+        "MS-CV": "1QLkR/BMmkaAXW51fyrgfQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0U3WOYwAAAAA7Qb4pyl1iTI8sTYoEdIf2UFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08IOOYwAAAAAsb303SdvWRrqry1hE8d67UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "273ms"
+        "X-Processing-Time": "169ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -195,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-8dc2d9c686b78d8ad667f87452eed8ce-c1bc7d51012646f4-00",
+        "traceparent": "00-148ce6523c79b05e96e11efdcebfc79c-a6b082b8d4ac5260-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "72fbf75a990b3538fa13fa2aa3160753",
+        "x-ms-client-request-id": "2829b1ae0dd3e2b71a85ebdfad15c276",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:51 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:12 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -207,13 +193,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:51 GMT",
-        "MS-CV": "6p2ArSXI0UWutabZ8lm5wA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:12 GMT",
+        "MS-CV": "9bITuPrGaU\u002BnyvhZHm2bUg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0U3WOYwAAAABqJTFMj\u002BEMRasrIa28HXFeUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08IOOYwAAAAASHk\u002BBsrL8RKXB4kQ41hJ5UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
+        "X-Processing-Time": "84ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -235,10 +221,213 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-01ddf9ead95a9b6b21eb6efc1ff7f9f2-30e6959132481add-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "42358da088111f5b82328e52ce132685",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:12 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:12 GMT",
+        "MS-CV": "c3j2xvRLPkKN1xFpqDf0XQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "08IOOYwAAAADN9puF2ICJRITXj3yIOHKCUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "80ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-4d01ff16856355ca1e0f3f14413799f6-f6de00da35853f5b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "17f772110e52864f7bbcb0521445ce03",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:13 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:12 GMT",
+        "MS-CV": "rAKnUSMxOUW1IpqZQljbQw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "08IOOYwAAAADUar2UGfLnSI4q8WmA/19zUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "163ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8032045f3b1c27bcdde4ef5ebb72540a-0b51d4fc76b97313-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "06d2af4291d22692550aa6a17e651307",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:13 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:12 GMT",
+        "MS-CV": "rHxfwj/tNEOauCcibJ6NUw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "08YOOYwAAAADBNgCNKqp2SrIteVQ1XarcUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "85ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-022d8e7e10d9760631a82df2da8a2ad9-69655ca06b80fd55-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3bce665eab1e91243eafc754d7090a3d",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:13 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:12 GMT",
+        "MS-CV": "2zR125w/ZEejFRf5mc1MKA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "08YOOYwAAAADTwj3INdhYRKuLgblV51uJUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "84ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "44",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-022d8e7e10d9760631a82df2da8a2ad9-7fc890e2427a9082-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1e108b64204080b2dfd0c24867ad0716",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:13 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.com": null,
+          "sbs2.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:13 GMT",
+        "MS-CV": "wX7\u002BArgyYkapb6aHDqpMjQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "08YOOYwAAAAC0Y6sBahoXQblJ5eajfBPiUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "262ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1896327327"
+    "RandomSeed": "1257491746"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResource.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -67,7 +67,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -116,7 +116,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -176,7 +176,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -223,7 +223,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -270,7 +270,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -312,7 +312,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -350,7 +350,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -388,7 +388,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -427,7 +427,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "1257491746"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResource.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-c3676fdd1235538cb862aaf2fdcfd457-09a2a2aae47a00c6-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "944830d18fbb8f2fa3b25be9aaae9d51",
+        "traceparent": "00-8d124da8a9e8a994e9be048196f6996d-30133d82c34521f9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "daf9f847f6e480152642e5feb94246b5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:16 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:50 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,20 +22,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:16 GMT",
-        "MS-CV": "2lhSxYKzwEuOGicMKKhsaQ.0",
+        "Date": "Mon, 05 Dec 2022 22:48:49 GMT",
+        "MS-CV": "S7DsazrPNEuR5/X7Y5ZMvA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sNZDYwAAAAAu93FtYTzDQLIfZ1jIerQfTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0UnWOYwAAAABtGVqi98ptTLSj73DE027RUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "100ms"
+        "X-Processing-Time": "294ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -43,16 +43,16 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f36f4d8aab17b9e5cdb9e82cd63117c5-b202d04f82a5cfd8-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "37cbc85b2ccc383d7cee72e602f5ccf8",
+        "traceparent": "00-1c15d735f581efcfb386a293d78c3a54-f1e34370fee7f2f1-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0382ef9a722cce316ae8a609f346e8ed",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:16 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:50 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,20 +60,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:16 GMT",
-        "MS-CV": "nqN4n/YzXEK7j9vBZmwthQ.0",
+        "Date": "Mon, 05 Dec 2022 22:48:50 GMT",
+        "MS-CV": "lEfSUAyF6UKwEX1lwAlm9g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sdZDYwAAAAAna4cgLV1EQaBlG/MMqH/WTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0UnWOYwAAAADKE5\u002Bjb\u002Bq2SZyC2IM7Y09VUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "82ms"
+        "X-Processing-Time": "86ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -81,26 +81,26 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "114",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-f36f4d8aab17b9e5cdb9e82cd63117c5-679e77849b2eb756-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d742549c87556b1b4d7d55f025981b46",
+        "traceparent": "00-1c15d735f581efcfb386a293d78c3a54-51a3e3ffacdad57c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ac374702657d6ef50902ce1bc717d702",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:16 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:50 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -109,20 +109,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:16 GMT",
-        "MS-CV": "1PgyKbjDE02cNeKu4F6Otw.0",
+        "Date": "Mon, 05 Dec 2022 22:48:50 GMT",
+        "MS-CV": "mladsOEn4UizZqdOmN9oOg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sdZDYwAAAAD8tc9arHCOTahp8DrH63tBTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0UnWOYwAAAAAzmBIoayJPQ73YBJBh0JuMUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "159ms"
+        "X-Processing-Time": "416ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -130,18 +130,18 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "178",
+        "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-296fc5ef96b8791680fe1fc91fb31905-5c0d10a3c8fd6f83-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4a8f7fe654b0a4c9f31018cc1d488cae",
+        "traceparent": "00-423646da25b535d7d8f2d12212a5c43c-eb0f2542a4ce4d4e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1d22d34c0df4d49ac72a70fb4f0b8ce0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:16 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:51 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -151,7 +151,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -160,20 +160,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:16 GMT",
-        "MS-CV": "BhDlLueApUqSiKPLUEHy2Q.0",
+        "Date": "Mon, 05 Dec 2022 22:48:51 GMT",
+        "MS-CV": "gB6mhzAFoEikVpzV\u002BtoadA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sdZDYwAAAAAfswwfTgb0QYxFF84qFWNxTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0U3WOYwAAAAA7Qb4pyl1iTI8sTYoEdIf2UFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
+        "X-Processing-Time": "273ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -183,23 +183,23 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-cceddf633dee572f5e83d772e904dd56-745fad0252ae7ce9-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "564c62e6c66cd3fcad5fe94fd64d13e4",
+        "traceparent": "00-8dc2d9c686b78d8ad667f87452eed8ce-c1bc7d51012646f4-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "72fbf75a990b3538fa13fa2aa3160753",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:17 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:51 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -207,20 +207,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:17 GMT",
-        "MS-CV": "uCHPn1dBcUmzgBQUjN5QcA.0",
+        "Date": "Mon, 05 Dec 2022 22:48:51 GMT",
+        "MS-CV": "6p2ArSXI0UWutabZ8lm5wA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sdZDYwAAAADoXcTLemc4Qq9aixHnCrJ2TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0U3WOYwAAAABqJTFMj\u002BEMRasrIa28HXFeUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "71ms"
+        "X-Processing-Time": "83ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -230,7 +230,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -238,7 +238,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1228236862"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "1896327327"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-9e8b26714eb8d6cabc6073b9352ed500-c9b531d945f7f468-00",
+        "traceparent": "00-76c5be6c1c064e391b8119b5c92c1ae6-693c559faa5e59f0-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4741cfd4c72bff6149fcc1e221e8430d",
+        "x-ms-client-request-id": "24fd684560194f5dc838153c486081c5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:39:59 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:00 GMT",
-        "MS-CV": "kVxH9z49q0\u002BRTZaFDCkOQA.0",
+        "Date": "Tue, 13 Dec 2022 20:17:00 GMT",
+        "MS-CV": "U/s1oK3Uj0\u002BxVLFfcfaJQg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08NeXYwAAAABDqnGAAgIoS4op8rZxqlnPUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0u92YYwAAAADPJK9tiv5lRpS637MiC2RaUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "117ms"
+        "X-Processing-Time": "206ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-fa63ebfcf1587b8b6718cec7444acb41-ea120bc82ef12f9a-00",
+        "traceparent": "00-c0671c6d57449eb98ec1fc98a404004e-e7e2687c46f96e96-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "bcab805660afe9342fffcb4c2defb737",
+        "x-ms-client-request-id": "ca5fe5daf994c4d680df54a31725288b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:00 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:59 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:00 GMT",
-        "MS-CV": "naUhB6WbD0OZX5rCdvGnxQ.0",
+        "Date": "Tue, 13 Dec 2022 20:17:00 GMT",
+        "MS-CV": "5a/Y3sz8A0yU0Tv0kM2MJQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08NeXYwAAAAD8FxRKP71fTrgqMrgYvgKvUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0vN2YYwAAAACiu4TvzKX8Q4smWB93hDhTUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "75ms"
+        "X-Processing-Time": "82ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-fa63ebfcf1587b8b6718cec7444acb41-24c0f5adef6efe14-00",
+        "traceparent": "00-c0671c6d57449eb98ec1fc98a404004e-be383b1731b63e9c-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "17dca74457adf00b4bb4a2b9d04ffb85",
+        "x-ms-client-request-id": "9a4940a2cca2cb76874408f75889bf01",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:00 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:59 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
+          "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
+          "sbs2.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:00 GMT",
-        "MS-CV": "nfvV726MnEK/kShdjnDzzw.0",
+        "Date": "Tue, 13 Dec 2022 20:17:00 GMT",
+        "MS-CV": "i2RLadtm50me6KnSI3hV6g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08NeXYwAAAAAFRU4PLohrSbXfKpDNRDIQUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0vN2YYwAAAADw8USipPylTrkI1g\u002Bo73EnUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "254ms"
+        "X-Processing-Time": "483ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
+          "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
+          "sbs2.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-0155cf74ad58e93c8fba6ac63023804b-9f7942fa1d1d09a2-00",
+        "traceparent": "00-3f19f063fff7c6aabdfc6e6b550438b8-e19cf970bd366418-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "785a8572138474219a57172bfb15d259",
+        "x-ms-client-request-id": "fce775470aa34c8c9239a4390bba37a3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:00 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:59 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com"
+              "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:01 GMT",
-        "MS-CV": "GCSuqqMxgUqgOBplIs9WZw.0",
+        "Date": "Tue, 13 Dec 2022 20:17:01 GMT",
+        "MS-CV": "t/k9eflB40maLB5OIzY/lw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08deXYwAAAAC9Inf/6kZ0SapJ1NSYgshTUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0vN2YYwAAAADT9KJpU2nbSYzKX1eAvHrkUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "105ms"
+        "X-Processing-Time": "156ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
+          "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
+          "sbs2.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,54 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-18a43aff4af52abece0d26bd0976bebe-0357aa4af58f7cdb-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7a9d8a442c0bfe6074ba70fbbd7a19e0",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:00 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:01 GMT",
-        "MS-CV": "YGvn82RtQUSLuTv6O7RdDw.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08deXYwAAAADEpcF/fM4/Qp0VRHFgmOE/UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "79ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com"
+              "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com"
             ]
           }
         ]
@@ -228,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-ef4801ad945728f023fd722fb1eb8add-391baf1537235645-00",
+        "traceparent": "00-5f2ee142671ec445eb436a21d18e82ae-259de12cf88fa95b-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a7d945043f9531b385687c5540dff536",
+        "x-ms-client-request-id": "0799890fe6170e226e934350f0de6bf6",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:01 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:00 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -240,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:01 GMT",
-        "MS-CV": "Lthmp6Dxwk2mkTWrQpkn6g.0",
+        "Date": "Tue, 13 Dec 2022 20:17:01 GMT",
+        "MS-CV": "19fBLRS24EiudKu7lhP2XA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08deXYwAAAADaqaPWqfygTr9k\u002BytEQ78dUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0vd2YYwAAAABMy\u002BoxZSV5SqeiO\u002BrBhEZBUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "77ms"
+        "X-Processing-Time": "85ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
+          "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
+          "sbs2.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,7 +216,101 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com"
+              "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-15ba14e40fab15f701a4f5682871e4cf-52661da09d28e00e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a15c531f2c3d97e8b4fc0768273cc0cc",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:00 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:17:01 GMT",
+        "MS-CV": "i/I7BYcMZk6UVssrjNslGQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0vd2YYwAAAACXIWVnl4ExR4fSJAD20Q9qUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "80ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-84b5a8324cba89cdc15f166cef32a4df-089858cbac7128c9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cfe8640cb8f060ea52d98d0fc63c5bb4",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:00 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:17:01 GMT",
+        "MS-CV": "9BGR5GbfWU6KR94lB3fUFA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0vd2YYwAAAACmtl62Y67\u002BR45K\u002Bgy\u002BM0iBUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "90ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com"
             ]
           }
         ]
@@ -277,11 +324,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-ca22b17de7744d6b0eb937af28809b35-c046826a190804eb-00",
+        "traceparent": "00-c03a1333df4ac6e3b7c10c8091d93d93-31c1c768b0ad66f4-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "467548e280b1457a255b03c9a326b61f",
+        "x-ms-client-request-id": "b81aaece965de266a001531adebae631",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:01 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:00 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -291,20 +338,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:01 GMT",
-        "MS-CV": "t53W/gUgXUONeZZW\u002BUGNyQ.0",
+        "Date": "Tue, 13 Dec 2022 20:17:01 GMT",
+        "MS-CV": "/ow7NHeHQUuTX4f/M4ISkA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08deXYwAAAAAYCmhiX701RIta7Y1m7jsMUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0vd2YYwAAAAAxI9YAiovkRbkfBrScNPECUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "96ms"
+        "X-Processing-Time": "167ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
+          "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
+          "sbs2.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -317,11 +364,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-34659ef143cdaee80ce6df21fa8cedd4-5e76ad81375d6dc8-00",
+        "traceparent": "00-46a4ca0b5dcb1ef9f52c33af300315b4-d8309b28029aadd8-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b627363e2a3b05c4d66cf5a2b00bbe94",
+        "x-ms-client-request-id": "8b4376d39cf6670568fb4e639ed9d178",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:01 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:01 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -329,58 +376,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:01 GMT",
-        "MS-CV": "g81YVNmid0yFMTEblad0mg.0",
+        "Date": "Tue, 13 Dec 2022 20:17:02 GMT",
+        "MS-CV": "E9SPVD2bTkiclxtQ\u002B39Tuw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08deXYwAAAABsOnx\u002B7zkMQ6l7oC3BRunmUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0vt2YYwAAAAA1qOP\u002BfM/hSLRqTy5I3Xd/UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "76ms"
+        "X-Processing-Time": "82ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
+          "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-7097a83174e20a855eaa005a95acf805-aaee62967b92970b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "75193ac5d305832fca9382393be98e5e",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:01 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:02 GMT",
-        "MS-CV": "pc5JSmobd0aHBJi7/DlaRQ.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08teXYwAAAABhXVlSVdmZRIK6lNZPcv7eUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "86ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
+          "sbs2.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -395,30 +404,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-7097a83174e20a855eaa005a95acf805-35bd4441a4756dd7-00",
+        "traceparent": "00-46a4ca0b5dcb1ef9f52c33af300315b4-143078c37a9791c2-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "09165cb23eb8b8fa836f6f458bd79519",
+        "x-ms-client-request-id": "799953a10822766ffe052eee64d08198",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:01 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:01 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": null,
-          "sbs2.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": null
+          "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": null,
+          "sbs2.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:02 GMT",
-        "MS-CV": "FgioTXkqAkyc4TxLNV6vvQ.0",
+        "Date": "Tue, 13 Dec 2022 20:17:02 GMT",
+        "MS-CV": "kBHXYS/keESYjK4BDA/Tvw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08teXYwAAAACw7lm7mBLYRp5rFggT9BRkUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0vt2YYwAAAAC2wfWPRm0US5H5p\u002BPZFrATUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "118ms"
+        "X-Processing-Time": "304ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -428,6 +437,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1573301402"
+    "RandomSeed": "1967763910"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-32ad0383aee1a27cc91e9c126e18fdfc-99b477188edd473a-00",
+        "traceparent": "00-d474553090c541d1b3b670e2992b647b-3a85e52641e73650-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "15dad4ef89481901bf2752059f7a22e0",
+        "x-ms-client-request-id": "86cbbc7f974e8a75d5470fb32d94748a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:16 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:41 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,23 +22,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:16 GMT",
-        "MS-CV": "pLUeV/q/akuka9O4dXDYKg.0",
+        "Date": "Mon, 05 Dec 2022 23:51:40 GMT",
+        "MS-CV": "ZSFz7fy\u002BUE6/ibUI40v7YA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0bHWOYwAAAADhepDRg2aLQr3JU\u002B9L27XxUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0DYSOYwAAAAAPQD3cTtI1QYfmzWvqMpMnUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "110ms"
+        "X-Processing-Time": "173ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -48,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-5f19e7a384aaa0c64d09ca988d63a851-6ca5de91be0e7103-00",
+        "traceparent": "00-6956c420a4e07c7c73f087053a4cf9cb-ee8a5430be71a566-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "759c46b6ebeef6f6ca01cdc8563c594c",
+        "x-ms-client-request-id": "101f5b6b492bd4f934d172a97dc47d49",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:16 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:41 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,23 +53,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:16 GMT",
-        "MS-CV": "giiMmXj5PUOaMWED1d5jhA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:40 GMT",
+        "MS-CV": "9oR3kbNC7EuPpyvsFHsSEA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0bHWOYwAAAAA5RXN/t3cxRIrThmveVWaPUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0DYSOYwAAAAAY8cdb4U\u002BsTo112nYTThF5UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "76ms"
+        "X-Processing-Time": "89ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -88,11 +74,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-5f19e7a384aaa0c64d09ca988d63a851-ee69d5f9ebd92dd7-00",
+        "traceparent": "00-6956c420a4e07c7c73f087053a4cf9cb-2ec1c7d32447cc89-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a7bf775f1a2a607a711c27d7dad77f3d",
+        "x-ms-client-request-id": "d411a9c633449e0060521e4de4fd67bc",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:16 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:41 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -109,13 +95,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:16 GMT",
-        "MS-CV": "RF2G8sNmY0KDostZBLETRA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:41 GMT",
+        "MS-CV": "HUJJYW1c/EuI6fdwINHSjA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0bHWOYwAAAABPiuoi919xS6PyyXnZJbYEUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0DYSOYwAAAABgn7D8O\u002BsmQKHlWX1ejaxCUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "190ms"
+        "X-Processing-Time": "494ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -137,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-3a8a6efb1c986635e36eb96b373a29d7-f7f5a5b56ccfa0cd-00",
+        "traceparent": "00-17ffc7285474adf9d0eb41b7fd0f9d6e-30b5616c00ef26c6-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "99406f04fe97047cdde44a47bc38c383",
+        "x-ms-client-request-id": "d0e6109eff153524c2f7517c24cc0d10",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:16 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:42 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -160,13 +146,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:16 GMT",
-        "MS-CV": "qlfvs0JP0k6DOD\u002BxM00ilg.0",
+        "Date": "Mon, 05 Dec 2022 23:51:41 GMT",
+        "MS-CV": "Jtn/plsHYUmHDwqaVH3dEg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0bHWOYwAAAAB4r8vYDW4dQpVMCJJsDFd3UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0DoSOYwAAAACKPNYLuZugTbb4RX0LFspWUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "253ms"
+        "X-Processing-Time": "216ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -195,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-4009c7402f73524dccf7468d8489ad24-0c6d2c8910ca494c-00",
+        "traceparent": "00-7d24def09a378f500f21b80d76f5917b-70a05fb52cb58a76-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "27a506cd7aba9bb5cb3c04d1c41e1bf3",
+        "x-ms-client-request-id": "83ecc6ca9f8237455b80b0d92babef36",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:17 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:42 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -207,13 +193,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:17 GMT",
-        "MS-CV": "5LeRBFY6b0aaFNMct3WrWg.0",
+        "Date": "Mon, 05 Dec 2022 23:51:42 GMT",
+        "MS-CV": "sLasEvGGF0ybZupSzox1Xg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0bXWOYwAAAABaQocpRotcR57Sjz/CsPN6UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0DoSOYwAAAACqdD8j/K5FT7e3\u002BJxQZ1d9UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "102ms"
+        "X-Processing-Time": "90ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -235,10 +221,213 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ace5719c3fe55d9d0a922fe61149078f-3876a71e516c7a42-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6c0ab56aacdec73384dc114ce1837a94",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:42 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:42 GMT",
+        "MS-CV": "zdRULfULtE6yY59C3D6OXA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0DoSOYwAAAAAj8f1ORaDjQ7qlQ7wfsvl/UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "89ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-d05f3a4ea93baf13ae0feb4464cf5492-23226d15841be980-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1e830d45e310fe3acaae75944f4b0a17",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:43 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:42 GMT",
+        "MS-CV": "e5nU\u002BLaV/0q7\u002BqmHMTHzYQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0D4SOYwAAAACLudWZco8hQLpNyvS/7HJ\u002BUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "166ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-497af35ae280e8422df365cb28bbdb4a-27aa38c87a8d6f5f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6f111b08a0c11e329225fea68df955d7",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:43 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:42 GMT",
+        "MS-CV": "u9nLS3lJvUiPXHdRgMUNDg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0D4SOYwAAAAB1AFbXCuu7RJFJmrQsk\u002B5eUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "87ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4d66049ae313748c5897e8fe8bf72fd3-1284bb59e15a9ce9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1e931c06d02886257b0ca230369e7738",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:43 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:42 GMT",
+        "MS-CV": "vcXqAejwWEmWqRqBOJxEBA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0D4SOYwAAAAC5vkm5bml9QKWmgzliCOLzUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "84ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "44",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-4d66049ae313748c5897e8fe8bf72fd3-23cd04f500065611-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c644fad20a71a5d2db658ceae49371d1",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:43 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.com": null,
+          "sbs2.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:43 GMT",
+        "MS-CV": "kgW0znJiKU6jvTuXL4l9zw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0D4SOYwAAAAD\u002BXlf/j21nRqymzvDFnv3cUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "262ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "2030046373"
+    "RandomSeed": "1813150146"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResourceAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -67,7 +67,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -116,7 +116,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -176,7 +176,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -223,7 +223,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -270,7 +270,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -312,7 +312,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -350,7 +350,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -388,7 +388,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -427,7 +427,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "1813150146"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d474553090c541d1b3b670e2992b647b-3a85e52641e73650-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "86cbbc7f974e8a75d5470fb32d94748a",
+        "traceparent": "00-9e8b26714eb8d6cabc6073b9352ed500-c9b531d945f7f468-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4741cfd4c72bff6149fcc1e221e8430d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:41 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:39:59 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:40 GMT",
-        "MS-CV": "ZSFz7fy\u002BUE6/ibUI40v7YA.0",
+        "Date": "Tue, 13 Dec 2022 01:40:00 GMT",
+        "MS-CV": "kVxH9z49q0\u002BRTZaFDCkOQA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0DYSOYwAAAAAPQD3cTtI1QYfmzWvqMpMnUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08NeXYwAAAABDqnGAAgIoS4op8rZxqlnPUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "173ms"
+        "X-Processing-Time": "117ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-6956c420a4e07c7c73f087053a4cf9cb-ee8a5430be71a566-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "101f5b6b492bd4f934d172a97dc47d49",
+        "traceparent": "00-fa63ebfcf1587b8b6718cec7444acb41-ea120bc82ef12f9a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bcab805660afe9342fffcb4c2defb737",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:41 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:00 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:40 GMT",
-        "MS-CV": "9oR3kbNC7EuPpyvsFHsSEA.0",
+        "Date": "Tue, 13 Dec 2022 01:40:00 GMT",
+        "MS-CV": "naUhB6WbD0OZX5rCdvGnxQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0DYSOYwAAAAAY8cdb4U\u002BsTo112nYTThF5UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08NeXYwAAAAD8FxRKP71fTrgqMrgYvgKvUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
+        "X-Processing-Time": "75ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -72,21 +72,21 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "86",
+        "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-6956c420a4e07c7c73f087053a4cf9cb-2ec1c7d32447cc89-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d411a9c633449e0060521e4de4fd67bc",
+        "traceparent": "00-fa63ebfcf1587b8b6718cec7444acb41-24c0f5adef6efe14-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "17dca74457adf00b4bb4a2b9d04ffb85",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:41 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:00 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:41 GMT",
-        "MS-CV": "HUJJYW1c/EuI6fdwINHSjA.0",
+        "Date": "Tue, 13 Dec 2022 01:40:00 GMT",
+        "MS-CV": "nfvV726MnEK/kShdjnDzzw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0DYSOYwAAAABgn7D8O\u002BsmQKHlWX1ejaxCUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08NeXYwAAAAAFRU4PLohrSbXfKpDNRDIQUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "494ms"
+        "X-Processing-Time": "254ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -121,13 +121,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "164",
+        "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-17ffc7285474adf9d0eb41b7fd0f9d6e-30b5616c00ef26c6-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d0e6109eff153524c2f7517c24cc0d10",
+        "traceparent": "00-0155cf74ad58e93c8fba6ac63023804b-9f7942fa1d1d09a2-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "785a8572138474219a57172bfb15d259",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:42 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:00 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:41 GMT",
-        "MS-CV": "Jtn/plsHYUmHDwqaVH3dEg.0",
+        "Date": "Tue, 13 Dec 2022 01:40:01 GMT",
+        "MS-CV": "GCSuqqMxgUqgOBplIs9WZw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0DoSOYwAAAACKPNYLuZugTbb4RX0LFspWUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08deXYwAAAAC9Inf/6kZ0SapJ1NSYgshTUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "216ms"
+        "X-Processing-Time": "105ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,54 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-7d24def09a378f500f21b80d76f5917b-70a05fb52cb58a76-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "83ecc6ca9f8237455b80b0d92babef36",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:42 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:42 GMT",
-        "MS-CV": "sLasEvGGF0ybZupSzox1Xg.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0DoSOYwAAAACqdD8j/K5FT7e3\u002BJxQZ1d9UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "90ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.com"
+              "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com"
             ]
           }
         ]
@@ -228,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-ace5719c3fe55d9d0a922fe61149078f-3876a71e516c7a42-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6c0ab56aacdec73384dc114ce1837a94",
+        "traceparent": "00-18a43aff4af52abece0d26bd0976bebe-0357aa4af58f7cdb-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7a9d8a442c0bfe6074ba70fbbd7a19e0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:42 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:00 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -240,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:42 GMT",
-        "MS-CV": "zdRULfULtE6yY59C3D6OXA.0",
+        "Date": "Tue, 13 Dec 2022 01:40:01 GMT",
+        "MS-CV": "YGvn82RtQUSLuTv6O7RdDw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0DoSOYwAAAAAj8f1ORaDjQ7qlQ7wfsvl/UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08deXYwAAAADEpcF/fM4/Qp0VRHFgmOE/UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
+        "X-Processing-Time": "79ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,7 +216,54 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ef4801ad945728f023fd722fb1eb8add-391baf1537235645-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a7d945043f9531b385687c5540dff536",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:01 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:40:01 GMT",
+        "MS-CV": "Lthmp6Dxwk2mkTWrQpkn6g.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "08deXYwAAAADaqaPWqfygTr9k\u002BytEQ78dUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "77ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com"
             ]
           }
         ]
@@ -277,11 +277,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d05f3a4ea93baf13ae0feb4464cf5492-23226d15841be980-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1e830d45e310fe3acaae75944f4b0a17",
+        "traceparent": "00-ca22b17de7744d6b0eb937af28809b35-c046826a190804eb-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "467548e280b1457a255b03c9a326b61f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:43 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:01 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -291,20 +291,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:42 GMT",
-        "MS-CV": "e5nU\u002BLaV/0q7\u002BqmHMTHzYQ.0",
+        "Date": "Tue, 13 Dec 2022 01:40:01 GMT",
+        "MS-CV": "t53W/gUgXUONeZZW\u002BUGNyQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0D4SOYwAAAACLudWZco8hQLpNyvS/7HJ\u002BUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08deXYwAAAAAYCmhiX701RIta7Y1m7jsMUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "166ms"
+        "X-Processing-Time": "96ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -317,11 +317,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-497af35ae280e8422df365cb28bbdb4a-27aa38c87a8d6f5f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6f111b08a0c11e329225fea68df955d7",
+        "traceparent": "00-34659ef143cdaee80ce6df21fa8cedd4-5e76ad81375d6dc8-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b627363e2a3b05c4d66cf5a2b00bbe94",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:43 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:01 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -329,20 +329,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:42 GMT",
-        "MS-CV": "u9nLS3lJvUiPXHdRgMUNDg.0",
+        "Date": "Tue, 13 Dec 2022 01:40:01 GMT",
+        "MS-CV": "g81YVNmid0yFMTEblad0mg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0D4SOYwAAAAB1AFbXCuu7RJFJmrQsk\u002B5eUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08deXYwAAAABsOnx\u002B7zkMQ6l7oC3BRunmUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
+        "X-Processing-Time": "76ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -355,11 +355,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-4d66049ae313748c5897e8fe8bf72fd3-1284bb59e15a9ce9-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1e931c06d02886257b0ca230369e7738",
+        "traceparent": "00-7097a83174e20a855eaa005a95acf805-aaee62967b92970b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "75193ac5d305832fca9382393be98e5e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:43 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:01 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -367,20 +367,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:42 GMT",
-        "MS-CV": "vcXqAejwWEmWqRqBOJxEBA.0",
+        "Date": "Tue, 13 Dec 2022 01:40:02 GMT",
+        "MS-CV": "pc5JSmobd0aHBJi7/DlaRQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0D4SOYwAAAAC5vkm5bml9QKWmgzliCOLzUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08teXYwAAAABhXVlSVdmZRIK6lNZPcv7eUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
+        "X-Processing-Time": "86ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -393,32 +393,32 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "44",
+        "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-4d66049ae313748c5897e8fe8bf72fd3-23cd04f500065611-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c644fad20a71a5d2db658ceae49371d1",
+        "traceparent": "00-7097a83174e20a855eaa005a95acf805-35bd4441a4756dd7-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "09165cb23eb8b8fa836f6f458bd79519",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:43 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:01 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": null,
-          "sbs2.com": null
+          "sbs1.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": null,
+          "sbs2.ebb4adb7-92b6-1c31-6eb6-93b0f82fcfd1.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:43 GMT",
-        "MS-CV": "kgW0znJiKU6jvTuXL4l9zw.0",
+        "Date": "Tue, 13 Dec 2022 01:40:02 GMT",
+        "MS-CV": "FgioTXkqAkyc4TxLNV6vvQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0D4SOYwAAAAD\u002BXlf/j21nRqymzvDFnv3cUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08teXYwAAAACw7lm7mBLYRp5rFggT9BRkUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "262ms"
+        "X-Processing-Time": "118ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -428,6 +428,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1813150146"
+    "RandomSeed": "1573301402"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResourceAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-b0da5bf4a8edc5b3eaa967b8dc083408-68e82bb72b69ba8d-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b5c33d0b4895d247a3198dff464e5b3a",
+        "traceparent": "00-32ad0383aee1a27cc91e9c126e18fdfc-99b477188edd473a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "15dad4ef89481901bf2752059f7a22e0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:28 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:16 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,20 +22,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:28 GMT",
-        "MS-CV": "HaA32sosfkeU1RROTsSJiA.0",
+        "Date": "Mon, 05 Dec 2022 22:49:16 GMT",
+        "MS-CV": "pLUeV/q/akuka9O4dXDYKg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vNZDYwAAAADS0dro62IBQ72ywJ9dPt5LTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0bHWOYwAAAADhepDRg2aLQr3JU\u002B9L27XxUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "389ms"
+        "X-Processing-Time": "110ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -43,16 +43,16 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-ed6a9318f56d983ca107286d6ef66467-3a4fad1623c7c048-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b6f28bf00557cae72f45cc4c6b9b6717",
+        "traceparent": "00-5f19e7a384aaa0c64d09ca988d63a851-6ca5de91be0e7103-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "759c46b6ebeef6f6ca01cdc8563c594c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:28 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:16 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,20 +60,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:28 GMT",
-        "MS-CV": "WpByFn/9V0mRAGub5lrZMA.0",
+        "Date": "Mon, 05 Dec 2022 22:49:16 GMT",
+        "MS-CV": "giiMmXj5PUOaMWED1d5jhA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vdZDYwAAAAAfJYaMUNn0QY1KnsQVCrg9TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0bHWOYwAAAAA5RXN/t3cxRIrThmveVWaPUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "67ms"
+        "X-Processing-Time": "76ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -81,26 +81,26 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "114",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-ed6a9318f56d983ca107286d6ef66467-70b2a4569fbd6fd6-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c0d9795bd89030bc543e59dede908cc0",
+        "traceparent": "00-5f19e7a384aaa0c64d09ca988d63a851-ee69d5f9ebd92dd7-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a7bf775f1a2a607a711c27d7dad77f3d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:28 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:16 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -109,20 +109,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:29 GMT",
-        "MS-CV": "fgl/vnt9mUigcHQtt2XWQQ.0",
+        "Date": "Mon, 05 Dec 2022 22:49:16 GMT",
+        "MS-CV": "RF2G8sNmY0KDostZBLETRA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vdZDYwAAAAAopXmATlQQQLLiIp1d9fDATFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0bHWOYwAAAABPiuoi919xS6PyyXnZJbYEUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "340ms"
+        "X-Processing-Time": "190ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -130,18 +130,18 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "178",
+        "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-dc6282b1467a423a00be8efbf2297ea9-74bf43dd54878a36-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0f32421dc728054d56f886507bfa6707",
+        "traceparent": "00-3a8a6efb1c986635e36eb96b373a29d7-f7f5a5b56ccfa0cd-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "99406f04fe97047cdde44a47bc38c383",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:29 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:16 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -151,7 +151,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -160,20 +160,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:29 GMT",
-        "MS-CV": "SaBhY0cbZE6bltVrldC5rQ.0",
+        "Date": "Mon, 05 Dec 2022 22:49:16 GMT",
+        "MS-CV": "qlfvs0JP0k6DOD\u002BxM00ilg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vdZDYwAAAABR4LtgucKMQazk6KfxPdSITFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0bHWOYwAAAAB4r8vYDW4dQpVMCJJsDFd3UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "138ms"
+        "X-Processing-Time": "253ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -183,23 +183,23 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-974ae5640c4d4bb187e33339c4b61eb5-18ed687f299d9017-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "cca375b19b7518aacec16118ac08ec9e",
+        "traceparent": "00-4009c7402f73524dccf7468d8489ad24-0c6d2c8910ca494c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "27a506cd7aba9bb5cb3c04d1c41e1bf3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:29 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:17 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -207,20 +207,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:29 GMT",
-        "MS-CV": "ndi8R8YAO0qi/tSmqSuBpw.0",
+        "Date": "Mon, 05 Dec 2022 22:49:17 GMT",
+        "MS-CV": "5LeRBFY6b0aaFNMct3WrWg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vtZDYwAAAAAylUHAA6wyQZDXJKkl3rNLTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0bXWOYwAAAABaQocpRotcR57Sjz/CsPN6UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "116ms"
+        "X-Processing-Time": "102ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -230,7 +230,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -238,7 +238,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1173761658"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "2030046373"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResource.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -67,7 +67,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -116,7 +116,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -176,7 +176,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -223,7 +223,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -270,7 +270,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -312,7 +312,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -350,7 +350,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -388,7 +388,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -427,7 +427,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "1255279718"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-ca45064257e75f13341a5c58f5859d62-383b7795726f4951-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d7884689e96b4a03b05ba41646eb8cae",
+        "traceparent": "00-f274f962f085998d931a8a6efc8f10fc-7acf1166c07ca0a4-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7c85a51e6f8188183653eefc926f9a9e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:14 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:48 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:13 GMT",
-        "MS-CV": "Buljkytbo0ahfOKr2XFh3g.0",
+        "Date": "Tue, 13 Dec 2022 01:18:49 GMT",
+        "MS-CV": "hSF/uR6E/kSzcjAnrWsATA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08oOOYwAAAACjwJgneoYuQ4mnp8Z6qAmmUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BdKXYwAAAACVGvVnhflnR7PD0hCTyCyPUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "168ms"
+        "X-Processing-Time": "146ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-94ea3edb7e8873a320b04f708238ea6e-8885d2a531a8ee78-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e0c7a1b4e91b3c87e718b04ff7268838",
+        "traceparent": "00-e4e8b9629d2d9c447fb9c5914e1aa869-e7a74e8c4f57b68b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c076049ebff63ad372f874ee9776c7d2",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:14 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:49 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:13 GMT",
-        "MS-CV": "TvSNEx7lLUuXLkXuIfnwmA.0",
+        "Date": "Tue, 13 Dec 2022 01:18:49 GMT",
+        "MS-CV": "SsDBuK2W4EuT5c1UUtTLeQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08oOOYwAAAACp1yUbx0MxSZXbu\u002BtbZhKQUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BdKXYwAAAADDWyN/UYyEQbMSi1ybmv0YUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "91ms"
+        "X-Processing-Time": "90ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -72,21 +72,21 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "86",
+        "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-94ea3edb7e8873a320b04f708238ea6e-37eef230716ca29f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "37e50e41ca80c6d0bc5b8ed8d4731439",
+        "traceparent": "00-e4e8b9629d2d9c447fb9c5914e1aa869-bf50cae97220aba7-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f25ecef7d11ea65ecd365a3b4cac2966",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:14 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:49 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:14 GMT",
-        "MS-CV": "zbxrG\u002B3/RUybGFbe4W5IkQ.0",
+        "Date": "Tue, 13 Dec 2022 01:18:50 GMT",
+        "MS-CV": "5CbiwFh3F0GzwvYPuP/ABQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08oOOYwAAAABFYPqxnTNFT7l9E5C2jUYkUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BdKXYwAAAAC72Rl3M7BgTrw6SW787shKUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "548ms"
+        "X-Processing-Time": "289ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -121,13 +121,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "164",
+        "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-af14c063c025b2c4e45ae171fe68f7b6-b8001911034a2dd4-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e5e7151a7630a05fbe4bf05239b45289",
+        "traceparent": "00-d4b1e54cef935d53c34d096809012adb-195231b57a9bb880-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f09b29fdb2c35e01d14a0a88fa29f1c0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:15 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:49 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:14 GMT",
-        "MS-CV": "V0xjw/xnZkizUjmjxCSkoA.0",
+        "Date": "Tue, 13 Dec 2022 01:18:50 GMT",
+        "MS-CV": "GLaDBk0/k0\u002BlFQMcx67ENQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "084OOYwAAAAAZLJnQL0y2Q7k1Y87F36AsUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BtKXYwAAAADgxBfMDYntT6U0qNnEkMOtUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "169ms"
+        "X-Processing-Time": "102ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,54 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-dfa5a0bfdc89c9dfa7280f7efd612ed8-a334a78bedbd75a6-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "38d46bd25505ea2ed10124c05aaf6873",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:15 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:15 GMT",
-        "MS-CV": "nFe3cd5Ep0OzrzZV4MOoBw.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "084OOYwAAAAB507EWhv/xT6/oh3t/n6SgUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.com"
+              "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com"
             ]
           }
         ]
@@ -228,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-4746d962c320fefedc414921d9c82ed0-8c73bdb2153fad3b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e2347604a23fcb08af457835da7d8c08",
+        "traceparent": "00-94da02c1239b09e9b48e8c22c38545da-4a3093f66e3e7abe-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c3041b8ba711cc80a6d0f2bf6597eec6",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:15 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:50 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -240,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:15 GMT",
-        "MS-CV": "vBo4we5gQkWvs716imvlvw.0",
+        "Date": "Tue, 13 Dec 2022 01:18:50 GMT",
+        "MS-CV": "3PR8d6O86k6rFSoDGEjsWw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "084OOYwAAAACI6Ln9CdAcQY8vYJwd8ikdUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BtKXYwAAAABr9z\u002B1x5P3R6Sab4xXftk2UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
+        "X-Processing-Time": "97ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,7 +216,54 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-585c14d54ddfce1f05add2faf87b8779-73476558fd2c3012-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6ef10dced7da450fcdff20d3c6d5aca3",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:50 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:18:50 GMT",
+        "MS-CV": "y09KxT3djUy0oZqyXVTJQg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0\u002BtKXYwAAAACKCxqIX8HIQqF\u002BETYR/dA9UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "77ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com"
             ]
           }
         ]
@@ -277,11 +277,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-1df45a67acf7ae9e470f90eb8fbc0d80-2f1d6467b438e233-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "68050408db9fc534e6fc142e519e450f",
+        "traceparent": "00-824b741b20a22dd72ef71422b8ec3749-f4c7fd66bc9420bc-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "31af9a4565a75555a9ce49f3bf41f939",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:15 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:50 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -291,58 +291,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:15 GMT",
-        "MS-CV": "wzDUsuY6hUC7awdyb5IVOw.0",
+        "Date": "Tue, 13 Dec 2022 01:18:50 GMT",
+        "MS-CV": "B/jyx6fMZ0KTOIGDtAtC6Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "084OOYwAAAACMR3kDblgyTZC8HYnLUyh/UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "174ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-9d9d6905c5877883c6c66f4a08993221-72e54eece2086e39-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c24e7ce2707f2f49630989c0dcf91053",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:16 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:15 GMT",
-        "MS-CV": "wRUFm9523kq\u002BGo78VfCMwQ.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09IOOYwAAAAD99LGvkB8uRaJ8HwGuDm16UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BtKXYwAAAAA\u002BQQ6IawaRQplZkNiNZZxwUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "99ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -355,11 +317,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-760b53ebd5dc721e01899621efa949fa-1814edf87615a29e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "55b71c7400a929d4426efb438ed97910",
+        "traceparent": "00-bad3c226ed6679cc4ffed99c252fac78-d769650ba2ff3b17-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ecb9445c8338b4e50bbff61187ac06d1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:16 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:50 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -367,20 +329,58 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:15 GMT",
-        "MS-CV": "vMuVjaxwukC0EooQLG4s3g.0",
+        "Date": "Tue, 13 Dec 2022 01:18:51 GMT",
+        "MS-CV": "3nOysRRFgEeeZm7uTuCzig.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09IOOYwAAAADAUP7chHaMTo9OufcTyZsCUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002B9KXYwAAAAA6YJbLgd5CQpGIyxv7UGnbUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "86ms"
+        "X-Processing-Time": "85ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-59899646c73499019588355a0b609f11-e688959c557bd1cc-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ca794f23bce8691eb89bc40c8d1c858b",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:50 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:18:51 GMT",
+        "MS-CV": "v\u002BBvygfkUkuGukrtQuY97g.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0\u002B9KXYwAAAAAm1wAFWfAQRo1gbLx1MonZUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "74ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -393,32 +393,32 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "44",
+        "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-760b53ebd5dc721e01899621efa949fa-e372f3e96b67450c-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5d5269ffc92f9788bbd605955174e9ed",
+        "traceparent": "00-59899646c73499019588355a0b609f11-c26c16bf5d9d3420-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8277e605c01bc26bb4fa25e86f44cefc",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:16 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:51 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": null,
-          "sbs2.com": null
+          "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": null,
+          "sbs2.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:16 GMT",
-        "MS-CV": "W710HK\u002BIRUSq/C4jylto1w.0",
+        "Date": "Tue, 13 Dec 2022 01:18:51 GMT",
+        "MS-CV": "EVlnWgNjRkiaRGCR8\u002BFH7g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09IOOYwAAAAAXeB8KbWPYQqqpTpWiaYFSUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002B9KXYwAAAAABHhFIzJnSTpiOtPVKuhrdUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "297ms"
+        "X-Processing-Time": "132ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -428,6 +428,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1255279718"
+    "RandomSeed": "1011036362"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResource.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-8cad79513e00edc8ce9f1e57a755a1ec-d7aa085b1dd3b2ab-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e2a427a35bbc76d15476476a5ed7d90a",
+        "traceparent": "00-597aed67d1bc8416c6f3a12531aef561-212e8b81cc0d78cc-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "76dd8cc955341d92a1c087ad713fe569",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:17 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,20 +22,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:17 GMT",
-        "MS-CV": "M28wJmz1\u002BkOT99KT6c9SMg.0",
+        "Date": "Mon, 05 Dec 2022 22:48:51 GMT",
+        "MS-CV": "c7VtEEN3UE\u002BtvoioUgrn5Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sdZDYwAAAABB\u002BmC64vkPQqMm/JR2nQN0TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0VHWOYwAAAAC02RbdbQKsTINxhl75hg7SUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "86ms"
+        "X-Processing-Time": "253ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -43,16 +43,16 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-1a96c29ec2e721073d1b23fea87e1af9-af97530e185c01d6-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "bbe3cf43c771f823f85bde82044bee9e",
+        "traceparent": "00-6f545de5e29b07d3544d77787ef91a74-b97a77ccf6149a39-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6cb4eb10f05be42d2c9e92a8ba4d2cfa",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:17 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,20 +60,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:17 GMT",
-        "MS-CV": "OraSN38az0aQbR8\u002BludsjQ.0",
+        "Date": "Mon, 05 Dec 2022 22:48:51 GMT",
+        "MS-CV": "nHbi7wDIWk2T6f\u002BpEpDGgg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0stZDYwAAAACXDqaRs6aAQYET1r4vAH65TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0VHWOYwAAAAA/uBHFPVSeTLZzLyyVYBClUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "72ms"
+        "X-Processing-Time": "75ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -81,26 +81,26 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "114",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-1a96c29ec2e721073d1b23fea87e1af9-e7dcebde5b0213e1-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d4d242e044a93924f976a5afca310883",
+        "traceparent": "00-6f545de5e29b07d3544d77787ef91a74-55359ae3a3413556-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3097c42389a0dfe29b5371d195c77fc7",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:17 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -109,20 +109,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:17 GMT",
-        "MS-CV": "8UHydSttL0KtL91SjmLrnw.0",
+        "Date": "Mon, 05 Dec 2022 22:48:52 GMT",
+        "MS-CV": "KMXJiJhw1UeUqFGS\u002BAalSg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0stZDYwAAAAAFzAxHeA9gSZVebD\u002BYJkuwTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0VHWOYwAAAACCnzqO6w2TSLFBLwfpeJvBUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "244ms"
+        "X-Processing-Time": "161ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -130,18 +130,18 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "178",
+        "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-07f7ccacce0408af5ce9216d950cdbce-a9adc053cfbb87ba-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "816bc12c82c9db1904abea607c4e7109",
+        "traceparent": "00-5546382770f8d6763a431ec2a06b4ffb-939ae86345e87913-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1d3fc8d73d6bd85d5ef84a96c2ea6354",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:18 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -151,7 +151,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -160,20 +160,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:18 GMT",
-        "MS-CV": "6Osh77KSTkejVLoVvcypKg.0",
+        "Date": "Mon, 05 Dec 2022 22:48:52 GMT",
+        "MS-CV": "zcbs/atA3Eyryz\u002BvQwbC7A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0stZDYwAAAACgkJLl0qj4T4XwZ/wmhj5CTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0VHWOYwAAAABbtgnLvVHgR5hUahVP7uAaUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "109ms"
+        "X-Processing-Time": "108ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -183,23 +183,23 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-d065b9ed6d8ea71ec89dc7e27a9392a5-6174c091bb276883-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1b89a9870505fe61aaa9c2fa21742dc7",
+        "traceparent": "00-ee67144ea053f0416e8b23e06b463e76-ffa26411e5a18b9b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ac8a8d93b4a787c809d5d1087e5b4f64",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:18 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -207,20 +207,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:18 GMT",
-        "MS-CV": "B6DPf6j5XEKFndb0v\u002BCo/w.0",
+        "Date": "Mon, 05 Dec 2022 22:48:52 GMT",
+        "MS-CV": "ZGUicS2zt06QB9\u002BOR9glUA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0stZDYwAAAACIIpxJ3a3fRYhQEKrP2dMMTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0VXWOYwAAAACJ75wcn08sRKV8iYfjotxxUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "69ms"
+        "X-Processing-Time": "79ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -230,7 +230,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -238,7 +238,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "464725334"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "308115739"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-f274f962f085998d931a8a6efc8f10fc-7acf1166c07ca0a4-00",
+        "traceparent": "00-5a7b8e3107f61d8d6f23d8dc091dbc7e-bd4169a2bc96c60d-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7c85a51e6f8188183653eefc926f9a9e",
+        "x-ms-client-request-id": "5d246a9749565a4dedd2ff91a944258f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:48 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:34 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:49 GMT",
-        "MS-CV": "hSF/uR6E/kSzcjAnrWsATA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:34 GMT",
+        "MS-CV": "tlnqKQGyCkGLCfijgh83pA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BdKXYwAAAACVGvVnhflnR7PD0hCTyCyPUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0o92YYwAAAAABPx3qywmvQ5krBoKtj0haUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "146ms"
+        "X-Processing-Time": "92ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-e4e8b9629d2d9c447fb9c5914e1aa869-e7a74e8c4f57b68b-00",
+        "traceparent": "00-2158723de8464cc4eef801889353daf7-efa974e1a66705a7-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c076049ebff63ad372f874ee9776c7d2",
+        "x-ms-client-request-id": "e363dbdd0a8ff270b3c396bb1a360c50",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:49 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:34 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:49 GMT",
-        "MS-CV": "SsDBuK2W4EuT5c1UUtTLeQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:34 GMT",
+        "MS-CV": "8Er91BZ3CkWcaI7/slPN6w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BdKXYwAAAADDWyN/UYyEQbMSi1ybmv0YUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0o92YYwAAAADKEo/K6E0AR7ZHnQLwcpMmUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "90ms"
+        "X-Processing-Time": "80ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-e4e8b9629d2d9c447fb9c5914e1aa869-bf50cae97220aba7-00",
+        "traceparent": "00-2158723de8464cc4eef801889353daf7-a68627462cf12d10-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f25ecef7d11ea65ecd365a3b4cac2966",
+        "x-ms-client-request-id": "983eee4118e14731a3acc8f02bee265f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:49 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:34 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
+          "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
+          "sbs2.b507f190-2bc2-d07f-a482-576bd627436c.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:50 GMT",
-        "MS-CV": "5CbiwFh3F0GzwvYPuP/ABQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:35 GMT",
+        "MS-CV": "tQ/jJbIkskK2V9UgDamSGw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BdKXYwAAAAC72Rl3M7BgTrw6SW787shKUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0o92YYwAAAAAof6QfT3SLRrNrp9sDi2UUUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "289ms"
+        "X-Processing-Time": "459ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
+          "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
+          "sbs2.b507f190-2bc2-d07f-a482-576bd627436c.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d4b1e54cef935d53c34d096809012adb-195231b57a9bb880-00",
+        "traceparent": "00-39c2db3f298d77c8f44109d02c4b2fd3-da43123cba12557d-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f09b29fdb2c35e01d14a0a88fa29f1c0",
+        "x-ms-client-request-id": "fa8ec85d60c48cdcfa31a993b29140b6",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:49 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:35 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com"
+              "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:50 GMT",
-        "MS-CV": "GLaDBk0/k0\u002BlFQMcx67ENQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:35 GMT",
+        "MS-CV": "tVk7tkm3NE\u002BHH0s0Sqlipg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BtKXYwAAAADgxBfMDYntT6U0qNnEkMOtUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pN2YYwAAAAAaC9lJUBTNR4Y1exEWtAi7UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "102ms"
+        "X-Processing-Time": "101ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
+          "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
+          "sbs2.b507f190-2bc2-d07f-a482-576bd627436c.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,54 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-94da02c1239b09e9b48e8c22c38545da-4a3093f66e3e7abe-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c3041b8ba711cc80a6d0f2bf6597eec6",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:50 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:50 GMT",
-        "MS-CV": "3PR8d6O86k6rFSoDGEjsWw.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BtKXYwAAAABr9z\u002B1x5P3R6Sab4xXftk2UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "97ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com"
+              "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com"
             ]
           }
         ]
@@ -228,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-585c14d54ddfce1f05add2faf87b8779-73476558fd2c3012-00",
+        "traceparent": "00-f8b78c8d6999d9fcfb423d39b8dd55fa-a408ef1e784d8fd3-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6ef10dced7da450fcdff20d3c6d5aca3",
+        "x-ms-client-request-id": "bb50aec58d06c5adaa1b3fe3427fc7c5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:50 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:35 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -240,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:50 GMT",
-        "MS-CV": "y09KxT3djUy0oZqyXVTJQg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:35 GMT",
+        "MS-CV": "o2lzcR31qEubRFab3j3TmA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BtKXYwAAAACKCxqIX8HIQqF\u002BETYR/dA9UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pN2YYwAAAABFDQb8QQuJT4ukBAArpyBTUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "77ms"
+        "X-Processing-Time": "78ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
+          "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
+          "sbs2.b507f190-2bc2-d07f-a482-576bd627436c.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,7 +216,101 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com"
+              "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0c71d876a383098fe4d08b1736b43681-030aeb9a2cec6adc-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "515e379c12a8e08c12b19eb06e9e9511",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:35 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:16:35 GMT",
+        "MS-CV": "8G6tAiWYR0CwHCwtR4EJzw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0pN2YYwAAAABAFw3U4xWcSIbPvoz9zqzNUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "79ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.b507f190-2bc2-d07f-a482-576bd627436c.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d6a143bdee932d3472a74d8a4cb2ae3a-09d410d1d515a007-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7c2b116c6b9ecf581ac850a820f9497a",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:35 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:16:35 GMT",
+        "MS-CV": "5Axeo8CrPEK1Zh0cWtKK4A.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0pN2YYwAAAAA34i5wz6R4S5ng\u002BUiL4zz\u002BUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "81ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.b507f190-2bc2-d07f-a482-576bd627436c.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com"
             ]
           }
         ]
@@ -277,11 +324,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-824b741b20a22dd72ef71422b8ec3749-f4c7fd66bc9420bc-00",
+        "traceparent": "00-4a6f5d86bf8af99f217e19543e1da08e-4d2f523cb197ffd8-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "31af9a4565a75555a9ce49f3bf41f939",
+        "x-ms-client-request-id": "7af6e469ee33b20e226fa855effd570c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:50 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:35 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -291,20 +338,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:50 GMT",
-        "MS-CV": "B/jyx6fMZ0KTOIGDtAtC6Q.0",
+        "Date": "Tue, 13 Dec 2022 20:16:36 GMT",
+        "MS-CV": "oAEEQfXbEUKQV8w3LapPHg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BtKXYwAAAAA\u002BQQ6IawaRQplZkNiNZZxwUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pN2YYwAAAAAeFYfgs5drRq9fgc4vCnHDUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "99ms"
+        "X-Processing-Time": "129ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
+          "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
+          "sbs2.b507f190-2bc2-d07f-a482-576bd627436c.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -317,11 +364,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-bad3c226ed6679cc4ffed99c252fac78-d769650ba2ff3b17-00",
+        "traceparent": "00-0db28931bc4636c12820281d35a3ec69-a545908e90cd3406-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ecb9445c8338b4e50bbff61187ac06d1",
+        "x-ms-client-request-id": "30762d864b543026de8e37dfc2e3bf18",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:50 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:36 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -329,58 +376,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:51 GMT",
-        "MS-CV": "3nOysRRFgEeeZm7uTuCzig.0",
+        "Date": "Tue, 13 Dec 2022 20:16:36 GMT",
+        "MS-CV": "8Q56Ccu5w0SD4okW6tvJVg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002B9KXYwAAAAA6YJbLgd5CQpGIyxv7UGnbUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pd2YYwAAAAAUTw4BE13PQZ5tl9kv\u002Bd3BUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "85ms"
+        "X-Processing-Time": "79ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
+          "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-59899646c73499019588355a0b609f11-e688959c557bd1cc-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ca794f23bce8691eb89bc40c8d1c858b",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:50 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:51 GMT",
-        "MS-CV": "v\u002BBvygfkUkuGukrtQuY97g.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002B9KXYwAAAAAm1wAFWfAQRo1gbLx1MonZUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "74ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": {
+          "sbs2.b507f190-2bc2-d07f-a482-576bd627436c.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -395,30 +404,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-59899646c73499019588355a0b609f11-c26c16bf5d9d3420-00",
+        "traceparent": "00-0db28931bc4636c12820281d35a3ec69-cbb5fb70c10cfc65-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8277e605c01bc26bb4fa25e86f44cefc",
+        "x-ms-client-request-id": "8a4623671aa77ede0278592fc203e01c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:51 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:36 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": null,
-          "sbs2.91bfe615-3a8f-bba8-d697-c839f53a72f7.com": null
+          "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com": null,
+          "sbs2.b507f190-2bc2-d07f-a482-576bd627436c.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:51 GMT",
-        "MS-CV": "EVlnWgNjRkiaRGCR8\u002BFH7g.0",
+        "Date": "Tue, 13 Dec 2022 20:16:36 GMT",
+        "MS-CV": "SLUwasqJnE2ICPKLGiIr2g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002B9KXYwAAAAABHhFIzJnSTpiOtPVKuhrdUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pd2YYwAAAAArf9ZfWT4cTZOax5LkAvisUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "132ms"
+        "X-Processing-Time": "115ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -428,6 +437,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1011036362"
+    "RandomSeed": "1095461107"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-597aed67d1bc8416c6f3a12531aef561-212e8b81cc0d78cc-00",
+        "traceparent": "00-ca45064257e75f13341a5c58f5859d62-383b7795726f4951-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "76dd8cc955341d92a1c087ad713fe569",
+        "x-ms-client-request-id": "d7884689e96b4a03b05ba41646eb8cae",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:52 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:14 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,23 +22,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:51 GMT",
-        "MS-CV": "c7VtEEN3UE\u002BtvoioUgrn5Q.0",
+        "Date": "Mon, 05 Dec 2022 23:51:13 GMT",
+        "MS-CV": "Buljkytbo0ahfOKr2XFh3g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0VHWOYwAAAAC02RbdbQKsTINxhl75hg7SUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08oOOYwAAAACjwJgneoYuQ4mnp8Z6qAmmUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "253ms"
+        "X-Processing-Time": "168ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -48,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-6f545de5e29b07d3544d77787ef91a74-b97a77ccf6149a39-00",
+        "traceparent": "00-94ea3edb7e8873a320b04f708238ea6e-8885d2a531a8ee78-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6cb4eb10f05be42d2c9e92a8ba4d2cfa",
+        "x-ms-client-request-id": "e0c7a1b4e91b3c87e718b04ff7268838",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:52 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:14 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,23 +53,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:51 GMT",
-        "MS-CV": "nHbi7wDIWk2T6f\u002BpEpDGgg.0",
+        "Date": "Mon, 05 Dec 2022 23:51:13 GMT",
+        "MS-CV": "TvSNEx7lLUuXLkXuIfnwmA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0VHWOYwAAAAA/uBHFPVSeTLZzLyyVYBClUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08oOOYwAAAACp1yUbx0MxSZXbu\u002BtbZhKQUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "75ms"
+        "X-Processing-Time": "91ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -88,11 +74,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-6f545de5e29b07d3544d77787ef91a74-55359ae3a3413556-00",
+        "traceparent": "00-94ea3edb7e8873a320b04f708238ea6e-37eef230716ca29f-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3097c42389a0dfe29b5371d195c77fc7",
+        "x-ms-client-request-id": "37e50e41ca80c6d0bc5b8ed8d4731439",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:52 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:14 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -109,13 +95,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:52 GMT",
-        "MS-CV": "KMXJiJhw1UeUqFGS\u002BAalSg.0",
+        "Date": "Mon, 05 Dec 2022 23:51:14 GMT",
+        "MS-CV": "zbxrG\u002B3/RUybGFbe4W5IkQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0VHWOYwAAAACCnzqO6w2TSLFBLwfpeJvBUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08oOOYwAAAABFYPqxnTNFT7l9E5C2jUYkUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "161ms"
+        "X-Processing-Time": "548ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -137,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-5546382770f8d6763a431ec2a06b4ffb-939ae86345e87913-00",
+        "traceparent": "00-af14c063c025b2c4e45ae171fe68f7b6-b8001911034a2dd4-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1d3fc8d73d6bd85d5ef84a96c2ea6354",
+        "x-ms-client-request-id": "e5e7151a7630a05fbe4bf05239b45289",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:52 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:15 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -160,13 +146,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:52 GMT",
-        "MS-CV": "zcbs/atA3Eyryz\u002BvQwbC7A.0",
+        "Date": "Mon, 05 Dec 2022 23:51:14 GMT",
+        "MS-CV": "V0xjw/xnZkizUjmjxCSkoA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0VHWOYwAAAABbtgnLvVHgR5hUahVP7uAaUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "084OOYwAAAAAZLJnQL0y2Q7k1Y87F36AsUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "108ms"
+        "X-Processing-Time": "169ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -195,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-ee67144ea053f0416e8b23e06b463e76-ffa26411e5a18b9b-00",
+        "traceparent": "00-dfa5a0bfdc89c9dfa7280f7efd612ed8-a334a78bedbd75a6-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ac8a8d93b4a787c809d5d1087e5b4f64",
+        "x-ms-client-request-id": "38d46bd25505ea2ed10124c05aaf6873",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:53 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:15 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -207,13 +193,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:52 GMT",
-        "MS-CV": "ZGUicS2zt06QB9\u002BOR9glUA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:15 GMT",
+        "MS-CV": "nFe3cd5Ep0OzrzZV4MOoBw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0VXWOYwAAAACJ75wcn08sRKV8iYfjotxxUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "084OOYwAAAAB507EWhv/xT6/oh3t/n6SgUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "79ms"
+        "X-Processing-Time": "84ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -235,10 +221,213 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4746d962c320fefedc414921d9c82ed0-8c73bdb2153fad3b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e2347604a23fcb08af457835da7d8c08",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:15 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:15 GMT",
+        "MS-CV": "vBo4we5gQkWvs716imvlvw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "084OOYwAAAACI6Ln9CdAcQY8vYJwd8ikdUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "84ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-1df45a67acf7ae9e470f90eb8fbc0d80-2f1d6467b438e233-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "68050408db9fc534e6fc142e519e450f",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:15 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:15 GMT",
+        "MS-CV": "wzDUsuY6hUC7awdyb5IVOw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "084OOYwAAAACMR3kDblgyTZC8HYnLUyh/UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "174ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9d9d6905c5877883c6c66f4a08993221-72e54eece2086e39-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c24e7ce2707f2f49630989c0dcf91053",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:16 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:15 GMT",
+        "MS-CV": "wRUFm9523kq\u002BGo78VfCMwQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "09IOOYwAAAAD99LGvkB8uRaJ8HwGuDm16UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "99ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-760b53ebd5dc721e01899621efa949fa-1814edf87615a29e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "55b71c7400a929d4426efb438ed97910",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:16 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:15 GMT",
+        "MS-CV": "vMuVjaxwukC0EooQLG4s3g.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "09IOOYwAAAADAUP7chHaMTo9OufcTyZsCUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "86ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "44",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-760b53ebd5dc721e01899621efa949fa-e372f3e96b67450c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5d5269ffc92f9788bbd605955174e9ed",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:16 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.com": null,
+          "sbs2.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:16 GMT",
+        "MS-CV": "W710HK\u002BIRUSq/C4jylto1w.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "09IOOYwAAAAAXeB8KbWPYQqqpTpWiaYFSUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "297ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "308115739"
+    "RandomSeed": "1255279718"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResourceAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-0d9e47e77d11fa995b56eb9d261f167d-e868b4abef0ef17e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2070611b358f1101ae59dca812212f37",
+        "traceparent": "00-de5267f47a5ddad4fde576ce2f22ab60-c6bdbdac646a593e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "623a8f2967a5d87178b1fb53262110f1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:29 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:17 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,20 +22,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:29 GMT",
-        "MS-CV": "BS4i2KPWNEedqa1vJ1A0BA.0",
+        "Date": "Mon, 05 Dec 2022 22:49:17 GMT",
+        "MS-CV": "KQwfyj2pMEmzvzWrFnwxDw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vtZDYwAAAACZ\u002BJYG3MXYRKtaapfhGYT6TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0bXWOYwAAAABWTmJ3gAfRT7zc\u002BOjRcgtqUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
+        "X-Processing-Time": "110ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -43,16 +43,16 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-46e7eb8110f4cace6ce71bbc01cb6d84-aee87c30e40445be-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a000e212c914840671cc545673a4d5af",
+        "traceparent": "00-443170f0bf3b75ad5160b7e1dd365e67-4b2e085ff1971a12-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "738d4cc67478c0644863dd56aee9c640",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:30 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:17 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,20 +60,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:29 GMT",
-        "MS-CV": "W6Rtr9lLjEKOu33UnuzVIQ.0",
+        "Date": "Mon, 05 Dec 2022 22:49:17 GMT",
+        "MS-CV": "kQmwSyvD9k2p/aOHncv8kA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vtZDYwAAAADk8EMsRqYZQK5PQ/E2d/kMTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0bXWOYwAAAAAsSE748EzLT5coawemQ9JaUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "68ms"
+        "X-Processing-Time": "89ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -81,26 +81,26 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "114",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-46e7eb8110f4cace6ce71bbc01cb6d84-c5a2451575843276-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "02128325991cfb23428c83d34df15f5f",
+        "traceparent": "00-443170f0bf3b75ad5160b7e1dd365e67-64335893cb4ddfa9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "06bc07c8a66adc9dc7cd6c62a088644a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:30 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:17 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -109,20 +109,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:30 GMT",
-        "MS-CV": "AW6qLSQS/UyY6\u002BKgjhKfpg.0",
+        "Date": "Mon, 05 Dec 2022 22:49:17 GMT",
+        "MS-CV": "n/IMss/c6Um5TGkFZqkH2A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vtZDYwAAAADGnRiJcOp1Q5IydjWHmDygTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0bXWOYwAAAAAjXSTCCc/SRYRue/MtDoNnUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "138ms"
+        "X-Processing-Time": "152ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -130,18 +130,18 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "178",
+        "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-c651cb125c58f271647bba2262baff8a-2fbf3c7bcba42cf1-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "643740b5f8cc51715aecaec3e0ab9e09",
+        "traceparent": "00-e5a40feb4a098a869a042d47351b7cdc-cd3a81d1f402da79-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "57a503686842b5932b791a42891b2a8e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:30 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:18 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -151,7 +151,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -160,20 +160,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:30 GMT",
-        "MS-CV": "6qVWW61HCU2pZFr/jtyWJQ.0",
+        "Date": "Mon, 05 Dec 2022 22:49:18 GMT",
+        "MS-CV": "8xcs6hhirE\u002BIRSlq7zPDtA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0v9ZDYwAAAAC2GWWcOloxRJ1OQrpO16JJTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0bnWOYwAAAABiCZK/CynJRrXOq9bfu8U/UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "238ms"
+        "X-Processing-Time": "106ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -183,23 +183,23 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-4cb3e6a5e3fbafd9d0b083d21d1dd37e-3d160854c0c3f629-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8f822d832c0f791abe055d8746333680",
+        "traceparent": "00-e7849e5a349973f2fbe5e46892cee626-129169d3fea566b9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1f8abaeb09652086afb0abab070220bf",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:31 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:18 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -207,20 +207,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:30 GMT",
-        "MS-CV": "CYQYH9cehE24VWIw6o87pw.0",
+        "Date": "Mon, 05 Dec 2022 22:49:18 GMT",
+        "MS-CV": "5n4G\u002BNgZT0yfbyVEL5iy5A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0v9ZDYwAAAACOJkglJHgORJgl86bEiBNNTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0bnWOYwAAAABn\u002BTyZZ/LBRIebVmkTTjOaUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "72ms"
+        "X-Processing-Time": "89ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -230,7 +230,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -238,7 +238,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "2094655444"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "276970571"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-de5267f47a5ddad4fde576ce2f22ab60-c6bdbdac646a593e-00",
+        "traceparent": "00-0ec6e161e05f263064f09214f34be0b1-4df035562dbaaa87-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "623a8f2967a5d87178b1fb53262110f1",
+        "x-ms-client-request-id": "fde32b65bbdd5c8a52c606f0f8abf3bf",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:17 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:44 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,23 +22,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:17 GMT",
-        "MS-CV": "KQwfyj2pMEmzvzWrFnwxDw.0",
+        "Date": "Mon, 05 Dec 2022 23:51:43 GMT",
+        "MS-CV": "PkebVbcjhEmxJY7tPtRi9g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0bXWOYwAAAABWTmJ3gAfRT7zc\u002BOjRcgtqUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0EISOYwAAAAAH6fvmF7pxR5zBrEITcMZyUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "110ms"
+        "X-Processing-Time": "167ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -48,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-443170f0bf3b75ad5160b7e1dd365e67-4b2e085ff1971a12-00",
+        "traceparent": "00-bc28fc227a7b0b3a74e7ad168a067466-de7f6a78ced61f37-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "738d4cc67478c0644863dd56aee9c640",
+        "x-ms-client-request-id": "cb15c439b661ba5e7045fee19ad8c66b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:17 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:44 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,23 +53,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:17 GMT",
-        "MS-CV": "kQmwSyvD9k2p/aOHncv8kA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:43 GMT",
+        "MS-CV": "aVVtCykOnEaZ61THPvbitQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0bXWOYwAAAAAsSE748EzLT5coawemQ9JaUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0EISOYwAAAAB8SwymwurIT76v3\u002BArOhzNUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
+        "X-Processing-Time": "96ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -88,11 +74,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-443170f0bf3b75ad5160b7e1dd365e67-64335893cb4ddfa9-00",
+        "traceparent": "00-bc28fc227a7b0b3a74e7ad168a067466-93fea93a8000d21a-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "06bc07c8a66adc9dc7cd6c62a088644a",
+        "x-ms-client-request-id": "4ba9fcb5d589f632dcde384bc4c203aa",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:17 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:44 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -109,13 +95,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:17 GMT",
-        "MS-CV": "n/IMss/c6Um5TGkFZqkH2A.0",
+        "Date": "Mon, 05 Dec 2022 23:51:44 GMT",
+        "MS-CV": "NGbseUAT1k2SUPnw9iJSTw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0bXWOYwAAAAAjXSTCCc/SRYRue/MtDoNnUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0EISOYwAAAADg51ZCJ78RRqmN584LHE6eUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "152ms"
+        "X-Processing-Time": "476ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -137,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-e5a40feb4a098a869a042d47351b7cdc-cd3a81d1f402da79-00",
+        "traceparent": "00-7ac7b84262efaf99fdd0dab2ba3b7fae-5e0d41f01b285ada-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "57a503686842b5932b791a42891b2a8e",
+        "x-ms-client-request-id": "2c5021c4284caeaccd298c97bda8c179",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:18 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:45 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -160,13 +146,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:18 GMT",
-        "MS-CV": "8xcs6hhirE\u002BIRSlq7zPDtA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:44 GMT",
+        "MS-CV": "x0gIk8WmyUGkElAd3nRpbQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0bnWOYwAAAABiCZK/CynJRrXOq9bfu8U/UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0EYSOYwAAAAA/ND2dx83\u002BTpGPPcfTFGLBUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "106ms"
+        "X-Processing-Time": "175ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -195,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-e7849e5a349973f2fbe5e46892cee626-129169d3fea566b9-00",
+        "traceparent": "00-772ae6d6944768d3752e2e7912b0bf83-879e4547f7659a83-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1f8abaeb09652086afb0abab070220bf",
+        "x-ms-client-request-id": "fc3a9bffa7026335921fef837e12f5ae",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:18 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:45 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -207,13 +193,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:18 GMT",
-        "MS-CV": "5n4G\u002BNgZT0yfbyVEL5iy5A.0",
+        "Date": "Mon, 05 Dec 2022 23:51:44 GMT",
+        "MS-CV": "Hd\u002BaoKe\u002BG0mT\u002Bj0NV3X8lg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0bnWOYwAAAABn\u002BTyZZ/LBRIebVmkTTjOaUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0EYSOYwAAAABVr2rFdGnNQaLYCv/RYDroUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
+        "X-Processing-Time": "85ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -235,10 +221,213 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d11d3b2d16a8783ac3a5790b248b214c-e6a6ae30bce45649-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "791d544199878d1e4ffa7e60499a3933",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:45 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:45 GMT",
+        "MS-CV": "a1dVkL2dtEOCcPIu7Wa5fg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0EYSOYwAAAACI0fCyuZc2S68KzBE/PysAUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "87ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-56f773ad3cae6e89c9f1c8240e96d07b-7ec6b3bc64b090d9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "294bbf1d07871ca7eced9a2d382930ba",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:46 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:45 GMT",
+        "MS-CV": "oDvqBdSJWECFPO2Ot6kSrA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0EoSOYwAAAACJRqMrZwyGRaDhsAPmHO22UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "172ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-829929e0d9009ec98c37df684e5b4d2d-dcc59c4e711660be-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6856de33478b65f17cadac0729d41af7",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:46 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:45 GMT",
+        "MS-CV": "7vQgSn52cUqT3dQevfpIqw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0EoSOYwAAAAACk1LuGcF7Q5uuEWMmgW0iUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "90ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-656ca6c98a32be2974f5dfda1c608293-f5d9ba51c14e75b1-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bf65bce5ccc73926ac008c9afff05426",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:46 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:45 GMT",
+        "MS-CV": "F4MwPluHSUS4V1/hcYDx4A.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0EoSOYwAAAABSAPxSw6HxQ4ghfFc\u002B3NHzUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "92ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "44",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-656ca6c98a32be2974f5dfda1c608293-fcbbe092ab015376-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6a2dc4cad044d5a7cde5acd95b9ff317",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:46 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.com": null,
+          "sbs2.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:46 GMT",
+        "MS-CV": "IB8OX/mo9EiHv5je6I5edw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0EoSOYwAAAADTDJQO2lSUTaZbARiaRj5jUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "805ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "276970571"
+    "RandomSeed": "174448227"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-49a2645dd816fe4445173a64718d236d-78d9a8210d18f65f-00",
+        "traceparent": "00-330865feebdb52a0d12769f8de4152b0-8ee032486f66664a-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "fca904dd8816c34200a285babed1c2f5",
+        "x-ms-client-request-id": "7b72351405bb3fcbafb1ac785c450d98",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:02 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:01 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:02 GMT",
-        "MS-CV": "IrQGf2ptpkKaIoBqulCc4w.0",
+        "Date": "Tue, 13 Dec 2022 20:17:02 GMT",
+        "MS-CV": "0nJihXzLkUW5MvjjXPbR/g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08teXYwAAAABMPlfiMH05Tpl4cCpKEFy9UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0vt2YYwAAAADZMse5LSyOQoePRMxqT7usUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "107ms"
+        "X-Processing-Time": "159ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-9af0ecb61c3f74f7c2dfbc4774ea863f-1e4ab5cd83992bfc-00",
+        "traceparent": "00-e49fc70688aca8d36c94d2e302d87f9b-07de034a81c2a639-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "865b201c208b44c9d53bf72a03ed0e6a",
+        "x-ms-client-request-id": "27fcaa1986a6890453c23fd7659a5bab",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:02 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:01 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:02 GMT",
-        "MS-CV": "fTTnnUSzHkqLESsJqoxscA.0",
+        "Date": "Tue, 13 Dec 2022 20:17:03 GMT",
+        "MS-CV": "5ip/yD0je02qMsQwS\u002Bh4/Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08teXYwAAAAC2YgDjVP7kQJeh7tJFT\u002BOvUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0vt2YYwAAAABAc8qKRPx1RZaJDCML9axVUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
+        "X-Processing-Time": "104ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-9af0ecb61c3f74f7c2dfbc4774ea863f-1c16aceca295cae5-00",
+        "traceparent": "00-e49fc70688aca8d36c94d2e302d87f9b-44b2fc9717be4c9f-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1012b4fd8200d503527639190fd8cff5",
+        "x-ms-client-request-id": "057c5b4e05524d0272e24480805af2a4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:02 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:02 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
+          "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
+          "sbs2.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:03 GMT",
-        "MS-CV": "vKS2jFxWlUWma4S5cKvq1Q.0",
+        "Date": "Tue, 13 Dec 2022 20:17:03 GMT",
+        "MS-CV": "DqtT8w6FJkKsZzEKL2tg9Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "08teXYwAAAADte4fm2OuhTL80wC8In6MpUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0v92YYwAAAABKTvuAcavYQoywZfGMQB2iUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "259ms"
+        "X-Processing-Time": "560ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
+          "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
+          "sbs2.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-2956c67cfa6968b447fc245153379f16-4438f04b722afae8-00",
+        "traceparent": "00-55392bc0eea6adaedd711437b82b90e9-00a2973490837f1b-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3341069d0e76bcfe3a6526db9117bf13",
+        "x-ms-client-request-id": "6547f8a104c68ea631e828f8c5f4d914",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:02 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:02 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com"
+              "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:03 GMT",
-        "MS-CV": "YaKN8nqja0ePRL26NZfGyA.0",
+        "Date": "Tue, 13 Dec 2022 20:17:03 GMT",
+        "MS-CV": "YzpRD/GUF0CY6KMl\u002BsnK\u002BQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "089eXYwAAAABTkObtzMxmRrESNwfNVwnlUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0v92YYwAAAABaOvWfQCbwRIkVm1CS2FGIUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "112ms"
+        "X-Processing-Time": "170ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
+          "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
+          "sbs2.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,54 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-f350f026bd3a7f65baf5fe2682dcf334-753def6f387329bc-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0abd1a93b1be99f41d853315e7af35fd",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:03 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:03 GMT",
-        "MS-CV": "HLl5lP6C6kaL43iQ6k0WXw.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "089eXYwAAAAD4oS3NK04BTL6XSGBIiHzMUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "114ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com"
+              "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com"
             ]
           }
         ]
@@ -228,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-b005565d05a6846547ead9b46215bbb8-f42ec2ae339b9b7f-00",
+        "traceparent": "00-336987b9d988510d68967e555ac70a21-9bc07e42f9950f07-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "fc8c016bdbabeff4b656d59b5c27443a",
+        "x-ms-client-request-id": "0129015508c91346a8afb4c4418308f8",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:03 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:03 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -240,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:03 GMT",
-        "MS-CV": "t5NSWwu7jkG5rXxzwT1GCg.0",
+        "Date": "Tue, 13 Dec 2022 20:17:04 GMT",
+        "MS-CV": "2mgkxhfevkaueYzdW1gDkQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "089eXYwAAAACN9pS1AW36R57gBXDMI/iNUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0wN2YYwAAAAB06Ri9Zfn\u002BR6aOzsCZgnWcUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "78ms"
+        "X-Processing-Time": "80ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
+          "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
+          "sbs2.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,7 +216,101 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com"
+              "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d56daf21d1290cb0ddeca5e5d6b6d737-4acb553a72c2b0ae-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6d369ad0f65349e4b5eed369dd09887d",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:03 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:17:04 GMT",
+        "MS-CV": "UyM595UEQUCfjwW3q3CDxQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0wN2YYwAAAABUvfXwmc1SQqamaTCKRO52UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "79ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9432d3a6afc0fb70fbc7c45dd748603c-89601f52aa5dc4f7-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7f2b3008f13098dbb233bd174fe14cae",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:03 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:17:04 GMT",
+        "MS-CV": "XwxNH14Zl0a3iEkl4tEsCA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0wN2YYwAAAABlq4AuLmPGToFbrBgDLnhPUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "97ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com"
             ]
           }
         ]
@@ -277,11 +324,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-8292e5f40360fc9f5a6525dcacaaa37e-6c85ae163b40591d-00",
+        "traceparent": "00-471e1f15676a25f50cf3519ce5fa371d-845f3c9c774979c7-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f48626b6c41aeb3612a715f0dae9d58b",
+        "x-ms-client-request-id": "2a282fe06cbe5fc01de04cda35dd369e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:03 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:03 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -291,20 +338,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:04 GMT",
-        "MS-CV": "uKwFQMfHIUqt0Ozc0FwB/A.0",
+        "Date": "Tue, 13 Dec 2022 20:17:04 GMT",
+        "MS-CV": "PQaQ/EX62ka2mUv31Kb/IA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "089eXYwAAAACFJy8N5LCjSo5qZvJTDK\u002BcUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0wN2YYwAAAABscdx73JvIRL5/euh3DuFkUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "101ms"
+        "X-Processing-Time": "162ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
+          "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
+          "sbs2.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -317,11 +364,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-daec8c950e195352d67e5aeb6b87c1e4-070410b119b2a69c-00",
+        "traceparent": "00-680799fa55072920609d3f390d4d8c0c-fa65eadb76420b26-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8f6f292fc38bb86725cd5368dc593df5",
+        "x-ms-client-request-id": "11bb36268957dec8be9dba2038ccf9d3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:03 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:03 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -329,58 +376,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:04 GMT",
-        "MS-CV": "KZMSlC3qB0efc/76jehVww.0",
+        "Date": "Tue, 13 Dec 2022 20:17:04 GMT",
+        "MS-CV": "IryLkFyKr0aIExis7KtnkA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09NeXYwAAAAAkswH9vDxsTpBsEku8jEQJUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0wN2YYwAAAAADhp7WSv/cR5yfeSNz\u002B2LjUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "73ms"
+        "X-Processing-Time": "86ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
+          "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-b749da60f78ee5ac0b433daac0f38c17-ac7a1b7a633431b7-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c15ef8404029a7e2caa1ea04c50415cc",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:03 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:04 GMT",
-        "MS-CV": "PCqMcR09TUO/Y\u002B8dIdC2lw.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09NeXYwAAAADQ3u3BRqH7TqpsLZCOuVcLUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "78ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
+          "sbs2.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -395,30 +404,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-b749da60f78ee5ac0b433daac0f38c17-bbae4aaa0548b73c-00",
+        "traceparent": "00-680799fa55072920609d3f390d4d8c0c-af910aab6e208053-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "336b4a80b5b8f3afbecdcf4d71ce0fb9",
+        "x-ms-client-request-id": "ad8924a25ee19cbf6fcc6150a50163d5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:04 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:04 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": null,
-          "sbs2.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": null
+          "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": null,
+          "sbs2.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:04 GMT",
-        "MS-CV": "eNAxlN2MPEKq3qi5HccfRQ.0",
+        "Date": "Tue, 13 Dec 2022 20:17:05 GMT",
+        "MS-CV": "zps0s94nn0KsarsmxWEfww.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09NeXYwAAAACVMdgxgf25SJflIV\u002BJm7MvUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0wd2YYwAAAABKxnzAqonlS7\u002BpF4UOAE2iUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "111ms"
+        "X-Processing-Time": "261ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -428,6 +437,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "751001808"
+    "RandomSeed": "1762340353"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-0ec6e161e05f263064f09214f34be0b1-4df035562dbaaa87-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "fde32b65bbdd5c8a52c606f0f8abf3bf",
+        "traceparent": "00-49a2645dd816fe4445173a64718d236d-78d9a8210d18f65f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fca904dd8816c34200a285babed1c2f5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:44 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:02 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:43 GMT",
-        "MS-CV": "PkebVbcjhEmxJY7tPtRi9g.0",
+        "Date": "Tue, 13 Dec 2022 01:40:02 GMT",
+        "MS-CV": "IrQGf2ptpkKaIoBqulCc4w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0EISOYwAAAAAH6fvmF7pxR5zBrEITcMZyUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08teXYwAAAABMPlfiMH05Tpl4cCpKEFy9UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "167ms"
+        "X-Processing-Time": "107ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-bc28fc227a7b0b3a74e7ad168a067466-de7f6a78ced61f37-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "cb15c439b661ba5e7045fee19ad8c66b",
+        "traceparent": "00-9af0ecb61c3f74f7c2dfbc4774ea863f-1e4ab5cd83992bfc-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "865b201c208b44c9d53bf72a03ed0e6a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:44 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:02 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:43 GMT",
-        "MS-CV": "aVVtCykOnEaZ61THPvbitQ.0",
+        "Date": "Tue, 13 Dec 2022 01:40:02 GMT",
+        "MS-CV": "fTTnnUSzHkqLESsJqoxscA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0EISOYwAAAAB8SwymwurIT76v3\u002BArOhzNUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08teXYwAAAAC2YgDjVP7kQJeh7tJFT\u002BOvUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "96ms"
+        "X-Processing-Time": "83ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -72,21 +72,21 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "86",
+        "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-bc28fc227a7b0b3a74e7ad168a067466-93fea93a8000d21a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4ba9fcb5d589f632dcde384bc4c203aa",
+        "traceparent": "00-9af0ecb61c3f74f7c2dfbc4774ea863f-1c16aceca295cae5-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1012b4fd8200d503527639190fd8cff5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:44 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:02 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:44 GMT",
-        "MS-CV": "NGbseUAT1k2SUPnw9iJSTw.0",
+        "Date": "Tue, 13 Dec 2022 01:40:03 GMT",
+        "MS-CV": "vKS2jFxWlUWma4S5cKvq1Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0EISOYwAAAADg51ZCJ78RRqmN584LHE6eUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "08teXYwAAAADte4fm2OuhTL80wC8In6MpUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "476ms"
+        "X-Processing-Time": "259ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -121,13 +121,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "164",
+        "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-7ac7b84262efaf99fdd0dab2ba3b7fae-5e0d41f01b285ada-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2c5021c4284caeaccd298c97bda8c179",
+        "traceparent": "00-2956c67cfa6968b447fc245153379f16-4438f04b722afae8-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3341069d0e76bcfe3a6526db9117bf13",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:45 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:02 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:44 GMT",
-        "MS-CV": "x0gIk8WmyUGkElAd3nRpbQ.0",
+        "Date": "Tue, 13 Dec 2022 01:40:03 GMT",
+        "MS-CV": "YaKN8nqja0ePRL26NZfGyA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0EYSOYwAAAAA/ND2dx83\u002BTpGPPcfTFGLBUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "089eXYwAAAABTkObtzMxmRrESNwfNVwnlUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "175ms"
+        "X-Processing-Time": "112ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,54 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-772ae6d6944768d3752e2e7912b0bf83-879e4547f7659a83-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "fc3a9bffa7026335921fef837e12f5ae",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:45 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:44 GMT",
-        "MS-CV": "Hd\u002BaoKe\u002BG0mT\u002Bj0NV3X8lg.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0EYSOYwAAAABVr2rFdGnNQaLYCv/RYDroUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "85ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.com"
+              "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com"
             ]
           }
         ]
@@ -228,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-d11d3b2d16a8783ac3a5790b248b214c-e6a6ae30bce45649-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "791d544199878d1e4ffa7e60499a3933",
+        "traceparent": "00-f350f026bd3a7f65baf5fe2682dcf334-753def6f387329bc-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0abd1a93b1be99f41d853315e7af35fd",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:45 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:03 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -240,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:45 GMT",
-        "MS-CV": "a1dVkL2dtEOCcPIu7Wa5fg.0",
+        "Date": "Tue, 13 Dec 2022 01:40:03 GMT",
+        "MS-CV": "HLl5lP6C6kaL43iQ6k0WXw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0EYSOYwAAAACI0fCyuZc2S68KzBE/PysAUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "089eXYwAAAAD4oS3NK04BTL6XSGBIiHzMUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
+        "X-Processing-Time": "114ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,7 +216,54 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b005565d05a6846547ead9b46215bbb8-f42ec2ae339b9b7f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fc8c016bdbabeff4b656d59b5c27443a",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:03 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:40:03 GMT",
+        "MS-CV": "t5NSWwu7jkG5rXxzwT1GCg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "089eXYwAAAACN9pS1AW36R57gBXDMI/iNUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "78ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com"
             ]
           }
         ]
@@ -277,11 +277,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-56f773ad3cae6e89c9f1c8240e96d07b-7ec6b3bc64b090d9-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "294bbf1d07871ca7eced9a2d382930ba",
+        "traceparent": "00-8292e5f40360fc9f5a6525dcacaaa37e-6c85ae163b40591d-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f48626b6c41aeb3612a715f0dae9d58b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:46 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:03 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -291,20 +291,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:45 GMT",
-        "MS-CV": "oDvqBdSJWECFPO2Ot6kSrA.0",
+        "Date": "Tue, 13 Dec 2022 01:40:04 GMT",
+        "MS-CV": "uKwFQMfHIUqt0Ozc0FwB/A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0EoSOYwAAAACJRqMrZwyGRaDhsAPmHO22UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "089eXYwAAAACFJy8N5LCjSo5qZvJTDK\u002BcUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "172ms"
+        "X-Processing-Time": "101ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -317,11 +317,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-829929e0d9009ec98c37df684e5b4d2d-dcc59c4e711660be-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6856de33478b65f17cadac0729d41af7",
+        "traceparent": "00-daec8c950e195352d67e5aeb6b87c1e4-070410b119b2a69c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8f6f292fc38bb86725cd5368dc593df5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:46 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:03 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -329,20 +329,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:45 GMT",
-        "MS-CV": "7vQgSn52cUqT3dQevfpIqw.0",
+        "Date": "Tue, 13 Dec 2022 01:40:04 GMT",
+        "MS-CV": "KZMSlC3qB0efc/76jehVww.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0EoSOYwAAAAACk1LuGcF7Q5uuEWMmgW0iUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09NeXYwAAAAAkswH9vDxsTpBsEku8jEQJUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "90ms"
+        "X-Processing-Time": "73ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -355,11 +355,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-656ca6c98a32be2974f5dfda1c608293-f5d9ba51c14e75b1-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "bf65bce5ccc73926ac008c9afff05426",
+        "traceparent": "00-b749da60f78ee5ac0b433daac0f38c17-ac7a1b7a633431b7-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c15ef8404029a7e2caa1ea04c50415cc",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:46 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:03 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -367,20 +367,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:45 GMT",
-        "MS-CV": "F4MwPluHSUS4V1/hcYDx4A.0",
+        "Date": "Tue, 13 Dec 2022 01:40:04 GMT",
+        "MS-CV": "PCqMcR09TUO/Y\u002B8dIdC2lw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0EoSOYwAAAABSAPxSw6HxQ4ghfFc\u002B3NHzUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09NeXYwAAAADQ3u3BRqH7TqpsLZCOuVcLUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "92ms"
+        "X-Processing-Time": "78ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -393,32 +393,32 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "44",
+        "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-656ca6c98a32be2974f5dfda1c608293-fcbbe092ab015376-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6a2dc4cad044d5a7cde5acd95b9ff317",
+        "traceparent": "00-b749da60f78ee5ac0b433daac0f38c17-bbae4aaa0548b73c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "336b4a80b5b8f3afbecdcf4d71ce0fb9",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:46 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:04 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": null,
-          "sbs2.com": null
+          "sbs1.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": null,
+          "sbs2.3a39955e-94bc-8e92-c760-fb5d53d1948a.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:46 GMT",
-        "MS-CV": "IB8OX/mo9EiHv5je6I5edw.0",
+        "Date": "Tue, 13 Dec 2022 01:40:04 GMT",
+        "MS-CV": "eNAxlN2MPEKq3qi5HccfRQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0EoSOYwAAAADTDJQO2lSUTaZbARiaRj5jUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09NeXYwAAAACVMdgxgf25SJflIV\u002BJm7MvUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "805ms"
+        "X-Processing-Time": "111ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -428,6 +428,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "174448227"
+    "RandomSeed": "751001808"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResourceAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -67,7 +67,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -116,7 +116,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -176,7 +176,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -223,7 +223,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -270,7 +270,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -312,7 +312,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -350,7 +350,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -388,7 +388,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -427,7 +427,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "174448227"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResource.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-5ddb2860a8e6eb3d66f0fe00f5657171-d19957e1226cc452-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "99f80ae85ca8332bc019962ec2df5a38",
+        "traceparent": "00-97486f0dac7b6be674402a65a912689c-5070b584c12750a5-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ba2c30591bdc12d4867d136185e66d84",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:18 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,20 +22,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:18 GMT",
-        "MS-CV": "TcCw5nH6B0yyFhf7yZfdSw.0",
+        "Date": "Mon, 05 Dec 2022 22:48:52 GMT",
+        "MS-CV": "L3FBv9A2MUqbzSb1Kso6MA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0s9ZDYwAAAADnUmP3g/bPRIkcenDSmpR3TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0VXWOYwAAAADwmCw/vysiRYt5lLjAcBs8UFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "88ms"
+        "X-Processing-Time": "103ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -43,16 +43,16 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-32b2809e79eff42361fd4d95ed3351fa-8cad5d3d47ba3454-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7a100571ecda902cd77ab537cccfe9e9",
+        "traceparent": "00-c690f6dfe9de30f02055dacfb2f41978-5c9e2e568a893eaa-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4d672d69200730354ba42a391fc026ed",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:18 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,20 +60,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:18 GMT",
-        "MS-CV": "NVJukuB\u002Bh0i4VaJhsi0G2Q.0",
+        "Date": "Mon, 05 Dec 2022 22:48:52 GMT",
+        "MS-CV": "aFyqUQlhkESjfCJuE05byA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0s9ZDYwAAAACJ4uwvClPsT5oB9pSDlWK1TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0VXWOYwAAAAACdyuxs7SzRpK0/6L1aVbgUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "67ms"
+        "X-Processing-Time": "75ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -81,26 +81,26 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "114",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-32b2809e79eff42361fd4d95ed3351fa-7987ab41e3ebd657-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "55fbe1698238a86206b89ce1e9f7eef4",
+        "traceparent": "00-c690f6dfe9de30f02055dacfb2f41978-ad3292fd1460865f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "220aa5b16f5f62d1a44cc7273901b8d1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:18 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -109,20 +109,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:18 GMT",
-        "MS-CV": "7RjbhMrG5kGVf/Tl79/MUg.0",
+        "Date": "Mon, 05 Dec 2022 22:48:53 GMT",
+        "MS-CV": "RQJIfOZtxUKAMfiBKLpCNg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0s9ZDYwAAAACQo7pxQzdXQqvvatNNoledTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0VXWOYwAAAADOup86IkzjR4\u002BCDFuqZwrxUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "136ms"
+        "X-Processing-Time": "153ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -130,18 +130,18 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "178",
+        "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-52ccd6e0db533f3b9c1c8cb6b8fe9137-3ab482117b46d912-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "dc7231134814fba6de67c22ea6f366f1",
+        "traceparent": "00-781d8717883efe102cddbc787cc7a65f-8b339f79e77919ce-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f3ac47b99e6e3809fbfb6f37f19af3c6",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:19 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:54 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -151,7 +151,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -160,20 +160,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:19 GMT",
-        "MS-CV": "pNpCrR85AEi3Y\u002BxXwSnJVw.0",
+        "Date": "Mon, 05 Dec 2022 22:48:53 GMT",
+        "MS-CV": "C5\u002BjxaidzEecUxLEOb1nIA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0s9ZDYwAAAAA3UKrCNkmxQp5mcXXeDppYTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0VXWOYwAAAACwNlQTRSp7QJA1UVVcl5iWUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "102ms"
+        "X-Processing-Time": "123ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -183,25 +183,25 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "184",
+        "Content-Length": "156",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d72904ae7a56d81138d42228684a4398-efba2f814205483f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e0c5ac3005e3ee00a3677322504ba7df",
+        "traceparent": "00-740e7db9a75cab968ef121565268ec81-c29ad442d5ef91ce-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dfb026564bdbfa255b05a9ba580ef74a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:19 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:54 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -211,8 +211,8 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.sipconfigtest.com",
-              "sbs2.sipconfigtest.com"
+              "sbs1.com",
+              "sbs2.com"
             ]
           }
         ]
@@ -221,20 +221,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:19 GMT",
-        "MS-CV": "/9pZ6T6QR0ql4HXBJPSzmg.0",
+        "Date": "Mon, 05 Dec 2022 22:48:53 GMT",
+        "MS-CV": "Ldz5sGa\u002BHE6MSw/fkw3Sww.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0s9ZDYwAAAACHA0hadrvZQraAy2h900UITFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0VnWOYwAAAACi3CR9XTtLR6HbE70Jde2ZUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "186ms"
+        "X-Processing-Time": "120ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -244,24 +244,24 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.sipconfigtest.com",
-              "sbs2.sipconfigtest.com"
+              "sbs1.com",
+              "sbs2.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-1b6d0e59673c1ba17f03ac87ba437234-370a8b8119a12b63-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "9a24c18b0c5c20d53aff77d0c0330212",
+        "traceparent": "00-872c0fea769d32293619016a86240e34-09a65c792e3af954-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d87f59eb3313127f9cd12663ff997109",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:19 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:54 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -269,20 +269,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:19 GMT",
-        "MS-CV": "IzurOZnBl06z1qsdRqRdog.0",
+        "Date": "Mon, 05 Dec 2022 22:48:53 GMT",
+        "MS-CV": "3UWn9uZeLE2CO869yOX1NQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0tNZDYwAAAABEWRwfQkvQT5EVXcKotb6vTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0VnWOYwAAAACLAQoyWDc\u002BSrLhratDyHGrUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "63ms"
+        "X-Processing-Time": "89ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -292,8 +292,8 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.sipconfigtest.com",
-              "sbs2.sipconfigtest.com"
+              "sbs1.com",
+              "sbs2.com"
             ]
           }
         ]
@@ -301,7 +301,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "944872807"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "1605368401"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-fc91b1c4710d18f5442990adae3d4746-0efa16b041d5e398-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c46812db9269c7f002e025734ed4da96",
+        "traceparent": "00-1cdf9ad2027ce78f6efc886b7d9296f9-632bfc0f64d9cd9a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "231f76598c5ed2e52cb8e30123b44057",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:17 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:51 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:16 GMT",
-        "MS-CV": "KnePBaOWS0KenTNPJmR1bQ.0",
+        "Date": "Tue, 13 Dec 2022 01:18:51 GMT",
+        "MS-CV": "r7rCV6U6uUWAkI3izbUmUA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09IOOYwAAAADPOQiBoVZBQ67Bgqlnh\u002BsKUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002B9KXYwAAAACmmHIOXqedRIiKPvvpgGmzUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "173ms"
+        "X-Processing-Time": "97ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-d7b41ef9847c855b7bc887bd85ac6e46-8f0fcdf15b18d19c-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "069a341372ff9bdb68cb1703d13cd003",
+        "traceparent": "00-4012f4ed925778f622d0affb05edd0da-60c6e63534deb5c2-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "97c92754fb984f8fdfb496af7e7ffc46",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:17 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:51 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:16 GMT",
-        "MS-CV": "QTo1eyKNlka24Ny28kUOmw.0",
+        "Date": "Tue, 13 Dec 2022 01:18:51 GMT",
+        "MS-CV": "K1Opy/b4kk2zk9/IOg3Zig.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09YOOYwAAAABt8AqtVokQS4Sv8KXZE0iQUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002B9KXYwAAAAAgyiJ0HfysQo2joR7mqPYtUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "88ms"
+        "X-Processing-Time": "83ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -72,21 +72,21 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "86",
+        "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d7b41ef9847c855b7bc887bd85ac6e46-68773b30eb9f76ae-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "819bc3944df6e0a61cfb3bb755035def",
+        "traceparent": "00-4012f4ed925778f622d0affb05edd0da-5357bd963ead2355-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "da3d22461475d322f9d35cf1910e47c7",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:17 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:51 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:17 GMT",
-        "MS-CV": "WYvuZXpVy0aKCKuPGghlHA.0",
+        "Date": "Tue, 13 Dec 2022 01:18:52 GMT",
+        "MS-CV": "w2b1Mr0jrkyh6RC\u002BSY8RYA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09YOOYwAAAAClYeI\u002ByLm2SoNjOXzX2/JtUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/NKXYwAAAACaoyK/SWnwRYQTICOy0aAzUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "671ms"
+        "X-Processing-Time": "247ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -121,13 +121,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "164",
+        "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-72cd79379efa0ab7abd44e05629b9beb-7d3894418a111e20-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4b236f8de8c9685f36cd5c9e7becf5c5",
+        "traceparent": "00-d0540f42e2a952e9e7b1eef04e35902d-3e27794f5802923b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dabcbb3b82f55e64e7cf44a9f53654ac",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:18 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:17 GMT",
-        "MS-CV": "pmVV5TMaDEa/uDXXdPL5kw.0",
+        "Date": "Tue, 13 Dec 2022 01:18:52 GMT",
+        "MS-CV": "lmfvXYc\u002BIk6Ywwlg75\u002BK\u002Bw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09oOOYwAAAABxIaJPKNkETLpsX7OgZ7CsUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/NKXYwAAAAD01nTS2oPNQ4oG2dYyEj/JUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "169ms"
+        "X-Processing-Time": "122ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com"
             ]
           }
         ]
@@ -181,13 +181,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "156",
+        "Content-Length": "230",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-749c97a762d878657ac2710f60c0bc54-9f38430d0796feff-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8ade22105939c5a08dbaea0337244564",
+        "traceparent": "00-5ae7d3fb2c36e145bd0f07fad73fc281-d434387770dc51e5-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "01bb9cbb657740e104f59ec59e9dbed0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:18 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -197,8 +197,8 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.com",
-              "sbs2.com"
+              "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com",
+              "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com"
             ]
           }
         ]
@@ -207,20 +207,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:18 GMT",
-        "MS-CV": "fPlpmO3VOUO182fEtLoCoA.0",
+        "Date": "Tue, 13 Dec 2022 01:18:52 GMT",
+        "MS-CV": "Eo\u002Bzemm\u002BkU62w2qCJZuzjg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09oOOYwAAAACMtyllBhWqSaoE1HYD2DHWUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/NKXYwAAAACKUhGSGALuT5tEWOzEhWkDUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "167ms"
+        "X-Processing-Time": "100ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -230,56 +230,8 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.com",
-              "sbs2.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-d275e3ad35306eae78d05fe84832f0f4-7cd512904e6bcd30-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6176276d8519ac3964324a29f0086430",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:18 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:18 GMT",
-        "MS-CV": "NXWdFJmsDEqMgUP2ZXfHWw.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09oOOYwAAAADwNG2Lu23uSqw10L12zndeUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "82ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle all other numbers\u0027",
-            "name": "Last rule",
-            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
-            "trunks": [
-              "sbs1.com",
-              "sbs2.com"
+              "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com",
+              "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com"
             ]
           }
         ]
@@ -291,11 +243,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-a45fab3b2c91e5930d57a1bd07f22ead-fafafab75cb0e06f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "33a67505d22533b6cf5dbd0ffe5b3011",
+        "traceparent": "00-799db9167e77e8cdd626f278b80ca2c8-854e09154d87aa29-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c273cf6d22c3c351bddef3a6d079ddc3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:19 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -303,20 +255,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:18 GMT",
-        "MS-CV": "LfECsCiaI0qeB\u002By7HP5umQ.0",
+        "Date": "Tue, 13 Dec 2022 01:18:52 GMT",
+        "MS-CV": "qPSUTt0W3E\u002BknUYOB7b6GA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09oOOYwAAAACGBJ/OZNbTTLKu9jlm7kKRUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/NKXYwAAAADCc7Trxg92QbSw9NW9B7fgUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
+        "X-Processing-Time": "75ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -326,8 +278,56 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.com",
-              "sbs2.com"
+              "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com",
+              "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5489bf75ee0df0f8bac4290454c903fe-bde137f270ddf591-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f436af7e4652d550d97bd5ffe49fc049",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:52 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:18:53 GMT",
+        "MS-CV": "b5EhwXdX7kSK1v/dDLP0cw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0/dKXYwAAAABxnPHS3pn2SKeOjPr/E7VbUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "75ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle all other numbers\u0027",
+            "name": "Last rule",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": [
+              "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com",
+              "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com"
             ]
           }
         ]
@@ -341,11 +341,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-3a5138df180ce2799643bb0c089ae3d0-16976a8cb7e98f3e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5330f88793758bace83226060e77d585",
+        "traceparent": "00-972988879cc44a41d2dfe48b8dd20ccb-0fa9c0b8d80119e8-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "263c731092c299e94bf74398723b708b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:19 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -355,20 +355,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:18 GMT",
-        "MS-CV": "mxhzPWjdYkSVVP9sNajIsA.0",
+        "Date": "Tue, 13 Dec 2022 01:18:53 GMT",
+        "MS-CV": "CGn557KAf0eLyok6Fd6WLg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "094OOYwAAAAAjUCOxdmUSRItqJqvpNK\u002BhUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/dKXYwAAAACCX\u002BvRr6rCQ5CT1gaMtb\u002B3UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "181ms"
+        "X-Processing-Time": "107ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -381,11 +381,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-b9f698769e54cfaa621f0ba41f9d3520-0bd840a464d0a801-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c1fdba55127e9b3f714392bcc72aae09",
+        "traceparent": "00-57ba4d6ce046efb03530ca8adf683b02-16f88a809d29c5f6-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ef46db18ca67277d7f9ee8474c51df1e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:19 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -393,20 +393,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:18 GMT",
-        "MS-CV": "bN4cloD4tEWMHajpV6HLZw.0",
+        "Date": "Tue, 13 Dec 2022 01:18:53 GMT",
+        "MS-CV": "PWpXp4AZikW2m\u002BJCrzCgDA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "094OOYwAAAABMXW4GsxPaS7GjIxItUV2hUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/dKXYwAAAACjQA6m1ienSKvoCNNI1lH2UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
+        "X-Processing-Time": "80ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -419,11 +419,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-be27b298b64aa59d4ddf77847bf0b412-6cdd5755509a7ea6-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f8a2390110d771bac91b4bf2acaf2458",
+        "traceparent": "00-83cf34f6e1f05baf68616fb153317f0c-52e51baa3e11885e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5c95a91eb73cec00c69ca85b02b7629e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:19 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -431,20 +431,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:19 GMT",
-        "MS-CV": "9UiFCg\u002BkDU6m96pIBeGrng.0",
+        "Date": "Tue, 13 Dec 2022 01:18:53 GMT",
+        "MS-CV": "nVxVS7qzF0\u002BtwjA/02SteQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "094OOYwAAAAAYZVUYxL2bQKrY23rZ67hMUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/dKXYwAAAACqmOzzWJUeRaE6ddAK4Ik5UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "92ms"
+        "X-Processing-Time": "75ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -457,32 +457,32 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "44",
+        "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-be27b298b64aa59d4ddf77847bf0b412-6524e6e4c6a9a245-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "44b937886f5d7493b895e23201efc3bd",
+        "traceparent": "00-83cf34f6e1f05baf68616fb153317f0c-9df50b530baabfe0-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "08e74a0bd15846e2f515a624aaa14dfa",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:19 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": null,
-          "sbs2.com": null
+          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": null,
+          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:19 GMT",
-        "MS-CV": "/leZh\u002BONoEyqdhXZKATZ4Q.0",
+        "Date": "Tue, 13 Dec 2022 01:18:53 GMT",
+        "MS-CV": "Mtjuq875EE29SIOgZDe\u002BUg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "094OOYwAAAAAB\u002BY6qng5\u002BSoju7SOcQPoAUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/dKXYwAAAADHdJMUX6lFSJ6xQ41Bkb\u002BJUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "339ms"
+        "X-Processing-Time": "117ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -492,6 +492,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1738141640"
+    "RandomSeed": "1317491303"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResource.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -67,7 +67,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -116,7 +116,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -176,7 +176,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -238,7 +238,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -286,7 +286,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -334,7 +334,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -376,7 +376,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -414,7 +414,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -452,7 +452,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -491,7 +491,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "1738141640"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-1cdf9ad2027ce78f6efc886b7d9296f9-632bfc0f64d9cd9a-00",
+        "traceparent": "00-871673ac6f079d336eb83a254bd9cb01-cdbf7639ecbe56b9-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "231f76598c5ed2e52cb8e30123b44057",
+        "x-ms-client-request-id": "5d94e9aa566e59801a05e4e8bbe95aa2",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:51 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:36 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:51 GMT",
-        "MS-CV": "r7rCV6U6uUWAkI3izbUmUA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:36 GMT",
+        "MS-CV": "Nw9DLtXA1katc33lFl8GHw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002B9KXYwAAAACmmHIOXqedRIiKPvvpgGmzUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pd2YYwAAAABtEaipf0YNQpffp9reN1C8UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "97ms"
+        "X-Processing-Time": "107ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-4012f4ed925778f622d0affb05edd0da-60c6e63534deb5c2-00",
+        "traceparent": "00-d478ebf21f40731252f003a733aebf29-10721e0a921e1b38-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "97c92754fb984f8fdfb496af7e7ffc46",
+        "x-ms-client-request-id": "b24697f535645ef8ac7412f17a7c6b86",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:51 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:36 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:51 GMT",
-        "MS-CV": "K1Opy/b4kk2zk9/IOg3Zig.0",
+        "Date": "Tue, 13 Dec 2022 20:16:37 GMT",
+        "MS-CV": "8xeYOPlGk0GKlN2ZvcilQg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002B9KXYwAAAAAgyiJ0HfysQo2joR7mqPYtUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pd2YYwAAAADLNK1VlZFWRbtEBT2kwwDQUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
+        "X-Processing-Time": "78ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-4012f4ed925778f622d0affb05edd0da-5357bd963ead2355-00",
+        "traceparent": "00-d478ebf21f40731252f003a733aebf29-df5ec4d99357a8e3-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "da3d22461475d322f9d35cf1910e47c7",
+        "x-ms-client-request-id": "185633093834bcbaae248d5a17722e04",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:51 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:37 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
+          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
+          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:52 GMT",
-        "MS-CV": "w2b1Mr0jrkyh6RC\u002BSY8RYA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:37 GMT",
+        "MS-CV": "2bNrPAEEDUavZ\u002Bu70q4HPA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/NKXYwAAAACaoyK/SWnwRYQTICOy0aAzUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pd2YYwAAAAAu9Uh09ySfSZFy4Da9RUciUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "247ms"
+        "X-Processing-Time": "257ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
+          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
+          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d0540f42e2a952e9e7b1eef04e35902d-3e27794f5802923b-00",
+        "traceparent": "00-d48f68530bb52bffdfe64155d7b3663a-a4aaadf101ac8a4b-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "dabcbb3b82f55e64e7cf44a9f53654ac",
+        "x-ms-client-request-id": "bc816cf656b97409f135b1fa448fdf9d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:52 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:37 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com"
+              "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:52 GMT",
-        "MS-CV": "lmfvXYc\u002BIk6Ywwlg75\u002BK\u002Bw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:37 GMT",
+        "MS-CV": "DCgmA5iQ7EaW/DNPSSWv9w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/NKXYwAAAAD01nTS2oPNQ4oG2dYyEj/JUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pt2YYwAAAACj0xcom1xDSaAgACUVfIJ5UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "122ms"
+        "X-Processing-Time": "98ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
+          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
+          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com"
+              "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com"
             ]
           }
         ]
@@ -183,11 +183,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "230",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-5ae7d3fb2c36e145bd0f07fad73fc281-d434387770dc51e5-00",
+        "traceparent": "00-b122e2c0395f8bb83ec1426554fc6c50-7d75500049dee2f1-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "01bb9cbb657740e104f59ec59e9dbed0",
+        "x-ms-client-request-id": "88de5d9a4192bd6ddc89043fa79e4639",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:52 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:37 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -197,8 +197,8 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com",
-              "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com"
+              "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com",
+              "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com"
             ]
           }
         ]
@@ -207,20 +207,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:52 GMT",
-        "MS-CV": "Eo\u002Bzemm\u002BkU62w2qCJZuzjg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:37 GMT",
+        "MS-CV": "pgBj3XdTqkaxcRkXBaU6pw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/NKXYwAAAACKUhGSGALuT5tEWOzEhWkDUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pt2YYwAAAABg/6I1Xi18TIkqI0kszF6ZUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "100ms"
+        "X-Processing-Time": "110ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
+          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
+          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -230,56 +230,8 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com",
-              "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-799db9167e77e8cdd626f278b80ca2c8-854e09154d87aa29-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c273cf6d22c3c351bddef3a6d079ddc3",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:52 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:52 GMT",
-        "MS-CV": "qPSUTt0W3E\u002BknUYOB7b6GA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/NKXYwAAAADCc7Trxg92QbSw9NW9B7fgUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "75ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle all other numbers\u0027",
-            "name": "Last rule",
-            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
-            "trunks": [
-              "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com",
-              "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com"
+              "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com",
+              "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com"
             ]
           }
         ]
@@ -291,11 +243,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-5489bf75ee0df0f8bac4290454c903fe-bde137f270ddf591-00",
+        "traceparent": "00-c5bdb2298fc1a7c74f4c397e5660628a-e83d7526daf9b6c0-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f436af7e4652d550d97bd5ffe49fc049",
+        "x-ms-client-request-id": "0dfa0d45aefab3cc2ae126fe87c0781e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:52 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:37 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -303,20 +255,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:53 GMT",
-        "MS-CV": "b5EhwXdX7kSK1v/dDLP0cw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:37 GMT",
+        "MS-CV": "7wam7uqVVEOmEdYGntsMiw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/dKXYwAAAABxnPHS3pn2SKeOjPr/E7VbUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pt2YYwAAAABySQ6By1AHRb79IJhbNhHjUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "75ms"
+        "X-Processing-Time": "76ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
+          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
+          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -326,8 +278,104 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com",
-              "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com"
+              "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com",
+              "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b1108597faa2db3ab9e45cfde0bb2634-a399294af3fb0e3f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b9bff045a694b471fec4e02f52c9cd53",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:38 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:16:38 GMT",
+        "MS-CV": "3MIbhDH/bEuxpz67MyRhMQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0pt2YYwAAAABVXueM47rLSIVlyWzkDLBKUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "91ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle all other numbers\u0027",
+            "name": "Last rule",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": [
+              "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com",
+              "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2661ca95e73e263c9a2bb96531fc653f-95935387899d9ba7-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "36b477eed295eca3912a5eb01b6f361b",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:38 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:16:38 GMT",
+        "MS-CV": "xOS5OaHErE6AXr0uCsRwrg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0p92YYwAAAACrH6D\u002BHJJWRrRcsMqmXnnIUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "96ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle all other numbers\u0027",
+            "name": "Last rule",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": [
+              "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com",
+              "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com"
             ]
           }
         ]
@@ -341,11 +389,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-972988879cc44a41d2dfe48b8dd20ccb-0fa9c0b8d80119e8-00",
+        "traceparent": "00-a5c44124a093724a57636088cb95a832-f4e3f3f1e4cbf1f6-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "263c731092c299e94bf74398723b708b",
+        "x-ms-client-request-id": "b7fae5118dde9fa59c450e35cd9d6160",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:52 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:38 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -355,20 +403,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:53 GMT",
-        "MS-CV": "CGn557KAf0eLyok6Fd6WLg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:38 GMT",
+        "MS-CV": "sib0JFLhhkWrWfA/0Ui1wA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/dKXYwAAAACCX\u002BvRr6rCQ5CT1gaMtb\u002B3UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0p92YYwAAAADEigkpd0y7TrbMUZF8/OlhUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "107ms"
+        "X-Processing-Time": "99ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
+          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
+          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -381,11 +429,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-57ba4d6ce046efb03530ca8adf683b02-16f88a809d29c5f6-00",
+        "traceparent": "00-ffa9612045368ef7bcf869fd54c41b1f-73cf0fe0d51bbded-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ef46db18ca67277d7f9ee8474c51df1e",
+        "x-ms-client-request-id": "0f0fd314410c73894cd2286948c0998f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:53 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:38 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -393,58 +441,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:53 GMT",
-        "MS-CV": "PWpXp4AZikW2m\u002BJCrzCgDA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:38 GMT",
+        "MS-CV": "UQrj91gbmkGLMMIJfeBkIw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/dKXYwAAAACjQA6m1ienSKvoCNNI1lH2UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "80ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-83cf34f6e1f05baf68616fb153317f0c-52e51baa3e11885e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5c95a91eb73cec00c69ca85b02b7629e",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:53 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:53 GMT",
-        "MS-CV": "nVxVS7qzF0\u002BtwjA/02SteQ.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/dKXYwAAAACqmOzzWJUeRaE6ddAK4Ik5UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0p92YYwAAAADB1jncHVxIQKxz\u002Bs67pbp5UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "75ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
+          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": {
+          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -459,30 +469,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-83cf34f6e1f05baf68616fb153317f0c-9df50b530baabfe0-00",
+        "traceparent": "00-ffa9612045368ef7bcf869fd54c41b1f-acb92f83e7e3891f-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "08e74a0bd15846e2f515a624aaa14dfa",
+        "x-ms-client-request-id": "6d1dc58e16cf6174d2149a4fc36d1ef3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:53 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:38 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": null,
-          "sbs2.89a6de5f-74a9-6b10-7b7b-131101bf1afd.com": null
+          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": null,
+          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:53 GMT",
-        "MS-CV": "Mtjuq875EE29SIOgZDe\u002BUg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:38 GMT",
+        "MS-CV": "m/WO8Qoos0GTmWMHoyJ87Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/dKXYwAAAADHdJMUX6lFSJ6xQ41Bkb\u002BJUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0p92YYwAAAADAb1NCVfvTRJrANiy9mq7KUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "117ms"
+        "X-Processing-Time": "115ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -492,6 +502,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1317491303"
+    "RandomSeed": "689531479"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-97486f0dac7b6be674402a65a912689c-5070b584c12750a5-00",
+        "traceparent": "00-fc91b1c4710d18f5442990adae3d4746-0efa16b041d5e398-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ba2c30591bdc12d4867d136185e66d84",
+        "x-ms-client-request-id": "c46812db9269c7f002e025734ed4da96",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:53 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:17 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,23 +22,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:52 GMT",
-        "MS-CV": "L3FBv9A2MUqbzSb1Kso6MA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:16 GMT",
+        "MS-CV": "KnePBaOWS0KenTNPJmR1bQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0VXWOYwAAAADwmCw/vysiRYt5lLjAcBs8UFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09IOOYwAAAADPOQiBoVZBQ67Bgqlnh\u002BsKUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "103ms"
+        "X-Processing-Time": "173ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -48,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-c690f6dfe9de30f02055dacfb2f41978-5c9e2e568a893eaa-00",
+        "traceparent": "00-d7b41ef9847c855b7bc887bd85ac6e46-8f0fcdf15b18d19c-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4d672d69200730354ba42a391fc026ed",
+        "x-ms-client-request-id": "069a341372ff9bdb68cb1703d13cd003",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:53 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:17 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,23 +53,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:52 GMT",
-        "MS-CV": "aFyqUQlhkESjfCJuE05byA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:16 GMT",
+        "MS-CV": "QTo1eyKNlka24Ny28kUOmw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0VXWOYwAAAAACdyuxs7SzRpK0/6L1aVbgUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09YOOYwAAAABt8AqtVokQS4Sv8KXZE0iQUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "75ms"
+        "X-Processing-Time": "88ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -88,11 +74,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-c690f6dfe9de30f02055dacfb2f41978-ad3292fd1460865f-00",
+        "traceparent": "00-d7b41ef9847c855b7bc887bd85ac6e46-68773b30eb9f76ae-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "220aa5b16f5f62d1a44cc7273901b8d1",
+        "x-ms-client-request-id": "819bc3944df6e0a61cfb3bb755035def",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:53 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:17 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -109,13 +95,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:53 GMT",
-        "MS-CV": "RQJIfOZtxUKAMfiBKLpCNg.0",
+        "Date": "Mon, 05 Dec 2022 23:51:17 GMT",
+        "MS-CV": "WYvuZXpVy0aKCKuPGghlHA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0VXWOYwAAAADOup86IkzjR4\u002BCDFuqZwrxUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09YOOYwAAAAClYeI\u002ByLm2SoNjOXzX2/JtUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "153ms"
+        "X-Processing-Time": "671ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -137,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-781d8717883efe102cddbc787cc7a65f-8b339f79e77919ce-00",
+        "traceparent": "00-72cd79379efa0ab7abd44e05629b9beb-7d3894418a111e20-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f3ac47b99e6e3809fbfb6f37f19af3c6",
+        "x-ms-client-request-id": "4b236f8de8c9685f36cd5c9e7becf5c5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:54 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:18 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -160,13 +146,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:53 GMT",
-        "MS-CV": "C5\u002BjxaidzEecUxLEOb1nIA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:17 GMT",
+        "MS-CV": "pmVV5TMaDEa/uDXXdPL5kw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0VXWOYwAAAACwNlQTRSp7QJA1UVVcl5iWUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09oOOYwAAAABxIaJPKNkETLpsX7OgZ7CsUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "123ms"
+        "X-Processing-Time": "169ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -197,11 +183,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "156",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-740e7db9a75cab968ef121565268ec81-c29ad442d5ef91ce-00",
+        "traceparent": "00-749c97a762d878657ac2710f60c0bc54-9f38430d0796feff-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "dfb026564bdbfa255b05a9ba580ef74a",
+        "x-ms-client-request-id": "8ade22105939c5a08dbaea0337244564",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:54 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:18 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -221,13 +207,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:53 GMT",
-        "MS-CV": "Ldz5sGa\u002BHE6MSw/fkw3Sww.0",
+        "Date": "Mon, 05 Dec 2022 23:51:18 GMT",
+        "MS-CV": "fPlpmO3VOUO182fEtLoCoA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0VnWOYwAAAACi3CR9XTtLR6HbE70Jde2ZUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09oOOYwAAAACMtyllBhWqSaoE1HYD2DHWUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "120ms"
+        "X-Processing-Time": "167ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -257,11 +243,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-872c0fea769d32293619016a86240e34-09a65c792e3af954-00",
+        "traceparent": "00-d275e3ad35306eae78d05fe84832f0f4-7cd512904e6bcd30-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d87f59eb3313127f9cd12663ff997109",
+        "x-ms-client-request-id": "6176276d8519ac3964324a29f0086430",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:54 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:18 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -269,11 +255,59 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:53 GMT",
-        "MS-CV": "3UWn9uZeLE2CO869yOX1NQ.0",
+        "Date": "Mon, 05 Dec 2022 23:51:18 GMT",
+        "MS-CV": "NXWdFJmsDEqMgUP2ZXfHWw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0VnWOYwAAAACLAQoyWDc\u002BSrLhratDyHGrUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09oOOYwAAAADwNG2Lu23uSqw10L12zndeUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "82ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle all other numbers\u0027",
+            "name": "Last rule",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": [
+              "sbs1.com",
+              "sbs2.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a45fab3b2c91e5930d57a1bd07f22ead-fafafab75cb0e06f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "33a67505d22533b6cf5dbd0ffe5b3011",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:19 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:18 GMT",
+        "MS-CV": "LfECsCiaI0qeB\u002By7HP5umQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "09oOOYwAAAACGBJ/OZNbTTLKu9jlm7kKRUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "89ms"
       },
@@ -298,10 +332,166 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-3a5138df180ce2799643bb0c089ae3d0-16976a8cb7e98f3e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5330f88793758bace83226060e77d585",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:19 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:18 GMT",
+        "MS-CV": "mxhzPWjdYkSVVP9sNajIsA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "094OOYwAAAAAjUCOxdmUSRItqJqvpNK\u002BhUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "181ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b9f698769e54cfaa621f0ba41f9d3520-0bd840a464d0a801-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c1fdba55127e9b3f714392bcc72aae09",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:19 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:18 GMT",
+        "MS-CV": "bN4cloD4tEWMHajpV6HLZw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "094OOYwAAAABMXW4GsxPaS7GjIxItUV2hUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "84ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-be27b298b64aa59d4ddf77847bf0b412-6cdd5755509a7ea6-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f8a2390110d771bac91b4bf2acaf2458",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:19 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:19 GMT",
+        "MS-CV": "9UiFCg\u002BkDU6m96pIBeGrng.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "094OOYwAAAAAYZVUYxL2bQKrY23rZ67hMUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "92ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "44",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-be27b298b64aa59d4ddf77847bf0b412-6524e6e4c6a9a245-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "44b937886f5d7493b895e23201efc3bd",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:19 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.com": null,
+          "sbs2.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:19 GMT",
+        "MS-CV": "/leZh\u002BONoEyqdhXZKATZ4Q.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "094OOYwAAAAAB\u002BY6qng5\u002BSoju7SOcQPoAUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "339ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1605368401"
+    "RandomSeed": "1738141640"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-4429c8281c643c126c73c4f6f99af7a9-13aa6cf20e90c56a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ebc3660472ff4c7e72630c66bd3552ec",
+        "traceparent": "00-5b525554c08eaa82665aa9e583d8c818-50bebb07eddbdbe0-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bd2953de4dc968babef5ca6860d5ec4f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:47 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:04 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:46 GMT",
-        "MS-CV": "tZZdvazxx0Wv9/PueSN80w.0",
+        "Date": "Tue, 13 Dec 2022 01:40:04 GMT",
+        "MS-CV": "8g9Elfdpf0eyryyI1j5UwA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0E4SOYwAAAADoPpEVFPzSRK8yiN12NbPUUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09NeXYwAAAAD7cArjyLTNSLuBLXgn2fhZUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "188ms"
+        "X-Processing-Time": "126ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-0ece9851195b561c4b523f23b56d6d46-8de9b9b20b48c1d2-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c561073d0eb80aead5e893cc824d1f03",
+        "traceparent": "00-e9e260ff25b1addddee8b4d0d12d15d8-b023665a3b1701a3-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "865978739f1737c19066583f76782926",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:47 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:04 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:47 GMT",
-        "MS-CV": "q2ewv2PP00em7FFgYAwWyw.0",
+        "Date": "Tue, 13 Dec 2022 01:40:05 GMT",
+        "MS-CV": "WE8se3AgOEOew75liqWrvA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0E4SOYwAAAACzLrtCGp82TYXkFYy6UJWXUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09NeXYwAAAAC5EN\u002BN3QFzTKq8ANJEZi1QUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "92ms"
+        "X-Processing-Time": "77ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -72,21 +72,21 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "86",
+        "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-0ece9851195b561c4b523f23b56d6d46-4e83ace7ca1eb451-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "37de35a83220ca9ac4da40bca00ce31d",
+        "traceparent": "00-e9e260ff25b1addddee8b4d0d12d15d8-7709cd161854b1d0-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "40d74509756e8987ebc97a4de6cf9024",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:48 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:04 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:47 GMT",
-        "MS-CV": "o/WVHp3DRUqBl6QlTWZSSg.0",
+        "Date": "Tue, 13 Dec 2022 01:40:05 GMT",
+        "MS-CV": "3GgNhkS5K02CkthggtCMoQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0FISOYwAAAABIgeaRu564SKlmUGECZuUMUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09deXYwAAAAAqb1U8Ug1kT4U4rinJFeqRUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "605ms"
+        "X-Processing-Time": "257ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -121,13 +121,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "164",
+        "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-7fa08d519e9ff265a824defd35f405b9-e430ef0eeaa15140-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "fe94d49de473f63b7bb81617deb1ca24",
+        "traceparent": "00-41841c2f266bbf614706b5fbd7a76648-d88332c0babc19ca-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e3264f0d91273e6192f12c63f47bf145",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:48 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:05 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:48 GMT",
-        "MS-CV": "PaMzQVaWgkmlNU5R1dLLxg.0",
+        "Date": "Tue, 13 Dec 2022 01:40:05 GMT",
+        "MS-CV": "JdXg6CS8dEqCh6pkBRloYQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0FISOYwAAAAD4tfOTsewyRrW9N73db05AUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09deXYwAAAAABOzgQQhTWSp1sDy3IFcjuUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "172ms"
+        "X-Processing-Time": "97ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com"
             ]
           }
         ]
@@ -181,13 +181,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "156",
+        "Content-Length": "230",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-fe6b7693d91c76a36c8cd5079065899f-ec3943ae6e7afac2-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "87be08431b570bcb6d9600decd2e6ac8",
+        "traceparent": "00-43d7794073f4129e21429f8f9ecd1f94-757dfad96b2695ae-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1b5fa3cbacfefee1f0cf9b4e257450c0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:49 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:05 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -197,8 +197,8 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.com",
-              "sbs2.com"
+              "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com",
+              "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com"
             ]
           }
         ]
@@ -207,20 +207,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:48 GMT",
-        "MS-CV": "ERBx9lTjL0O94isCAfop7w.0",
+        "Date": "Tue, 13 Dec 2022 01:40:05 GMT",
+        "MS-CV": "nP6LP4OkoUOc9nXN52GGAA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0FYSOYwAAAADzY9T\u002BvbGvQIR\u002BfpW0bkrHUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09deXYwAAAADEPa8JiHbCR7wO5bQV9Ya2UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "172ms"
+        "X-Processing-Time": "97ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -230,56 +230,8 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.com",
-              "sbs2.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-41336c1ad6095b4ee6dae1f60b029231-3ff2941cd0f34043-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ae2e750521b8c38ffae7bb681b82eb13",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:49 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:48 GMT",
-        "MS-CV": "SSoxE/mz5kaDHNtAhwQ0jg.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0FYSOYwAAAAC3KD9VfQsVS5J\u002BSVQbESFqUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle all other numbers\u0027",
-            "name": "Last rule",
-            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
-            "trunks": [
-              "sbs1.com",
-              "sbs2.com"
+              "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com",
+              "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com"
             ]
           }
         ]
@@ -291,11 +243,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f529f66274af94ba411dcd6e22a2f4e8-8de35cb5331409e9-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "97781b105c4e82c6088991dde45d284d",
+        "traceparent": "00-4ded4bfbf0dbed7402ddba2b443406c0-4472670c224969a6-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "273233d6455278fee398ad7c48249570",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:49 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:05 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -303,20 +255,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:48 GMT",
-        "MS-CV": "PdYd\u002B76MIU242n287euLgg.0",
+        "Date": "Tue, 13 Dec 2022 01:40:05 GMT",
+        "MS-CV": "MFrNalQE70mnEA\u002B1yd4nKQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0FYSOYwAAAACzVzaw5fmERqFe456YUvJsUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09deXYwAAAAB\u002BSt02qnyMQ4DI1tlzcJM4UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
+        "X-Processing-Time": "76ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -326,8 +278,56 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.com",
-              "sbs2.com"
+              "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com",
+              "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c250644e0500ce32b0257c18eb7ceeff-453b18110551ac8d-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "428134d7747060266e27f358f613191d",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:05 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:40:06 GMT",
+        "MS-CV": "nhG9GGACgkGTAVit/2xXqg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "09teXYwAAAADIbpYnkwa7RLM28qv\u002BrjueUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "85ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle all other numbers\u0027",
+            "name": "Last rule",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": [
+              "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com",
+              "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com"
             ]
           }
         ]
@@ -341,11 +341,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-65b5590d7d6b8726fe8f35a465f99dec-dae49cf6a8f2e817-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "69114d4d1b82216c78fb8d6f5f63efea",
+        "traceparent": "00-ac5c6fbbd51c7caf73fb1a587820cc68-aa5caf42a0c6ab28-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c18d6ba0ca4985f3a5e63866fe65b5cc",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:49 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:05 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -355,20 +355,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:50 GMT",
-        "MS-CV": "mL5GgadVUUmFVsel23PkWg.0",
+        "Date": "Tue, 13 Dec 2022 01:40:06 GMT",
+        "MS-CV": "Wjejd1IlPUSucP93fhnAkg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0FYSOYwAAAADQemsOZAxISblLjqExFSU1UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09teXYwAAAABVXa3yDnBLSaqDTj4sMcopUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "163ms"
+        "X-Processing-Time": "102ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -381,11 +381,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-ee47103ed97dab89f24831445df5c791-39662b7f9825a50c-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b2cdedabd2b5a97aafaca52f90b2df9d",
+        "traceparent": "00-549a96799f8f99f1e3ae618d6a483037-74746c02a353f3d9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f1762a3a0ef261500cd1b82a52a682cf",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:50 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:06 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -393,20 +393,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:50 GMT",
-        "MS-CV": "kw3wa5YXZEKyzdC5\u002BzEbqA.0",
+        "Date": "Tue, 13 Dec 2022 01:40:06 GMT",
+        "MS-CV": "UrxrCH9xRUOuswyjVyk4RQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0FoSOYwAAAAAgnc1LPpKmQLGYl/q4afu5UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09teXYwAAAABlLb9WP/x0QKhfml8KpCZKUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "85ms"
+        "X-Processing-Time": "77ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -419,11 +419,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-74f66518a5152e4770682f617064fdd9-c037dc135e442331-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ce1a6ebf8271f590af571f52ce5623a5",
+        "traceparent": "00-29472124a7044fb89ec5bcd951eb9f34-f1a6e34685511ea5-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dddb8f7ed3970d2641fc9d8a3cc06209",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:50 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:06 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -431,20 +431,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:50 GMT",
-        "MS-CV": "EVsXIkPuY02lnS9luAgAVQ.0",
+        "Date": "Tue, 13 Dec 2022 01:40:06 GMT",
+        "MS-CV": "WNATlVkEaU2GAYw8gZUxVw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0FoSOYwAAAACanmxRQ5DMQILc0Ek4xrgfUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09teXYwAAAACsInUBSxyUTbSJ1IijtM6/UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
+        "X-Processing-Time": "81ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -457,32 +457,32 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "44",
+        "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-74f66518a5152e4770682f617064fdd9-b1060fc420ec1439-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f631a699768f7a98d268b9d6753d90c5",
+        "traceparent": "00-29472124a7044fb89ec5bcd951eb9f34-d6a0065f50d99fa3-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cb1d2772289d922b1b2bb47811c833fe",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:50 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:06 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": null,
-          "sbs2.com": null
+          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": null,
+          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:50 GMT",
-        "MS-CV": "B\u002BwamQb/UkyalI7CNMWZxA.0",
+        "Date": "Tue, 13 Dec 2022 01:40:07 GMT",
+        "MS-CV": "Z/yfwvtJxkOUxvAVLKy1bQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0FoSOYwAAAADocqmuQEzfQYnx8AzNot8IUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "09teXYwAAAAD64p/\u002BMzNsRJ2xsznoM65hUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "279ms"
+        "X-Processing-Time": "257ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -492,6 +492,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "366380311"
+    "RandomSeed": "1411253904"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-acc502664f70fb0dedbf5cf39acb0475-c62f631c3279affa-00",
+        "traceparent": "00-4429c8281c643c126c73c4f6f99af7a9-13aa6cf20e90c56a-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "16c62c29b502666c92ecf8e6084fdfd2",
+        "x-ms-client-request-id": "ebc3660472ff4c7e72630c66bd3552ec",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:18 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:47 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,23 +22,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:18 GMT",
-        "MS-CV": "o3baR7vHlEu5SK3rMubMGg.0",
+        "Date": "Mon, 05 Dec 2022 23:51:46 GMT",
+        "MS-CV": "tZZdvazxx0Wv9/PueSN80w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0bnWOYwAAAADv1PA/yyysTqkRWGPck\u002Be5UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0E4SOYwAAAADoPpEVFPzSRK8yiN12NbPUUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "116ms"
+        "X-Processing-Time": "188ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -48,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-9036965cbc3b29f94d61d0c692bd996b-af6f674fcdbb2c46-00",
+        "traceparent": "00-0ece9851195b561c4b523f23b56d6d46-8de9b9b20b48c1d2-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "dac793cee9f771343f5c7fe91bbf0ac1",
+        "x-ms-client-request-id": "c561073d0eb80aead5e893cc824d1f03",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:18 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:47 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,23 +53,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:18 GMT",
-        "MS-CV": "Ygl8WWyUvk2nZO2u4xw4wA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:47 GMT",
+        "MS-CV": "q2ewv2PP00em7FFgYAwWyw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0bnWOYwAAAAAAdRPczwx2Rpe2miFJqEZiUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0E4SOYwAAAACzLrtCGp82TYXkFYy6UJWXUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "109ms"
+        "X-Processing-Time": "92ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -88,11 +74,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-9036965cbc3b29f94d61d0c692bd996b-2cce8fbecbc78706-00",
+        "traceparent": "00-0ece9851195b561c4b523f23b56d6d46-4e83ace7ca1eb451-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "fd82b7fc868a62f711957df1f84a0c39",
+        "x-ms-client-request-id": "37de35a83220ca9ac4da40bca00ce31d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:19 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:48 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -109,13 +95,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:19 GMT",
-        "MS-CV": "M9wilxqjmkW/dJMmqqD7LQ.0",
+        "Date": "Mon, 05 Dec 2022 23:51:47 GMT",
+        "MS-CV": "o/WVHp3DRUqBl6QlTWZSSg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0bnWOYwAAAAAkT0L1/meqR6BdF2H29dz2UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0FISOYwAAAABIgeaRu564SKlmUGECZuUMUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "249ms"
+        "X-Processing-Time": "605ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -137,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-bc025e9368e6a5fd5ada5262453d3d2b-7dddfe887f7aa97c-00",
+        "traceparent": "00-7fa08d519e9ff265a824defd35f405b9-e430ef0eeaa15140-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b2086cb8bbf53f09f854d6a635834ad3",
+        "x-ms-client-request-id": "fe94d49de473f63b7bb81617deb1ca24",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:19 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:48 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -160,13 +146,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:19 GMT",
-        "MS-CV": "X7zjut91qk\u002B9YWeLkTDnQg.0",
+        "Date": "Mon, 05 Dec 2022 23:51:48 GMT",
+        "MS-CV": "PaMzQVaWgkmlNU5R1dLLxg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0b3WOYwAAAABmuQnk1fKhQpB/ohbcatC1UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0FISOYwAAAAD4tfOTsewyRrW9N73db05AUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "111ms"
+        "X-Processing-Time": "172ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -197,11 +183,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "156",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-419287bd71847d6014e75327ce7dbede-3f38119eb2182685-00",
+        "traceparent": "00-fe6b7693d91c76a36c8cd5079065899f-ec3943ae6e7afac2-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "51e936e1e1cd47489b65c9616c4379f5",
+        "x-ms-client-request-id": "87be08431b570bcb6d9600decd2e6ac8",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:19 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:49 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -221,13 +207,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:19 GMT",
-        "MS-CV": "LJ1yEoy/T0mboSiRx5Dwog.0",
+        "Date": "Mon, 05 Dec 2022 23:51:48 GMT",
+        "MS-CV": "ERBx9lTjL0O94isCAfop7w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0b3WOYwAAAABUbnsP907zTIy9d3Gmj8gRUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0FYSOYwAAAADzY9T\u002BvbGvQIR\u002BfpW0bkrHUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "104ms"
+        "X-Processing-Time": "172ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -257,11 +243,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f811225aaca935f3177adcd388d34fdd-bca6b80e02798ea3-00",
+        "traceparent": "00-41336c1ad6095b4ee6dae1f60b029231-3ff2941cd0f34043-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ae30465058b640ccad430536af512c8d",
+        "x-ms-client-request-id": "ae2e750521b8c38ffae7bb681b82eb13",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:19 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:49 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -269,13 +255,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:19 GMT",
-        "MS-CV": "x3MsKMjhs02tgb9KWpjumQ.0",
+        "Date": "Mon, 05 Dec 2022 23:51:48 GMT",
+        "MS-CV": "SSoxE/mz5kaDHNtAhwQ0jg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0b3WOYwAAAACM0OtBtlFJToJsuD9ADPHCUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0FYSOYwAAAAC3KD9VfQsVS5J\u002BSVQbESFqUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "78ms"
+        "X-Processing-Time": "83ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -298,10 +284,214 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f529f66274af94ba411dcd6e22a2f4e8-8de35cb5331409e9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "97781b105c4e82c6088991dde45d284d",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:49 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:48 GMT",
+        "MS-CV": "PdYd\u002B76MIU242n287euLgg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0FYSOYwAAAACzVzaw5fmERqFe456YUvJsUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "87ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle all other numbers\u0027",
+            "name": "Last rule",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": [
+              "sbs1.com",
+              "sbs2.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-65b5590d7d6b8726fe8f35a465f99dec-dae49cf6a8f2e817-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "69114d4d1b82216c78fb8d6f5f63efea",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:49 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:50 GMT",
+        "MS-CV": "mL5GgadVUUmFVsel23PkWg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0FYSOYwAAAADQemsOZAxISblLjqExFSU1UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "163ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ee47103ed97dab89f24831445df5c791-39662b7f9825a50c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b2cdedabd2b5a97aafaca52f90b2df9d",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:50 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:50 GMT",
+        "MS-CV": "kw3wa5YXZEKyzdC5\u002BzEbqA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0FoSOYwAAAAAgnc1LPpKmQLGYl/q4afu5UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "85ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-74f66518a5152e4770682f617064fdd9-c037dc135e442331-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ce1a6ebf8271f590af571f52ce5623a5",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:50 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:50 GMT",
+        "MS-CV": "EVsXIkPuY02lnS9luAgAVQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0FoSOYwAAAACanmxRQ5DMQILc0Ek4xrgfUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "87ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "44",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-74f66518a5152e4770682f617064fdd9-b1060fc420ec1439-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f631a699768f7a98d268b9d6753d90c5",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:50 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.com": null,
+          "sbs2.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:50 GMT",
+        "MS-CV": "B\u002BwamQb/UkyalI7CNMWZxA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0FoSOYwAAAADocqmuQEzfQYnx8AzNot8IUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "279ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "404249972"
+    "RandomSeed": "366380311"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResourceAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-78fdb50b4c4b36409d935d567e2f9cbf-4815eb8825740d74-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "00c4498d05e705c606c6c4c8348bf827",
+        "traceparent": "00-acc502664f70fb0dedbf5cf39acb0475-c62f631c3279affa-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "16c62c29b502666c92ecf8e6084fdfd2",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:31 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:18 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,20 +22,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:31 GMT",
-        "MS-CV": "8wStn7Zw3EWUplZaG6O8DQ.0",
+        "Date": "Mon, 05 Dec 2022 22:49:18 GMT",
+        "MS-CV": "o3baR7vHlEu5SK3rMubMGg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0v9ZDYwAAAAAnOxzSilRYS7HacF2XBgx5TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0bnWOYwAAAADv1PA/yyysTqkRWGPck\u002Be5UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "93ms"
+        "X-Processing-Time": "116ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -43,16 +43,16 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-beb41aa0f44f1220ae0e1dbba7351a20-6ccb24b2c1217d7e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7a5763e4d9a946011c99d4a3b15ba64f",
+        "traceparent": "00-9036965cbc3b29f94d61d0c692bd996b-af6f674fcdbb2c46-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dac793cee9f771343f5c7fe91bbf0ac1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:31 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:18 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,20 +60,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:31 GMT",
-        "MS-CV": "A3wH3kBBAESYvA2RAi2N\u002Bg.0",
+        "Date": "Mon, 05 Dec 2022 22:49:18 GMT",
+        "MS-CV": "Ygl8WWyUvk2nZO2u4xw4wA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wNZDYwAAAABSklxJuojvR5FoerAt8CnyTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0bnWOYwAAAAAAdRPczwx2Rpe2miFJqEZiUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "69ms"
+        "X-Processing-Time": "109ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -81,26 +81,26 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "114",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-beb41aa0f44f1220ae0e1dbba7351a20-49a4bcdd18b6f29f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "20bfe37462a797a3db6800812a4f444d",
+        "traceparent": "00-9036965cbc3b29f94d61d0c692bd996b-2cce8fbecbc78706-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fd82b7fc868a62f711957df1f84a0c39",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:31 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:19 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -109,20 +109,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:31 GMT",
-        "MS-CV": "ZsfDDH89l0Ctu/Vtgmaf\u002Bw.0",
+        "Date": "Mon, 05 Dec 2022 22:49:19 GMT",
+        "MS-CV": "M9wilxqjmkW/dJMmqqD7LQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wNZDYwAAAADnQ1O4G9YcSJqoeD3ssOYITFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0bnWOYwAAAAAkT0L1/meqR6BdF2H29dz2UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "160ms"
+        "X-Processing-Time": "249ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -130,18 +130,18 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "178",
+        "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-ea2283808639c34ae6361d7f02a3afc4-111d0eb4b0048855-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "93fc1d9ce03ab4d6477de44d302354ab",
+        "traceparent": "00-bc025e9368e6a5fd5ada5262453d3d2b-7dddfe887f7aa97c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b2086cb8bbf53f09f854d6a635834ad3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:31 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:19 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -151,7 +151,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -160,20 +160,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:31 GMT",
-        "MS-CV": "oa6\u002BCq7h1kCQf8eZyNCaJw.0",
+        "Date": "Mon, 05 Dec 2022 22:49:19 GMT",
+        "MS-CV": "X7zjut91qk\u002B9YWeLkTDnQg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wNZDYwAAAADCiR1NqzEYSalmxAnHwqiKTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0b3WOYwAAAABmuQnk1fKhQpB/ohbcatC1UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "109ms"
+        "X-Processing-Time": "111ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -183,25 +183,25 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "184",
+        "Content-Length": "156",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-2e7c199a573850f51fe2bd653815d67c-1c7902e7417b801d-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "50537520d8cc827fbfc09f41d9801ccc",
+        "traceparent": "00-419287bd71847d6014e75327ce7dbede-3f38119eb2182685-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "51e936e1e1cd47489b65c9616c4379f5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:32 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:19 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -211,8 +211,8 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.sipconfigtest.com",
-              "sbs2.sipconfigtest.com"
+              "sbs1.com",
+              "sbs2.com"
             ]
           }
         ]
@@ -221,20 +221,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:32 GMT",
-        "MS-CV": "ubX8iN/zK0e9dfkwSxAgOA.0",
+        "Date": "Mon, 05 Dec 2022 22:49:19 GMT",
+        "MS-CV": "LJ1yEoy/T0mboSiRx5Dwog.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wNZDYwAAAAB1w1t5EIHKQbfjV6KVIkjRTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0b3WOYwAAAABUbnsP907zTIy9d3Gmj8gRUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "104ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -244,24 +244,24 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.sipconfigtest.com",
-              "sbs2.sipconfigtest.com"
+              "sbs1.com",
+              "sbs2.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-77f118dc7654df5c09ef1e55965b56ef-5291ddebe0d6700d-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "93068655125e93150c0ad82a7e5666b7",
+        "traceparent": "00-f811225aaca935f3177adcd388d34fdd-bca6b80e02798ea3-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ae30465058b640ccad430536af512c8d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:32 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:19 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -269,20 +269,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:32 GMT",
-        "MS-CV": "YLGA89zCr0mCThO4wROL5A.0",
+        "Date": "Mon, 05 Dec 2022 22:49:19 GMT",
+        "MS-CV": "x3MsKMjhs02tgb9KWpjumQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wNZDYwAAAACDB4xonCPVTK6D4hZFROUcTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0b3WOYwAAAACM0OtBtlFJToJsuD9ADPHCUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "67ms"
+        "X-Processing-Time": "78ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -292,8 +292,8 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.sipconfigtest.com",
-              "sbs2.sipconfigtest.com"
+              "sbs1.com",
+              "sbs2.com"
             ]
           }
         ]
@@ -301,7 +301,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "20180678"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "404249972"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResourceAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -67,7 +67,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -116,7 +116,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -176,7 +176,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -238,7 +238,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -286,7 +286,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -334,7 +334,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -376,7 +376,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -414,7 +414,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -452,7 +452,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -491,7 +491,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "366380311"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-5b525554c08eaa82665aa9e583d8c818-50bebb07eddbdbe0-00",
+        "traceparent": "00-ff78de55ce17df1d19dc01487ba79b5b-d60c465d48c24851-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "bd2953de4dc968babef5ca6860d5ec4f",
+        "x-ms-client-request-id": "1d73fc752d0358338349386642d8ab26",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:04 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:04 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:04 GMT",
-        "MS-CV": "8g9Elfdpf0eyryyI1j5UwA.0",
+        "Date": "Tue, 13 Dec 2022 20:17:05 GMT",
+        "MS-CV": "CmJ1PYU2eEeK5OzB66RiUQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09NeXYwAAAAD7cArjyLTNSLuBLXgn2fhZUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0wd2YYwAAAAAxvzP50xZHS5GqZw/3WqW3UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "126ms"
+        "X-Processing-Time": "160ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-e9e260ff25b1addddee8b4d0d12d15d8-b023665a3b1701a3-00",
+        "traceparent": "00-f9133a04baa32e788b219f88484383bc-ae9bfe1c51b9d0a1-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "865978739f1737c19066583f76782926",
+        "x-ms-client-request-id": "73b736eb01756ce9659a88770c73722d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:04 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:04 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:05 GMT",
-        "MS-CV": "WE8se3AgOEOew75liqWrvA.0",
+        "Date": "Tue, 13 Dec 2022 20:17:05 GMT",
+        "MS-CV": "qwt18yOaekCSsNMCXM/igw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09NeXYwAAAAC5EN\u002BN3QFzTKq8ANJEZi1QUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0wd2YYwAAAACb1jT//UlSQIMMAIy\u002BjQJsUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "77ms"
+        "X-Processing-Time": "79ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-e9e260ff25b1addddee8b4d0d12d15d8-7709cd161854b1d0-00",
+        "traceparent": "00-f9133a04baa32e788b219f88484383bc-752677e2d07c1a87-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "40d74509756e8987ebc97a4de6cf9024",
+        "x-ms-client-request-id": "a9f6500b39138bdb9a9408c2ecc03c04",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:04 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:04 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
+          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
+          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:05 GMT",
-        "MS-CV": "3GgNhkS5K02CkthggtCMoQ.0",
+        "Date": "Tue, 13 Dec 2022 20:17:06 GMT",
+        "MS-CV": "OgU4YDxQbk\u002BvKCaZxEalCA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09deXYwAAAAAqb1U8Ug1kT4U4rinJFeqRUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0wd2YYwAAAACfsFUkVWnUSrjm\u002BL68NDC2UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "257ms"
+        "X-Processing-Time": "683ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
+          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
+          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-41841c2f266bbf614706b5fbd7a76648-d88332c0babc19ca-00",
+        "traceparent": "00-bfaeba0a059a93796a8bcba2520af320-7be17fd5c7932225-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e3264f0d91273e6192f12c63f47bf145",
+        "x-ms-client-request-id": "ddec415ab24474a81206b768a5bb4c10",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:05 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:05 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com"
+              "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:05 GMT",
-        "MS-CV": "JdXg6CS8dEqCh6pkBRloYQ.0",
+        "Date": "Tue, 13 Dec 2022 20:17:06 GMT",
+        "MS-CV": "mUlJVT2bKUS21xNNYy6ubQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09deXYwAAAAABOzgQQhTWSp1sDy3IFcjuUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0wt2YYwAAAAC5e2IGsHKGQ4x4bErIT7dsUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "97ms"
+        "X-Processing-Time": "185ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
+          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
+          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com"
+              "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com"
             ]
           }
         ]
@@ -183,11 +183,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "230",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-43d7794073f4129e21429f8f9ecd1f94-757dfad96b2695ae-00",
+        "traceparent": "00-2d3cfc197d317b126c4293f0aa69a19c-712e007843dc0f77-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1b5fa3cbacfefee1f0cf9b4e257450c0",
+        "x-ms-client-request-id": "f25a0bd601e1b2125a2bd9e0f82780a5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:05 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:06 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -197,8 +197,8 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com",
-              "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com"
+              "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com",
+              "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com"
             ]
           }
         ]
@@ -207,20 +207,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:05 GMT",
-        "MS-CV": "nP6LP4OkoUOc9nXN52GGAA.0",
+        "Date": "Tue, 13 Dec 2022 20:17:07 GMT",
+        "MS-CV": "A1wvLTY3nkeMUAmqBTlszw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09deXYwAAAADEPa8JiHbCR7wO5bQV9Ya2UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0w92YYwAAAABppN0yK/V/RZFPcqNy2JvDUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "97ms"
+        "X-Processing-Time": "185ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
+          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
+          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -230,56 +230,8 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com",
-              "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-4ded4bfbf0dbed7402ddba2b443406c0-4472670c224969a6-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "273233d6455278fee398ad7c48249570",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:05 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:05 GMT",
-        "MS-CV": "MFrNalQE70mnEA\u002B1yd4nKQ.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09deXYwAAAAB\u002BSt02qnyMQ4DI1tlzcJM4UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "76ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle all other numbers\u0027",
-            "name": "Last rule",
-            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
-            "trunks": [
-              "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com",
-              "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com"
+              "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com",
+              "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com"
             ]
           }
         ]
@@ -291,11 +243,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-c250644e0500ce32b0257c18eb7ceeff-453b18110551ac8d-00",
+        "traceparent": "00-bc0bcbe4c92b2b3bcd194d469d87ff79-e9463f3d8be94d87-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "428134d7747060266e27f358f613191d",
+        "x-ms-client-request-id": "cb1d835e948659e8a882960d8272e6df",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:05 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:06 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -303,20 +255,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:06 GMT",
-        "MS-CV": "nhG9GGACgkGTAVit/2xXqg.0",
+        "Date": "Tue, 13 Dec 2022 20:17:07 GMT",
+        "MS-CV": "lVe5Itae\u002BUW5DmkVKiZ4SA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09teXYwAAAADIbpYnkwa7RLM28qv\u002BrjueUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0w92YYwAAAABJZairHq8JSLZ7AiYd1yvDUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "85ms"
+        "X-Processing-Time": "95ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
+          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
+          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -326,8 +278,104 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com",
-              "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com"
+              "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com",
+              "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-dbe9e3c11f2a2bc740ddafc8a85b917c-30429613d3c28252-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e1ebf8484a6558232e3a8219d8c77ceb",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:06 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:17:07 GMT",
+        "MS-CV": "RAxLUbdew0OcRYPVJc4\u002BGg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0w92YYwAAAADSGtPJJDqxS7s6Ov1rGC5nUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "93ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle all other numbers\u0027",
+            "name": "Last rule",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": [
+              "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com",
+              "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8c7f56ff8d827f49495efef6d8aa4aa0-090713ca9c80687f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "210a1285819d41892200495f6a0430e7",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:06 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:17:07 GMT",
+        "MS-CV": "dkiiy\u002BALXEuKIO/zrtRyeg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0w92YYwAAAAA3mXll8S70T5ywJUnR43RIUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "101ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle all other numbers\u0027",
+            "name": "Last rule",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": [
+              "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com",
+              "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com"
             ]
           }
         ]
@@ -341,11 +389,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-ac5c6fbbd51c7caf73fb1a587820cc68-aa5caf42a0c6ab28-00",
+        "traceparent": "00-67c2963f2ac5277e7ba2889ae0575ae9-36fabdcd6902e43f-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c18d6ba0ca4985f3a5e63866fe65b5cc",
+        "x-ms-client-request-id": "ff98fa459e3b143f60c49c4c12cf81e0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:05 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:06 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -355,20 +403,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:06 GMT",
-        "MS-CV": "Wjejd1IlPUSucP93fhnAkg.0",
+        "Date": "Tue, 13 Dec 2022 20:17:08 GMT",
+        "MS-CV": "56POyr9Bj02IPuyJ6oPDMQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09teXYwAAAABVXa3yDnBLSaqDTj4sMcopUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0w92YYwAAAABB6saF3w8CSY6/fn44FESYUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "102ms"
+        "X-Processing-Time": "184ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
+          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
+          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -381,11 +429,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-549a96799f8f99f1e3ae618d6a483037-74746c02a353f3d9-00",
+        "traceparent": "00-faac09587e6e6007fb315bf28679587c-4417da87ed08110b-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f1762a3a0ef261500cd1b82a52a682cf",
+        "x-ms-client-request-id": "6f87ab05c468c6416faabe6500c4ee29",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:06 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:07 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -393,58 +441,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:06 GMT",
-        "MS-CV": "UrxrCH9xRUOuswyjVyk4RQ.0",
+        "Date": "Tue, 13 Dec 2022 20:17:08 GMT",
+        "MS-CV": "mA/aij6YTEa9Ti\u002Btjln78A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09teXYwAAAABlLb9WP/x0QKhfml8KpCZKUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0xN2YYwAAAADi9/ncr1GRQYDq9aAER4L8UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "77ms"
+        "X-Processing-Time": "92ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
+          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-29472124a7044fb89ec5bcd951eb9f34-f1a6e34685511ea5-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "dddb8f7ed3970d2641fc9d8a3cc06209",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:06 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:06 GMT",
-        "MS-CV": "WNATlVkEaU2GAYw8gZUxVw.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09teXYwAAAACsInUBSxyUTbSJ1IijtM6/UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "81ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": {
+          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -459,30 +469,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-29472124a7044fb89ec5bcd951eb9f34-d6a0065f50d99fa3-00",
+        "traceparent": "00-faac09587e6e6007fb315bf28679587c-c9c2e45fcc277bc5-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "cb1d2772289d922b1b2bb47811c833fe",
+        "x-ms-client-request-id": "ded39a0a7c2ee6b0d3f5c1d9e43d2f53",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:06 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:07 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.3831a6d6-b042-f038-faf9-9f9a5c811879.com": null,
-          "sbs2.3831a6d6-b042-f038-faf9-9f9a5c811879.com": null
+          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": null,
+          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:07 GMT",
-        "MS-CV": "Z/yfwvtJxkOUxvAVLKy1bQ.0",
+        "Date": "Tue, 13 Dec 2022 20:17:08 GMT",
+        "MS-CV": "nzvb2gSLVEewGPEENZKGyw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "09teXYwAAAAD64p/\u002BMzNsRJ2xsznoM65hUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0xN2YYwAAAADw2L\u002Btp72jQr6I55AeQvNvUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "257ms"
+        "X-Processing-Time": "256ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -492,6 +502,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1411253904"
+    "RandomSeed": "609120764"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResource.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -67,7 +67,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -116,7 +116,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -176,7 +176,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -218,7 +218,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -256,7 +256,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -301,7 +301,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -336,7 +336,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -371,7 +371,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -406,7 +406,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -441,7 +441,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -479,7 +479,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "1163748775"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResource.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-ee963e2b192b27db34f4aedc47bcf148-15629df7cab16ffd-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3c3d74140874cb65cf3723eab67d0fea",
+        "traceparent": "00-745a032efd10791cbf2694d9c435af91-b9db019bb7e059d4-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1086efe039ca46db6b506d41b6a7e03a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:19 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:54 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,20 +22,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:19 GMT",
-        "MS-CV": "gJStCsiEnUeUQwyitaIjYQ.0",
+        "Date": "Mon, 05 Dec 2022 22:48:54 GMT",
+        "MS-CV": "tc1gzTzFuUm8vDy6Dp5Slw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0tNZDYwAAAABohbWNxUVRR4ZQzq\u002BX0HEBTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0VnWOYwAAAACF4b03xC7yTqUh\u002BFS\u002BJubnUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "94ms"
+        "X-Processing-Time": "212ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -43,16 +43,16 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-b320d5e4a52513ee8004d54711770896-94b29a639103f86c-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "07149e58eb499f147f1082f71316754f",
+        "traceparent": "00-76ab01d7dce14d80862b31d514684799-739a69d92a785a7f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7b3470425b2337b2776a9faa5da0371b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:20 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,20 +60,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:19 GMT",
-        "MS-CV": "6Fdf5Cy10E28hEmFLGBUKA.0",
+        "Date": "Mon, 05 Dec 2022 22:48:54 GMT",
+        "MS-CV": "J6qwHwaDS0C7E1KslXInGw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0tNZDYwAAAAAbkCRozWGkS6kjqXIZYLr/TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0VnWOYwAAAABeD6jSOk6yQb6S6PUcNQ8\u002BUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "66ms"
+        "X-Processing-Time": "77ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -81,26 +81,26 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "114",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-b320d5e4a52513ee8004d54711770896-69e3bcfc5c85df62-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c46fb819c985ed69c2c486215fc22adb",
+        "traceparent": "00-76ab01d7dce14d80862b31d514684799-a9b22e571238637e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "60d73be5aed5fd251c06fc9fb363441d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:20 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -109,20 +109,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:20 GMT",
-        "MS-CV": "Betb35n2HkaKeQ8yeVv\u002BHQ.0",
+        "Date": "Mon, 05 Dec 2022 22:48:54 GMT",
+        "MS-CV": "2/GZTY8tcUKpRjsP70gjkQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0tNZDYwAAAADBW2goKk6zQoaanorDKxP9TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0V3WOYwAAAAAvJ7S7zPNqSbd0LpDAki0oUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "151ms"
+        "X-Processing-Time": "142ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -130,18 +130,18 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "178",
+        "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-15c4d36caa946df0035c7ce7f3ca76ca-d7de07a7dda0d389-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "be5ef001971528db5f9dbc64866eb7b9",
+        "traceparent": "00-bf5e24c3c1bb395be261141a327bdb3b-18b341772c3797e9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4afb2425850d85fd3d4e99609a30e9ca",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:20 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -151,7 +151,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -160,20 +160,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:20 GMT",
-        "MS-CV": "GfK7xx7IWU\u002BUgS9wLMDk8A.0",
+        "Date": "Mon, 05 Dec 2022 22:48:54 GMT",
+        "MS-CV": "OyQQHbh2/0OtQjsEv0XMHw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0tNZDYwAAAADzsASRbMOIRq3VoytY4cXbTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0V3WOYwAAAACnZfbSEa2cRaQKCENTTkn0UFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "120ms"
+        "X-Processing-Time": "104ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -183,25 +183,25 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-f65a64c441163be6cc092de2159348e8-2d96a9a0c618cf14-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "fdd1d4c24a0d8f653427448564f33fbc",
+        "traceparent": "00-408fa8f788d3f164f8d4911279ac22fe-67e3402d741fae15-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7a5b52187fd093644b365f1d5e128414",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:20 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -211,20 +211,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:20 GMT",
-        "MS-CV": "O4c60vY700WX6fOtCJdjkQ.0",
+        "Date": "Mon, 05 Dec 2022 22:48:55 GMT",
+        "MS-CV": "fCkvhS/nnE\u002BkiXPZiE5VuQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0tdZDYwAAAABeORGvMWS6S5ydayDeCONTTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0V3WOYwAAAADVuzZ7FynWSIHSkiqlyP6KUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "88ms"
+        "X-Processing-Time": "108ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -232,16 +232,16 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-78b6b509b6b9653cbc79b97d8e0a6ac8-9a223f164ec57419-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "23f5a7e5b6b8813add4765e70c056753",
+        "traceparent": "00-54843badf5fb0f4c3a876c9609fc3c6f-c5c18e3b0239f707-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "38858225eda5600d3d52238715c563eb",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:20 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:56 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -249,20 +249,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:20 GMT",
-        "MS-CV": "dmPrGVfADUqAY66GD7autg.0",
+        "Date": "Mon, 05 Dec 2022 22:48:55 GMT",
+        "MS-CV": "qTaOOOA9Bk2fZgsDz/V\u002B0Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0tdZDYwAAAACMtRqJE5aYRYENKakTU0GpTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0V3WOYwAAAABgVo4Fe1KyQ5yRB/UD1NxRUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "157ms"
+        "X-Processing-Time": "91ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -270,44 +270,44 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "125",
+        "Content-Length": "83",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-78b6b509b6b9653cbc79b97d8e0a6ac8-ef20e3003b0c9ba7-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8b5fcc0c2df1b7cd8acf8aed5356c46b",
+        "traceparent": "00-54843badf5fb0f4c3a876c9609fc3c6f-c0d5293eae3b7e56-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6086321dca08a54cbf67fed726e0262a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:21 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:56 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           },
-          "sbs1.sipconfigtest.com": null,
-          "sbs2.sipconfigtest.com": null
+          "sbs1.com": null,
+          "sbs2.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:21 GMT",
-        "MS-CV": "QEcLFRnSREClBFqztwz/Ng.0",
+        "Date": "Mon, 05 Dec 2022 22:48:55 GMT",
+        "MS-CV": "mrCZ0mKu50KbesRwwlzydg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0tdZDYwAAAAA1UK4vF7oXTKh46i1bFGDrTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0WHWOYwAAAAAXG9URM6JUTqRU7jiP4PSfUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "342ms"
+        "X-Processing-Time": "207ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -315,16 +315,16 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-535c3cc36cc3f2af60e21364a1c5ea56-2bea5fa6d05110e8-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "de7e005d94780b01994f20c6e47d822e",
+        "traceparent": "00-dd15c6b45c58e5163648a806479ec213-8d453421cdf54a3b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "183a85c9b0ab2a2544fb3c7e5cdd7e85",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:21 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:56 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -332,17 +332,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:21 GMT",
-        "MS-CV": "UT/CeJMu8EC2RnFyg604iw.0",
+        "Date": "Mon, 05 Dec 2022 22:48:55 GMT",
+        "MS-CV": "hbWkKJGol0SSZ1KQGbUF\u002Bg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ttZDYwAAAADCOMZUD2DnS67BfEz6hnp8TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0WHWOYwAAAABgmnW\u002BR4ysRIiGizGMR9wJUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "120ms"
+        "X-Processing-Time": "75ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -351,7 +351,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1192438535"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "98700010"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-05fe20fb20a250ab78d96ab4c4575cd1-7dec280e9a84de89-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b1771613789a36565579d5bc54ae06c0",
+        "traceparent": "00-ceb6404062c6215dfe3e2681262f92ed-12fe72b6f8084071-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4f01a94df3e52006a878b17671e38d50",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:20 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:19 GMT",
-        "MS-CV": "5bewqKhJyUqFkbfKCOf3Pw.0",
+        "Date": "Tue, 13 Dec 2022 01:18:54 GMT",
+        "MS-CV": "9eOzAxo9YkaJu5FJv5KWXA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BIOOYwAAAADBUhRil5aqTKY5LpQJZezIUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/tKXYwAAAACcfEFtK6/yR7HQyQUPSNGKUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "175ms"
+        "X-Processing-Time": "121ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-946fc7b01478b9a5dd779b14396e95e1-bd7e84a196a1f189-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c3d1ae0b701184cbee122a838f53d059",
+        "traceparent": "00-ee7ac52e11eb2ee7d521e040f6c00d49-cd9e76e9f3a15803-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5f5272b9e9950d4d74377417c76f3a32",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:20 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:20 GMT",
-        "MS-CV": "\u002BbGWWiOv1kO9yunxAwuSLA.0",
+        "Date": "Tue, 13 Dec 2022 01:18:54 GMT",
+        "MS-CV": "GI2P5FecYEKVn//fMXymkA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BIOOYwAAAADub5GdtJIwQoJ6431ss4HcUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/tKXYwAAAACy1/dBMvmOR6uLqk6Yx7MCUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "86ms"
+        "X-Processing-Time": "79ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -72,21 +72,21 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "86",
+        "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-946fc7b01478b9a5dd779b14396e95e1-624883e5e5f475da-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "27355e91030ed99141b9c6935dbdd258",
+        "traceparent": "00-ee7ac52e11eb2ee7d521e040f6c00d49-9449c672d5f92d02-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9ed76f074b3407f0aba5afa35a4a92c0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:20 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:54 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:20 GMT",
-        "MS-CV": "iwc1RMkHOkOjcXvQ154nXg.0",
+        "Date": "Tue, 13 Dec 2022 01:18:54 GMT",
+        "MS-CV": "5XBSa11dxUKU9/3eMKO5GA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BIOOYwAAAAACsJ\u002Bn8VneQKamio08HVrDUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/tKXYwAAAACrtZ/Sf8VpQ5dhWMGxp4T4UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "595ms"
+        "X-Processing-Time": "255ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -121,13 +121,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "164",
+        "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-b3a06923311bdd0edde5bb2414b1d7c7-04c3f1ee4f61902b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6782ac689f52a39e4af3c2884ed3a702",
+        "traceparent": "00-8aed339d787fbe92461be3179945a50d-cfa4f749c6f0a2df-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6b288c287ae9638a5cf3dbae7fef5938",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:21 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:54 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:21 GMT",
-        "MS-CV": "us2xlyHYgUyNUxux\u002BkGtYQ.0",
+        "Date": "Tue, 13 Dec 2022 01:18:54 GMT",
+        "MS-CV": "DUMuMIXOCE2trF0n/J7xSQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BYOOYwAAAADSSvLqoFnMRLJZL7HWBO68UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/tKXYwAAAACWdrAsPdPzSYIQV8Gl5gXlUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "163ms"
+        "X-Processing-Time": "95ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com"
             ]
           }
         ]
@@ -183,11 +183,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-7a655945e1e51c8928c8302a0f609d57-cef1b824008a669f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f52b7ca8de7907b11cf88258a9382630",
+        "traceparent": "00-65619e7136c6f6c309f57876d730f8af-bedfd5fca159b97c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "026f7f3def0c6e1b824ab3ef3aa9b229",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:21 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:54 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -197,20 +197,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:21 GMT",
-        "MS-CV": "NIfQThL\u002BTUSGSgAJGFki4A.0",
+        "Date": "Tue, 13 Dec 2022 01:18:55 GMT",
+        "MS-CV": "KrtuOiF520afz71Ft3kw9A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BYOOYwAAAABkUSf6nNepT4girBb9ouPoUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/9KXYwAAAADpMQqJrpKlR6uNmKSegpAiUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "172ms"
+        "X-Processing-Time": "128ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -223,11 +223,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-2ac43f649e142e3079454f346ab571f5-5a3a5808b44151e6-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e21bd13f69d1f106c092dc1b41088a6e",
+        "traceparent": "00-67e946e897924a29f73d8ae8b8f7d23d-a5b5c563c3e5c72d-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3beeb3a4ce478c48e5744240704288bc",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:22 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:54 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -235,20 +235,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:21 GMT",
-        "MS-CV": "p53P3ZJ4xUKr/9Tz8wpQ7g.0",
+        "Date": "Tue, 13 Dec 2022 01:18:55 GMT",
+        "MS-CV": "t69pUJvoLEKPaXXSbM28bw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BoOOYwAAAACcKJbSUSWUTaaOtfwzgLoTUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/9KXYwAAAABpMUK5ovpOTYr2K\u002BFq3\u002BmFUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "88ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -261,39 +261,39 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "83",
+        "Content-Length": "194",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-2ac43f649e142e3079454f346ab571f5-c846a1837b57a5ef-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e1eac412dc9289defb7a4a591d45f912",
+        "traceparent": "00-67e946e897924a29f73d8ae8b8f7d23d-3b00b806a523eae9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "db65764c90da39b470b9e99ec69a28b2",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:22 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
             "sipSignalingPort": 3333
           },
-          "sbs1.com": null,
-          "sbs2.com": null
+          "sbs1.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": null,
+          "sbs2.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:22 GMT",
-        "MS-CV": "yROahJxmhEWcVsmy1mfYxQ.0",
+        "Date": "Tue, 13 Dec 2022 01:18:55 GMT",
+        "MS-CV": "mXoK86/LlUyWn8oE\u002BZ0UzQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BoOOYwAAAACg9081i5oYQoMSw33tve7qUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/9KXYwAAAACgy\u002BiBWQ6RRqHR2AGKBtOhUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "551ms"
+        "X-Processing-Time": "282ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -306,11 +306,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-5a5a90215ab4a489aad53c8a6ca685c4-84e7c69ef884d82a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7c4991cdc4b73f31753935e70296c613",
+        "traceparent": "00-d34d343d1229606b5c44e64bd77cadd8-6f9be08fa16d2db1-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cc09b1411d006ff136e21d98acdafe3f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:23 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -318,17 +318,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:22 GMT",
-        "MS-CV": "3F9mRMQiKk2QSRrRXXQmdA.0",
+        "Date": "Tue, 13 Dec 2022 01:18:55 GMT",
+        "MS-CV": "IFaRAsM6zEOCd6Xo5wneZw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BoOOYwAAAAC5IhfKOplwT57aJrd4gLNoUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/9KXYwAAAAAwb5zovb0JQ7K4rF6K7h92UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
+        "X-Processing-Time": "91ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -341,11 +341,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-705dc6c152d54b6855be03ca8f1e5e09-57228bdbfa5bcb62-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e446136d444d629ef391e7571fadd47a",
+        "traceparent": "00-5a382f1b7f915b530d6907777ece66a9-6263fec36ffe2d71-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c3a2f7c2d743144ffeb5ca8de4a9c64a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:23 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -353,17 +353,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:22 GMT",
-        "MS-CV": "I1a2BzByFUah2ynFGF0C/Q.0",
+        "Date": "Tue, 13 Dec 2022 01:18:56 GMT",
+        "MS-CV": "FZc5VZdXVEedMCp1Ua925g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002B4OOYwAAAAA0zD4dPaJATYiCFVaXNzcLUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ANOXYwAAAAC6S2RUdobjQa6n10nKuc6\u002BUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
+        "X-Processing-Time": "77ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -376,11 +376,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-b5d4213c2b05c98e0143ef7f279c6d37-12a73b26385d68cf-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "af4dca980ebf4db693ab6b59a6f78764",
+        "traceparent": "00-55ce728ed183e6c0af5413e5036c60b4-5eceb38ff9e3522e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "beff904bbc392fbc85f6a4f7731c8c95",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:23 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -388,17 +388,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:22 GMT",
-        "MS-CV": "LEmI0nTtr0qG9B5oHTNK4A.0",
+        "Date": "Tue, 13 Dec 2022 01:18:56 GMT",
+        "MS-CV": "j\u002BMVMLK1a0avKRhaeRZ/xg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002B4OOYwAAAAC3xzFLSAc3TKNwd\u002BkxqqM3UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ANOXYwAAAACgBcLNFp2kRLcimy\u002BhidicUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
+        "X-Processing-Time": "76ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -411,11 +411,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-59b95d654e6a0c8b7341db17142cb6fa-695ca24b5c6bbc5d-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0aec36b314ff88c5f3e68926ddda1fc8",
+        "traceparent": "00-91cdd5f95ba197068c6a28746c59a170-e73f2c289a905d22-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cedcaabb65f7696e62f4cd4b53638b8c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:23 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:56 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -423,17 +423,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:22 GMT",
-        "MS-CV": "Y56ozr4pY0\u002Bu0vNiAlQN4A.0",
+        "Date": "Tue, 13 Dec 2022 01:18:56 GMT",
+        "MS-CV": "7jrDUm9uiEuBoqA90c5wcA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002B4OOYwAAAABhJlxX0IwUQrHNlgNtEiZbUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ANOXYwAAAADpDacgBZItRJW0CY0I4sXRUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "88ms"
+        "X-Processing-Time": "166ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -446,31 +446,31 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "30",
+        "Content-Length": "67",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-59b95d654e6a0c8b7341db17142cb6fa-39efb99a927cca2a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "374fbb6417485f545cf951a1d944bcfc",
+        "traceparent": "00-91cdd5f95ba197068c6a28746c59a170-ae1151c6974bcec5-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1c4cd21b3fdb06063b733e4d3357a1e2",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:23 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:56 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.com": null
+          "newsbs.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:23 GMT",
-        "MS-CV": "dDclw1bHNEOUt2I0X2wntg.0",
+        "Date": "Tue, 13 Dec 2022 01:18:56 GMT",
+        "MS-CV": "MYFqJZWzJEuYsjYK\u002BCFT2w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002B4OOYwAAAABWxgahu\u002B3BQ6zL3JLu5uZhUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ANOXYwAAAABAswkhri4kTZ8dxgDAJtK4UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "278ms"
+        "X-Processing-Time": "125ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -480,6 +480,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1163748775"
+    "RandomSeed": "327616324"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-ceb6404062c6215dfe3e2681262f92ed-12fe72b6f8084071-00",
+        "traceparent": "00-2aa2c5edd184375cc6e65065ae90b034-585658620be2579b-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4f01a94df3e52006a878b17671e38d50",
+        "x-ms-client-request-id": "9460e048c42ec3e8260e05c78b849804",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:53 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:39 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:54 GMT",
-        "MS-CV": "9eOzAxo9YkaJu5FJv5KWXA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:39 GMT",
+        "MS-CV": "zkONfAWggkiTeQrVJqJKHg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/tKXYwAAAACcfEFtK6/yR7HQyQUPSNGKUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0qN2YYwAAAADiKxKr0cehTKC\u002BrMa/9dRCUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "121ms"
+        "X-Processing-Time": "112ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-ee7ac52e11eb2ee7d521e040f6c00d49-cd9e76e9f3a15803-00",
+        "traceparent": "00-da6153a52b9d615acfd5e059047691b0-0be1a3e87bf9ee11-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5f5272b9e9950d4d74377417c76f3a32",
+        "x-ms-client-request-id": "68382e47a402bddfd4ed4771356898d6",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:53 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:39 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:54 GMT",
-        "MS-CV": "GI2P5FecYEKVn//fMXymkA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:39 GMT",
+        "MS-CV": "bHs5fGqoDEGqbR5HmeqaCw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/tKXYwAAAACy1/dBMvmOR6uLqk6Yx7MCUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0qN2YYwAAAAB9CvFobIbLSImBBx5RS8TUUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "79ms"
+        "X-Processing-Time": "84ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-ee7ac52e11eb2ee7d521e040f6c00d49-9449c672d5f92d02-00",
+        "traceparent": "00-da6153a52b9d615acfd5e059047691b0-99c28cf65cb48348-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "9ed76f074b3407f0aba5afa35a4a92c0",
+        "x-ms-client-request-id": "2ebf349c411c185710a2dfdebf36a69c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:54 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:39 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
+          "sbs1.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
+          "sbs2.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:54 GMT",
-        "MS-CV": "5XBSa11dxUKU9/3eMKO5GA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:39 GMT",
+        "MS-CV": "Lx7LkskPMkuny2A4msh/0g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/tKXYwAAAACrtZ/Sf8VpQ5dhWMGxp4T4UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0qN2YYwAAAAA7YD7zyqzGTLChrRc2mJ2KUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "255ms"
+        "X-Processing-Time": "267ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
+          "sbs1.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
+          "sbs2.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-8aed339d787fbe92461be3179945a50d-cfa4f749c6f0a2df-00",
+        "traceparent": "00-b17ae8be4f6e5a9c861bab4e12a8c1bf-68c8021569b78bc0-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6b288c287ae9638a5cf3dbae7fef5938",
+        "x-ms-client-request-id": "8b94f7cf49f0a38501a2c0417c778dbd",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:54 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:39 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com"
+              "sbs1.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:54 GMT",
-        "MS-CV": "DUMuMIXOCE2trF0n/J7xSQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:40 GMT",
+        "MS-CV": "wTCT7IdomEO/QVrapDPr2Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/tKXYwAAAACWdrAsPdPzSYIQV8Gl5gXlUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0qN2YYwAAAACR/rCSiFBSTbNLnaPssQOUUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "95ms"
+        "X-Processing-Time": "107ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
+          "sbs1.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
+          "sbs2.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com"
+              "sbs1.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com"
             ]
           }
         ]
@@ -183,11 +183,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-65619e7136c6f6c309f57876d730f8af-bedfd5fca159b97c-00",
+        "traceparent": "00-61cccf3231c273bca8ded9fc6f19389f-341aeac666b87021-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "026f7f3def0c6e1b824ab3ef3aa9b229",
+        "x-ms-client-request-id": "572a2f766ac505e8d7205860c501fd9e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:54 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:40 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -197,20 +197,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:55 GMT",
-        "MS-CV": "KrtuOiF520afz71Ft3kw9A.0",
+        "Date": "Tue, 13 Dec 2022 20:16:40 GMT",
+        "MS-CV": "qk8XXZQhxkS4XcYjSYCQmQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/9KXYwAAAADpMQqJrpKlR6uNmKSegpAiUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0qd2YYwAAAADxUf3Rq/wNR73OycM99UvgUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "128ms"
+        "X-Processing-Time": "195ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
+          "sbs1.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
+          "sbs2.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -223,11 +223,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-67e946e897924a29f73d8ae8b8f7d23d-a5b5c563c3e5c72d-00",
+        "traceparent": "00-15ec5b68e4a77a0b4a246ac6f280f2ae-07c80fb08b4fbc26-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3beeb3a4ce478c48e5744240704288bc",
+        "x-ms-client-request-id": "3da1aa470dd453e5af1b2d7981169b99",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:54 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:40 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -235,20 +235,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:55 GMT",
-        "MS-CV": "t69pUJvoLEKPaXXSbM28bw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:40 GMT",
+        "MS-CV": "Q9IRqw/Kl0GouGmTnH6sIg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/9KXYwAAAABpMUK5ovpOTYr2K\u002BFq3\u002BmFUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0qd2YYwAAAAC7pZYwq7ROR6qe6P3FtTGlUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "88ms"
+        "X-Processing-Time": "194ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
+          "sbs1.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
+          "sbs2.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,37 +263,37 @@
         "Authorization": "Sanitized",
         "Content-Length": "194",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-67e946e897924a29f73d8ae8b8f7d23d-3b00b806a523eae9-00",
+        "traceparent": "00-15ec5b68e4a77a0b4a246ac6f280f2ae-eb68629b071a7319-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "db65764c90da39b470b9e99ec69a28b2",
+        "x-ms-client-request-id": "906822144f0b65d70f8fb3cff125deff",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:55 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:40 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
+          "newsbs.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
             "sipSignalingPort": 3333
           },
-          "sbs1.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": null,
-          "sbs2.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": null
+          "sbs1.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": null,
+          "sbs2.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:55 GMT",
-        "MS-CV": "mXoK86/LlUyWn8oE\u002BZ0UzQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:41 GMT",
+        "MS-CV": "LrZU5Ce1g06ZDRQ6TQrZuQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/9KXYwAAAACgy\u002BiBWQ6RRqHR2AGKBtOhUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0qd2YYwAAAAB3YtK0UgUUTqk76ki2wzzwUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "282ms"
+        "X-Processing-Time": "914ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
+          "newsbs.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -306,11 +306,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-d34d343d1229606b5c44e64bd77cadd8-6f9be08fa16d2db1-00",
+        "traceparent": "00-16d499dc1ee1701272957c38ca6fb2dd-ed2b81002684ab1c-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "cc09b1411d006ff136e21d98acdafe3f",
+        "x-ms-client-request-id": "d2fa21a550d568e849d7a7a93c6e83c0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:55 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:41 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -318,17 +318,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:55 GMT",
-        "MS-CV": "IFaRAsM6zEOCd6Xo5wneZw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:42 GMT",
+        "MS-CV": "RE78mqsEhkesIfwiooZQBw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/9KXYwAAAAAwb5zovb0JQ7K4rF6K7h92UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0qt2YYwAAAAAaxwhkRIYSQLVekat\u002BQOn2UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "91ms"
+        "X-Processing-Time": "82ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
+          "newsbs.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -341,11 +341,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-5a382f1b7f915b530d6907777ece66a9-6263fec36ffe2d71-00",
+        "traceparent": "00-70de81e1a8faa0fc0f02fa852945961a-4467966dc5987a01-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c3a2f7c2d743144ffeb5ca8de4a9c64a",
+        "x-ms-client-request-id": "a24bbe856d99f792d33c2e455916618a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:55 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:42 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -353,17 +353,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:56 GMT",
-        "MS-CV": "FZc5VZdXVEedMCp1Ua925g.0",
+        "Date": "Tue, 13 Dec 2022 20:16:42 GMT",
+        "MS-CV": "KI5XOpSDlEetuwfKsQ84KQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ANOXYwAAAAC6S2RUdobjQa6n10nKuc6\u002BUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0q92YYwAAAACzLSsawW24TYuuZHzRkBPPUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "77ms"
+        "X-Processing-Time": "80ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
+          "newsbs.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -376,11 +376,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-55ce728ed183e6c0af5413e5036c60b4-5eceb38ff9e3522e-00",
+        "traceparent": "00-6ea519292223b7fdecc4ff16df744899-aa2893f6eb0e8182-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "beff904bbc392fbc85f6a4f7731c8c95",
+        "x-ms-client-request-id": "5fd42d3dc91cc4c439ff4634a72e29a1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:55 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:42 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -388,17 +388,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:56 GMT",
-        "MS-CV": "j\u002BMVMLK1a0avKRhaeRZ/xg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:42 GMT",
+        "MS-CV": "09xr41vxFUiIkKlrdjzM8w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ANOXYwAAAACgBcLNFp2kRLcimy\u002BhidicUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0q92YYwAAAABB3DQ4gIZOQLCSkZ7GRlfAUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "76ms"
+        "X-Processing-Time": "84ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
+          "newsbs.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -411,11 +411,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-91cdd5f95ba197068c6a28746c59a170-e73f2c289a905d22-00",
+        "traceparent": "00-374e6815e766f57b952fedbddc2e9197-c63fe9a466924648-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "cedcaabb65f7696e62f4cd4b53638b8c",
+        "x-ms-client-request-id": "324af30b3bd937668f02fe9921a30f33",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:56 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:42 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -423,17 +423,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:56 GMT",
-        "MS-CV": "7jrDUm9uiEuBoqA90c5wcA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:42 GMT",
+        "MS-CV": "F0AwmMGwr0SmwyO98wHlKQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ANOXYwAAAADpDacgBZItRJW0CY0I4sXRUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0q92YYwAAAACkL7jLRoJTRp8YzAkS8RpJUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "166ms"
+        "X-Processing-Time": "87ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": {
+          "newsbs.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -448,29 +448,29 @@
         "Authorization": "Sanitized",
         "Content-Length": "67",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-91cdd5f95ba197068c6a28746c59a170-ae1151c6974bcec5-00",
+        "traceparent": "00-374e6815e766f57b952fedbddc2e9197-aef30e103230240e-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1c4cd21b3fdb06063b733e4d3357a1e2",
+        "x-ms-client-request-id": "0e6b1d75239abba4fa866999265e50a4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:56 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:42 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.57c6b1fb-0c1b-04c1-a4b6-dce2de3cd920.com": null
+          "newsbs.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:56 GMT",
-        "MS-CV": "MYFqJZWzJEuYsjYK\u002BCFT2w.0",
+        "Date": "Tue, 13 Dec 2022 20:16:43 GMT",
+        "MS-CV": "4dLBMO7O80Cwky9Ea3Q8Dw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ANOXYwAAAABAswkhri4kTZ8dxgDAJtK4UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0q92YYwAAAAAX1MNDep9ESZMk\u002BcRywFHYUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "125ms"
+        "X-Processing-Time": "283ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -480,6 +480,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "327616324"
+    "RandomSeed": "242078849"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-745a032efd10791cbf2694d9c435af91-b9db019bb7e059d4-00",
+        "traceparent": "00-05fe20fb20a250ab78d96ab4c4575cd1-7dec280e9a84de89-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1086efe039ca46db6b506d41b6a7e03a",
+        "x-ms-client-request-id": "b1771613789a36565579d5bc54ae06c0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:54 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:20 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,23 +22,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:54 GMT",
-        "MS-CV": "tc1gzTzFuUm8vDy6Dp5Slw.0",
+        "Date": "Mon, 05 Dec 2022 23:51:19 GMT",
+        "MS-CV": "5bewqKhJyUqFkbfKCOf3Pw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0VnWOYwAAAACF4b03xC7yTqUh\u002BFS\u002BJubnUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BIOOYwAAAADBUhRil5aqTKY5LpQJZezIUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "212ms"
+        "X-Processing-Time": "175ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -48,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-76ab01d7dce14d80862b31d514684799-739a69d92a785a7f-00",
+        "traceparent": "00-946fc7b01478b9a5dd779b14396e95e1-bd7e84a196a1f189-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7b3470425b2337b2776a9faa5da0371b",
+        "x-ms-client-request-id": "c3d1ae0b701184cbee122a838f53d059",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:55 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:20 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,23 +53,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:54 GMT",
-        "MS-CV": "J6qwHwaDS0C7E1KslXInGw.0",
+        "Date": "Mon, 05 Dec 2022 23:51:20 GMT",
+        "MS-CV": "\u002BbGWWiOv1kO9yunxAwuSLA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0VnWOYwAAAABeD6jSOk6yQb6S6PUcNQ8\u002BUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BIOOYwAAAADub5GdtJIwQoJ6431ss4HcUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "77ms"
+        "X-Processing-Time": "86ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -88,11 +74,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-76ab01d7dce14d80862b31d514684799-a9b22e571238637e-00",
+        "traceparent": "00-946fc7b01478b9a5dd779b14396e95e1-624883e5e5f475da-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "60d73be5aed5fd251c06fc9fb363441d",
+        "x-ms-client-request-id": "27355e91030ed99141b9c6935dbdd258",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:55 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:20 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -109,13 +95,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:54 GMT",
-        "MS-CV": "2/GZTY8tcUKpRjsP70gjkQ.0",
+        "Date": "Mon, 05 Dec 2022 23:51:20 GMT",
+        "MS-CV": "iwc1RMkHOkOjcXvQ154nXg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0V3WOYwAAAAAvJ7S7zPNqSbd0LpDAki0oUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BIOOYwAAAAACsJ\u002Bn8VneQKamio08HVrDUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "142ms"
+        "X-Processing-Time": "595ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -137,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-bf5e24c3c1bb395be261141a327bdb3b-18b341772c3797e9-00",
+        "traceparent": "00-b3a06923311bdd0edde5bb2414b1d7c7-04c3f1ee4f61902b-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4afb2425850d85fd3d4e99609a30e9ca",
+        "x-ms-client-request-id": "6782ac689f52a39e4af3c2884ed3a702",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:55 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:21 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -160,13 +146,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:54 GMT",
-        "MS-CV": "OyQQHbh2/0OtQjsEv0XMHw.0",
+        "Date": "Mon, 05 Dec 2022 23:51:21 GMT",
+        "MS-CV": "us2xlyHYgUyNUxux\u002BkGtYQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0V3WOYwAAAACnZfbSEa2cRaQKCENTTkn0UFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BYOOYwAAAADSSvLqoFnMRLJZL7HWBO68UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "104ms"
+        "X-Processing-Time": "163ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -197,11 +183,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-408fa8f788d3f164f8d4911279ac22fe-67e3402d741fae15-00",
+        "traceparent": "00-7a655945e1e51c8928c8302a0f609d57-cef1b824008a669f-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7a5b52187fd093644b365f1d5e128414",
+        "x-ms-client-request-id": "f52b7ca8de7907b11cf88258a9382630",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:55 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:21 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -211,13 +197,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:55 GMT",
-        "MS-CV": "fCkvhS/nnE\u002BkiXPZiE5VuQ.0",
+        "Date": "Mon, 05 Dec 2022 23:51:21 GMT",
+        "MS-CV": "NIfQThL\u002BTUSGSgAJGFki4A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0V3WOYwAAAADVuzZ7FynWSIHSkiqlyP6KUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BYOOYwAAAABkUSf6nNepT4girBb9ouPoUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "108ms"
+        "X-Processing-Time": "172ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -237,11 +223,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-54843badf5fb0f4c3a876c9609fc3c6f-c5c18e3b0239f707-00",
+        "traceparent": "00-2ac43f649e142e3079454f346ab571f5-5a3a5808b44151e6-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "38858225eda5600d3d52238715c563eb",
+        "x-ms-client-request-id": "e21bd13f69d1f106c092dc1b41088a6e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:56 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:22 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -249,13 +235,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:55 GMT",
-        "MS-CV": "qTaOOOA9Bk2fZgsDz/V\u002B0Q.0",
+        "Date": "Mon, 05 Dec 2022 23:51:21 GMT",
+        "MS-CV": "p53P3ZJ4xUKr/9Tz8wpQ7g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0V3WOYwAAAABgVo4Fe1KyQ5yRB/UD1NxRUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BoOOYwAAAACcKJbSUSWUTaaOtfwzgLoTUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "91ms"
+        "X-Processing-Time": "88ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -277,11 +263,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "83",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-54843badf5fb0f4c3a876c9609fc3c6f-c0d5293eae3b7e56-00",
+        "traceparent": "00-2ac43f649e142e3079454f346ab571f5-c846a1837b57a5ef-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6086321dca08a54cbf67fed726e0262a",
+        "x-ms-client-request-id": "e1eac412dc9289defb7a4a591d45f912",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:56 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:22 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -297,13 +283,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:55 GMT",
-        "MS-CV": "mrCZ0mKu50KbesRwwlzydg.0",
+        "Date": "Mon, 05 Dec 2022 23:51:22 GMT",
+        "MS-CV": "yROahJxmhEWcVsmy1mfYxQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0WHWOYwAAAAAXG9URM6JUTqRU7jiP4PSfUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BoOOYwAAAACg9081i5oYQoMSw33tve7qUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "207ms"
+        "X-Processing-Time": "551ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -320,11 +306,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-dd15c6b45c58e5163648a806479ec213-8d453421cdf54a3b-00",
+        "traceparent": "00-5a5a90215ab4a489aad53c8a6ca685c4-84e7c69ef884d82a-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "183a85c9b0ab2a2544fb3c7e5cdd7e85",
+        "x-ms-client-request-id": "7c4991cdc4b73f31753935e70296c613",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:56 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:23 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -332,13 +318,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:55 GMT",
-        "MS-CV": "hbWkKJGol0SSZ1KQGbUF\u002Bg.0",
+        "Date": "Mon, 05 Dec 2022 23:51:22 GMT",
+        "MS-CV": "3F9mRMQiKk2QSRrRXXQmdA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0WHWOYwAAAABgmnW\u002BR4ysRIiGizGMR9wJUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BoOOYwAAAAC5IhfKOplwT57aJrd4gLNoUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "75ms"
+        "X-Processing-Time": "87ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -348,10 +334,152 @@
         },
         "routes": []
       }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-705dc6c152d54b6855be03ca8f1e5e09-57228bdbfa5bcb62-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e446136d444d629ef391e7571fadd47a",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:23 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:22 GMT",
+        "MS-CV": "I1a2BzByFUah2ynFGF0C/Q.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0\u002B4OOYwAAAAA0zD4dPaJATYiCFVaXNzcLUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "84ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b5d4213c2b05c98e0143ef7f279c6d37-12a73b26385d68cf-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "af4dca980ebf4db693ab6b59a6f78764",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:23 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:22 GMT",
+        "MS-CV": "LEmI0nTtr0qG9B5oHTNK4A.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0\u002B4OOYwAAAAC3xzFLSAc3TKNwd\u002BkxqqM3UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "89ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-59b95d654e6a0c8b7341db17142cb6fa-695ca24b5c6bbc5d-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0aec36b314ff88c5f3e68926ddda1fc8",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:23 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:22 GMT",
+        "MS-CV": "Y56ozr4pY0\u002Bu0vNiAlQN4A.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0\u002B4OOYwAAAABhJlxX0IwUQrHNlgNtEiZbUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "88ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "30",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-59b95d654e6a0c8b7341db17142cb6fa-39efb99a927cca2a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "374fbb6417485f545cf951a1d944bcfc",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:23 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "newsbs.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:23 GMT",
+        "MS-CV": "dDclw1bHNEOUt2I0X2wntg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0\u002B4OOYwAAAABWxgahu\u002B3BQ6zL3JLu5uZhUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "278ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "98700010"
+    "RandomSeed": "1163748775"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-09a1869f15ae7eceb51c747a10b2f389-0fe6264460667208-00",
+        "traceparent": "00-8da4034184f6df3eebe1b441f388574d-18e4d57fe33fe856-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "bbf44f9232091e6bde7154d4cdb3abbf",
+        "x-ms-client-request-id": "f9f6394607139b7a26679eb209b01a48",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:20 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:50 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,23 +22,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:20 GMT",
-        "MS-CV": "C6ulwC/mg0e8yI2RskK35A.0",
+        "Date": "Mon, 05 Dec 2022 23:51:51 GMT",
+        "MS-CV": "0sYjSx47KUqxsNtspkRDPw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0cHWOYwAAAABh0JjQbf8dRYTIMVpFvir2UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0FoSOYwAAAABUMKc/VqrKR6H5p99Sw1V9UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "134ms"
+        "X-Processing-Time": "187ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -48,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-48ad49e1d759b4d9e52616c246f3821f-5d892a7f64717fc0-00",
+        "traceparent": "00-d67f02efe6fce9a0e5f08616110c8282-5e36dff6958037c7-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8b04f8cd3a1f6f12482f705a789eb671",
+        "x-ms-client-request-id": "ac232520d1210aed3be021992196d814",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:20 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:51 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,23 +53,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:20 GMT",
-        "MS-CV": "JjeUKgphSkuSFvIQ6EXb0Q.0",
+        "Date": "Mon, 05 Dec 2022 23:51:51 GMT",
+        "MS-CV": "ye7jpw14pEu5POTz0XFSNg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0cHWOYwAAAADJnwtw9dgeR4d74bvr3R1aUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0F4SOYwAAAADG6/iyVTJtT6ABZDkQI1nbUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "83ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -88,11 +74,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-48ad49e1d759b4d9e52616c246f3821f-582ba751d161fa6f-00",
+        "traceparent": "00-d67f02efe6fce9a0e5f08616110c8282-1c5b634d2ccf6ad2-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e6a26b4842d741bfeb73848357c9adf1",
+        "x-ms-client-request-id": "d66542054d5d1b70ddbee175c9e4b5da",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:20 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:51 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -109,13 +95,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:20 GMT",
-        "MS-CV": "oVH1ZlPWHEG551xXx1mzfg.0",
+        "Date": "Mon, 05 Dec 2022 23:51:52 GMT",
+        "MS-CV": "X4zVY4BQCUOsWjJfdaEwdA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0cHWOYwAAAADnfdX/yEAXT4k59a7GnAt8UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0F4SOYwAAAAC82/3Yc2uURbyeAVlD6ojdUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "171ms"
+        "X-Processing-Time": "586ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -137,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-295962c169a8a828c3a2a80aa0e3513a-c8e5bd0135ddd543-00",
+        "traceparent": "00-acc620f2b81977f21fec757e8a0ba10b-461c10dbfb7c6750-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1232612d4c9b589b3c8573d9c111a63f",
+        "x-ms-client-request-id": "608f28ad94b5741b4becbd32e5e07a8f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:20 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -160,13 +146,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:20 GMT",
-        "MS-CV": "H7J\u002BDw\u002BIRkSRV7S7/sWKBw.0",
+        "Date": "Mon, 05 Dec 2022 23:51:52 GMT",
+        "MS-CV": "NZmD65mBO0O\u002Bfb1VZd7oZw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0cHWOYwAAAABD6V57ToXaToufeG9q9fCKUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0GISOYwAAAADiDgspWc12Q5kSx3FXNxpdUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "99ms"
+        "X-Processing-Time": "245ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -197,11 +183,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-4cea53fff60c97948b1a139535f378a4-869c49dd947f6039-00",
+        "traceparent": "00-57b3dad4d3898598fff87f483238c365-1f84cd95382f5f2f-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "628be2bbc5108ae739c2a0abb68f177e",
+        "x-ms-client-request-id": "c7ac8a8f434bd3eab407cf62f0774056",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:21 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -211,13 +197,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:20 GMT",
-        "MS-CV": "fzSWt0ACdU2QVh4yCQYdcQ.0",
+        "Date": "Mon, 05 Dec 2022 23:51:52 GMT",
+        "MS-CV": "vCWOeCdcSUi0NkvX5nj0Kg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0cHWOYwAAAAC0wE6W1ibwSZIkgAXJTjaXUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0GISOYwAAAADiP8jZu88KRYwbDo25KNZuUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "104ms"
+        "X-Processing-Time": "167ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -237,11 +223,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-7f7839d9348a0fe5b941fcd0a6a65fd9-a7677ab05ebc1588-00",
+        "traceparent": "00-5f7d51f6092edc0608f283bd270bd780-78d22d534b25e424-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "172d7e81a36bfbd6cf4aa952cfe57fda",
+        "x-ms-client-request-id": "f9eb472b7706705f26f08b718f3d35fc",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:21 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -249,13 +235,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:21 GMT",
-        "MS-CV": "GVbiMqe8EEiDRMhzIEz/0A.0",
+        "Date": "Mon, 05 Dec 2022 23:51:52 GMT",
+        "MS-CV": "qKeo0sG44k2c3Rx3XhbO0g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0cXWOYwAAAAA/Fe\u002Bj850ZR4ESJM\u002BOp7DwUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0GISOYwAAAADkOyzojRxCSJOnXH8F8DuLUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
+        "X-Processing-Time": "84ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -277,11 +263,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "83",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-7f7839d9348a0fe5b941fcd0a6a65fd9-4ccd833f8136a1db-00",
+        "traceparent": "00-5f7d51f6092edc0608f283bd270bd780-d6e4b32a4bfb058a-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "74c744cd4b3e68e179a8d9d8acefa2ac",
+        "x-ms-client-request-id": "3ee65144ee376a8f3dbbabadc5b984d4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:21 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -297,13 +283,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:21 GMT",
-        "MS-CV": "Siqg46YnKE\u002BMlCS9J8Gu7w.0",
+        "Date": "Mon, 05 Dec 2022 23:51:53 GMT",
+        "MS-CV": "61rTQuCRSE2Ciqpxmucm3w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0cXWOYwAAAABSoFIS8u3DTptT3e\u002BQSOXeUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0GISOYwAAAAA\u002BHSssazLMTYS4bZrXVA5QUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "389ms"
+        "X-Processing-Time": "721ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -320,11 +306,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-34f2a7b2f63f634afba2ece7cdbd4f2f-562ba9f002b62b53-00",
+        "traceparent": "00-9ea0cc8e20191084cc2f05f5680ad9c5-34aebfe993c99b25-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4257f46e8ee417d40c8f92c61b95ba54",
+        "x-ms-client-request-id": "9e0767ab81f517882b3ca15ab8794476",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:21 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -332,13 +318,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:21 GMT",
-        "MS-CV": "o6cD1XIXVkuqz2s6jGR8LA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:53 GMT",
+        "MS-CV": "Gn/o3gTpIUe0wHlLzZtRvQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0cXWOYwAAAAANNLBILi4JRo61jPPf3lozUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0GYSOYwAAAAA2FiN/LPiFSIbUjmZ7Wa\u002BXUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "86ms"
+        "X-Processing-Time": "82ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -348,10 +334,152 @@
         },
         "routes": []
       }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8e8662ed2cbfcd79cde9500b2986ee24-dab68129b1b3e056-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9e1ed2d202913d1eb780bb4bccb1aa6d",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:53 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:54 GMT",
+        "MS-CV": "ILh7WPczQE2BPunKlD1ipA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0GYSOYwAAAABHS/fvagPmSKNR71lc95rBUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "89ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2fe1220100332964e7ac72e12becd73b-63b3f20e4e78d2bb-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "27c6b66c9736c207c9ce13fb4d35b2c4",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:54 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:54 GMT",
+        "MS-CV": "hooYl\u002BzNFUqwIVDtvfrQEw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0GoSOYwAAAABaJ7VGIQpCRJc1vLfi/dY4UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "95ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ac049d906142ff14b592c488ca228fdf-8539095c353849ee-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f3db3477e69ba94348cae674c53d4b79",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:54 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:54 GMT",
+        "MS-CV": "ZvAA/lZYNU2jz9RQo58rVA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0GoSOYwAAAABVIQFRob\u002BoR4qVDdhA9FtfUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "91ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "newsbs.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "30",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-ac049d906142ff14b592c488ca228fdf-c6f2a5d160a8b01f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "01ed33911cb23a40cb5bd5c2ee23f082",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:54 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "newsbs.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:54 GMT",
+        "MS-CV": "ymnR6M4ou0eKeyCgJ3fDnQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0GoSOYwAAAADlqyOEcIP7R6i0WDqZ82eJUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "276ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1409171742"
+    "RandomSeed": "262348763"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResourceAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-dfa5bdd6d7140d7030e6a80303b78e53-e56f32ea93beb1d6-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0649d5958984267498885aecb60a94c1",
+        "traceparent": "00-09a1869f15ae7eceb51c747a10b2f389-0fe6264460667208-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bbf44f9232091e6bde7154d4cdb3abbf",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:32 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:20 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,20 +22,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:32 GMT",
-        "MS-CV": "R4677SvzbkabAY3OJOHuAA.0",
+        "Date": "Mon, 05 Dec 2022 22:49:20 GMT",
+        "MS-CV": "C6ulwC/mg0e8yI2RskK35A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wdZDYwAAAADjTxN/O67MS4MtJEY1ANZUTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0cHWOYwAAAABh0JjQbf8dRYTIMVpFvir2UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
+        "X-Processing-Time": "134ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -43,16 +43,16 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-320386fba497d5383687473610b93ed3-bf32422b2210d63b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1829d7c4b7c28af1411d6aabf125b17a",
+        "traceparent": "00-48ad49e1d759b4d9e52616c246f3821f-5d892a7f64717fc0-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8b04f8cd3a1f6f12482f705a789eb671",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:32 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:20 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,20 +60,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:32 GMT",
-        "MS-CV": "XhVB2pqbp0eVVc5o/dqbYA.0",
+        "Date": "Mon, 05 Dec 2022 22:49:20 GMT",
+        "MS-CV": "JjeUKgphSkuSFvIQ6EXb0Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wdZDYwAAAABzVB1Gn4BfRZaWUOdyxGzITFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0cHWOYwAAAADJnwtw9dgeR4d74bvr3R1aUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "67ms"
+        "X-Processing-Time": "83ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -81,26 +81,26 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "114",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-320386fba497d5383687473610b93ed3-086617877acd72c1-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "bb101b7e32b342b11eccf985cf3e75ab",
+        "traceparent": "00-48ad49e1d759b4d9e52616c246f3821f-582ba751d161fa6f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e6a26b4842d741bfeb73848357c9adf1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:32 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:20 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -109,20 +109,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:32 GMT",
-        "MS-CV": "LKTyNYsuXUuVR\u002BcmpojgTA.0",
+        "Date": "Mon, 05 Dec 2022 22:49:20 GMT",
+        "MS-CV": "oVH1ZlPWHEG551xXx1mzfg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wdZDYwAAAAChghYpyEmuQoomVp6MrJjnTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0cHWOYwAAAADnfdX/yEAXT4k59a7GnAt8UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "146ms"
+        "X-Processing-Time": "171ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -130,18 +130,18 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "178",
+        "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-9a8392bd66402811d0cfb3ac3fcd9cc7-077055b39931d37c-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a6c431c41394dd9ae4bec4661ec83472",
+        "traceparent": "00-295962c169a8a828c3a2a80aa0e3513a-c8e5bd0135ddd543-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1232612d4c9b589b3c8573d9c111a63f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:33 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:20 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -151,7 +151,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -160,20 +160,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:33 GMT",
-        "MS-CV": "uCa6thQsMU6N9hKm/i99lg.0",
+        "Date": "Mon, 05 Dec 2022 22:49:20 GMT",
+        "MS-CV": "H7J\u002BDw\u002BIRkSRV7S7/sWKBw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wdZDYwAAAACwlQvfVw1BSJ3l\u002B2VrPdOdTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0cHWOYwAAAABD6V57ToXaToufeG9q9fCKUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
+        "X-Processing-Time": "99ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -183,25 +183,25 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-c1bb79299ed3cd671584b18a8c527ca8-276329968ee6672e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "9b6de0d6d9fa920e25e6faf5bd6bbb03",
+        "traceparent": "00-4cea53fff60c97948b1a139535f378a4-869c49dd947f6039-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "628be2bbc5108ae739c2a0abb68f177e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:33 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:21 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -211,20 +211,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:33 GMT",
-        "MS-CV": "sAKjzzVX5k6u7QUCr7LTZw.0",
+        "Date": "Mon, 05 Dec 2022 22:49:20 GMT",
+        "MS-CV": "fzSWt0ACdU2QVh4yCQYdcQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wdZDYwAAAADtt\u002BVqXIzoS7rJHSRZfpk2TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0cHWOYwAAAAC0wE6W1ibwSZIkgAXJTjaXUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "102ms"
+        "X-Processing-Time": "104ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -232,16 +232,16 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-66886e092c580b06f8dc0fbead9bc881-a55fa21ad7e64325-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c0e7bfa80b616be58132d6f46e4a2355",
+        "traceparent": "00-7f7839d9348a0fe5b941fcd0a6a65fd9-a7677ab05ebc1588-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "172d7e81a36bfbd6cf4aa952cfe57fda",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:33 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:21 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -249,20 +249,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:33 GMT",
-        "MS-CV": "XfqdcD0Dr0Ga9UdTYheJfg.0",
+        "Date": "Mon, 05 Dec 2022 22:49:21 GMT",
+        "MS-CV": "GVbiMqe8EEiDRMhzIEz/0A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wtZDYwAAAABmlgs2tpXQQo6KFfLyyjLfTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0cXWOYwAAAAA/Fe\u002Bj850ZR4ESJM\u002BOp7DwUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "66ms"
+        "X-Processing-Time": "83ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -270,44 +270,44 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "125",
+        "Content-Length": "83",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-66886e092c580b06f8dc0fbead9bc881-69a8316a414da048-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "efaf8797dad0ebb1223280ad18a41f79",
+        "traceparent": "00-7f7839d9348a0fe5b941fcd0a6a65fd9-4ccd833f8136a1db-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "74c744cd4b3e68e179a8d9d8acefa2ac",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:33 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:21 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           },
-          "sbs1.sipconfigtest.com": null,
-          "sbs2.sipconfigtest.com": null
+          "sbs1.com": null,
+          "sbs2.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:33 GMT",
-        "MS-CV": "y0LI7Pj5/kStDlZe/3Tz1w.0",
+        "Date": "Mon, 05 Dec 2022 22:49:21 GMT",
+        "MS-CV": "Siqg46YnKE\u002BMlCS9J8Gu7w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wtZDYwAAAAB3jEoLygmFT7Rw2TxpeivZTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0cXWOYwAAAABSoFIS8u3DTptT3e\u002BQSOXeUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "237ms"
+        "X-Processing-Time": "389ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -315,16 +315,16 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-66fba157fddb6c96435a28a25778d7ec-eb8f456a97dede0d-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5fbdc10374e1ca11fa0219c7021a24da",
+        "traceparent": "00-34f2a7b2f63f634afba2ece7cdbd4f2f-562ba9f002b62b53-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4257f46e8ee417d40c8f92c61b95ba54",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:34 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:21 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -332,17 +332,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:33 GMT",
-        "MS-CV": "WChfonzD4EW1AMuluGOkWw.0",
+        "Date": "Mon, 05 Dec 2022 22:49:21 GMT",
+        "MS-CV": "o6cD1XIXVkuqz2s6jGR8LA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wtZDYwAAAACMs\u002BkRfOwBTKpw22QFlLQKTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0cXWOYwAAAAANNLBILi4JRo61jPPf3lozUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "67ms"
+        "X-Processing-Time": "86ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -351,7 +351,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1200182377"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "1409171742"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d7277bf4db5eccefe230131512cbc398-b0ee58fe33cbf0cd-00",
+        "traceparent": "00-664b8985742486c084855d70e83e1c7a-50e2f1dc4e48f0bf-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3532107f48088c0cfbd0f2282b471121",
+        "x-ms-client-request-id": "59ca48c433996eb876564dc446cfcf21",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:06 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:07 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:07 GMT",
-        "MS-CV": "SE1OSYHKdEWwkuKuMeewrA.0",
+        "Date": "Tue, 13 Dec 2022 20:17:09 GMT",
+        "MS-CV": "Vf3O\u002BIzFT0iedRdIVs4a2w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "099eXYwAAAACdyL78fr8hRZNqNgy5svqQUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0xN2YYwAAAACoFLZtpQuTSpVC5ZdIqnvxUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "95ms"
+        "X-Processing-Time": "251ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-1df458d7b3b82aa0affed5e242012c1b-49374951c222b951-00",
+        "traceparent": "00-307fd51b261947d9247b2a800afec144-17a1c0afb0215f4a-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3445a5026b5f68ec9c14dfa33eed94fe",
+        "x-ms-client-request-id": "89f2734def770b84174683c04890c113",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:06 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:08 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:07 GMT",
-        "MS-CV": "Qn\u002BgA2qq30mF/ozdZX0nog.0",
+        "Date": "Tue, 13 Dec 2022 20:17:09 GMT",
+        "MS-CV": "6xeQ6OUvkEyGKDAZnHICCg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "099eXYwAAAACFAmRQqmEvS5ZWGo77RZj2UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0xd2YYwAAAAC5iMdKdlo8TZ5XcJJzcb/yUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
+        "X-Processing-Time": "107ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-1df458d7b3b82aa0affed5e242012c1b-a7208c75e7c829f1-00",
+        "traceparent": "00-307fd51b261947d9247b2a800afec144-0cae731986325632-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0afbfe151705b16348c1fb6c43c3f7e1",
+        "x-ms-client-request-id": "f387d7529ad7550dbd7ca9d0f6ecd71f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:07 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:08 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
+          "sbs1.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
+          "sbs2.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:07 GMT",
-        "MS-CV": "FkIhRz9lDUi0FRrx1tgi9g.0",
+        "Date": "Tue, 13 Dec 2022 20:17:09 GMT",
+        "MS-CV": "vbhYW0EmFkeRpKDSTtzwaw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "099eXYwAAAABNQ7LR9DMfSo1Lt7b4h6VhUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0xd2YYwAAAAD0gWyhBC/1RrniDB39ZSRtUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "336ms"
+        "X-Processing-Time": "454ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
+          "sbs1.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
+          "sbs2.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-977c7b9b0915a9851bfb88c799aa1926-c7e5b9665b50fad0-00",
+        "traceparent": "00-c3d7d2024360698719f9803a25a78b5a-e941ae60dab4ea55-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8a017e9a570a141d23c998f368684d0d",
+        "x-ms-client-request-id": "5e859807efaed445c4bf4252b0f826e6",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:07 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:08 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.f74d54f9-353d-23eb-29ac-a00430508b7d.com"
+              "sbs1.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:08 GMT",
-        "MS-CV": "O7Zu3peDpkiZyBGZTx4YQg.0",
+        "Date": "Tue, 13 Dec 2022 20:17:10 GMT",
+        "MS-CV": "opZPuXEUN0a/ead\u002BJttD0w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BNeXYwAAAAAkkxiCUxrrTq3gL\u002B6gIgVXUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0xd2YYwAAAABEoPvQGZO0TKHk9fjG1QuyUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "105ms"
+        "X-Processing-Time": "193ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
+          "sbs1.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
+          "sbs2.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.f74d54f9-353d-23eb-29ac-a00430508b7d.com"
+              "sbs1.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com"
             ]
           }
         ]
@@ -183,11 +183,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-604b0c6cb76b6d1242dbdfe12d30fed0-81bc2d3e181d55d4-00",
+        "traceparent": "00-d3f66a0779789d8ae97eb64e3ebcf83a-a64a1dc2364f585e-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2c12f33c074ceb1c4294eb9d6f8024d9",
+        "x-ms-client-request-id": "6f723994dc48b34a669dccfa46b3142b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:07 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:09 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -197,20 +197,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:08 GMT",
-        "MS-CV": "foOdEQZ08U6eabbTynURXQ.0",
+        "Date": "Tue, 13 Dec 2022 20:17:10 GMT",
+        "MS-CV": "wLR\u002Bwi/m9kaIMoqErZbfZQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BNeXYwAAAACIEb\u002BpbNEMQ6Xq3e9OI0lLUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0xt2YYwAAAACTMXvHB/8zTYuf5z77cS2TUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "146ms"
+        "X-Processing-Time": "156ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
+          "sbs1.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
+          "sbs2.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -223,11 +223,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-0468359f5777c01a5020f9d3d2716f79-f12ff224a2189016-00",
+        "traceparent": "00-1a7a62eaf1daabdb8c8817235c3cd835-238769833e7f993c-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c009fe1c09ebbef4e1e7e73b7f6f48df",
+        "x-ms-client-request-id": "b0b8636f630b626491b22e1758baa4c5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:08 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:09 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -235,20 +235,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:08 GMT",
-        "MS-CV": "A0EaC\u002B8fFUOuf9Lzhq97Qg.0",
+        "Date": "Tue, 13 Dec 2022 20:17:11 GMT",
+        "MS-CV": "vIC/A\u002B9KQUe/AqWYm08srQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BNeXYwAAAAAdlCRnr2QLR4sT9YdS7hoRUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0xt2YYwAAAABzpShGb/KpT7JrnQSLBHqmUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "78ms"
+        "X-Processing-Time": "321ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
+          "sbs1.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
+          "sbs2.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,37 +263,37 @@
         "Authorization": "Sanitized",
         "Content-Length": "194",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-0468359f5777c01a5020f9d3d2716f79-819ca6f37c8cf7ca-00",
+        "traceparent": "00-1a7a62eaf1daabdb8c8817235c3cd835-21717111d1e5dabc-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "502fed74cab09395621648766b80a5a2",
+        "x-ms-client-request-id": "bd3bc35667792bd74dd2f811234b8e10",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:08 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:10 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
+          "newsbs.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
             "sipSignalingPort": 3333
           },
-          "sbs1.f74d54f9-353d-23eb-29ac-a00430508b7d.com": null,
-          "sbs2.f74d54f9-353d-23eb-29ac-a00430508b7d.com": null
+          "sbs1.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": null,
+          "sbs2.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:09 GMT",
-        "MS-CV": "XycmYAXMT0eJkodKjMjM0w.0",
+        "Date": "Tue, 13 Dec 2022 20:17:11 GMT",
+        "MS-CV": "\u002BA9YsAKAskuXkTI/5qr1hQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BNeXYwAAAABKP3a66bthTq5HF3Av9MdyUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0x92YYwAAAAAVktkYnEQBTKtGOBDx94FUUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "297ms"
+        "X-Processing-Time": "696ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
+          "newsbs.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -306,11 +306,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-5b4d95ef0530b628ffb53a80232a73a9-f33818d6ab7aeabf-00",
+        "traceparent": "00-d3187af4e2385ea4f0b26d6a3c51353b-b13109b610a63007-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6ad6bfa48d5f3222ff534b6520e06cd2",
+        "x-ms-client-request-id": "4de316ab763f31dad40fde95ad325aab",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:08 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:10 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -318,17 +318,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:09 GMT",
-        "MS-CV": "0VAnL5qCAESKDRNvHvrr7A.0",
+        "Date": "Tue, 13 Dec 2022 20:17:12 GMT",
+        "MS-CV": "Z7Q/Wed9B0qHFY1FlCDPNA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BdeXYwAAAACTX7IzCQLPSZ/S0JJv/S2eUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0x92YYwAAAABqokrR8FJHR7WcNsen/oXfUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "96ms"
+        "X-Processing-Time": "118ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
+          "newsbs.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -341,11 +341,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-532eeaf2622303c5d4ef945f845a23e8-280bc24ee8189d22-00",
+        "traceparent": "00-cafc44f5969cf3a070630d2ab68ddd7e-428c67a9b672330a-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "81280b4bd451522869755dd5c17d5261",
+        "x-ms-client-request-id": "83a406f9577707b18c8d62396a533f46",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:08 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:11 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -353,17 +353,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:09 GMT",
-        "MS-CV": "HKU4n8PAH0CZabxdBnXH8w.0",
+        "Date": "Tue, 13 Dec 2022 20:17:12 GMT",
+        "MS-CV": "s6i1Esn6zEanoLILRONayQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BdeXYwAAAAAPBdArZH4ZSr\u002BjoJciNk12UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0yN2YYwAAAABPajeTpEemTbZN\u002BOkB91\u002BXUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "77ms"
+        "X-Processing-Time": "101ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
+          "newsbs.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -376,11 +376,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-02a58cb5ed3240567bff7f598bbf3d67-3817dd63a8ffcb94-00",
+        "traceparent": "00-ee914af936026121a252a4b5aae96cc5-245a7adf580bd26e-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c0974442de98e780cbfc515c7e2f7382",
+        "x-ms-client-request-id": "416c1e2357d7e085e80ae86a89427d1b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:09 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:11 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -388,17 +388,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:09 GMT",
-        "MS-CV": "XIGY//FHkEi9wyzmyjBXtA.0",
+        "Date": "Tue, 13 Dec 2022 20:17:12 GMT",
+        "MS-CV": "lWiGiTMCpEuyRyNdhMQJvA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BdeXYwAAAAD1Fp99D7lqT54x2rCkZGdEUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0yN2YYwAAAAAs\u002BcNMXY\u002BrSIghbaYfBkmDUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "77ms"
+        "X-Processing-Time": "108ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
+          "newsbs.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -411,11 +411,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-ca535068260c7d15569e4292b0c8d14b-c5d6951e2ed56cb5-00",
+        "traceparent": "00-b873749422de74c63f0241d4748a986b-1d8909e7c0ae5109-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "602b75aa2457d051968401e92f4c7181",
+        "x-ms-client-request-id": "1c184c770ba6539965dbc0b214a1c680",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:09 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:11 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -423,17 +423,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:09 GMT",
-        "MS-CV": "UTuD9JAgwEaoHpOWNivz\u002Bw.0",
+        "Date": "Tue, 13 Dec 2022 20:17:12 GMT",
+        "MS-CV": "EnpOaWDOUEuxX6y6KLjM5Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BdeXYwAAAADIZ1BBRUqmTJRHoKvhA2mQUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0yN2YYwAAAAD33pz/7ekoRY7AJ0v6cyGhUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "80ms"
+        "X-Processing-Time": "90ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
+          "newsbs.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -448,29 +448,29 @@
         "Authorization": "Sanitized",
         "Content-Length": "67",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-ca535068260c7d15569e4292b0c8d14b-adf8cd32391a5b94-00",
+        "traceparent": "00-b873749422de74c63f0241d4748a986b-3380e433bd3ab1d0-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "db23ea01ab496d3a8b41b55483cbd339",
+        "x-ms-client-request-id": "8f7197cf18c6a1d380c49a6d6e477d4a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:09 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:11 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.f74d54f9-353d-23eb-29ac-a00430508b7d.com": null
+          "newsbs.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:10 GMT",
-        "MS-CV": "nCV8KaKDm0SUz/OLFRdpzw.0",
+        "Date": "Tue, 13 Dec 2022 20:17:13 GMT",
+        "MS-CV": "3pNI3yylU0aes/JyvbHobg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BdeXYwAAAADvV3s5Tqr\u002BTo4whIY1B6qeUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0yN2YYwAAAACQkNYJ5MiAS6O6tOxCf7hAUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "125ms"
+        "X-Processing-Time": "262ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -480,6 +480,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1640124856"
+    "RandomSeed": "1865169759"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResourceAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -67,7 +67,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -116,7 +116,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -176,7 +176,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -218,7 +218,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -256,7 +256,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -301,7 +301,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -336,7 +336,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -371,7 +371,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -406,7 +406,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -441,7 +441,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -479,7 +479,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "262348763"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-8da4034184f6df3eebe1b441f388574d-18e4d57fe33fe856-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f9f6394607139b7a26679eb209b01a48",
+        "traceparent": "00-d7277bf4db5eccefe230131512cbc398-b0ee58fe33cbf0cd-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3532107f48088c0cfbd0f2282b471121",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:50 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:06 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:51 GMT",
-        "MS-CV": "0sYjSx47KUqxsNtspkRDPw.0",
+        "Date": "Tue, 13 Dec 2022 01:40:07 GMT",
+        "MS-CV": "SE1OSYHKdEWwkuKuMeewrA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0FoSOYwAAAABUMKc/VqrKR6H5p99Sw1V9UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "099eXYwAAAACdyL78fr8hRZNqNgy5svqQUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "187ms"
+        "X-Processing-Time": "95ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-d67f02efe6fce9a0e5f08616110c8282-5e36dff6958037c7-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ac232520d1210aed3be021992196d814",
+        "traceparent": "00-1df458d7b3b82aa0affed5e242012c1b-49374951c222b951-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3445a5026b5f68ec9c14dfa33eed94fe",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:51 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:06 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:51 GMT",
-        "MS-CV": "ye7jpw14pEu5POTz0XFSNg.0",
+        "Date": "Tue, 13 Dec 2022 01:40:07 GMT",
+        "MS-CV": "Qn\u002BgA2qq30mF/ozdZX0nog.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0F4SOYwAAAADG6/iyVTJtT6ABZDkQI1nbUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "099eXYwAAAACFAmRQqmEvS5ZWGo77RZj2UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
+        "X-Processing-Time": "89ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -72,21 +72,21 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "86",
+        "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d67f02efe6fce9a0e5f08616110c8282-1c5b634d2ccf6ad2-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d66542054d5d1b70ddbee175c9e4b5da",
+        "traceparent": "00-1df458d7b3b82aa0affed5e242012c1b-a7208c75e7c829f1-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0afbfe151705b16348c1fb6c43c3f7e1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:51 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:07 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:52 GMT",
-        "MS-CV": "X4zVY4BQCUOsWjJfdaEwdA.0",
+        "Date": "Tue, 13 Dec 2022 01:40:07 GMT",
+        "MS-CV": "FkIhRz9lDUi0FRrx1tgi9g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0F4SOYwAAAAC82/3Yc2uURbyeAVlD6ojdUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "099eXYwAAAABNQ7LR9DMfSo1Lt7b4h6VhUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "586ms"
+        "X-Processing-Time": "336ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -121,13 +121,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "164",
+        "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-acc620f2b81977f21fec757e8a0ba10b-461c10dbfb7c6750-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "608f28ad94b5741b4becbd32e5e07a8f",
+        "traceparent": "00-977c7b9b0915a9851bfb88c799aa1926-c7e5b9665b50fad0-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8a017e9a570a141d23c998f368684d0d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:52 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:07 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.f74d54f9-353d-23eb-29ac-a00430508b7d.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:52 GMT",
-        "MS-CV": "NZmD65mBO0O\u002Bfb1VZd7oZw.0",
+        "Date": "Tue, 13 Dec 2022 01:40:08 GMT",
+        "MS-CV": "O7Zu3peDpkiZyBGZTx4YQg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0GISOYwAAAADiDgspWc12Q5kSx3FXNxpdUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BNeXYwAAAAAkkxiCUxrrTq3gL\u002B6gIgVXUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "245ms"
+        "X-Processing-Time": "105ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.f74d54f9-353d-23eb-29ac-a00430508b7d.com"
             ]
           }
         ]
@@ -183,11 +183,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-57b3dad4d3898598fff87f483238c365-1f84cd95382f5f2f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c7ac8a8f434bd3eab407cf62f0774056",
+        "traceparent": "00-604b0c6cb76b6d1242dbdfe12d30fed0-81bc2d3e181d55d4-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2c12f33c074ceb1c4294eb9d6f8024d9",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:52 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:07 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -197,20 +197,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:52 GMT",
-        "MS-CV": "vCWOeCdcSUi0NkvX5nj0Kg.0",
+        "Date": "Tue, 13 Dec 2022 01:40:08 GMT",
+        "MS-CV": "foOdEQZ08U6eabbTynURXQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0GISOYwAAAADiP8jZu88KRYwbDo25KNZuUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BNeXYwAAAACIEb\u002BpbNEMQ6Xq3e9OI0lLUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "167ms"
+        "X-Processing-Time": "146ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -223,11 +223,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-5f7d51f6092edc0608f283bd270bd780-78d22d534b25e424-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f9eb472b7706705f26f08b718f3d35fc",
+        "traceparent": "00-0468359f5777c01a5020f9d3d2716f79-f12ff224a2189016-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c009fe1c09ebbef4e1e7e73b7f6f48df",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:52 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:08 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -235,20 +235,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:52 GMT",
-        "MS-CV": "qKeo0sG44k2c3Rx3XhbO0g.0",
+        "Date": "Tue, 13 Dec 2022 01:40:08 GMT",
+        "MS-CV": "A0EaC\u002B8fFUOuf9Lzhq97Qg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0GISOYwAAAADkOyzojRxCSJOnXH8F8DuLUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BNeXYwAAAAAdlCRnr2QLR4sT9YdS7hoRUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
+        "X-Processing-Time": "78ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.com": {
+          "sbs2.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -261,39 +261,39 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "83",
+        "Content-Length": "194",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-5f7d51f6092edc0608f283bd270bd780-d6e4b32a4bfb058a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3ee65144ee376a8f3dbbabadc5b984d4",
+        "traceparent": "00-0468359f5777c01a5020f9d3d2716f79-819ca6f37c8cf7ca-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "502fed74cab09395621648766b80a5a2",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:52 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:08 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
             "sipSignalingPort": 3333
           },
-          "sbs1.com": null,
-          "sbs2.com": null
+          "sbs1.f74d54f9-353d-23eb-29ac-a00430508b7d.com": null,
+          "sbs2.f74d54f9-353d-23eb-29ac-a00430508b7d.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:53 GMT",
-        "MS-CV": "61rTQuCRSE2Ciqpxmucm3w.0",
+        "Date": "Tue, 13 Dec 2022 01:40:09 GMT",
+        "MS-CV": "XycmYAXMT0eJkodKjMjM0w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0GISOYwAAAAA\u002BHSssazLMTYS4bZrXVA5QUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BNeXYwAAAABKP3a66bthTq5HF3Av9MdyUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "721ms"
+        "X-Processing-Time": "297ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -306,11 +306,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-9ea0cc8e20191084cc2f05f5680ad9c5-34aebfe993c99b25-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "9e0767ab81f517882b3ca15ab8794476",
+        "traceparent": "00-5b4d95ef0530b628ffb53a80232a73a9-f33818d6ab7aeabf-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6ad6bfa48d5f3222ff534b6520e06cd2",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:53 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:08 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -318,17 +318,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:53 GMT",
-        "MS-CV": "Gn/o3gTpIUe0wHlLzZtRvQ.0",
+        "Date": "Tue, 13 Dec 2022 01:40:09 GMT",
+        "MS-CV": "0VAnL5qCAESKDRNvHvrr7A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0GYSOYwAAAAA2FiN/LPiFSIbUjmZ7Wa\u002BXUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BdeXYwAAAACTX7IzCQLPSZ/S0JJv/S2eUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "82ms"
+        "X-Processing-Time": "96ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -341,11 +341,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-8e8662ed2cbfcd79cde9500b2986ee24-dab68129b1b3e056-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "9e1ed2d202913d1eb780bb4bccb1aa6d",
+        "traceparent": "00-532eeaf2622303c5d4ef945f845a23e8-280bc24ee8189d22-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "81280b4bd451522869755dd5c17d5261",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:53 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:08 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -353,17 +353,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:54 GMT",
-        "MS-CV": "ILh7WPczQE2BPunKlD1ipA.0",
+        "Date": "Tue, 13 Dec 2022 01:40:09 GMT",
+        "MS-CV": "HKU4n8PAH0CZabxdBnXH8w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0GYSOYwAAAABHS/fvagPmSKNR71lc95rBUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BdeXYwAAAAAPBdArZH4ZSr\u002BjoJciNk12UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
+        "X-Processing-Time": "77ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -376,11 +376,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-2fe1220100332964e7ac72e12becd73b-63b3f20e4e78d2bb-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "27c6b66c9736c207c9ce13fb4d35b2c4",
+        "traceparent": "00-02a58cb5ed3240567bff7f598bbf3d67-3817dd63a8ffcb94-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c0974442de98e780cbfc515c7e2f7382",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:54 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:09 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -388,17 +388,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:54 GMT",
-        "MS-CV": "hooYl\u002BzNFUqwIVDtvfrQEw.0",
+        "Date": "Tue, 13 Dec 2022 01:40:09 GMT",
+        "MS-CV": "XIGY//FHkEi9wyzmyjBXtA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0GoSOYwAAAABaJ7VGIQpCRJc1vLfi/dY4UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BdeXYwAAAAD1Fp99D7lqT54x2rCkZGdEUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "95ms"
+        "X-Processing-Time": "77ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -411,11 +411,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-ac049d906142ff14b592c488ca228fdf-8539095c353849ee-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f3db3477e69ba94348cae674c53d4b79",
+        "traceparent": "00-ca535068260c7d15569e4292b0c8d14b-c5d6951e2ed56cb5-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "602b75aa2457d051968401e92f4c7181",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:54 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:09 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -423,17 +423,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:54 GMT",
-        "MS-CV": "ZvAA/lZYNU2jz9RQo58rVA.0",
+        "Date": "Tue, 13 Dec 2022 01:40:09 GMT",
+        "MS-CV": "UTuD9JAgwEaoHpOWNivz\u002Bw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0GoSOYwAAAABVIQFRob\u002BoR4qVDdhA9FtfUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BdeXYwAAAADIZ1BBRUqmTJRHoKvhA2mQUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "91ms"
+        "X-Processing-Time": "80ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
+          "newsbs.f74d54f9-353d-23eb-29ac-a00430508b7d.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -446,31 +446,31 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "30",
+        "Content-Length": "67",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-ac049d906142ff14b592c488ca228fdf-c6f2a5d160a8b01f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "01ed33911cb23a40cb5bd5c2ee23f082",
+        "traceparent": "00-ca535068260c7d15569e4292b0c8d14b-adf8cd32391a5b94-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "db23ea01ab496d3a8b41b55483cbd339",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:54 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:09 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.com": null
+          "newsbs.f74d54f9-353d-23eb-29ac-a00430508b7d.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:54 GMT",
-        "MS-CV": "ymnR6M4ou0eKeyCgJ3fDnQ.0",
+        "Date": "Tue, 13 Dec 2022 01:40:10 GMT",
+        "MS-CV": "nCV8KaKDm0SUz/OLFRdpzw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0GoSOYwAAAADlqyOEcIP7R6i0WDqZ82eJUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BdeXYwAAAADvV3s5Tqr\u002BTo4whIY1B6qeUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "276ms"
+        "X-Processing-Time": "125ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -480,6 +480,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "262348763"
+    "RandomSeed": "1640124856"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthentication.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthentication.json
@@ -8,14 +8,14 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-2368be13be853ef6875cd1b40b60a7ed-9d65bdb9fe752726-00",
+        "traceparent": "00-6e462a588a8366eaf9641e0ba269a57e-63684faf6b1822c5-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8e715837c1b31e5921d06d636df7f2a9",
+        "x-ms-client-request-id": "1b35ba6bb9ef0142b524bee9a1ddf12f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.a7d62ae2-5ef2-344d-1602-bb213af5ee67.com": {
+          "sbs1.f5c433d6-e4ff-2a1a-5713-e95f12d36dc7.com": {
             "sipSignalingPort": 5555
           }
         }
@@ -24,17 +24,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:25 GMT",
-        "MS-CV": "5KXzHhsOE0OIPw1E2\u002BzXwA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:43 GMT",
+        "MS-CV": "9gYBKLQQjkmh\u002BLKy4XwEWw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rdmXYwAAAACA7bK1\u002BGODTaAnMaQP7SzgUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0rN2YYwAAAAB18pSOayeIToVtJz\u002BozhWsUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "651ms"
+        "X-Processing-Time": "528ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.a7d62ae2-5ef2-344d-1602-bb213af5ee67.com": {
+          "sbs1.f5c433d6-e4ff-2a1a-5713-e95f12d36dc7.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -47,11 +47,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-bc41d0985f1643f899608b14e78fd71e-c67277184f9c9cb4-00",
+        "traceparent": "00-3bee7c949ea37f0e1d911afbe37299df-c72701741242b54d-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b85f4d90ed57a321628b4867ea256a08",
+        "x-ms-client-request-id": "91e55788d9e9ef1b28476d9857dcd8bc",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:26 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:43 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -59,17 +59,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:26 GMT",
-        "MS-CV": "O26xedY/SESfDfekwa12HQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:43 GMT",
+        "MS-CV": "ClwhT6lFhkq2JKW\u002BOZAyOA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rtmXYwAAAAC7OVNQQjPnSIBtlMen0tQ1UFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0rN2YYwAAAACHCYol5Q1iRo2R6Dgu3K0qUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "90ms"
+        "X-Processing-Time": "105ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.a7d62ae2-5ef2-344d-1602-bb213af5ee67.com": {
+          "sbs1.f5c433d6-e4ff-2a1a-5713-e95f12d36dc7.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -82,11 +82,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-65fa70296c14fd65f885ce1508137c9e-9a75ab102c775b58-00",
+        "traceparent": "00-35ebfe89ef3c5643ca60c072a71b86e2-61cd0585f5cb8d76-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "282646220a7b214cd0b88621f1e9c61f",
+        "x-ms-client-request-id": "c6fe65f3b1791c41f0c33fdb2530897a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:26 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:44 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -94,17 +94,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:26 GMT",
-        "MS-CV": "ooe4mZMzWkadOC6xghcytw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:45 GMT",
+        "MS-CV": "le9\u002BqKTiQUiOO5axSwfN/Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0r9mXYwAAAADKbcaOS2Y3TLEqHCaMV/JGUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0rN2YYwAAAACLz76\u002BN8NQSrA/3WVYzGyqUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
+        "X-Processing-Time": "84ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.a7d62ae2-5ef2-344d-1602-bb213af5ee67.com": {
+          "sbs1.f5c433d6-e4ff-2a1a-5713-e95f12d36dc7.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -117,11 +117,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-cb55ee47201ea6effa1f9f3464b18ffa-ab38e02e8bdad713-00",
+        "traceparent": "00-b447669b3a16cba1c26629bc0cf95c27-82268d2076b43d14-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ed90111035954a1036ce2c2878f133fc",
+        "x-ms-client-request-id": "bad7b922dbee91de9f45f3a84caaa9d8",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:26 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:44 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -129,17 +129,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:26 GMT",
-        "MS-CV": "1QQ3W\u002Br7Lkqol0ybr7seug.0",
+        "Date": "Tue, 13 Dec 2022 20:16:45 GMT",
+        "MS-CV": "resYAyvy1EOhdYsIfIg8tw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0r9mXYwAAAADus/M7mkExQav09DvqMAPMUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0rd2YYwAAAABOjTMxKyGWT7PeYJIYbmqvUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "82ms"
+        "X-Processing-Time": "93ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.a7d62ae2-5ef2-344d-1602-bb213af5ee67.com": {
+          "sbs1.f5c433d6-e4ff-2a1a-5713-e95f12d36dc7.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -154,29 +154,29 @@
         "Authorization": "Sanitized",
         "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-cb55ee47201ea6effa1f9f3464b18ffa-1012178948bc4aa0-00",
+        "traceparent": "00-b447669b3a16cba1c26629bc0cf95c27-772eb9f177c38394-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "26416466c9d0862e013ee79f6700b278",
+        "x-ms-client-request-id": "3bf6024c2bded7b615c8a0269940caf7",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:26 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:44 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.a7d62ae2-5ef2-344d-1602-bb213af5ee67.com": null
+          "sbs1.f5c433d6-e4ff-2a1a-5713-e95f12d36dc7.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:26 GMT",
-        "MS-CV": "RysAC/m9u0eSMho5IeuLzw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:45 GMT",
+        "MS-CV": "VCtsW9XYvkWLV3tdqSWE6w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0r9mXYwAAAACaqwu67kJ6QJNf/Lr8h5G/UFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0rd2YYwAAAAAfwfbEo3L4QZOQ6y1rq4cZUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "118ms"
+        "X-Processing-Time": "272ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -186,6 +186,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1947843242"
+    "RandomSeed": "1270219646"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthentication.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthentication.json
@@ -1,21 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "63",
+        "Content-Length": "49",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-e7248a07ceac26191f15f38cf92bb1f1-0a64fed897f85edb-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0630a3c53b1527477577fd34906f2e80",
+        "traceparent": "00-39a6767c2c6c4aa896cf25c41fd7e2e0-d073da6928e38493-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "753792d63eda78a446b6d4c2c9a2ad8f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 5555
           }
         }
@@ -24,20 +24,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:22 GMT",
-        "MS-CV": "zxYnGY791USutPzohqM/RQ.0",
+        "Date": "Mon, 05 Dec 2022 22:48:56 GMT",
+        "MS-CV": "PubpTNQuYUisj4N6GosQsw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ttZDYwAAAAAJFiNu5YnOTI4LfQkxfkr7TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0WHWOYwAAAAB7KDu1s91IS7ejtzlB53cMUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "478ms"
+        "X-Processing-Time": "395ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           },
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -46,7 +46,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1692188471"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "1856095690"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthentication.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthentication.json
@@ -6,16 +6,16 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "49",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-05fbd01a259820f91347c3cdac1a801d-1c9794a4e6be0393-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "90ce2687e9c6d21d7f10763210b40cfa",
+        "traceparent": "00-2368be13be853ef6875cd1b40b60a7ed-9d65bdb9fe752726-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8e715837c1b31e5921d06d636df7f2a9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.a7d62ae2-5ef2-344d-1602-bb213af5ee67.com": {
             "sipSignalingPort": 5555
           }
         }
@@ -24,17 +24,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:23 GMT",
-        "MS-CV": "EsUv78Ma7UuExUrN0NmhfQ.0",
+        "Date": "Tue, 13 Dec 2022 01:47:25 GMT",
+        "MS-CV": "5KXzHhsOE0OIPw1E2\u002BzXwA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/IOOYwAAAACVOyqMKJ2hSpDnghkcwZ8hUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0rdmXYwAAAACA7bK1\u002BGODTaAnMaQP7SzgUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "487ms"
+        "X-Processing-Time": "651ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.a7d62ae2-5ef2-344d-1602-bb213af5ee67.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -47,11 +47,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-6b72bf1d4763a37cdc14308385fa195b-80fc22149e3275b5-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7fcb5fdedbb7088889b1144953a7ce4d",
+        "traceparent": "00-bc41d0985f1643f899608b14e78fd71e-c67277184f9c9cb4-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b85f4d90ed57a321628b4867ea256a08",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:24 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:26 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -59,17 +59,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:24 GMT",
-        "MS-CV": "gwutG6speUK23O8dgdEMMg.0",
+        "Date": "Tue, 13 Dec 2022 01:47:26 GMT",
+        "MS-CV": "O26xedY/SESfDfekwa12HQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/IOOYwAAAADoYl1jy9J1QKfJvXA5uAVvUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0rtmXYwAAAAC7OVNQQjPnSIBtlMen0tQ1UFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "85ms"
+        "X-Processing-Time": "90ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.a7d62ae2-5ef2-344d-1602-bb213af5ee67.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -82,11 +82,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-4586a4cb168b53a50be353ff332e4dbe-24f222bf0fdbbfe5-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4315fab97b19e2c6c8c2441277724d9f",
+        "traceparent": "00-65fa70296c14fd65f885ce1508137c9e-9a75ab102c775b58-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "282646220a7b214cd0b88621f1e9c61f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:24 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:26 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -94,17 +94,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:24 GMT",
-        "MS-CV": "iRIaUBxA10C5C7MV/W8aHg.0",
+        "Date": "Tue, 13 Dec 2022 01:47:26 GMT",
+        "MS-CV": "ooe4mZMzWkadOC6xghcytw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/IOOYwAAAAAsCBpi/0oMQ4nZZR1oJbNGUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0r9mXYwAAAADKbcaOS2Y3TLEqHCaMV/JGUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
+        "X-Processing-Time": "83ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.a7d62ae2-5ef2-344d-1602-bb213af5ee67.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -117,11 +117,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-237b5664fbd6375131937219164c6a96-b54ac2b2b1b01283-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "018d8e990715acd29dc50615d5d47fd7",
+        "traceparent": "00-cb55ee47201ea6effa1f9f3464b18ffa-ab38e02e8bdad713-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ed90111035954a1036ce2c2878f133fc",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:25 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:26 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -129,17 +129,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:24 GMT",
-        "MS-CV": "3MuwbVS5H0i5b0ciqWegtA.0",
+        "Date": "Tue, 13 Dec 2022 01:47:26 GMT",
+        "MS-CV": "1QQ3W\u002Br7Lkqol0ybr7seug.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/YOOYwAAAADneYEnC0fdR6YeLFnV2/9jUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0r9mXYwAAAADus/M7mkExQav09DvqMAPMUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "82ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.a7d62ae2-5ef2-344d-1602-bb213af5ee67.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -152,31 +152,31 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "28",
+        "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-237b5664fbd6375131937219164c6a96-48aa69c845aa400a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "16782942c89f62e198e9b6f597759117",
+        "traceparent": "00-cb55ee47201ea6effa1f9f3464b18ffa-1012178948bc4aa0-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "26416466c9d0862e013ee79f6700b278",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:25 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:26 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": null
+          "sbs1.a7d62ae2-5ef2-344d-1602-bb213af5ee67.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:25 GMT",
-        "MS-CV": "pY418FTKQ0uiMfbl4M30uQ.0",
+        "Date": "Tue, 13 Dec 2022 01:47:26 GMT",
+        "MS-CV": "RysAC/m9u0eSMho5IeuLzw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/YOOYwAAAAC6k6z2Xa/ISK\u002BqsvBH9BLOUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0r9mXYwAAAACaqwu67kJ6QJNf/Lr8h5G/UFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "323ms"
+        "X-Processing-Time": "118ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -186,6 +186,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "425201136"
+    "RandomSeed": "1947843242"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthentication.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthentication.json
@@ -8,9 +8,9 @@
         "Authorization": "Sanitized",
         "Content-Length": "49",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-39a6767c2c6c4aa896cf25c41fd7e2e0-d073da6928e38493-00",
+        "traceparent": "00-05fbd01a259820f91347c3cdac1a801d-1c9794a4e6be0393-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "753792d63eda78a446b6d4c2c9a2ad8f",
+        "x-ms-client-request-id": "90ce2687e9c6d21d7f10763210b40cfa",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -24,29 +24,168 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:56 GMT",
-        "MS-CV": "PubpTNQuYUisj4N6GosQsw.0",
+        "Date": "Mon, 05 Dec 2022 23:51:23 GMT",
+        "MS-CV": "EsUv78Ma7UuExUrN0NmhfQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0WHWOYwAAAAB7KDu1s91IS7ejtzlB53cMUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/IOOYwAAAACVOyqMKJ2hSpDnghkcwZ8hUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "395ms"
+        "X-Processing-Time": "487ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
-            "sipSignalingPort": 3333
-          },
           "sbs1.com": {
             "sipSignalingPort": 5555
           }
         },
         "routes": []
       }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6b72bf1d4763a37cdc14308385fa195b-80fc22149e3275b5-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7fcb5fdedbb7088889b1144953a7ce4d",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:24 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:24 GMT",
+        "MS-CV": "gwutG6speUK23O8dgdEMMg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0/IOOYwAAAADoYl1jy9J1QKfJvXA5uAVvUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "85ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 5555
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4586a4cb168b53a50be353ff332e4dbe-24f222bf0fdbbfe5-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4315fab97b19e2c6c8c2441277724d9f",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:24 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:24 GMT",
+        "MS-CV": "iRIaUBxA10C5C7MV/W8aHg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0/IOOYwAAAAAsCBpi/0oMQ4nZZR1oJbNGUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "84ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 5555
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-237b5664fbd6375131937219164c6a96-b54ac2b2b1b01283-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "018d8e990715acd29dc50615d5d47fd7",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:25 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:24 GMT",
+        "MS-CV": "3MuwbVS5H0i5b0ciqWegtA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0/YOOYwAAAADneYEnC0fdR6YeLFnV2/9jUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "82ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 5555
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "28",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-237b5664fbd6375131937219164c6a96-48aa69c845aa400a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "16782942c89f62e198e9b6f597759117",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:25 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:25 GMT",
+        "MS-CV": "pY418FTKQ0uiMfbl4M30uQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0/YOOYwAAAAC6k6z2Xa/ISK\u002BqsvBH9BLOUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "323ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1856095690"
+    "RandomSeed": "425201136"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthentication.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthentication.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -42,7 +42,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -77,7 +77,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -112,7 +112,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -147,7 +147,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -185,7 +185,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "425201136"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthenticationAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthenticationAsync.json
@@ -8,14 +8,14 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-e497e0d80056d99653588c5ab980926b-6f66e708da4a08bb-00",
+        "traceparent": "00-44c7dcf487fcb79ccaacc6f5bd9ed138-0ab4e937a064886f-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1650a91f4fc2eaf65c10b9296be433b4",
+        "x-ms-client-request-id": "b01a67aa3ec5f0f9961dd91ae06153a8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.3ab5d285-c475-ec6c-b51c-68b637226797.com": {
+          "sbs1.662a58ec-7a98-ffa6-e5ef-65d746aeda31.com": {
             "sipSignalingPort": 5555
           }
         }
@@ -24,17 +24,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:27 GMT",
-        "MS-CV": "fiz7RobDAEeaXm1zwz8p4Q.0",
+        "Date": "Tue, 13 Dec 2022 20:17:13 GMT",
+        "MS-CV": "VWXqElf4eEWC0\u002BtDnAyvHg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sNmXYwAAAAAxPf1uqLW7Sa\u002B4xe//JJpBUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0yd2YYwAAAADbxRXwBuErRJNuayjpU5daUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "289ms"
+        "X-Processing-Time": "494ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.3ab5d285-c475-ec6c-b51c-68b637226797.com": {
+          "sbs1.662a58ec-7a98-ffa6-e5ef-65d746aeda31.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -47,11 +47,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-72cfebb743ad574a6746e79a7fc87d52-4416b46f6841371a-00",
+        "traceparent": "00-4d3702989ad73961bd38b2b1acd9d818-72a30ac67055c502-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4f08fe4e4cc882c1f94407f6eae75ec1",
+        "x-ms-client-request-id": "39b872ac816eb4af31de1818fbdbe5f7",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:28 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:12 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -59,17 +59,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:28 GMT",
-        "MS-CV": "DjEU0LtGjUuD677JweWLSA.0",
+        "Date": "Tue, 13 Dec 2022 20:17:13 GMT",
+        "MS-CV": "kW7m4nfrS02dWGo8RvoIIA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sNmXYwAAAAArsoH4xMGKRK8zUv\u002B7LkAIUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0yd2YYwAAAACSxVH89PlrQJ2zm1sY1FV4UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "92ms"
+        "X-Processing-Time": "96ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.3ab5d285-c475-ec6c-b51c-68b637226797.com": {
+          "sbs1.662a58ec-7a98-ffa6-e5ef-65d746aeda31.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -82,11 +82,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-6ca1ddbe933da7098990b0cc524268cc-b892c15098f1a923-00",
+        "traceparent": "00-e693e6a59be69bde13973bdb97ff1fca-b95ab947c52a5328-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3bb366ec25d7360fdccbde640b4381d0",
+        "x-ms-client-request-id": "9420ec6deefdae365e3ad07aa08b1e84",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:28 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:13 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -94,17 +94,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:28 GMT",
-        "MS-CV": "ET6/3TfLrUCcD46jcrbIqw.0",
+        "Date": "Tue, 13 Dec 2022 20:17:14 GMT",
+        "MS-CV": "VRJ/g2FoiU6PAZlr8zDd9w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sNmXYwAAAACI7YkV5QR\u002BQKaDl\u002BSIj9ImUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0yd2YYwAAAABStEZ05SKATZIjjeFffeQ2UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
+        "X-Processing-Time": "84ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.3ab5d285-c475-ec6c-b51c-68b637226797.com": {
+          "sbs1.662a58ec-7a98-ffa6-e5ef-65d746aeda31.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -117,11 +117,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-95e83fa29382dbe5bacd1cea65715000-182bb8b4be2c2a3f-00",
+        "traceparent": "00-00492d85db07f7c993d00a6afcb7be5f-a77780a5b29dbb1a-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3968b4e91719d2cfe7cd1c7e48ff0074",
+        "x-ms-client-request-id": "d42bbd9ba0f628c2b7667ee725e1f4bb",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:28 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:13 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -129,17 +129,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:28 GMT",
-        "MS-CV": "yX5mHgLTu0G98PmthpWk9w.0",
+        "Date": "Tue, 13 Dec 2022 20:17:14 GMT",
+        "MS-CV": "I3Sgx3jfYU\u002BLXB\u002BLVZMnoA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sdmXYwAAAAAwP0eEZeRhQrZQrm2i0kZsUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0yt2YYwAAAADM6l/6oNOjQL1TW5j0cK0pUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "82ms"
+        "X-Processing-Time": "91ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.3ab5d285-c475-ec6c-b51c-68b637226797.com": {
+          "sbs1.662a58ec-7a98-ffa6-e5ef-65d746aeda31.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -154,29 +154,29 @@
         "Authorization": "Sanitized",
         "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-95e83fa29382dbe5bacd1cea65715000-1b8f82953a6e7b87-00",
+        "traceparent": "00-00492d85db07f7c993d00a6afcb7be5f-09dea7e8e2138ba4-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "043cf7b1f73128dceed273fc6e5c77b6",
+        "x-ms-client-request-id": "f4ade238bf41bdab3b09db34b13513a5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:47:28 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:13 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.3ab5d285-c475-ec6c-b51c-68b637226797.com": null
+          "sbs1.662a58ec-7a98-ffa6-e5ef-65d746aeda31.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:47:28 GMT",
-        "MS-CV": "FL48nSldUkKMGNSV9mgSXQ.0",
+        "Date": "Tue, 13 Dec 2022 20:17:14 GMT",
+        "MS-CV": "J9P2aAPhRki96V1VaWNHOQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sdmXYwAAAADqDRVgsXLPQrCsMafnflO6UFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0yt2YYwAAAACFnsv/ocI2R5cxkhd9uQdgUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "119ms"
+        "X-Processing-Time": "260ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -186,6 +186,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1794360058"
+    "RandomSeed": "482819792"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthenticationAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthenticationAsync.json
@@ -8,9 +8,9 @@
         "Authorization": "Sanitized",
         "Content-Length": "49",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-ad57c9761fb381dd6cc6a2f38270a95c-768287013a203866-00",
+        "traceparent": "00-559c0f4dc72984e05798a895c77ccd7a-e624361fe0572692-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a1d04a5a77047b7e7eb0e89ed7371565",
+        "x-ms-client-request-id": "c353c864f5ca8625cb5dbc2a4912aba0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -24,29 +24,168 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:22 GMT",
-        "MS-CV": "9sLaDU4fBUK0G0sH9mJPhw.0",
+        "Date": "Mon, 05 Dec 2022 23:51:55 GMT",
+        "MS-CV": "0MHgAZwELUqzfZXZ/CSXDg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0cnWOYwAAAADV24BxaOAYQ7Yv0ePtxxd0UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0GoSOYwAAAADxnr90nfqLTJBTjrYR\u002BaT2UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "414ms"
+        "X-Processing-Time": "595ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.com": {
-            "sipSignalingPort": 3333
-          },
           "sbs1.com": {
             "sipSignalingPort": 5555
           }
         },
         "routes": []
       }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-75596d4fcc21698c52d612bafab3f095-5fda5dfe728be59a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dc4c33dda62fe3acdd8dabdc3ebf4397",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:55 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:55 GMT",
+        "MS-CV": "Eu6gaYbxlkq0EiZAdHIc/Q.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0G4SOYwAAAAB9G28CuLE2ToIOWkNAs/j3UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "89ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 5555
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f4ac16527889ab618fd16ad461504610-5c90938648332da9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f35d9fff44bbf76949b58da2d206743d",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:55 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:55 GMT",
+        "MS-CV": "Z0JnAQvAyEKlj8BN2Q6itA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0G4SOYwAAAAAqpaROQg0oSp5SYDjYhG//UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "84ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 5555
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8ec69284f56109ce44bbfe185d27b2b7-3986ebd51ad8e3cc-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3042a472dff8be251c70e63c4a48470b",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:56 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:56 GMT",
+        "MS-CV": "spNpagkC\u002B0aFGabFsI7WeA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0HISOYwAAAADzlI16ksXJS4e9i85lTK2jUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "84ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 5555
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "28",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-8ec69284f56109ce44bbfe185d27b2b7-95ffaaa64e767de4-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a92a251ab8b498e5c9559279190a10d6",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:56 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:56 GMT",
+        "MS-CV": "hGMbVYTRgkq3o8GIfhx\u002BqQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0HISOYwAAAAB5F6WljE5eQI4KeJ/xiIyZUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "262ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1900474114"
+    "RandomSeed": "201467533"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthenticationAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthenticationAsync.json
@@ -1,21 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "63",
+        "Content-Length": "49",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-bf796539c83e11ebe48e2cd8724e4f44-2ba5fc92bf52fe37-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7fa61bad7badecede72a4d306df2045b",
+        "traceparent": "00-ad57c9761fb381dd6cc6a2f38270a95c-768287013a203866-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a1d04a5a77047b7e7eb0e89ed7371565",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 5555
           }
         }
@@ -24,20 +24,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:34 GMT",
-        "MS-CV": "HUScO5h\u002ByE29v8pWjFzy8w.0",
+        "Date": "Mon, 05 Dec 2022 22:49:22 GMT",
+        "MS-CV": "9sLaDU4fBUK0G0sH9mJPhw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wtZDYwAAAACPxMEaZaaBRY9tj1CuQ35sTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0cnWOYwAAAADV24BxaOAYQ7Yv0ePtxxd0UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "576ms"
+        "X-Processing-Time": "414ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           },
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -46,7 +46,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1762378800"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "1900474114"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthenticationAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthenticationAsync.json
@@ -6,16 +6,16 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "49",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-559c0f4dc72984e05798a895c77ccd7a-e624361fe0572692-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c353c864f5ca8625cb5dbc2a4912aba0",
+        "traceparent": "00-e497e0d80056d99653588c5ab980926b-6f66e708da4a08bb-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1650a91f4fc2eaf65c10b9296be433b4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.3ab5d285-c475-ec6c-b51c-68b637226797.com": {
             "sipSignalingPort": 5555
           }
         }
@@ -24,17 +24,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:55 GMT",
-        "MS-CV": "0MHgAZwELUqzfZXZ/CSXDg.0",
+        "Date": "Tue, 13 Dec 2022 01:47:27 GMT",
+        "MS-CV": "fiz7RobDAEeaXm1zwz8p4Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0GoSOYwAAAADxnr90nfqLTJBTjrYR\u002BaT2UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0sNmXYwAAAAAxPf1uqLW7Sa\u002B4xe//JJpBUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "595ms"
+        "X-Processing-Time": "289ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.3ab5d285-c475-ec6c-b51c-68b637226797.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -47,11 +47,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-75596d4fcc21698c52d612bafab3f095-5fda5dfe728be59a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "dc4c33dda62fe3acdd8dabdc3ebf4397",
+        "traceparent": "00-72cfebb743ad574a6746e79a7fc87d52-4416b46f6841371a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4f08fe4e4cc882c1f94407f6eae75ec1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:55 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:28 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -59,17 +59,52 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:55 GMT",
-        "MS-CV": "Eu6gaYbxlkq0EiZAdHIc/Q.0",
+        "Date": "Tue, 13 Dec 2022 01:47:28 GMT",
+        "MS-CV": "DjEU0LtGjUuD677JweWLSA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0G4SOYwAAAAB9G28CuLE2ToIOWkNAs/j3UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0sNmXYwAAAAArsoH4xMGKRK8zUv\u002B7LkAIUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "92ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.3ab5d285-c475-ec6c-b51c-68b637226797.com": {
+            "sipSignalingPort": 5555
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6ca1ddbe933da7098990b0cc524268cc-b892c15098f1a923-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3bb366ec25d7360fdccbde640b4381d0",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:28 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:47:28 GMT",
+        "MS-CV": "ET6/3TfLrUCcD46jcrbIqw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0sNmXYwAAAACI7YkV5QR\u002BQKaDl\u002BSIj9ImUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "89ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.3ab5d285-c475-ec6c-b51c-68b637226797.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -82,11 +117,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f4ac16527889ab618fd16ad461504610-5c90938648332da9-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f35d9fff44bbf76949b58da2d206743d",
+        "traceparent": "00-95e83fa29382dbe5bacd1cea65715000-182bb8b4be2c2a3f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3968b4e91719d2cfe7cd1c7e48ff0074",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:55 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:28 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -94,52 +129,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:55 GMT",
-        "MS-CV": "Z0JnAQvAyEKlj8BN2Q6itA.0",
+        "Date": "Tue, 13 Dec 2022 01:47:28 GMT",
+        "MS-CV": "yX5mHgLTu0G98PmthpWk9w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0G4SOYwAAAAAqpaROQg0oSp5SYDjYhG//UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0sdmXYwAAAAAwP0eEZeRhQrZQrm2i0kZsUFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
+        "X-Processing-Time": "82ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 5555
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-8ec69284f56109ce44bbfe185d27b2b7-3986ebd51ad8e3cc-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3042a472dff8be251c70e63c4a48470b",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:56 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:56 GMT",
-        "MS-CV": "spNpagkC\u002B0aFGabFsI7WeA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0HISOYwAAAADzlI16ksXJS4e9i85lTK2jUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
+          "sbs1.3ab5d285-c475-ec6c-b51c-68b637226797.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -152,31 +152,31 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "28",
+        "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-8ec69284f56109ce44bbfe185d27b2b7-95ffaaa64e767de4-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a92a251ab8b498e5c9559279190a10d6",
+        "traceparent": "00-95e83fa29382dbe5bacd1cea65715000-1b8f82953a6e7b87-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "043cf7b1f73128dceed273fc6e5c77b6",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:56 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:47:28 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": null
+          "sbs1.3ab5d285-c475-ec6c-b51c-68b637226797.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:56 GMT",
-        "MS-CV": "hGMbVYTRgkq3o8GIfhx\u002BqQ.0",
+        "Date": "Tue, 13 Dec 2022 01:47:28 GMT",
+        "MS-CV": "FL48nSldUkKMGNSV9mgSXQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0HISOYwAAAAB5F6WljE5eQI4KeJ/xiIyZUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0sdmXYwAAAADqDRVgsXLPQrCsMafnflO6UFJHMDFFREdFMDkxNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "262ms"
+        "X-Processing-Time": "119ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -186,6 +186,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "201467533"
+    "RandomSeed": "1794360058"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthenticationAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthenticationAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -42,7 +42,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -77,7 +77,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -112,7 +112,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -147,7 +147,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -185,7 +185,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "201467533"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResource.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-5bef730f9f382d5582016ccd09ab6f10-155fcb666c2a6aee-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "bf0eb0dd516c01f8f36d147e3879a266",
+        "traceparent": "00-e4d1a090f49773c38d0b62b5ac0a0fa9-07b48fa9be2d1f64-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "869216ac02701493b54f25d3382eda3b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:22 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,20 +22,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:22 GMT",
-        "MS-CV": "RrRFe29N7kmnKzfcex569g.0",
+        "Date": "Mon, 05 Dec 2022 22:48:56 GMT",
+        "MS-CV": "/GN5o3kIl0qoPdJnJMM5dw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ttZDYwAAAABdIaCRclRaRLDzislqRNh\u002BTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0WXWOYwAAAADQvrGlhNWvSIYGHChgVmmqUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "112ms"
+        "X-Processing-Time": "96ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           },
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -43,16 +43,16 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-9081a6a12f8ba17dbf0817d61b5f3589-ff3e14566393a184-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5c68083cc4cd3d4fc8c48f534e02f137",
+        "traceparent": "00-3560d762ad8ec31340cd7bcd1745349c-5626c44a6c2d985f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "540c3c21e5d575b8eb311307b06ef2a4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:22 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,20 +60,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:22 GMT",
-        "MS-CV": "WxJ\u002BD979TkCMOaxehQhfjg.0",
+        "Date": "Mon, 05 Dec 2022 22:48:56 GMT",
+        "MS-CV": "xD7IXlDPDker4onWz4ht7A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0t9ZDYwAAAAA01AkCwS4KT6ETwurVceplTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0WXWOYwAAAACIuxNzIoYgRoIkIncth2CrUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "76ms"
+        "X-Processing-Time": "85ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           },
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -81,49 +81,49 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "146",
+        "Content-Length": "104",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-9081a6a12f8ba17dbf0817d61b5f3589-0239f6e792d9af3e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5360600880b56bf3470ca41ddbe44a9f",
+        "traceparent": "00-3560d762ad8ec31340cd7bcd1745349c-5bdf188f3e0cadeb-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e803917d121d20b24704b4ca028d80c3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:22 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.sipconfigtest.com": null
+          "newsbs.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:22 GMT",
-        "MS-CV": "gJg9DQWwzUeI9fkrnAOTGg.0",
+        "Date": "Mon, 05 Dec 2022 22:48:57 GMT",
+        "MS-CV": "Et1Q/o2p/kqlrAQNXtBW8g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0t9ZDYwAAAAD1fr/Ne5thRpebrPvX87cfTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0WXWOYwAAAADECAAvbG1LRIMk14hJNZoAUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "339ms"
+        "X-Processing-Time": "224ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -131,18 +131,18 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "178",
+        "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-480c6400dbbfa7a9c02c1b8d5678df3a-59d63f530ee591db-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7b4efcec3f86189960d0f6a7c2a5b3f1",
+        "traceparent": "00-369f6715fc4a1852bf55b9be1432cee0-fe4d00cd863d4046-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3eabb4f8ec92c7745e1d9a3eef8c6447",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:23 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -152,7 +152,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -161,20 +161,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:23 GMT",
-        "MS-CV": "QTBdeRpQ50K0WXFjpeoPQg.0",
+        "Date": "Mon, 05 Dec 2022 22:48:57 GMT",
+        "MS-CV": "RWtyVBqGvkCBZyojC1LTQA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0t9ZDYwAAAAAMWUnPWkCHT6hbxO3l/PspTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0WXWOYwAAAADZOCMSU8K9RpEMZ2oypEU3UFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "101ms"
+        "X-Processing-Time": "107ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -184,30 +184,30 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "63",
+        "Content-Length": "49",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-288e875f07c3ab24b0cfa5b8d8fcd5ed-0018476c734ed396-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d876dd7c4e18bcb115fc15c1203262e3",
+        "traceparent": "00-6bf25b1e5ede5c430e24cbb3aa4b7af0-f6c917d1bfd3223a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a755805cf12b0e1e89ec0dd031ed725e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:23 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 9999
           }
         }
@@ -216,20 +216,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:23 GMT",
-        "MS-CV": "lG8Wq/11yk2KD\u002Be0kra\u002BJQ.0",
+        "Date": "Mon, 05 Dec 2022 22:48:57 GMT",
+        "MS-CV": "LHW72r5ahEKDcXDQXknUuw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0t9ZDYwAAAAD\u002B2BlLzCdKSoLDE30sJRO1TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0WnWOYwAAAAA0pqMzPxq2TZj4uyDMxLUeUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "187ms"
+        "X-Processing-Time": "148ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -239,23 +239,23 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-6b38c306b44d4adb401e08ae8f180d78-136ba4d84f73cf18-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5166f07975b4c9b0c648f3e4894ba9a2",
+        "traceparent": "00-dce497d110cb61f84872bfa12e27686c-b0559ab2f422f4b1-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fb0f4fb0b4c291121d3b8a00777331bb",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:23 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:48:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -263,20 +263,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:23 GMT",
-        "MS-CV": "3beBjRSfYkm/tYzVjQBgGg.0",
+        "Date": "Mon, 05 Dec 2022 22:48:57 GMT",
+        "MS-CV": "3gaB8z0XU0qpMNAAfKp75Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0uNZDYwAAAADxvaDBx7eXQ4sQJbrLdBB7TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0WnWOYwAAAAAnAO4lGuOLSa\u002B2CGoDgrO9UFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "69ms"
+        "X-Processing-Time": "80ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -286,7 +286,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -294,7 +294,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "430956229"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "1414789406"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-528093a8d92356f2e22f634c3fd83d09-7f083b278ed8f826-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "734713a86c69170f2eb1bf4640cf67da",
+        "traceparent": "00-26eff018bbb9d867cbcb26d2bc793f79-0fdda81bd8b19f99-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "481f9151ef157412257f7d12d47cd0e3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:25 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:25 GMT",
-        "MS-CV": "ZnBXw2d1LEuIK/pcPZ0x0g.0",
+        "Date": "Tue, 13 Dec 2022 01:18:57 GMT",
+        "MS-CV": "C//C3p\u002BDqkyTET3Nxhoang.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/YOOYwAAAAAMnvHvcHNrS57jh91GHhYYUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0AdOXYwAAAABnlICO/DMdTrHhlZ7oGb2KUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "179ms"
+        "X-Processing-Time": "97ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-946055858f70e690484abc050f4f702f-613953dfd45c3ef3-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8e43881ce0860bdc5ae00f7a95bcdcdb",
+        "traceparent": "00-d2192f54859c7917022030fb3441f00e-9b9af794f66adcb3-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "29c8b0f262bc4648d4c7bf112b34d2a3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:26 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,17 +53,126 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:25 GMT",
-        "MS-CV": "kDQbHTQGQk28\u002BURHBDSivA.0",
+        "Date": "Tue, 13 Dec 2022 01:18:57 GMT",
+        "MS-CV": "2Qm73KMpa0mRlPQOnz11AA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/oOOYwAAAAAHPSpggIVtSrxKA8y2sxuwUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0AdOXYwAAAACXdVYLiAzbQIC/OzmxfGg9UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "86ms"
+        "X-Processing-Time": "83ms"
       },
       "ResponseBody": {
         "trunks": {},
         "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "160",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-d2192f54859c7917022030fb3441f00e-469b76c462129bb0-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9f1169a66f31e8629cfb6524c75f4c86",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:57 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+            "sipSignalingPort": 1123
+          }
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:18:58 GMT",
+        "MS-CV": "yUAFwUn57k2COM9wsbfxtQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0AdOXYwAAAADg1yUmobaoT6Mt6izQjdpkUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "256ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "201",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-173a7bf33bedcedf6c77dfda7bb18dbb-162f08c4a235e241-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0aaaf9013a58ef8b48d8734e300148f1",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:57 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com"
+            ]
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:18:58 GMT",
+        "MS-CV": "tPysTyEpwEGei\u002BFD8iMsxg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0AtOXYwAAAACzcleh4bKmSYm68aFyGPlWUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "105ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com"
+            ]
+          }
+        ]
       }
     },
     {
@@ -74,125 +183,16 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-946055858f70e690484abc050f4f702f-f6aec52ca9a2f56c-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d23b18303c2ea4bc350e0473d83d0b53",
+        "traceparent": "00-04daf3cc3b6ec97592221844190659ed-7929ae69a8f60e67-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6b6bd9ac306a82b14ee08dc0fd237f75",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:26 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:26 GMT",
-        "MS-CV": "fLQdHCrY0EGv4QkQHj4oNg.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/oOOYwAAAACpkUp1EID7T6W7HPOSHK2tUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "459ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "PATCH",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "164",
-        "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-616305b2034ebd6d66988855569f0d0e-17ca82eb82b92352-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "06ab4fbc038ac7d1373b18885c948172",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:27 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.com"
-            ]
-          }
-        ]
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:26 GMT",
-        "MS-CV": "dmREHFuI2EGw7CzvC1zgaQ.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/oOOYwAAAACO/A57qlXiR6\u002Bryc9jR6xgUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "171ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "PATCH",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "49",
-        "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-75aef6c7206d54f08b4d21db653487c2-e353cb711ad5a1c1-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2716e4d49494dfaccb9e5878dc68321d",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:27 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "trunks": {
-          "sbs1.com": {
+          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
             "sipSignalingPort": 9999
           }
         }
@@ -201,20 +201,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:27 GMT",
-        "MS-CV": "2WLeGh/ttEO9XHiREtM9jQ.0",
+        "Date": "Tue, 13 Dec 2022 01:18:58 GMT",
+        "MS-CV": "mO5YwsGJSkqWLrs87ZBWyw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/4OOYwAAAACE9EltAzijS4NM2SXnnZmOUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0AtOXYwAAAADU4MnnF02hQJubcxh3WHaHUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "646ms"
+        "X-Processing-Time": "145ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.com": {
+          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -224,7 +224,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com"
             ]
           }
         ]
@@ -236,11 +236,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-1b0cba2a1c8e755de3a18ee2ee0b8343-70e01b51392455f6-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "46bdbbd5d6102c5046739bf2243348a0",
+        "traceparent": "00-eb383604b3af290672348a03a336e889-da902e79f3f14b85-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "320f387bc88a6b4bdd225759fc14b89b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:28 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -248,20 +248,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:27 GMT",
-        "MS-CV": "F09JjrN80EW\u002BUN7uWO2M\u002Bg.0",
+        "Date": "Tue, 13 Dec 2022 01:18:58 GMT",
+        "MS-CV": "TVMWYY0zqEqa0Uzfqzpw2g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0AISOYwAAAAB2mOq16\u002Bh0S7f4o5WLb3b3UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0AtOXYwAAAABFCbpM8ipGRZTMXfOkCjgZUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "224ms"
+        "X-Processing-Time": "81ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.com": {
+          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -271,7 +271,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com"
             ]
           }
         ]
@@ -283,11 +283,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-df2475b16e030e5c378591b675bafb1e-6f956380385130af-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f49e918ce32728bfa2cb3aebab59ebcf",
+        "traceparent": "00-9a21dba440910e78ba3c00c24d18e5e8-2c50f98f7ae55ffd-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ed7873b3e0f3d11c4727bc78adcaf224",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:28 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -295,20 +295,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:27 GMT",
-        "MS-CV": "u91cHMlV80eqMcO2MqubXQ.0",
+        "Date": "Tue, 13 Dec 2022 01:18:58 GMT",
+        "MS-CV": "wnyDqHLwd0mzruQvQTfeag.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0AISOYwAAAAC4Bp7\u002BHkhRTKS40kCbgKeWUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0AtOXYwAAAACZeXkzAYY9Qrov7KSVnQ1KUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "94ms"
+        "X-Processing-Time": "75ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.com": {
+          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -318,7 +318,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com"
             ]
           }
         ]
@@ -332,11 +332,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-479ce374bcf8887f75fec10792993155-de568bb1c639dc0c-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a0b3fb093bd6fe6193eae120f9babb97",
+        "traceparent": "00-562e27495f0325c369ee9b455e171842-0b8402bdca00feb4-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f7d2fe5916f1e3668e008d47d9588639",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:28 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -346,20 +346,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:28 GMT",
-        "MS-CV": "G1Ihpb/PXUqn\u002BJXMbMPvRw.0",
+        "Date": "Tue, 13 Dec 2022 01:18:59 GMT",
+        "MS-CV": "1jsJ1MTrtE\u002BKuMzdNX1vxg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0AISOYwAAAACi9l6ty116RbJG67aYdzdYUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0A9OXYwAAAAAFVa88O6bTT491sa5rd9eMUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "694ms"
+        "X-Processing-Time": "145ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.com": {
+          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -372,11 +372,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-58fd47e7c74e6fe333b5129b61cbb55d-fc5a9ed1c2786f53-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4aebb7563ec9f1f6fc95a4449b6581ed",
+        "traceparent": "00-2f8f07ac93e9a01ed08dba199e0f8128-79fbb1c4fe8353f2-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "890df22792ab9a811c3eea620cd3bd12",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:29 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -384,20 +384,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:28 GMT",
-        "MS-CV": "bcSByrl1kUyKeZE9AnTjZg.0",
+        "Date": "Tue, 13 Dec 2022 01:18:59 GMT",
+        "MS-CV": "RdP3bimwsE2EnnIeVKAyLw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0AYSOYwAAAAABw5yqgFRjQ4vtT7ilAXZzUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0A9OXYwAAAABEiurpGWEPRahGdNWzq64NUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
+        "X-Processing-Time": "76ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.com": {
+          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -410,11 +410,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-c35a32057d30708af5a3d5e283b1f141-188c4632e341ad98-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "28e9cc88a78051ca2fa0603c029f2fe7",
+        "traceparent": "00-b62f9b6f2fb0aa6496b36e04595e6db0-befdef0a3ecd0b06-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fd003230c1419ca90d945ef353d4f7ee",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:29 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:59 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -422,20 +422,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:28 GMT",
-        "MS-CV": "j6aZ/FL97E2xrWF3IdcU1Q.0",
+        "Date": "Tue, 13 Dec 2022 01:18:59 GMT",
+        "MS-CV": "89qIldh130GFFRDH6eVtPg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0AYSOYwAAAACRT1L6ifnfS60ap0Q\u002BDCZkUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0A9OXYwAAAABvStLlPCWIQLfE7NIwLt\u002BoUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
+        "X-Processing-Time": "82ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.com": {
+          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -448,32 +448,32 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "44",
+        "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-c35a32057d30708af5a3d5e283b1f141-de98d1937b90ebd7-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f395a310a16dca0505c1a441971c632e",
+        "traceparent": "00-b62f9b6f2fb0aa6496b36e04595e6db0-7cfcd72fde7775dd-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bb5082a068bdc6797d38dbb32c04d7bb",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:29 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:18:59 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": null,
-          "sbs2.com": null
+          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": null,
+          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:51:29 GMT",
-        "MS-CV": "lV/tjzHM5kiQTYU2U644uw.0",
+        "Date": "Tue, 13 Dec 2022 01:18:59 GMT",
+        "MS-CV": "b1PqVmm0R0ObgWDvbZtsLg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0AYSOYwAAAAClcQo7QoiwRrjTP2RuzcW4UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0A9OXYwAAAABu0N5UU4aeTYjYg6Hopy65UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "280ms"
+        "X-Processing-Time": "115ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -483,6 +483,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "493862128"
+    "RandomSeed": "1861615653"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-e4d1a090f49773c38d0b62b5ac0a0fa9-07b48fa9be2d1f64-00",
+        "traceparent": "00-528093a8d92356f2e22f634c3fd83d09-7f083b278ed8f826-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "869216ac02701493b54f25d3382eda3b",
+        "x-ms-client-request-id": "734713a86c69170f2eb1bf4640cf67da",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:57 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:25 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,23 +22,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:56 GMT",
-        "MS-CV": "/GN5o3kIl0qoPdJnJMM5dw.0",
+        "Date": "Mon, 05 Dec 2022 23:51:25 GMT",
+        "MS-CV": "ZnBXw2d1LEuIK/pcPZ0x0g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0WXWOYwAAAADQvrGlhNWvSIYGHChgVmmqUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/YOOYwAAAAAMnvHvcHNrS57jh91GHhYYUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "96ms"
+        "X-Processing-Time": "179ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "newsbs.com": {
-            "sipSignalingPort": 3333
-          },
-          "sbs1.com": {
-            "sipSignalingPort": 5555
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -48,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-3560d762ad8ec31340cd7bcd1745349c-5626c44a6c2d985f-00",
+        "traceparent": "00-946055858f70e690484abc050f4f702f-613953dfd45c3ef3-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "540c3c21e5d575b8eb311307b06ef2a4",
+        "x-ms-client-request-id": "8e43881ce0860bdc5ae00f7a95bcdcdb",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:57 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:26 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,23 +53,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:56 GMT",
-        "MS-CV": "xD7IXlDPDker4onWz4ht7A.0",
+        "Date": "Mon, 05 Dec 2022 23:51:25 GMT",
+        "MS-CV": "kDQbHTQGQk28\u002BURHBDSivA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0WXWOYwAAAACIuxNzIoYgRoIkIncth2CrUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/oOOYwAAAAAHPSpggIVtSrxKA8y2sxuwUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "85ms"
+        "X-Processing-Time": "86ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "newsbs.com": {
-            "sipSignalingPort": 3333
-          },
-          "sbs1.com": {
-            "sipSignalingPort": 5555
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -86,13 +72,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "104",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-3560d762ad8ec31340cd7bcd1745349c-5bdf188f3e0cadeb-00",
+        "traceparent": "00-946055858f70e690484abc050f4f702f-f6aec52ca9a2f56c-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e803917d121d20b24704b4ca028d80c3",
+        "x-ms-client-request-id": "d23b18303c2ea4bc350e0473d83d0b53",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:57 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:26 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -102,21 +88,20 @@
           },
           "sbs2.com": {
             "sipSignalingPort": 1123
-          },
-          "newsbs.com": null
+          }
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:57 GMT",
-        "MS-CV": "Et1Q/o2p/kqlrAQNXtBW8g.0",
+        "Date": "Mon, 05 Dec 2022 23:51:26 GMT",
+        "MS-CV": "fLQdHCrY0EGv4QkQHj4oNg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0WXWOYwAAAADECAAvbG1LRIMk14hJNZoAUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/oOOYwAAAACpkUp1EID7T6W7HPOSHK2tUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "224ms"
+        "X-Processing-Time": "459ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -138,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-369f6715fc4a1852bf55b9be1432cee0-fe4d00cd863d4046-00",
+        "traceparent": "00-616305b2034ebd6d66988855569f0d0e-17ca82eb82b92352-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3eabb4f8ec92c7745e1d9a3eef8c6447",
+        "x-ms-client-request-id": "06ab4fbc038ac7d1373b18885c948172",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:57 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:27 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -161,13 +146,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:57 GMT",
-        "MS-CV": "RWtyVBqGvkCBZyojC1LTQA.0",
+        "Date": "Mon, 05 Dec 2022 23:51:26 GMT",
+        "MS-CV": "dmREHFuI2EGw7CzvC1zgaQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0WXWOYwAAAADZOCMSU8K9RpEMZ2oypEU3UFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/oOOYwAAAACO/A57qlXiR6\u002Bryc9jR6xgUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "107ms"
+        "X-Processing-Time": "171ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -198,11 +183,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "49",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-6bf25b1e5ede5c430e24cbb3aa4b7af0-f6c917d1bfd3223a-00",
+        "traceparent": "00-75aef6c7206d54f08b4d21db653487c2-e353cb711ad5a1c1-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a755805cf12b0e1e89ec0dd031ed725e",
+        "x-ms-client-request-id": "2716e4d49494dfaccb9e5878dc68321d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:58 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:27 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -216,13 +201,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:57 GMT",
-        "MS-CV": "LHW72r5ahEKDcXDQXknUuw.0",
+        "Date": "Mon, 05 Dec 2022 23:51:27 GMT",
+        "MS-CV": "2WLeGh/ttEO9XHiREtM9jQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0WnWOYwAAAAA0pqMzPxq2TZj4uyDMxLUeUFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/4OOYwAAAACE9EltAzijS4NM2SXnnZmOUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "148ms"
+        "X-Processing-Time": "646ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -251,11 +236,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-dce497d110cb61f84872bfa12e27686c-b0559ab2f422f4b1-00",
+        "traceparent": "00-1b0cba2a1c8e755de3a18ee2ee0b8343-70e01b51392455f6-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "fb0f4fb0b4c291121d3b8a00777331bb",
+        "x-ms-client-request-id": "46bdbbd5d6102c5046739bf2243348a0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:48:58 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:28 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -263,13 +248,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:48:57 GMT",
-        "MS-CV": "3gaB8z0XU0qpMNAAfKp75Q.0",
+        "Date": "Mon, 05 Dec 2022 23:51:27 GMT",
+        "MS-CV": "F09JjrN80EW\u002BUN7uWO2M\u002Bg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0WnWOYwAAAAAnAO4lGuOLSa\u002B2CGoDgrO9UFJHMDFFREdFMDkxNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0AISOYwAAAAB2mOq16\u002Bh0S7f4o5WLb3b3UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "80ms"
+        "X-Processing-Time": "224ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -291,10 +276,213 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-df2475b16e030e5c378591b675bafb1e-6f956380385130af-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f49e918ce32728bfa2cb3aebab59ebcf",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:28 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:27 GMT",
+        "MS-CV": "u91cHMlV80eqMcO2MqubXQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0AISOYwAAAAC4Bp7\u002BHkhRTKS40kCbgKeWUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "94ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 9999
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-479ce374bcf8887f75fec10792993155-de568bb1c639dc0c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a0b3fb093bd6fe6193eae120f9babb97",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:28 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:28 GMT",
+        "MS-CV": "G1Ihpb/PXUqn\u002BJXMbMPvRw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0AISOYwAAAACi9l6ty116RbJG67aYdzdYUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "694ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 9999
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-58fd47e7c74e6fe333b5129b61cbb55d-fc5a9ed1c2786f53-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4aebb7563ec9f1f6fc95a4449b6581ed",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:29 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:28 GMT",
+        "MS-CV": "bcSByrl1kUyKeZE9AnTjZg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0AYSOYwAAAAABw5yqgFRjQ4vtT7ilAXZzUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "87ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 9999
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c35a32057d30708af5a3d5e283b1f141-188c4632e341ad98-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "28e9cc88a78051ca2fa0603c029f2fe7",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:29 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:28 GMT",
+        "MS-CV": "j6aZ/FL97E2xrWF3IdcU1Q.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0AYSOYwAAAACRT1L6ifnfS60ap0Q\u002BDCZkUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "87ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 9999
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "44",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-c35a32057d30708af5a3d5e283b1f141-de98d1937b90ebd7-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f395a310a16dca0505c1a441971c632e",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:29 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.com": null,
+          "sbs2.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:51:29 GMT",
+        "MS-CV": "lV/tjzHM5kiQTYU2U644uw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0AYSOYwAAAAClcQo7QoiwRrjTP2RuzcW4UFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "280ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1414789406"
+    "RandomSeed": "493862128"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-26eff018bbb9d867cbcb26d2bc793f79-0fdda81bd8b19f99-00",
+        "traceparent": "00-430c97640f99df03d7f20f006bcfcd75-956fe09a350ebf2c-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "481f9151ef157412257f7d12d47cd0e3",
+        "x-ms-client-request-id": "22a8463e66febc50e6e7a819a9f5cf58",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:57 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:44 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:57 GMT",
-        "MS-CV": "C//C3p\u002BDqkyTET3Nxhoang.0",
+        "Date": "Tue, 13 Dec 2022 20:16:46 GMT",
+        "MS-CV": "XoDr\u002B5/hJkKuZD/Ct1/exw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0AdOXYwAAAABnlICO/DMdTrHhlZ7oGb2KUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0rd2YYwAAAACo0ZI/ObuhRZcDl0/TrdNdUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "97ms"
+        "X-Processing-Time": "174ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-d2192f54859c7917022030fb3441f00e-9b9af794f66adcb3-00",
+        "traceparent": "00-345bac9dbf890f8548b62d04ad010b6e-6e74dadfa87b413a-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "29c8b0f262bc4648d4c7bf112b34d2a3",
+        "x-ms-client-request-id": "138635d20207b166c916437a79756ff3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:57 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:45 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:57 GMT",
-        "MS-CV": "2Qm73KMpa0mRlPQOnz11AA.0",
+        "Date": "Tue, 13 Dec 2022 20:16:46 GMT",
+        "MS-CV": "i9RwpOrw0kSA8We3HroUtg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0AdOXYwAAAACXdVYLiAzbQIC/OzmxfGg9UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0rt2YYwAAAADT33LOW70iSpK4KQche/2UUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
+        "X-Processing-Time": "86ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d2192f54859c7917022030fb3441f00e-469b76c462129bb0-00",
+        "traceparent": "00-345bac9dbf890f8548b62d04ad010b6e-26497679b74ff17f-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "9f1169a66f31e8629cfb6524c75f4c86",
+        "x-ms-client-request-id": "649f16c5062a0c099652db14aed55c81",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:57 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:45 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:58 GMT",
-        "MS-CV": "yUAFwUn57k2COM9wsbfxtQ.0",
+        "Date": "Tue, 13 Dec 2022 20:16:46 GMT",
+        "MS-CV": "SzWmq4O0TUSk\u002Bj7EgWm2SQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0AdOXYwAAAADg1yUmobaoT6Mt6izQjdpkUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0rt2YYwAAAADHfTa0fiFmQYkJ892OW9sLUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "256ms"
+        "X-Processing-Time": "481ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-173a7bf33bedcedf6c77dfda7bb18dbb-162f08c4a235e241-00",
+        "traceparent": "00-61055a5c630eaa8df31b022e69434713-1be6d1ef3e543c5c-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0aaaf9013a58ef8b48d8734e300148f1",
+        "x-ms-client-request-id": "cf678130dadc3bebdff659e722d64370",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:57 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:45 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com"
+              "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:58 GMT",
-        "MS-CV": "tPysTyEpwEGei\u002BFD8iMsxg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:47 GMT",
+        "MS-CV": "Gg\u002BD1gtsdESAeUb0iwC2mg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0AtOXYwAAAACzcleh4bKmSYm68aFyGPlWUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0rt2YYwAAAACrVCg9H\u002BYMQJ/TwidLR2QAUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "105ms"
+        "X-Processing-Time": "183ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com"
+              "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com"
             ]
           }
         ]
@@ -183,16 +183,16 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-04daf3cc3b6ec97592221844190659ed-7929ae69a8f60e67-00",
+        "traceparent": "00-64346450a3602dbb5149eedb785b886b-dcaaf21f8e23cc06-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6b6bd9ac306a82b14ee08dc0fd237f75",
+        "x-ms-client-request-id": "9254b5786a56cb2d2b797db4265103f3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:58 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:46 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
             "sipSignalingPort": 9999
           }
         }
@@ -201,20 +201,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:58 GMT",
-        "MS-CV": "mO5YwsGJSkqWLrs87ZBWyw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:47 GMT",
+        "MS-CV": "E\u002BTgYaMQGUmR4VbLxMMbLA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0AtOXYwAAAADU4MnnF02hQJubcxh3WHaHUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0r92YYwAAAAB1oS4AZWF4RZqLWnMQGF5CUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "145ms"
+        "X-Processing-Time": "250ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -224,7 +224,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com"
+              "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com"
             ]
           }
         ]
@@ -236,11 +236,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-eb383604b3af290672348a03a336e889-da902e79f3f14b85-00",
+        "traceparent": "00-f2b19a91c74a4f6ed51eab3b82d50199-aac617627991b89e-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "320f387bc88a6b4bdd225759fc14b89b",
+        "x-ms-client-request-id": "f749c2ba9f0dea162a638533ad21eabf",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:58 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:46 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -248,20 +248,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:58 GMT",
-        "MS-CV": "TVMWYY0zqEqa0Uzfqzpw2g.0",
+        "Date": "Tue, 13 Dec 2022 20:16:47 GMT",
+        "MS-CV": "kJuuWwJON0amt1BSihMiZA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0AtOXYwAAAABFCbpM8ipGRZTMXfOkCjgZUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0r92YYwAAAADSSXolGctKS5ubOdmbvbMaUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "81ms"
+        "X-Processing-Time": "106ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -271,7 +271,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com"
+              "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com"
             ]
           }
         ]
@@ -283,11 +283,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-9a21dba440910e78ba3c00c24d18e5e8-2c50f98f7ae55ffd-00",
+        "traceparent": "00-d53d1ac059c54feeefdd3e17eed56058-27693ea7675b60f3-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ed7873b3e0f3d11c4727bc78adcaf224",
+        "x-ms-client-request-id": "f89c6a0fc981c52b549ca3635d36148d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:58 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:46 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -295,20 +295,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:58 GMT",
-        "MS-CV": "wnyDqHLwd0mzruQvQTfeag.0",
+        "Date": "Tue, 13 Dec 2022 20:16:47 GMT",
+        "MS-CV": "I3chCn2Fp0SvnPc086I8TQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0AtOXYwAAAACZeXkzAYY9Qrov7KSVnQ1KUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0r92YYwAAAAC//Lg0DWq7RIpaw2Y55mYiUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "75ms"
+        "X-Processing-Time": "82ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -318,7 +318,54 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com"
+              "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e3f2e2e832c732a100bb63b705b4ddaa-da6c515f672a7728-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "602d65f34b8cd8639f6a67f2e5fa1d09",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:46 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:16:48 GMT",
+        "MS-CV": "GEM5vIxrLEWeh47TGmzqXA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0r92YYwAAAACGhtCTUMwbR6FfVbnPmE4vUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "88ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
+            "sipSignalingPort": 9999
+          },
+          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com"
             ]
           }
         ]
@@ -332,11 +379,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-562e27495f0325c369ee9b455e171842-0b8402bdca00feb4-00",
+        "traceparent": "00-1f4292e2692230a130261bec8a76ee16-8140f0b103fa1b81-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f7d2fe5916f1e3668e008d47d9588639",
+        "x-ms-client-request-id": "bba5bd8f0ab4f1729784a371fbb38cf4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:58 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:47 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -346,20 +393,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:59 GMT",
-        "MS-CV": "1jsJ1MTrtE\u002BKuMzdNX1vxg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:48 GMT",
+        "MS-CV": "jkmnJ58oVE2wFCVh7lAvpg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0A9OXYwAAAAAFVa88O6bTT491sa5rd9eMUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0sN2YYwAAAAAagTQkZbOeSarXsXp3ZI8jUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "145ms"
+        "X-Processing-Time": "153ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -372,11 +419,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-2f8f07ac93e9a01ed08dba199e0f8128-79fbb1c4fe8353f2-00",
+        "traceparent": "00-24f239df6d952e31b8e249f90a5c47a6-0bd1345c05083b86-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "890df22792ab9a811c3eea620cd3bd12",
+        "x-ms-client-request-id": "473ff74f89f4c43307c459176138e05a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:58 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:47 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -384,58 +431,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:59 GMT",
-        "MS-CV": "RdP3bimwsE2EnnIeVKAyLw.0",
+        "Date": "Tue, 13 Dec 2022 20:16:48 GMT",
+        "MS-CV": "4/Iv0EiuSkqNrxST/iGByA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0A9OXYwAAAABEiurpGWEPRahGdNWzq64NUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0sN2YYwAAAADyET8D22L3TpNS/3F1\u002Bfl\u002BUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "76ms"
+        "X-Processing-Time": "94ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-b62f9b6f2fb0aa6496b36e04595e6db0-befdef0a3ecd0b06-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "fd003230c1419ca90d945ef353d4f7ee",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:59 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:59 GMT",
-        "MS-CV": "89qIldh130GFFRDH6eVtPg.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0A9OXYwAAAABvStLlPCWIQLfE7NIwLt\u002BoUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "82ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
-            "sipSignalingPort": 9999
-          },
-          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": {
+          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -450,30 +459,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-b62f9b6f2fb0aa6496b36e04595e6db0-7cfcd72fde7775dd-00",
+        "traceparent": "00-24f239df6d952e31b8e249f90a5c47a6-04a83c68ba1f3477-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "bb5082a068bdc6797d38dbb32c04d7bb",
+        "x-ms-client-request-id": "9fd39a7e5991e9d8f33cc808a8f1dceb",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:18:59 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:16:47 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.8b70afd8-44a4-2071-03d2-dd9dba216448.com": null,
-          "sbs2.8b70afd8-44a4-2071-03d2-dd9dba216448.com": null
+          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": null,
+          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:18:59 GMT",
-        "MS-CV": "b1PqVmm0R0ObgWDvbZtsLg.0",
+        "Date": "Tue, 13 Dec 2022 20:16:48 GMT",
+        "MS-CV": "Bo9IvZD4HU6MsbLdLqB7ow.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0A9OXYwAAAABu0N5UU4aeTYjYg6Hopy65UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0sN2YYwAAAAA2vAGupLbMT7oEux1TqyskUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "115ms"
+        "X-Processing-Time": "257ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -483,6 +492,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1861615653"
+    "RandomSeed": "1752059362"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResource.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -67,7 +67,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -116,7 +116,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -176,7 +176,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -231,7 +231,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -278,7 +278,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -325,7 +325,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -367,7 +367,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -405,7 +405,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -443,7 +443,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -482,7 +482,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "493862128"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d06274c738f4b37f96631be07ee17554-61821a74a2ac21e8-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "755582669e6cf4fe5cc0f171e4dfa983",
+        "traceparent": "00-e316212ccb99785d47b7439c3eba9e83-c02f91b940071e2c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c902219e4008e91553a493fc354aa2f5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:51:56 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:09 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:52:01 GMT",
-        "MS-CV": "\u002BSfmgTtP90\u002ByTMhIHzc6Iw.0",
+        "Date": "Tue, 13 Dec 2022 01:40:10 GMT",
+        "MS-CV": "59WUBnCbiUWlK\u002BzPACfTBQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0HISOYwAAAABBaBVyxL3xSIWTHl12uWaLUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BteXYwAAAAA4B21W2F/PQI9yEyd10t3bUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "4136ms"
+        "X-Processing-Time": "102ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-2790df6495e2e42384d1d4950a83f97f-415ac4b778d3e2ee-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6edc4908b74d4ad37f26d85b224568d9",
+        "traceparent": "00-458086c744d68f1fff24ac7436174eea-c69222d70d28f5f5-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c09270d0f6281a840929acb45fef2f78",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:52:01 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:09 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,17 +53,126 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:52:01 GMT",
-        "MS-CV": "5a\u002BoJXjewUSj6y1nn8VkqQ.0",
+        "Date": "Tue, 13 Dec 2022 01:40:10 GMT",
+        "MS-CV": "MTDqBOKulECW0NGscH0akw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0IYSOYwAAAAAU61m7oUGiRrjAY3aq2eDKUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002BteXYwAAAAAHfZGHnO3rTpGN4B\u002BNCQffUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "95ms"
+        "X-Processing-Time": "76ms"
       },
       "ResponseBody": {
         "trunks": {},
         "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "160",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-458086c744d68f1fff24ac7436174eea-2d398d59621b09e2-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a7d4cf0cb6f14c2f36ae962fba882ea9",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:10 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+            "sipSignalingPort": 1123
+          }
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:40:10 GMT",
+        "MS-CV": "7mR2zPDl6kOiZDv\u002BEl4beA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0\u002BteXYwAAAABu4dZdFcQtS7qUColScf\u002BvUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "233ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "201",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-b3321a0e8e4e05d2d34480c420ff3eb6-01ae080cb6c960c1-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "121dacb7bd50a80c9ce7bfdf94608a63",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:10 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com"
+            ]
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 01:40:10 GMT",
+        "MS-CV": "SeXX6W\u002BZU0O2YPWhWGBQ\u002BA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0\u002BteXYwAAAACYWq96NbvrRJLFKCMvWWG3UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "107ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com"
+            ]
+          }
+        ]
       }
     },
     {
@@ -74,125 +183,16 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-2790df6495e2e42384d1d4950a83f97f-9a4212d16aaaa28b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7c37ea9ec044d35df95dad094fec6977",
+        "traceparent": "00-8059ff606c8e29e80739dfcd118a58ba-a9ad96f69138cace-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "66ef1a74fa7619034046897960556081",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:52:01 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:10 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:52:02 GMT",
-        "MS-CV": "hOxzoNnP1km/AzFwUaHJlg.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0IYSOYwAAAAByGMQjK3ydRYVJGKjUI74pUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "767ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "PATCH",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "164",
-        "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-57e3dac62abefea714eccca57729e5ff-ddb2ac2c2b8946bc-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "34cc289373f8af5aae0bf545c5a3d116",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:52:02 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.com"
-            ]
-          }
-        ]
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:52:02 GMT",
-        "MS-CV": "Tyszu6boyECrF/XIkLpNCg.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0IoSOYwAAAAA64RUIoNvIRJQ7aDT1NFaYUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "111ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "PATCH",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "49",
-        "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-bdb1f16ca0d103315f7ad05044cb879a-7ce8f94f2f56e897-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f9d318572ca8473eec0975ef0acafa93",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:52:02 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "trunks": {
-          "sbs1.com": {
+          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
             "sipSignalingPort": 9999
           }
         }
@@ -201,20 +201,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:52:02 GMT",
-        "MS-CV": "uNu6fy\u002B1nkObXf9uKfwFlw.0",
+        "Date": "Tue, 13 Dec 2022 01:40:11 GMT",
+        "MS-CV": "PMgbK1mTjUiku6xJPaJRqA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0IoSOYwAAAABCgcggO3XfTbSWgjB7t7PSUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002B9eXYwAAAADLVtJVJnhbTL6Cd3Oq0vAAUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "155ms"
+        "X-Processing-Time": "164ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.com": {
+          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -224,7 +224,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com"
             ]
           }
         ]
@@ -236,11 +236,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-c2e815f24f12dfee75add10f3891fd05-a27d3a645e283fe2-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "fac861bd34792be08f88ce39cb170d55",
+        "traceparent": "00-f1fc8ae3756066535f559a9c1a91e3fd-3f0d75e058457569-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b2fd03fa1dd24f28c22b0a09f750b7d6",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:52:02 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:10 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -248,20 +248,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:52:02 GMT",
-        "MS-CV": "agTkN4YahEqA33DHTjogkA.0",
+        "Date": "Tue, 13 Dec 2022 01:40:11 GMT",
+        "MS-CV": "vvxco6g180urlC7SrmRUfg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0IoSOYwAAAADo0T9wZktGQI83uOMB3DjyUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002B9eXYwAAAADMSQVIvujuSqXbwGby20puUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "77ms"
+        "X-Processing-Time": "76ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.com": {
+          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -271,7 +271,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com"
             ]
           }
         ]
@@ -283,11 +283,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-6bdc2435854305217c0a1e12edd458dd-51b888e93dbcdb63-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "37b2968b6f1966cee98448effd6ba5e4",
+        "traceparent": "00-7f1bdf915156731b290fda1cfa6db15b-e71b7212ff609cae-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a0ba3224c798bc32a803d10934934747",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:52:02 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:11 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -295,20 +295,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:52:02 GMT",
-        "MS-CV": "l1GpUt2wOUm5AGznqS7\u002BFg.0",
+        "Date": "Tue, 13 Dec 2022 01:40:11 GMT",
+        "MS-CV": "uIvTgEK93UCWWT42\u002B/3uHQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0IoSOYwAAAABoDC3j3N4rQLdKGddGWnDfUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002B9eXYwAAAADiJsEyXEtASryvdi3yUQDlUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "77ms"
+        "X-Processing-Time": "81ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.com": {
+          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -318,7 +318,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.com"
+              "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com"
             ]
           }
         ]
@@ -332,11 +332,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-80324b05c77649126dae13e5a54a89ce-65daf5d78b110d6d-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "63886110d7db239d37a869205e057bd4",
+        "traceparent": "00-50f43d6927904ece4d58c4f10a8aa072-0d778b9a25cf65e4-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "91e53d87d7635791f1a0a44aeffa22f0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:52:03 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:11 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -346,20 +346,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:52:03 GMT",
-        "MS-CV": "QGoxz3A\u002BDkKaccxAPKHuAA.0",
+        "Date": "Tue, 13 Dec 2022 01:40:11 GMT",
+        "MS-CV": "ZbuViezouk2iBL78e0qgcg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0I4SOYwAAAABNoFlVRG10T4znzxAbu0ONUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002B9eXYwAAAAB8C7vece\u002B5QabnFz\u002Bj/nVPUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "120ms"
+        "X-Processing-Time": "108ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.com": {
+          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -372,11 +372,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-4c2583129447220a0e1e8c8f4eb8152d-89cf99852767b7e8-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "73631ffbc3174d7a926110f4ebf02d24",
+        "traceparent": "00-675f855fecade1bb7c30de3f70669477-7e0d58eafea0d986-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2d54b38ebf9b32e9d04009ce4b1e1a2e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:52:03 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:11 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -384,20 +384,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:52:03 GMT",
-        "MS-CV": "mOwLkxhlm0CtG3DnXU2cjw.0",
+        "Date": "Tue, 13 Dec 2022 01:40:12 GMT",
+        "MS-CV": "nmSQZ6zBO0GRWypFF0J2SA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0I4SOYwAAAAD9wiljhZcJQaS4cM/AM0RfUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0\u002B9eXYwAAAACaYSt1HaF1RI\u002BY14ol7PJRUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "79ms"
+        "X-Processing-Time": "83ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.com": {
+          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -410,11 +410,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-2433fad77c5a1113e93bcdf4d3a13b72-9f58108056e1f2cd-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6928eae3a98eb479f88eff7006ae07e3",
+        "traceparent": "00-56d47a24524140ed277164cb9f23fd87-2a887b9698d99333-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b981c3e3266b4d72a163aef723e7cdae",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:52:03 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:11 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -422,20 +422,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:52:03 GMT",
-        "MS-CV": "GMBp13vlckmSacWooY5rbA.0",
+        "Date": "Tue, 13 Dec 2022 01:40:12 GMT",
+        "MS-CV": "HphI9J3mTkuMmMjESFowDA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0I4SOYwAAAACfEyLHAPiDQJPOAvPS1AMHUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/NeXYwAAAAAp/CjZCXhBR6QyYBaT2iYMUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "76ms"
+        "X-Processing-Time": "75ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.com": {
+          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.com": {
+          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -448,32 +448,32 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "44",
+        "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-2433fad77c5a1113e93bcdf4d3a13b72-ea4c4bfb7f8b4376-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "def3730831074dcce73bd079c6a93746",
+        "traceparent": "00-56d47a24524140ed277164cb9f23fd87-e092b2e7cfda5acf-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "817be1e1193ec8ab54b2c022cdc20bd3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 23:52:03 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 01:40:11 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.com": null,
-          "sbs2.com": null
+          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": null,
+          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 23:52:03 GMT",
-        "MS-CV": "/V/gQ0lWpUiHn8ue7GVZHw.0",
+        "Date": "Tue, 13 Dec 2022 01:40:12 GMT",
+        "MS-CV": "6ucyH2TqM0\u002B\u002B6cA1vO6syg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0I4SOYwAAAABCtEcNwmbqQrPYqv7S0IwiUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0/NeXYwAAAAAwg39Upkr5TJm53rf2ABwZUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "111ms"
+        "X-Processing-Time": "109ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -483,6 +483,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1771044239"
+    "RandomSeed": "3406901"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResourceAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-9362b0caae7f2ddd1ee0801c2328a8f7-edbd07bbc071a373-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0b14ad972aa2316f6043c9914675aceb",
+        "traceparent": "00-4231d9796bc2c87cd8951bfa7422ea6d-d53ce44059c0aec0-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "85a3da09ec5367e1323e8881de177eb7",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:34 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:22 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,20 +22,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:34 GMT",
-        "MS-CV": "Dg474FWXEUGwI2Mej4\u002BRgw.0",
+        "Date": "Mon, 05 Dec 2022 22:49:22 GMT",
+        "MS-CV": "pLsaBvc/ZU2u//uWymAq2w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0w9ZDYwAAAAAk82uaLo5\u002BRYGAK8VuM7uJTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0cnWOYwAAAACmgrATOsZbQpqRtPzh4FWeUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "102ms"
+        "X-Processing-Time": "108ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           },
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -43,16 +43,16 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-d928ceb36ee8c9f810f660ef054cc11b-893b493f048d641e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f3404e43061628fb69a0ff5c3adb7dd7",
+        "traceparent": "00-57d6e45df429656740868c14aeffb1a8-5b4a6b14932afde6-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ce6388a712a9dd2454e85c7fdfac0095",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:35 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:22 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,20 +60,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:35 GMT",
-        "MS-CV": "OZJK4BSWDUKarNpv\u002BJdj7A.0",
+        "Date": "Mon, 05 Dec 2022 22:49:22 GMT",
+        "MS-CV": "2ZDUIVa7CkiCK3HFbk2wXA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0w9ZDYwAAAABlcbf5v1ngQJIjjFrFNb1JTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0cnWOYwAAAAC9OsuCECE0QJND/4wIrx3pUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "74ms"
+        "X-Processing-Time": "81ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.sipconfigtest.com": {
+          "newsbs.com": {
             "sipSignalingPort": 3333
           },
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -81,49 +81,49 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "146",
+        "Content-Length": "104",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d928ceb36ee8c9f810f660ef054cc11b-a8efecdd438ef840-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7e605ee9052b24920d1d7d7bd63cd5d1",
+        "traceparent": "00-57d6e45df429656740868c14aeffb1a8-8ff41370f75a0d22-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f8a21586bdf59202eb3804a76d25ddae",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:35 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:23 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.sipconfigtest.com": null
+          "newsbs.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:35 GMT",
-        "MS-CV": "swBhy/bvPUiDJi7dg5cxxA.0",
+        "Date": "Mon, 05 Dec 2022 22:49:23 GMT",
+        "MS-CV": "fSVeD3ytmE6Mg3zCUkKRfA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0w9ZDYwAAAACNcYdAjhk6S49pWzdyp3H7TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0c3WOYwAAAADSBsbcJrgcSLPTxeFraFJjUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "219ms"
+        "X-Processing-Time": "365ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -131,18 +131,18 @@
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "178",
+        "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d7d8d3d6bef75f866076c80cb97402d9-d9ff463c6cfd47a6-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3349274e46c39008b2eba2022a12f685",
+        "traceparent": "00-c4f66e11d3d2e1de1d9f9e18105a4d17-8d4d898d0e157416-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4c35bc2c4e4ef62bb5c6316b90628786",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:35 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:23 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -152,7 +152,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -161,20 +161,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:35 GMT",
-        "MS-CV": "tpaQryzSxki88vo7cK6G7w.0",
+        "Date": "Mon, 05 Dec 2022 22:49:23 GMT",
+        "MS-CV": "ggGkA0c\u002BJkOxlkelMnG\u002Byw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0xNZDYwAAAAAUaNFPP\u002ByLSpKYhj3GKUwfTFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0c3WOYwAAAAC46kq/v6YyQZdom1EpRQn3UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "90ms"
+        "X-Processing-Time": "149ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -184,30 +184,30 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "63",
+        "Content-Length": "49",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-e3776f99b6a720dacb0167e9d5029269-2dc4bfd757add824-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e8a8f1c52e143ec0bb1be6f8897f522c",
+        "traceparent": "00-ac10e6073d4ee971632e371040d5db78-d385dce47b210e1e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c8faf33e8674eac185d1e3710d7d702e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:35 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:23 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 9999
           }
         }
@@ -216,20 +216,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:35 GMT",
-        "MS-CV": "vwHFlsF8T0K2/qdtIbYQnA.0",
+        "Date": "Mon, 05 Dec 2022 22:49:23 GMT",
+        "MS-CV": "4\u002BMAdLcX\u002B0KLtnT5QGLlOA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0xNZDYwAAAADp6JwrWMXvSagXHkezcOK1TFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0c3WOYwAAAADnlAmrwZ1zQYQcKoLvp\u002BLhUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "154ms"
+        "X-Processing-Time": "157ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -239,23 +239,23 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
       }
     },
     {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-fc01541dfaca82e8e64b1eef07bf42fe-c25ae21a0fc3cc20-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221010.1 (.NET 6.0.9; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "120e2dcb4a91a31456cfcb3f6290f9fa",
+        "traceparent": "00-01ec9861dd5257ff4a40a190ebb9564f-00d8541a306e04e8-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2353ad0bb3763847e9ab422f8c970289",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 10 Oct 2022 08:24:36 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 22:49:24 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -263,20 +263,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 10 Oct 2022 08:24:35 GMT",
-        "MS-CV": "JSg6SD0TH0WwKv2GUjmr2g.0",
+        "Date": "Mon, 05 Dec 2022 22:49:24 GMT",
+        "MS-CV": "LejkQRFfhEStKwZvaobvxA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0xNZDYwAAAAC2wnpNXqY/Sax1Wrm2rBiATFRTRURHRTEyMTAAOWZjN2I1MTktYThjYy00Zjg5LTkzNWUtYzkxNDhhZTA5ZTgx",
+        "X-Azure-Ref": "0dHWOYwAAAADyWF9IqRiTQrTV4w9DJ8QnUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "78ms"
+        "X-Processing-Time": "255ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.sipconfigtest.com": {
+          "sbs1.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.sipconfigtest.com": {
+          "sbs2.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -286,7 +286,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.sipconfigtest.com"
+              "sbs1.com"
             ]
           }
         ]
@@ -294,7 +294,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1820548946"
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "2109921534"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-4231d9796bc2c87cd8951bfa7422ea6d-d53ce44059c0aec0-00",
+        "traceparent": "00-d06274c738f4b37f96631be07ee17554-61821a74a2ac21e8-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "85a3da09ec5367e1323e8881de177eb7",
+        "x-ms-client-request-id": "755582669e6cf4fe5cc0f171e4dfa983",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:22 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:51:56 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,23 +22,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:22 GMT",
-        "MS-CV": "pLsaBvc/ZU2u//uWymAq2w.0",
+        "Date": "Mon, 05 Dec 2022 23:52:01 GMT",
+        "MS-CV": "\u002BSfmgTtP90\u002ByTMhIHzc6Iw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0cnWOYwAAAACmgrATOsZbQpqRtPzh4FWeUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0HISOYwAAAABBaBVyxL3xSIWTHl12uWaLUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "108ms"
+        "X-Processing-Time": "4136ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "newsbs.com": {
-            "sipSignalingPort": 3333
-          },
-          "sbs1.com": {
-            "sipSignalingPort": 5555
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -48,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-57d6e45df429656740868c14aeffb1a8-5b4a6b14932afde6-00",
+        "traceparent": "00-2790df6495e2e42384d1d4950a83f97f-415ac4b778d3e2ee-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ce6388a712a9dd2454e85c7fdfac0095",
+        "x-ms-client-request-id": "6edc4908b74d4ad37f26d85b224568d9",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:22 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:52:01 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,23 +53,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:22 GMT",
-        "MS-CV": "2ZDUIVa7CkiCK3HFbk2wXA.0",
+        "Date": "Mon, 05 Dec 2022 23:52:01 GMT",
+        "MS-CV": "5a\u002BoJXjewUSj6y1nn8VkqQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0cnWOYwAAAAC9OsuCECE0QJND/4wIrx3pUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0IYSOYwAAAAAU61m7oUGiRrjAY3aq2eDKUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "81ms"
+        "X-Processing-Time": "95ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "newsbs.com": {
-            "sipSignalingPort": 3333
-          },
-          "sbs1.com": {
-            "sipSignalingPort": 5555
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -86,13 +72,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "104",
+        "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-57d6e45df429656740868c14aeffb1a8-8ff41370f75a0d22-00",
+        "traceparent": "00-2790df6495e2e42384d1d4950a83f97f-9a4212d16aaaa28b-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f8a21586bdf59202eb3804a76d25ddae",
+        "x-ms-client-request-id": "7c37ea9ec044d35df95dad094fec6977",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:23 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:52:01 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -102,21 +88,20 @@
           },
           "sbs2.com": {
             "sipSignalingPort": 1123
-          },
-          "newsbs.com": null
+          }
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:23 GMT",
-        "MS-CV": "fSVeD3ytmE6Mg3zCUkKRfA.0",
+        "Date": "Mon, 05 Dec 2022 23:52:02 GMT",
+        "MS-CV": "hOxzoNnP1km/AzFwUaHJlg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0c3WOYwAAAADSBsbcJrgcSLPTxeFraFJjUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0IYSOYwAAAAByGMQjK3ydRYVJGKjUI74pUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "365ms"
+        "X-Processing-Time": "767ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -138,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "164",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-c4f66e11d3d2e1de1d9f9e18105a4d17-8d4d898d0e157416-00",
+        "traceparent": "00-57e3dac62abefea714eccca57729e5ff-ddb2ac2c2b8946bc-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4c35bc2c4e4ef62bb5c6316b90628786",
+        "x-ms-client-request-id": "34cc289373f8af5aae0bf545c5a3d116",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:23 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:52:02 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -161,13 +146,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:23 GMT",
-        "MS-CV": "ggGkA0c\u002BJkOxlkelMnG\u002Byw.0",
+        "Date": "Mon, 05 Dec 2022 23:52:02 GMT",
+        "MS-CV": "Tyszu6boyECrF/XIkLpNCg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0c3WOYwAAAAC46kq/v6YyQZdom1EpRQn3UFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0IoSOYwAAAAA64RUIoNvIRJQ7aDT1NFaYUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "149ms"
+        "X-Processing-Time": "111ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -198,11 +183,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "49",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-ac10e6073d4ee971632e371040d5db78-d385dce47b210e1e-00",
+        "traceparent": "00-bdb1f16ca0d103315f7ad05044cb879a-7ce8f94f2f56e897-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c8faf33e8674eac185d1e3710d7d702e",
+        "x-ms-client-request-id": "f9d318572ca8473eec0975ef0acafa93",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:23 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:52:02 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -216,13 +201,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:23 GMT",
-        "MS-CV": "4\u002BMAdLcX\u002B0KLtnT5QGLlOA.0",
+        "Date": "Mon, 05 Dec 2022 23:52:02 GMT",
+        "MS-CV": "uNu6fy\u002B1nkObXf9uKfwFlw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0c3WOYwAAAADnlAmrwZ1zQYQcKoLvp\u002BLhUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0IoSOYwAAAABCgcggO3XfTbSWgjB7t7PSUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "157ms"
+        "X-Processing-Time": "155ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -251,11 +236,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-01ec9861dd5257ff4a40a190ebb9564f-00d8541a306e04e8-00",
+        "traceparent": "00-c2e815f24f12dfee75add10f3891fd05-a27d3a645e283fe2-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2353ad0bb3763847e9ab422f8c970289",
+        "x-ms-client-request-id": "fac861bd34792be08f88ce39cb170d55",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Mon, 05 Dec 2022 22:49:24 GMT",
+        "x-ms-date": "Mon, 05 Dec 2022 23:52:02 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -263,13 +248,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 05 Dec 2022 22:49:24 GMT",
-        "MS-CV": "LejkQRFfhEStKwZvaobvxA.0",
+        "Date": "Mon, 05 Dec 2022 23:52:02 GMT",
+        "MS-CV": "agTkN4YahEqA33DHTjogkA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0dHWOYwAAAADyWF9IqRiTQrTV4w9DJ8QnUFJHMDFFREdFMDkxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0IoSOYwAAAADo0T9wZktGQI83uOMB3DjyUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "255ms"
+        "X-Processing-Time": "77ms"
       },
       "ResponseBody": {
         "trunks": {
@@ -291,10 +276,213 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6bdc2435854305217c0a1e12edd458dd-51b888e93dbcdb63-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "37b2968b6f1966cee98448effd6ba5e4",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:52:02 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:52:02 GMT",
+        "MS-CV": "l1GpUt2wOUm5AGznqS7\u002BFg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0IoSOYwAAAABoDC3j3N4rQLdKGddGWnDfUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "77ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 9999
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-80324b05c77649126dae13e5a54a89ce-65daf5d78b110d6d-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "63886110d7db239d37a869205e057bd4",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:52:03 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:52:03 GMT",
+        "MS-CV": "QGoxz3A\u002BDkKaccxAPKHuAA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0I4SOYwAAAABNoFlVRG10T4znzxAbu0ONUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "120ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 9999
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4c2583129447220a0e1e8c8f4eb8152d-89cf99852767b7e8-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "73631ffbc3174d7a926110f4ebf02d24",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:52:03 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:52:03 GMT",
+        "MS-CV": "mOwLkxhlm0CtG3DnXU2cjw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0I4SOYwAAAAD9wiljhZcJQaS4cM/AM0RfUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "79ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 9999
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2433fad77c5a1113e93bcdf4d3a13b72-9f58108056e1f2cd-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6928eae3a98eb479f88eff7006ae07e3",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:52:03 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:52:03 GMT",
+        "MS-CV": "GMBp13vlckmSacWooY5rbA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0I4SOYwAAAACfEyLHAPiDQJPOAvPS1AMHUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "76ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.com": {
+            "sipSignalingPort": 9999
+          },
+          "sbs2.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "44",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-2433fad77c5a1113e93bcdf4d3a13b72-ea4c4bfb7f8b4376-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "def3730831074dcce73bd079c6a93746",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Mon, 05 Dec 2022 23:52:03 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.com": null,
+          "sbs2.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 23:52:03 GMT",
+        "MS-CV": "/V/gQ0lWpUiHn8ue7GVZHw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0I4SOYwAAAABCtEcNwmbqQrPYqv7S0IwiUFJHMDFFREdFMDkxMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "111ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "2109921534"
+    "RandomSeed": "1771044239"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-e316212ccb99785d47b7439c3eba9e83-c02f91b940071e2c-00",
+        "traceparent": "00-d83b77c81607fb80c081e2f991ec139f-8a870d5966f92347-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c902219e4008e91553a493fc354aa2f5",
+        "x-ms-client-request-id": "ad39c9a9cefc2fb4fce128a24e1fe083",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:09 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:13 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:10 GMT",
-        "MS-CV": "59WUBnCbiUWlK\u002BzPACfTBQ.0",
+        "Date": "Tue, 13 Dec 2022 20:17:14 GMT",
+        "MS-CV": "xLnN3l9pH06uJ1EMtF6kZw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BteXYwAAAAA4B21W2F/PQI9yEyd10t3bUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0yt2YYwAAAAAm9icO5rk6TJ7g6FUkZE67UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "102ms"
+        "X-Processing-Time": "158ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-458086c744d68f1fff24ac7436174eea-c69222d70d28f5f5-00",
+        "traceparent": "00-06a6d1de8d0a504dbc8a70805110c5c3-24d53cb544c30450-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c09270d0f6281a840929acb45fef2f78",
+        "x-ms-client-request-id": "4bcf54fa04045607d949569bdbf9215b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:09 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:14 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:10 GMT",
-        "MS-CV": "MTDqBOKulECW0NGscH0akw.0",
+        "Date": "Tue, 13 Dec 2022 20:17:15 GMT",
+        "MS-CV": "UQPzHZM/00\u002BeDgDAVeo8UQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BteXYwAAAAAHfZGHnO3rTpGN4B\u002BNCQffUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0y92YYwAAAADk9l7xSoanRaGjlbDWJ4PGUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "76ms"
+        "X-Processing-Time": "95ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-458086c744d68f1fff24ac7436174eea-2d398d59621b09e2-00",
+        "traceparent": "00-06a6d1de8d0a504dbc8a70805110c5c3-3c8593b105c07687-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a7d4cf0cb6f14c2f36ae962fba882ea9",
+        "x-ms-client-request-id": "438f8237250b1cacd71d5b2a0325ba54",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:10 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:14 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:10 GMT",
-        "MS-CV": "7mR2zPDl6kOiZDv\u002BEl4beA.0",
+        "Date": "Tue, 13 Dec 2022 20:17:15 GMT",
+        "MS-CV": "HtuTpA0YDEiK20tpYEZl9g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BteXYwAAAABu4dZdFcQtS7qUColScf\u002BvUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0y92YYwAAAADzHIeRyw8oRK2KgOd60QwEUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "233ms"
+        "X-Processing-Time": "597ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-b3321a0e8e4e05d2d34480c420ff3eb6-01ae080cb6c960c1-00",
+        "traceparent": "00-7e0ac1d3707b332a56e06ef2d9315c6d-6e31956663d0b9e6-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "121dacb7bd50a80c9ce7bfdf94608a63",
+        "x-ms-client-request-id": "5ddc8485fc52a4cfc1e3d4b278185403",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:10 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:14 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com"
+              "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:10 GMT",
-        "MS-CV": "SeXX6W\u002BZU0O2YPWhWGBQ\u002BA.0",
+        "Date": "Tue, 13 Dec 2022 20:17:16 GMT",
+        "MS-CV": "bCKDYXaG\u002BESfPljko76WRQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002BteXYwAAAACYWq96NbvrRJLFKCMvWWG3UFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0y92YYwAAAADSXW4eZf4RQatjuH5xbQzAUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "107ms"
+        "X-Processing-Time": "264ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com"
+              "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com"
             ]
           }
         ]
@@ -183,16 +183,16 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-8059ff606c8e29e80739dfcd118a58ba-a9ad96f69138cace-00",
+        "traceparent": "00-0915d21cc63d7e66b14552fd2c549bea-913f48686a31b5c3-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "66ef1a74fa7619034046897960556081",
+        "x-ms-client-request-id": "cc6bccbf9c8fd578a8b273e6a8dc52b3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:10 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:15 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
             "sipSignalingPort": 9999
           }
         }
@@ -201,20 +201,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:11 GMT",
-        "MS-CV": "PMgbK1mTjUiku6xJPaJRqA.0",
+        "Date": "Tue, 13 Dec 2022 20:17:16 GMT",
+        "MS-CV": "ZMP/Ugw850Gk9RWJAPr/1A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002B9eXYwAAAADLVtJVJnhbTL6Cd3Oq0vAAUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0zN2YYwAAAACEJb2GKGiORaGL/GDYPWVHUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "164ms"
+        "X-Processing-Time": "265ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -224,7 +224,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com"
+              "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com"
             ]
           }
         ]
@@ -236,11 +236,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f1fc8ae3756066535f559a9c1a91e3fd-3f0d75e058457569-00",
+        "traceparent": "00-f11c7bf64ba5eb33fd903956d4b0718c-831f22ea92ca157a-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b2fd03fa1dd24f28c22b0a09f750b7d6",
+        "x-ms-client-request-id": "5616018fc31c3a09b2eb812850f9a4be",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:10 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:15 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -248,20 +248,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:11 GMT",
-        "MS-CV": "vvxco6g180urlC7SrmRUfg.0",
+        "Date": "Tue, 13 Dec 2022 20:17:16 GMT",
+        "MS-CV": "BXQOXIKLBUSPVdxOCoX\u002Blg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002B9eXYwAAAADMSQVIvujuSqXbwGby20puUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0zN2YYwAAAACttPlwY1p2Qbb2SmfudKn\u002BUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "76ms"
+        "X-Processing-Time": "94ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -271,7 +271,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com"
+              "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com"
             ]
           }
         ]
@@ -283,11 +283,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-7f1bdf915156731b290fda1cfa6db15b-e71b7212ff609cae-00",
+        "traceparent": "00-98c812e8c845b07a759685e52f0326a3-cffa4f3155659f3b-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a0ba3224c798bc32a803d10934934747",
+        "x-ms-client-request-id": "376b58c9eebae9c50c06b49f88e9fce4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:11 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:15 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -295,20 +295,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:11 GMT",
-        "MS-CV": "uIvTgEK93UCWWT42\u002B/3uHQ.0",
+        "Date": "Tue, 13 Dec 2022 20:17:16 GMT",
+        "MS-CV": "071NGSUaikeF3fcab5ZPBA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002B9eXYwAAAADiJsEyXEtASryvdi3yUQDlUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0zN2YYwAAAACICgQPoACoQ5fsG2aGfUL8UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "81ms"
+        "X-Processing-Time": "92ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -318,7 +318,54 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com"
+              "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8ae1a1a47cffe30cc24f5471543f1adb-b91f5adc6799fb62-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "76232090fe02fce6c33019a41b5084af",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:16 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Dec 2022 20:17:17 GMT",
+        "MS-CV": "UD1LEqr8z0CN\u002BbOKa8FkSg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0zd2YYwAAAABwixhw7mhsT58SzQXzWuctUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "80ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
+            "sipSignalingPort": 9999
+          },
+          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": [
+          {
+            "description": "Handle numbers starting with \u0027\u002B123\u0027",
+            "name": "First rule",
+            "numberPattern": "\\\u002B123[0-9]\u002B",
+            "trunks": [
+              "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com"
             ]
           }
         ]
@@ -332,11 +379,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-50f43d6927904ece4d58c4f10a8aa072-0d778b9a25cf65e4-00",
+        "traceparent": "00-63bc23d7631c8cf32dd6d6c315bf7509-e8543968c3e7a55a-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "91e53d87d7635791f1a0a44aeffa22f0",
+        "x-ms-client-request-id": "501db40e1b71a0f83b2d4a160f6ab2c9",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:11 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:16 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -346,20 +393,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:11 GMT",
-        "MS-CV": "ZbuViezouk2iBL78e0qgcg.0",
+        "Date": "Tue, 13 Dec 2022 20:17:17 GMT",
+        "MS-CV": "wAVmR8qwwEWXto4o48\u002BuVQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002B9eXYwAAAAB8C7vece\u002B5QabnFz\u002Bj/nVPUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0zd2YYwAAAACdaKHFfeWwTZleU78OhDIsUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "108ms"
+        "X-Processing-Time": "236ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -372,11 +419,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-675f855fecade1bb7c30de3f70669477-7e0d58eafea0d986-00",
+        "traceparent": "00-67aa75f25f56f74f1ec3c317e7e00585-c78b6a3ed50cb6ff-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2d54b38ebf9b32e9d04009ce4b1e1a2e",
+        "x-ms-client-request-id": "2f979dee2dd6cabc726e748ad420cdbb",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:11 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:16 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -384,58 +431,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:12 GMT",
-        "MS-CV": "nmSQZ6zBO0GRWypFF0J2SA.0",
+        "Date": "Tue, 13 Dec 2022 20:17:17 GMT",
+        "MS-CV": "mKvBTAxoVEyGobHuPcv\u002B6g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0\u002B9eXYwAAAACaYSt1HaF1RI\u002BY14ol7PJRUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0zd2YYwAAAABC8Yr1mVfWS5WZovnEYv4kUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
+        "X-Processing-Time": "78ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-56d47a24524140ed277164cb9f23fd87-2a887b9698d99333-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b981c3e3266b4d72a163aef723e7cdae",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:11 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:12 GMT",
-        "MS-CV": "HphI9J3mTkuMmMjESFowDA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/NeXYwAAAAAp/CjZCXhBR6QyYBaT2iYMUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "75ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
-            "sipSignalingPort": 9999
-          },
-          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": {
+          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -450,30 +459,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-56d47a24524140ed277164cb9f23fd87-e092b2e7cfda5acf-00",
+        "traceparent": "00-67aa75f25f56f74f1ec3c317e7e00585-8a34695b45401fe2-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "817be1e1193ec8ab54b2c022cdc20bd3",
+        "x-ms-client-request-id": "d4900581accc747328823ad5b3d0ed58",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 01:40:11 GMT",
+        "x-ms-date": "Tue, 13 Dec 2022 20:17:16 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": null,
-          "sbs2.e9984b8d-4dd3-6484-f359-a2ee82e27d34.com": null
+          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": null,
+          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 01:40:12 GMT",
-        "MS-CV": "6ucyH2TqM0\u002B\u002B6cA1vO6syg.0",
+        "Date": "Tue, 13 Dec 2022 20:17:18 GMT",
+        "MS-CV": "8BEqmRHchESjkEcjD80z1w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0/NeXYwAAAAAwg39Upkr5TJm53rf2ABwZUFJHMDFFREdFMDkwOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0zd2YYwAAAADh6byDK4hlSZq5h3n1xMCnUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "109ms"
+        "X-Processing-Time": "251ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -483,6 +492,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "3406901"
+    "RandomSeed": "1950990008"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResourceAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -67,7 +67,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -116,7 +116,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -176,7 +176,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -231,7 +231,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -278,7 +278,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -325,7 +325,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -367,7 +367,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -405,7 +405,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -443,7 +443,7 @@
       }
     },
     {
-      "RequestUri": "https://jannovak-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -482,7 +482,7 @@
     }
   ],
   "Variables": {
-    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jannovak-test.communication.azure.com/;accesskey=Kg==",
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
     "RandomSeed": "1771044239"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/Infrastructure/SipRoutingClientLiveTestBase.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/Infrastructure/SipRoutingClientLiveTestBase.cs
@@ -2,23 +2,29 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.TestFramework;
 using Azure.Core.TestFramework.Models;
 using Azure.Identity;
+using NUnit.Framework;
 
 namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
 {
     public class SipRoutingClientLiveTestBase : RecordedTestBase<SipRoutingClientTestEnvironment>
     {
-        private const string UniqueDomainRegEx = @"\.[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}\.";
-        protected readonly TestData TestData;
+        protected TestData? TestData;
+
         public SipRoutingClientLiveTestBase(bool isAsync) : base(isAsync)
         {
-            BodyRegexSanitizers.Add(new BodyRegexSanitizer(UniqueDomainRegEx, "."));
             JsonPathSanitizers.Add("$..credential");
             SanitizedHeaders.Add("x-ms-content-sha256");
-            TestData = new TestData(TestEnvironment.Mode);
+        }
+
+        [SetUp]
+        public void SetUpTestData()
+        {
+            TestData = new TestData(Recording.Random.NewGuid());
         }
 
         public bool SkipSipRoutingLiveTests

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/Infrastructure/SipRoutingClientLiveTestBase.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/Infrastructure/SipRoutingClientLiveTestBase.cs
@@ -2,17 +2,19 @@
 // Licensed under the MIT License.
 
 using System;
-using Azure.Communication.Pipeline;
 using Azure.Core;
 using Azure.Core.TestFramework;
+using Azure.Core.TestFramework.Models;
 using Azure.Identity;
 
 namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
 {
     public class SipRoutingClientLiveTestBase : RecordedTestBase<SipRoutingClientTestEnvironment>
     {
+        private const string UniqueDomainRegEx = @"\.[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}\.";
         public SipRoutingClientLiveTestBase(bool isAsync) : base(isAsync)
         {
+            BodyRegexSanitizers.Add(new BodyRegexSanitizer(UniqueDomainRegEx, "."));
             JsonPathSanitizers.Add("$..credential");
             SanitizedHeaders.Add("x-ms-content-sha256");
         }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/Infrastructure/SipRoutingClientLiveTestBase.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/Infrastructure/SipRoutingClientLiveTestBase.cs
@@ -29,7 +29,7 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
         protected SipRoutingClient CreateClient(bool isInstrumented = true)
         {
             var client = new SipRoutingClient(
-                    TestEnvironment.LiveTestStaticConnectionString,
+                    TestEnvironment.LiveTestDynamicConnectionString,
                     InstrumentClientOptions(new SipRoutingClientOptions()));
 
             // We always create the instrumented client to suppress the instrumentation check
@@ -45,7 +45,7 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
         protected SipRoutingClient CreateClientWithTokenCredential(bool isInstrumented = true)
         {
             var client = new SipRoutingClient(
-                    new Uri(ConnectionString.Parse(TestEnvironment.LiveTestStaticConnectionString, allowEmptyValues: true).GetRequired("endpoint")),
+                    new Uri(ConnectionString.Parse(TestEnvironment.LiveTestDynamicConnectionString, allowEmptyValues: true).GetRequired("endpoint")),
                     (Mode == RecordedTestMode.Playback) ? new MockCredential() : new DefaultAzureCredential(),
                     InstrumentClientOptions(new SipRoutingClientOptions()));
 

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/Infrastructure/SipRoutingClientLiveTestBase.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/Infrastructure/SipRoutingClientLiveTestBase.cs
@@ -12,11 +12,13 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
     public class SipRoutingClientLiveTestBase : RecordedTestBase<SipRoutingClientTestEnvironment>
     {
         private const string UniqueDomainRegEx = @"\.[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}\.";
+        protected readonly TestData TestData;
         public SipRoutingClientLiveTestBase(bool isAsync) : base(isAsync)
         {
             BodyRegexSanitizers.Add(new BodyRegexSanitizer(UniqueDomainRegEx, "."));
             JsonPathSanitizers.Add("$..credential");
             SanitizedHeaders.Add("x-ms-content-sha256");
+            TestData = new TestData(TestEnvironment.Mode);
         }
 
         public bool SkipSipRoutingLiveTests

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/Infrastructure/TestData.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/Infrastructure/TestData.cs
@@ -3,39 +3,49 @@
 
 using System;
 using System.Collections.Generic;
+using Azure.Core.TestFramework;
 
 namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
 {
-    internal static class TestData
+    public class TestData
     {
-        private static readonly Guid Domain = Guid.NewGuid();
-        public static readonly List<string> Fqdns = new List<string>(){ "sbs1." + Domain + ".com", "sbs2." + Domain + ".com" };
-        public static readonly int[] TrunkPorts = { 1122, 1123 };
+        private readonly string Domain;
+        public readonly List<string> Fqdns;
+        public readonly int[] TrunkPorts = { 1122, 1123 };
 
-        public static readonly List<SipTrunk> TrunkList = new List<SipTrunk>
+        public readonly List<SipTrunk> TrunkList;
+        public readonly SipTrunk NewTrunk;
+
+        public readonly SipTrunkRoute RuleNavigateToTrunk1;
+        public readonly SipTrunkRoute RuleNavigateToAllTrunks;
+        public readonly SipTrunkRoute RuleNavigateToNewTrunk;
+
+        public TestData(RecordedTestMode? mode)
         {
-            new SipTrunk(Fqdns[0], TrunkPorts[0]),
-            new SipTrunk(Fqdns[1], TrunkPorts[1])
-        };
+            Domain = mode != RecordedTestMode.Playback ? ("." + Guid.NewGuid()) : "";
+            Fqdns = new List<string>() { "sbs1" + Domain + ".com", "sbs2" + Domain + ".com" };
+            TrunkList = new List<SipTrunk>
+            {
+                new SipTrunk(Fqdns[0], TrunkPorts[0]),
+                new SipTrunk(Fqdns[1], TrunkPorts[1])
+            };
+            NewTrunk = new SipTrunk("newsbs" + Domain + ".com", 3333);
 
-        public static readonly SipTrunk NewTrunk = new SipTrunk("newsbs." + Domain + ".com", 3333);
-
-        public static readonly SipTrunkRoute RuleNavigateToTrunk1 = new SipTrunkRoute(
-            name: "First rule",
-            description: "Handle numbers starting with '+123'",
-            numberPattern: @"\+123[0-9]+",
-            trunks: new List<string> { Fqdns[0] });
-
-        public static readonly SipTrunkRoute RuleNavigateToAllTrunks = new SipTrunkRoute(
-            name: "Last rule",
-            description: "Handle all other numbers'",
-            numberPattern: @"\+[1-9][0-9]{3,23}",
-            trunks: Fqdns);
-
-        public static readonly SipTrunkRoute RuleNavigateToNewTrunk = new SipTrunkRoute(
-            name: "Alternative rule",
-            description: "Handle all numbers'",
-            numberPattern: @"\+[1-9][0-9]{3,23}",
-            trunks: new List<string> { NewTrunk.Fqdn });
+            RuleNavigateToTrunk1 = new SipTrunkRoute(
+                name: "First rule",
+                description: "Handle numbers starting with '+123'",
+                numberPattern: @"\+123[0-9]+",
+                trunks: new List<string> { Fqdns[0] });
+            RuleNavigateToAllTrunks = new SipTrunkRoute(
+                name: "Last rule",
+                description: "Handle all other numbers'",
+                numberPattern: @"\+[1-9][0-9]{3,23}",
+                trunks: Fqdns);
+            RuleNavigateToNewTrunk = new SipTrunkRoute(
+                name: "Alternative rule",
+                description: "Handle all numbers'",
+                numberPattern: @"\+[1-9][0-9]{3,23}",
+                trunks: new List<string> { NewTrunk.Fqdn });
+        }
     }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/Infrastructure/TestData.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/Infrastructure/TestData.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 
 namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
 {
     internal static class TestData
     {
-        public static readonly List<string> Fqdns = new List<string>(){ "sbs1.sipconfigtest.com", "sbs2.sipconfigtest.com" };
+        private static readonly Guid Domain = Guid.NewGuid();
+        public static readonly List<string> Fqdns = new List<string>(){ "sbs1." + Domain + ".com", "sbs2." + Domain + ".com" };
         public static readonly int[] TrunkPorts = { 1122, 1123 };
 
         public static readonly List<SipTrunk> TrunkList = new List<SipTrunk>
@@ -16,7 +18,7 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             new SipTrunk(Fqdns[1], TrunkPorts[1])
         };
 
-        public static readonly SipTrunk NewTrunk = new SipTrunk("newsbs.sipconfigtest.com", 3333);
+        public static readonly SipTrunk NewTrunk = new SipTrunk("newsbs." + Domain + ".com", 3333);
 
         public static readonly SipTrunkRoute RuleNavigateToTrunk1 = new SipTrunkRoute(
             name: "First rule",

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/Infrastructure/TestData.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/Infrastructure/TestData.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Azure.Core.TestFramework;
+using Azure.Core.Tests.TestFramework;
 
 namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
 {
@@ -20,16 +21,16 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
         public readonly SipTrunkRoute RuleNavigateToAllTrunks;
         public readonly SipTrunkRoute RuleNavigateToNewTrunk;
 
-        public TestData(RecordedTestMode? mode)
+        public TestData(Guid random)
         {
-            Domain = mode != RecordedTestMode.Playback ? ("." + Guid.NewGuid()) : "";
-            Fqdns = new List<string>() { "sbs1" + Domain + ".com", "sbs2" + Domain + ".com" };
+            Domain = random.ToString();
+            Fqdns = new List<string>() { "sbs1." + Domain + ".com", "sbs2." + Domain + ".com" };
             TrunkList = new List<SipTrunk>
             {
                 new SipTrunk(Fqdns[0], TrunkPorts[0]),
                 new SipTrunk(Fqdns[1], TrunkPorts[1])
             };
-            NewTrunk = new SipTrunk("newsbs" + Domain + ".com", 3333);
+            NewTrunk = new SipTrunk("newsbs." + Domain + ".com", 3333);
 
             RuleNavigateToTrunk1 = new SipTrunkRoute(
                 name: "First rule",

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/SipRoutingClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/SipRoutingClientLiveTests.cs
@@ -23,8 +23,8 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
         {
             var client = CreateClient();
             client.SetRoutesAsync(new List<SipTrunkRoute>()).Wait();
-            client.SetTrunksAsync(TestData.TrunkList).Wait();
-            client.SetRoutesAsync(new List<SipTrunkRoute> { TestData.RuleNavigateToTrunk1 }).Wait();
+            client.SetTrunksAsync(TestData!.TrunkList).Wait();
+            client.SetRoutesAsync(new List<SipTrunkRoute> { TestData!.RuleNavigateToTrunk1 }).Wait();
 
             return client;
         }
@@ -61,7 +61,7 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
         {
             var client = CreateClientWithTokenCredential();
 
-            var response = await client.SetTrunkAsync(new SipTrunk(TestData.TrunkList[0].Fqdn,5555)).ConfigureAwait(false);
+            var response = await client.SetTrunkAsync(new SipTrunk(TestData!.TrunkList[0].Fqdn,5555)).ConfigureAwait(false);
             Assert.AreEqual(200, response.Status);
         }
 
@@ -73,9 +73,9 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var trunks = response.Value;
 
             Assert.IsNotNull(trunks);
-            Assert.AreEqual(TestData.TrunkList.Count, trunks.Count());
-            Assert.IsTrue(TrunkAreEqual(TestData.TrunkList[0], trunks[0]));
-            Assert.IsTrue(TrunkAreEqual(TestData.TrunkList[1], trunks[1]));
+            Assert.AreEqual(TestData!.TrunkList.Count, trunks.Count());
+            Assert.IsTrue(TrunkAreEqual(TestData!.TrunkList[0], trunks[0]));
+            Assert.IsTrue(TrunkAreEqual(TestData!.TrunkList[1], trunks[1]));
         }
 
         [Test]
@@ -87,29 +87,29 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
 
             Assert.IsNotNull(routes);
             Assert.AreEqual(1, routes.Count());
-            Assert.IsTrue(RouteAreEqual(TestData.RuleNavigateToTrunk1, routes[0]));
+            Assert.IsTrue(RouteAreEqual(TestData!.RuleNavigateToTrunk1, routes[0]));
         }
 
         [Test]
         public async Task AddSipTrunkForResource()
         {
             var client = InitializeTest();
-            var response = await client.SetTrunkAsync(TestData.NewTrunk).ConfigureAwait(false);
+            var response = await client.SetTrunkAsync(TestData!.NewTrunk).ConfigureAwait(false);
             var actualTrunks = await client.GetTrunksAsync().ConfigureAwait(false);
 
             Assert.AreEqual(3, actualTrunks.Value.Count());
-            Assert.IsNotNull(actualTrunks.Value.FirstOrDefault(x => x.Fqdn == TestData.NewTrunk.Fqdn));
+            Assert.IsNotNull(actualTrunks.Value.FirstOrDefault(x => x.Fqdn == TestData!.NewTrunk.Fqdn));
         }
 
         [Test]
         public async Task SetSipTrunkForResource()
         {
-            var modifiedTrunk = new SipTrunk(TestData.TrunkList[0].Fqdn, 9999);
+            var modifiedTrunk = new SipTrunk(TestData!.TrunkList[0].Fqdn, 9999);
             var client = InitializeTest();
 
             await client.SetTrunkAsync(modifiedTrunk).ConfigureAwait(false);
 
-            var actualTrunk = await client.GetTrunkAsync(TestData.TrunkList[0].Fqdn).ConfigureAwait(false);
+            var actualTrunk = await client.GetTrunkAsync(TestData!.TrunkList[0].Fqdn).ConfigureAwait(false);
             Assert.AreEqual(modifiedTrunk.SipSignalingPort, actualTrunk.Value.SipSignalingPort);
         }
 
@@ -118,13 +118,13 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
         {
             var client = InitializeTest();
             var initialTrunks = await client.GetTrunksAsync().ConfigureAwait(false);
-            Assert.AreEqual(TestData.TrunkList.Count, initialTrunks.Value.Count());
+            Assert.AreEqual(TestData!.TrunkList.Count, initialTrunks.Value.Count());
 
-            await client.DeleteTrunkAsync(TestData.TrunkList[1].Fqdn).ConfigureAwait(false);
+            await client.DeleteTrunkAsync(TestData!.TrunkList[1].Fqdn).ConfigureAwait(false);
 
             var finalTrunks = await client.GetTrunksAsync().ConfigureAwait(false);
-            Assert.AreEqual(TestData.TrunkList.Count-1, finalTrunks.Value.Count());
-            Assert.IsNull(finalTrunks.Value.FirstOrDefault(x => x.Fqdn == TestData.TrunkList[1].Fqdn));
+            Assert.AreEqual(TestData!.TrunkList.Count-1, finalTrunks.Value.Count());
+            Assert.IsNull(finalTrunks.Value.FirstOrDefault(x => x.Fqdn == TestData!.TrunkList[1].Fqdn));
         }
 
         [Test]
@@ -132,11 +132,11 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
         {
             var client = InitializeTest();
 
-            var response = await client.GetTrunkAsync(TestData.TrunkList[1].Fqdn).ConfigureAwait(false);
+            var response = await client.GetTrunkAsync(TestData!.TrunkList[1].Fqdn).ConfigureAwait(false);
 
             var trunk = response.Value;
             Assert.IsNotNull(trunk);
-            Assert.IsTrue(TrunkAreEqual(TestData.TrunkList[1], trunk));
+            Assert.IsTrue(TrunkAreEqual(TestData!.TrunkList[1], trunk));
         }
 
         [Test]
@@ -144,13 +144,13 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
         {
             var client = InitializeTest();
 
-            await client.SetRoutesAsync(new List<SipTrunkRoute> { TestData.RuleNavigateToAllTrunks }).ConfigureAwait(false);
+            await client.SetRoutesAsync(new List<SipTrunkRoute> { TestData!.RuleNavigateToAllTrunks }).ConfigureAwait(false);
             var response = await client.GetRoutesAsync().ConfigureAwait(false);
 
             var newRoutes = response.Value;
             Assert.IsNotNull(newRoutes);
             Assert.AreEqual(1, newRoutes.Count);
-            Assert.IsTrue(RouteAreEqual(TestData.RuleNavigateToAllTrunks, newRoutes[0]));
+            Assert.IsTrue(RouteAreEqual(TestData!.RuleNavigateToAllTrunks, newRoutes[0]));
         }
 
         [Test]
@@ -159,13 +159,13 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var client = InitializeTest();
 
             await client.SetRoutesAsync(new List<SipTrunkRoute>()).ConfigureAwait(false);  // Need to clear the routes first
-            await client.SetTrunksAsync(new List<SipTrunk> { TestData.NewTrunk });
+            await client.SetTrunksAsync(new List<SipTrunk> { TestData!.NewTrunk });
             var response = await client.GetTrunksAsync().ConfigureAwait(false);
 
             var newTrunks = response.Value;
             Assert.IsNotNull(newTrunks);
             Assert.AreEqual(1, newTrunks.Count);
-            Assert.IsTrue(TrunkAreEqual(TestData.NewTrunk, newTrunks[0]));
+            Assert.IsTrue(TrunkAreEqual(TestData!.NewTrunk, newTrunks[0]));
         }
     }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/SipRoutingClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/SipRoutingClientLiveTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.Core.Pipeline;
 using NUnit.Framework;
 
 namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
@@ -34,11 +35,15 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var client = CreateClient();
             if (client.GetRoutesAsync().Result.Value.Count > 0)
             {
-                client.SetRoutesAsync(new List<SipTrunkRoute>()).EnsureCompleted();
+                var task = client.SetRoutesAsync(new List<SipTrunkRoute>());
+                task.Wait();
+                task.EnsureCompleted();
             }
             if (client.GetTrunksAsync().Result.Value.Count > 0)
             {
-                client.SetTrunksAsync(new List<SipTrunk>()).EnsureCompleted();
+                var task = client.SetTrunksAsync(new List<SipTrunk>());
+                task.Wait();
+                task.EnsureCompleted();
             }
         }
 

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/SipRoutingClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/SipRoutingClientLiveTests.cs
@@ -28,6 +28,20 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             return client;
         }
 
+        [TearDown]
+        public void ClearConfiguration()
+        {
+            var client = CreateClient();
+            if (client.GetRoutesAsync().Result.Value.Count > 0)
+            {
+                client.SetRoutesAsync(new List<SipTrunkRoute>()).Wait();
+            }
+            if (client.GetTrunksAsync().Result.Value.Count > 0)
+            {
+                client.SetTrunksAsync(new List<SipTrunk>()).Wait();
+            }
+        }
+
         [Test]
         public async Task GetFunctionUsingTokenAuthentication()
         {

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/SipRoutingClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/SipRoutingClientLiveTests.cs
@@ -34,11 +34,11 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var client = CreateClient();
             if (client.GetRoutesAsync().Result.Value.Count > 0)
             {
-                client.SetRoutesAsync(new List<SipTrunkRoute>()).Wait();
+                client.SetRoutesAsync(new List<SipTrunkRoute>()).EnsureCompleted();
             }
             if (client.GetTrunksAsync().Result.Value.Count > 0)
             {
-                client.SetTrunksAsync(new List<SipTrunk>()).Wait();
+                client.SetTrunksAsync(new List<SipTrunk>()).EnsureCompleted();
             }
         }
 

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/SipRoutingClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/SipRoutingClientLiveTests.cs
@@ -30,20 +30,20 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
         }
 
         [TearDown]
-        public void ClearConfiguration()
+        public async Task ClearConfiguration()
         {
             var client = CreateClient();
-            if (client.GetRoutesAsync().Result.Value.Count > 0)
+            var routes = await client.GetRoutesAsync();
+            var trunks = await client.GetTrunksAsync();
+            if (routes.Value.Count > 0)
             {
-                var task = client.SetRoutesAsync(new List<SipTrunkRoute>());
-                task.Wait();
-                task.EnsureCompleted();
+                var response = await client.SetRoutesAsync(new List<SipTrunkRoute>());
+                Assert.AreEqual(200, response.Status);
             }
-            if (client.GetTrunksAsync().Result.Value.Count > 0)
+            if (trunks.Value.Count > 0)
             {
-                var task = client.SetTrunksAsync(new List<SipTrunk>());
-                task.Wait();
-                task.EnsureCompleted();
+                var response = await client.SetTrunksAsync(new List<SipTrunk>());
+                Assert.AreEqual(200, response.Status);
             }
         }
 

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/samples/Sample_SipRoutingClient.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/samples/Sample_SipRoutingClient.cs
@@ -27,7 +27,7 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
             if (SkipSipRoutingLiveTests)
                 Assert.Ignore("Skip SIP routing live tests flag is on.");
 
-            var connectionString = TestEnvironment.LiveTestStaticConnectionString;
+            var connectionString = TestEnvironment.LiveTestDynamicConnectionString;
 
             #region Snippet:CreateSipRoutingClient
             // Get a connection string to Azure Communication resource.

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/samples/Sample_SipRoutingClient.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/samples/Sample_SipRoutingClient.cs
@@ -43,7 +43,7 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
             #endregion Snippet:CreateSipRoutingClientWithTokenCredential
 
             client = CreateClient();
-            var newTrunks = new List<SipTrunk> { TestData.NewTrunk };
+            var newTrunks = new List<SipTrunk> { TestData!.NewTrunk };
             var newRoutes = new List<SipTrunkRoute> { TestData.RuleNavigateToNewTrunk };
 
             #region Snippet:Replace
@@ -107,7 +107,7 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
                 Assert.Ignore("Skip SIP routing live tests flag is on.");
 
             var client = CreateClient();
-            var newTrunks = new List<SipTrunk> { TestData.NewTrunk };
+            var newTrunks = new List<SipTrunk> { TestData!.NewTrunk };
             var newRoutes = new List<SipTrunkRoute> { TestData.RuleNavigateToNewTrunk };
 
             #region Snippet:ReplaceAsync


### PR DESCRIPTION
# Description
The SIP Routing tests started to fail when run in parallel by pipelines.
Used dynamic resources instead of a static one. So each pipeline works with own resource.
Code altered to use randomized domain FQDNs based on UUID. (Each domain can be assigned only to one resource at the time)


[Issue #3047678 Fix Sip Routing Tests - .NET SDK](https://skype.visualstudio.com/SPOOL/_workitems/edit/3047678)
[Successful CI run #2034017](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2034017&view=results)

Related PR:
[Pull Request #23812 - JavaScript SDK](https://github.com/Azure/azure-sdk-for-js/pull/23812)
[Pull Request #32456- Java SDK](https://github.com/Azure/azure-sdk-for-java/pull/32456)
