### PR TITLE
{AzureBlobStorage} fixes Azure/azure-sdk-for-net#32910 fix description of AccessTier Property

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlobProperties.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlobProperties.cs
@@ -206,8 +206,8 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// The tier of page blob on a premium storage account or tier of block blob on blob storage LRS accounts.
         /// For a list of allowed premium page blob tiers, see
-        /// https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage#features. For blob
-        /// storage LRS accounts, valid values are Hot/Cool/Archive.
+        /// https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage#features. For general 
+        /// purpose v2 and blob storage account types, the valid values are Hot/Cool/Archive.
         /// </summary>
         public string AccessTier { get; }
 

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlobProperties.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlobProperties.cs
@@ -206,8 +206,13 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// The tier of page blob on a premium storage account or tier of block blob on blob storage LRS accounts.
         /// For a list of allowed premium page blob tiers, see
-        /// https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage#features. For general
-        /// purpose v2 and blob storage account types, the valid values are Hot/Cool/Archive.
+        /// <see href="https://docs.microsoft.com/azure/virtual-machines/windows/premium-storage#features" />. For general
+        /// purpose v2 and blob storage account types, the valid values are:
+        /// <list>
+        ///  <item><description>Hot</description></item>
+        ///  <item><description>Cool</description></item>
+        ///  <item><description>Archive</description></item>
+        /// </list>
         /// </summary>
         public string AccessTier { get; }
 

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlobProperties.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlobProperties.cs
@@ -206,7 +206,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// The tier of page blob on a premium storage account or tier of block blob on blob storage LRS accounts.
         /// For a list of allowed premium page blob tiers, see
-        /// https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage#features. For general 
+        /// https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage#features. For general
         /// purpose v2 and blob storage account types, the valid values are Hot/Cool/Archive.
         /// </summary>
         public string AccessTier { get; }


### PR DESCRIPTION
fix description of AccessTier Property

fixes Azure/azure-sdk-for-net#32910 

The description of fix description of AccessTier Property should indicate the account types which support access tiers.

To avoid customers using GPv1 storage accounts to set the blob access tiers.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
