### PR TITLE
[Search] Run CMK tests weekly

### DIFF
--- a/sdk/search/platform-matrix.json
+++ b/sdk/search/platform-matrix.json
@@ -1,0 +1,6 @@
+{
+    "matrix": {
+      "$IMPORT": "eng/pipelines/templates/stages/platform-matrix.json"
+      "ArmTemplateParameters": "@{ enableCmk = $false }"
+    }
+  }

--- a/sdk/search/platform-matrix.json
+++ b/sdk/search/platform-matrix.json
@@ -4,4 +4,3 @@
       "ArmTemplateParameters": "@{ enableCmk = $false }"
     }
   }
-  

--- a/sdk/search/platform-matrix.json
+++ b/sdk/search/platform-matrix.json
@@ -1,6 +1,6 @@
 {
     "matrix": {
-      "$IMPORT": "eng/pipelines/templates/stages/platform-matrix.json"
-      "ArmTemplateParameters": "@{ enableCmk = $false }"
+        "$IMPORT": "eng/pipelines/templates/stages/platform-matrix.json",
+        "ArmTemplateParameters": "@{ enableCmk = $false }"
     }
-  }
+}

--- a/sdk/search/platform-matrix.json
+++ b/sdk/search/platform-matrix.json
@@ -1,4 +1,8 @@
 {
+    "displayNames": {
+        "@{ enableCmk = $false }": "",
+        "@{ enableCmk = $true }": "CMK",
+    },
     "matrix": {
         "$IMPORT": "eng/pipelines/templates/stages/platform-matrix.json",
         "ArmTemplateParameters": "@{ enableCmk = $false }"

--- a/sdk/search/platform-matrix.json
+++ b/sdk/search/platform-matrix.json
@@ -4,3 +4,4 @@
       "ArmTemplateParameters": "@{ enableCmk = $false }"
     }
   }
+  

--- a/sdk/search/test-resources.json
+++ b/sdk/search/test-resources.json
@@ -64,7 +64,7 @@
         },
         "searchSku": {
             "type": "string",
-            "defaultValue": "[if(equals(parameters('enableCmk'), true), 'basic', 'free')]",
+            "defaultValue": "[if(equals(parameters('enableCmk'), bool('true')), 'basic', 'free')]",
             "allowedValues": [
                 "free",
                 "basic",

--- a/sdk/search/test-resources.json
+++ b/sdk/search/test-resources.json
@@ -64,7 +64,7 @@
         },
         "searchSku": {
             "type": "string",
-            "defaultValue": "[if(equals(parameter('enableCmk'), true)), 'basic', 'free')]",
+            "defaultValue": "[if(equals(parameter('enableCmk'), true), 'basic', 'free')]",
             "allowedValues": [
                 "free",
                 "basic",

--- a/sdk/search/test-resources.json
+++ b/sdk/search/test-resources.json
@@ -55,9 +55,16 @@
               "description": "The url suffix to use when accessing the storage data plane."
           }
         },
+        "enableCmk": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Whether to enable deployment of Managed CMK. The default is false."
+            }
+        },
         "searchSku": {
             "type": "string",
-            "defaultValue": "basic",
+            "defaultValue": "free",
             "allowedValues": [
                 "free",
                 "basic",
@@ -136,7 +143,7 @@
             "type": "Microsoft.KeyVault/vaults",
             "apiVersion": "[variables('keyVaultApiVersion')]",
             "name": "[variables('keyVaultName')]",
-            "condition": "[and(contains(variables('searchEncryptionLocations'), parameters('location')), not(equals(parameters('searchSku'), 'free')))]",
+            "condition": "[parameters('enableCmk')]",
             "location": "[parameters('location')]",
             "properties": {
                 "sku": {
@@ -206,7 +213,7 @@
         },
         "SEARCH_KEYVAULT_URL": {
             "type": "string",
-            "condition": "[and(contains(variables('searchEncryptionLocations'), parameters('location')), not(equals(parameters('searchSku'), 'free')))]",
+            "condition": "[parameters('enableCmk')]",
             "value": "[reference(variables('keyVaultName')).vaultUri]"
         }
     }

--- a/sdk/search/test-resources.json
+++ b/sdk/search/test-resources.json
@@ -64,7 +64,7 @@
         },
         "searchSku": {
             "type": "string",
-            "defaultValue": "[if(equals(parameter('enableCmk'), true), 'basic', 'free')]",
+            "defaultValue": "[if(equals(parameter('enableCmk'), true)), 'basic', 'free')]",
             "allowedValues": [
                 "free",
                 "basic",

--- a/sdk/search/test-resources.json
+++ b/sdk/search/test-resources.json
@@ -64,7 +64,7 @@
         },
         "searchSku": {
             "type": "string",
-            "defaultValue": "free",
+            "defaultValue": "[if(equals(parameter('enableCmk'), true), 'basic', 'free')]",
             "allowedValues": [
                 "free",
                 "basic",

--- a/sdk/search/test-resources.json
+++ b/sdk/search/test-resources.json
@@ -64,7 +64,7 @@
         },
         "searchSku": {
             "type": "string",
-            "defaultValue": "[if(equals(parameter('enableCmk'), true), 'basic', 'free')]",
+            "defaultValue": "[if(equals(parameters('enableCmk'), true), 'basic', 'free')]",
             "allowedValues": [
                 "free",
                 "basic",

--- a/sdk/search/tests.yml
+++ b/sdk/search/tests.yml
@@ -10,6 +10,11 @@ extends:
     SDKType: client
     TimeoutInMinutes: 240
     MaxParallel: 2
+    MatrixConfigs:
+      - Name: Search_cmk
+        Path: sdk/search/platform-matrix.json
+        Selection: sparse
+        GenerateVMJobs: true
     # TODO: change 'Preview' cloud back to public after search RP fixes deletion metadata issue
     # https://github.com/Azure/azure-sdk-tools/issues/2216
     Clouds: 'Preview'

--- a/sdk/search/tests.yml
+++ b/sdk/search/tests.yml
@@ -4,6 +4,9 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: search
+    ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly') }}:
+      MatrixReplace:
+        - ArmTemplateParameters=.*/@{ enableCmk = $true }
     SDKType: client
     TimeoutInMinutes: 240
     MaxParallel: 2
@@ -13,3 +16,4 @@ extends:
     SupportedClouds: 'Preview,UsGov,China'
     EnvVars:
       AZURE_SEARCH_TEST_MODE: Live
+

--- a/sdk/search/tests.yml
+++ b/sdk/search/tests.yml
@@ -16,4 +16,3 @@ extends:
     SupportedClouds: 'Preview,UsGov,China'
     EnvVars:
       AZURE_SEARCH_TEST_MODE: Live
-

--- a/sdk/search/tests.yml
+++ b/sdk/search/tests.yml
@@ -6,7 +6,7 @@ extends:
     ServiceDirectory: search
     ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly') }}:
       MatrixReplace:
-        - ArmTemplateParameters=.*/@{ enableCmk = $true }
+        - ArmTemplateParameters=.*/@{ enableCmk \= $true }
     SDKType: client
     TimeoutInMinutes: 240
     MaxParallel: 2


### PR DESCRIPTION
Customer-managed keys (CMKs) which require provisioning a Key Vault with the "basic" pricing tier, which adds cost over the free tier and because CMK support doesn't change much, we only want to do that weekly.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/16576