### PR TITLE
Update InvalidScopeMessage allowed characters list

### DIFF
--- a/sdk/identity/Azure.Identity/src/ScopeUtilities.cs
+++ b/sdk/identity/Azure.Identity/src/ScopeUtilities.cs
@@ -15,7 +15,7 @@ namespace Azure.Identity
         private const string DefaultSuffix = "/.default";
         private const string ScopePattern = "^[0-9a-zA-Z-_.:/]+$";
 
-        private const string InvalidScopeMessage = "The specified scope is not in expected format. Only alphanumeric characters, '.', '-', ':', and '/' are allowed";
+        private const string InvalidScopeMessage = "The specified scope is not in expected format. Only alphanumeric characters, '.', '-', ':', '_', and '/' are allowed";
         private static readonly Regex scopeRegex = new Regex(ScopePattern);
 
         public static string ScopesToResource(string[] scopes)


### PR DESCRIPTION
#31258 have updated the regex, but not the error message: https://github.com/Azure/azure-sdk-for-net/pull/31258/files#diff-68da68ee62f997d11abf2240a0bca2b9d88d6c167ed14fd31078380cf3a33072R16