### PR TITLE
[ASP.NET Extensions] Data Protection Bump

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -142,7 +142,7 @@
 
   <!-- Packages intended for Extensions libraries only -->
   <ItemGroup Condition="'$(IsExtensionClientLibrary)' == 'true'">
-    <PackageReference Update="Microsoft.AspNetCore.DataProtection" Version="3.1.28" />
+    <PackageReference Update="Microsoft.AspNetCore.DataProtection" Version="3.1.31" />
     <PackageReference Update="Microsoft.AspNetCore.Http" Version="2.1.22" />
     <PackageReference Update="Microsoft.AspNetCore.Http.Connections" Version="1.0.15" />
     <PackageReference Update="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Updated dependency version of `Microsoft.AspNetCore.DataProtection` to mitigate [CVE-2021-24112](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-24112).  Note that the vulnerability only exists in a dependency referenced by the `netcoreapp3.0` target, which reach end-of-life in December, 2019.  
+
 ## 1.2.3 (2022-09-12)
 
 ### Other Changes

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Updated dependency version of `Microsoft.AspNetCore.DataProtection` to mitigate [CVE-2021-24112](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-24112).  Note that the vulnerability only exists in a dependency referenced by the `netcoreapp3.0` target, which reach end-of-life in December, 2019. 
+
 ## 1.1.0 (2021-09-07)
 
 ### Changes


### PR DESCRIPTION
# Summary

The focus of these changes is to bump the version of the `Microsoft.AspNetCore.DataProtection` package to mitigate CVE-2021-24112.

# References and Related

- [CVE in System.Drawing.Common 4.7.0 dependency (#32781)](https://github.com/Azure/azure-sdk-for-net/issues/32781)
- [Release Data Protection Extensions Packages (#33010)](https://github.com/Azure/azure-sdk-for-net/issues/33010)