### PR TITLE
Fix issues related to cancellation in ResponseBodyPolicy

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs
@@ -75,7 +75,9 @@ namespace Azure.Core.Pipeline
 
             if (message.BufferResponse)
             {
-                if (networkTimeout != Timeout.InfiniteTimeSpan)
+                // If there is a network timeout or the user passed a cancellation token, then we will dispose the stream when
+                // cancellation is triggered.
+                if (networkTimeout != Timeout.InfiniteTimeSpan || oldToken.CanBeCanceled)
                 {
                     cts.Token.Register(state => ((Stream?)state)?.Dispose(), responseContentStream);
                 }
@@ -96,19 +98,8 @@ namespace Azure.Core.Pipeline
                     bufferedStream.Position = 0;
                     message.Response.ContentStream = bufferedStream;
                 }
-                // We dispose stream on timeout so catch and check if cancellation token was cancelled
-                catch (ObjectDisposedException ex)
-                {
-                    ThrowIfCancellationRequestedOrTimeout(oldToken, cts.Token, ex, networkTimeout);
-                    throw;
-                }
-                // We dispose stream on timeout so catch and check if cancellation token was cancelled
-                catch (IOException ex)
-                {
-                    ThrowIfCancellationRequestedOrTimeout(oldToken, cts.Token, ex, networkTimeout);
-                    throw;
-                }
-                catch (OperationCanceledException ex)
+                // We dispose stream on timeout or user cancellation so catch and check if cancellation token was cancelled
+                catch (Exception ex) when (ex is ObjectDisposedException or IOException or OperationCanceledException or NotSupportedException)
                 {
                     ThrowIfCancellationRequestedOrTimeout(oldToken, cts.Token, ex, networkTimeout);
                     throw;

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs
@@ -99,7 +99,11 @@ namespace Azure.Core.Pipeline
                     message.Response.ContentStream = bufferedStream;
                 }
                 // We dispose stream on timeout or user cancellation so catch and check if cancellation token was cancelled
-                catch (Exception ex) when (ex is ObjectDisposedException or IOException or OperationCanceledException or NotSupportedException)
+                catch (Exception ex)
+                    when (ex is ObjectDisposedException
+                              or IOException
+                              or OperationCanceledException
+                              or NotSupportedException)
                 {
                     ThrowIfCancellationRequestedOrTimeout(oldToken, cts.Token, ex, networkTimeout);
                     throw;

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs
@@ -75,8 +75,8 @@ namespace Azure.Core.Pipeline
 
             if (message.BufferResponse)
             {
-                // If there is a network timeout or the user passed a cancellation token, then we will dispose the stream when
-                // cancellation is triggered.
+                // If cancellation is possible (whether due to network timeout or a user cancellation token being passed), then
+                // register callback to dispose the stream on cancellation.
                 if (networkTimeout != Timeout.InfiniteTimeSpan || oldToken.CanBeCanceled)
                 {
                     cts.Token.Register(state => ((Stream?)state)?.Dispose(), responseContentStream);


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/32577

- Handle NotSupportedException being thrown by Stream when disposing due to cancellation
- Register cancellation delegate if the underlying user token can be cancelled