### PR TITLE
[Event Hubs] Include Inner Exception Details

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other Changes
 
+- Calling `ToString` on an `EventHubsException` now includes details of any inner exception.
+
 ## 5.7.5 (2022-11-22)
 
 ### Bugs Fixed

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other Changes
 
+- Calling `ToString` on an `EventHubsException` now includes details of any inner exception.
+
 ## 5.7.5 (2022-11-22)
 
 ### Acknowledgments

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsException.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsException.cs
@@ -201,7 +201,17 @@ namespace Azure.Messaging.EventHubs
         /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
         ///
         public override string ToString() =>
-            $"{ typeof(EventHubsException).FullName }({ Reason }): { Message }{ Environment.NewLine }{ StackTrace }";
+            $"{ typeof(EventHubsException).FullName }({ Reason }): { Message }{ Environment.NewLine }{ StackTrace }{ FormatInnerException() }";
+
+        /// <summary>
+        ///   Formats the <see cref="Exception.InnerException"/> for inclusion in the <see cref="ToString" />
+        ///   details.
+        /// </summary>
+        ///
+        /// <returns>The text to include for the inner exception, if any.</returns>
+        ///
+        private string FormatInnerException() =>
+            (InnerException == null) ? string.Empty : $"{ Environment.NewLine }{ InnerException }";
 
         /// <summary>
         ///   The set of well-known reasons for an Event Hubs operation failure that

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessErrorEventArgs.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessErrorEventArgs.cs
@@ -8,8 +8,8 @@ using Azure.Core;
 namespace Azure.Messaging.EventHubs.Processor
 {
     /// <summary>
-    ///   Contains information about a partition whose processing surfaced an exception, as well as
-    ///   the exception that occurred.
+    ///   Contains information about an exception that occurred within the processor, whether for a specific partition
+    ///   or as part of the processor's internal operations.
     /// </summary>
     ///
     /// <seealso href="https://www.nuget.org/packages/Azure.Messaging.EventHubs.Processor">Azure.Messaging.EventHubs.Processor (NuGet)</seealso>
@@ -17,7 +17,8 @@ namespace Azure.Messaging.EventHubs.Processor
     public struct ProcessErrorEventArgs
     {
         /// <summary>
-        ///   The identifier of the partition being processed when the exception occurred.
+        ///   The identifier of the partition being processed when the exception occurred.  If the exception did
+        ///   not occur for a specific partition, this value will be <c>null</c>.
         /// </summary>
         ///
         public string PartitionId { get; }
@@ -29,7 +30,7 @@ namespace Azure.Messaging.EventHubs.Processor
         public string Operation { get; }
 
         /// <summary>
-        ///   The exception that was occurred during partition processing.
+        ///   The exception that was occurred during processing.
         /// </summary>
         ///
         public Exception Exception { get; }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Errors/EventHubsExceptionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Errors/EventHubsExceptionTests.cs
@@ -205,5 +205,32 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(exceptionString, Contains.Substring(eventHubName), "The ToString value should contain the Event Hub name.");
             Assert.That(exceptionString, Contains.Substring($"{ Environment.NewLine }{ instance.StackTrace }"), "The ToString value should contain the stack trace on a new line.");
         }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubsException.ToString" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void ToStringContainsInnerExceptionDetails()
+        {
+            var message = "Inner message!";
+            var innerException = new DivideByZeroException(message);
+
+            EventHubsException instance;
+
+            try
+            {
+                throw new EventHubsException(false, "hub", "Outer", EventHubsException.FailureReason.QuotaExceeded, innerException);
+            }
+            catch (EventHubsException ex)
+            {
+                instance = ex;
+            }
+
+            var exceptionString = instance.ToString();
+            Assert.That(exceptionString, Is.Not.Null.And.Not.Empty, "The ToString value should be populated.");
+            Assert.That(exceptionString, Contains.Substring(innerException.ToString()), "The ToString value should contain the full set of details for the inner exception.");
+        }
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to include the details of any inner exception as part of the `ToString` output of `EventHubsException`.

# References and Related

- [[Event Hubs] Include inner exception output for EventHubsException.ToString() (#33009)](https://github.com/Azure/azure-sdk-for-net/issues/33009)