### PR TITLE
JsonData Updates: Add WriteTo(), ==operators, and PR FB

### DIFF
--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
@@ -112,16 +112,30 @@ namespace Azure.Core.Dynamic
     {
         public static dynamic ToDynamic(this System.BinaryData data) { throw null; }
     }
+    public abstract partial class DynamicData
+    {
+        protected DynamicData() { }
+        internal abstract void WriteTo(System.Text.Json.Utf8JsonWriter writer);
+        public static void WriteTo(System.Text.Json.Utf8JsonWriter writer, Azure.Core.Dynamic.DynamicData data) { }
+    }
     [System.Diagnostics.DebuggerDisplayAttribute("{DebuggerDisplay,nq}")]
-    public partial class JsonData : System.Dynamic.IDynamicMetaObjectProvider, System.IEquatable<Azure.Core.Dynamic.JsonData>
+    public partial class JsonData : Azure.Core.Dynamic.DynamicData, System.Dynamic.IDynamicMetaObjectProvider, System.IEquatable<Azure.Core.Dynamic.JsonData>
     {
         internal JsonData() { }
         public bool Equals(Azure.Core.Dynamic.JsonData other) { throw null; }
         public override bool Equals(object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Core.Dynamic.JsonData? left, bool right) { throw null; }
+        public static bool operator ==(Azure.Core.Dynamic.JsonData? left, double right) { throw null; }
         public static bool operator ==(Azure.Core.Dynamic.JsonData? left, int right) { throw null; }
+        public static bool operator ==(Azure.Core.Dynamic.JsonData? left, long right) { throw null; }
+        public static bool operator ==(Azure.Core.Dynamic.JsonData? left, float right) { throw null; }
         public static bool operator ==(Azure.Core.Dynamic.JsonData? left, string? right) { throw null; }
+        public static bool operator ==(bool left, Azure.Core.Dynamic.JsonData? right) { throw null; }
+        public static bool operator ==(double left, Azure.Core.Dynamic.JsonData? right) { throw null; }
         public static bool operator ==(int left, Azure.Core.Dynamic.JsonData? right) { throw null; }
+        public static bool operator ==(long left, Azure.Core.Dynamic.JsonData? right) { throw null; }
+        public static bool operator ==(float left, Azure.Core.Dynamic.JsonData? right) { throw null; }
         public static bool operator ==(string? left, Azure.Core.Dynamic.JsonData? right) { throw null; }
         public static implicit operator bool (Azure.Core.Dynamic.JsonData json) { throw null; }
         public static implicit operator double (Azure.Core.Dynamic.JsonData json) { throw null; }
@@ -134,9 +148,17 @@ namespace Azure.Core.Dynamic
         public static implicit operator float? (Azure.Core.Dynamic.JsonData json) { throw null; }
         public static implicit operator float (Azure.Core.Dynamic.JsonData json) { throw null; }
         public static implicit operator string (Azure.Core.Dynamic.JsonData json) { throw null; }
+        public static bool operator !=(Azure.Core.Dynamic.JsonData? left, bool right) { throw null; }
+        public static bool operator !=(Azure.Core.Dynamic.JsonData? left, double right) { throw null; }
         public static bool operator !=(Azure.Core.Dynamic.JsonData? left, int right) { throw null; }
+        public static bool operator !=(Azure.Core.Dynamic.JsonData? left, long right) { throw null; }
+        public static bool operator !=(Azure.Core.Dynamic.JsonData? left, float right) { throw null; }
         public static bool operator !=(Azure.Core.Dynamic.JsonData? left, string? right) { throw null; }
+        public static bool operator !=(bool left, Azure.Core.Dynamic.JsonData? right) { throw null; }
+        public static bool operator !=(double left, Azure.Core.Dynamic.JsonData? right) { throw null; }
         public static bool operator !=(int left, Azure.Core.Dynamic.JsonData? right) { throw null; }
+        public static bool operator !=(long left, Azure.Core.Dynamic.JsonData? right) { throw null; }
+        public static bool operator !=(float left, Azure.Core.Dynamic.JsonData? right) { throw null; }
         public static bool operator !=(string? left, Azure.Core.Dynamic.JsonData? right) { throw null; }
         System.Dynamic.DynamicMetaObject System.Dynamic.IDynamicMetaObjectProvider.GetMetaObject(System.Linq.Expressions.Expression parameter) { throw null; }
         public override string ToString() { throw null; }

--- a/sdk/core/Azure.Core.Experimental/src/BinaryDataExtensions.cs
+++ b/sdk/core/Azure.Core.Experimental/src/BinaryDataExtensions.cs
@@ -11,6 +11,7 @@ namespace Azure.Core.Dynamic
     public static class BinaryDataExtensions
     {
         /// <summary>
+        /// Return the content of the BinaryData as a dynamic type.
         /// </summary>
         public static dynamic ToDynamic(this BinaryData data)
         {

--- a/sdk/core/Azure.Core.Experimental/src/DynamicData.cs
+++ b/sdk/core/Azure.Core.Experimental/src/DynamicData.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+
+namespace Azure.Core.Dynamic
+{
+    /// <summary>
+    /// A dynamic abstraction over content data that may have an underlying
+    /// format of JSON or other format.
+    /// </summary>
+    public abstract class DynamicData
+    {
+        /// <summary>
+        /// Writes the data to the provided writer as a JSON value.
+        /// </summary>
+        /// <param name="writer">The writer to which to write the document.</param>
+        /// <param name="data">The dynamic data value to write.</param>
+        public static void WriteTo(Utf8JsonWriter writer, DynamicData data)
+        {
+            data.WriteTo(writer);
+        }
+
+        internal abstract void WriteTo(Utf8JsonWriter writer);
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/src/DynamicData.cs
+++ b/sdk/core/Azure.Core.Experimental/src/DynamicData.cs
@@ -6,8 +6,10 @@ using System.Text.Json;
 namespace Azure.Core.Dynamic
 {
     /// <summary>
-    /// A dynamic abstraction over content data that may have an underlying
-    /// format of JSON or other format.
+    /// A dynamic abstraction over content data.  Deriving types are implemented
+    /// for a specific format, such as JSON or XML.
+    ///
+    /// This and related types are not intended to be mocked.
     /// </summary>
     public abstract class DynamicData
     {

--- a/sdk/core/Azure.Core.Experimental/src/JsonData.Operators.cs
+++ b/sdk/core/Azure.Core.Experimental/src/JsonData.Operators.cs
@@ -49,7 +49,7 @@ namespace Azure.Core.Dynamic
         public static implicit operator double(JsonData json) => json.GetDouble();
 
         /// <summary>
-        /// Converts the value to a <see cref="bool"/>
+        /// Converts the value to a <see cref="bool"/> or null.
         /// </summary>
         /// <param name="json">The value to convert.</param>
         public static implicit operator bool?(JsonData json) => json.Kind == JsonValueKind.Null ? null : json.GetBoolean();
@@ -77,6 +77,164 @@ namespace Azure.Core.Dynamic
         /// </summary>
         /// <param name="json">The value to convert.</param>
         public static implicit operator double?(JsonData json) => json.Kind == JsonValueKind.Null ? null : json.GetDouble();
+
+        /// <summary>
+        /// Returns true if a <see cref="JsonData"/> has the same value as a given bool,
+        /// and false otherwise.
+        /// </summary>
+        /// <param name="left">The <see cref="JsonData"/> to compare.</param>
+        /// <param name="right">The <see cref="bool"/> to compare.</param>
+        /// <returns>True if the given JsonData represents the given bool, and false otherwise.</returns>
+        public static bool operator ==(JsonData? left, bool right)
+        {
+            if (left is null)
+            {
+                return false;
+            }
+
+            return (left.Kind == JsonValueKind.False || left.Kind == JsonValueKind.True) &&
+                ((bool)left) == right;
+        }
+
+        /// <summary>
+        /// Returns false if a <see cref="JsonData"/> has the same value as a given bool,
+        /// and true otherwise.
+        /// </summary>
+        /// <param name="left">The <see cref="JsonData"/> to compare.</param>
+        /// <param name="right">The <see cref="bool"/> to compare.</param>
+        /// <returns>False if the given JsonData represents the given string, and false otherwise</returns>
+        public static bool operator !=(JsonData? left, bool right) => !(left == right);
+
+        /// <summary>
+        /// Returns true if a <see cref="JsonData"/> has the same value as a given bool,
+        /// and false otherwise.
+        /// </summary>
+        /// <param name="left">The <see cref="bool"/> to compare.</param>
+        /// <param name="right">The <see cref="JsonData"/> to compare.</param>
+        /// <returns>True if the given JsonData represents the given bool, and false otherwise.</returns>
+        public static bool operator ==(bool left, JsonData? right)
+        {
+            if (right is null)
+            {
+                return false;
+            }
+
+            return (right.Kind == JsonValueKind.False || right.Kind == JsonValueKind.True) &&
+                ((bool)right) == left;
+        }
+
+        /// <summary>
+        /// Returns false if a <see cref="JsonData"/> has the same value as a given bool,
+        /// and true otherwise.
+        /// </summary>
+        /// <param name="left">The <see cref="bool"/> to compare.</param>
+        /// <param name="right">The <see cref="JsonData"/> to compare.</param>
+        /// <returns>False if the given JsonData represents the given bool, and false otherwise</returns>
+        public static bool operator !=(bool left, JsonData? right) => !(left == right);
+
+        /// <summary>
+        /// Returns true if a <see cref="JsonData"/> has the same value as a given int,
+        /// and false otherwise.
+        /// </summary>
+        /// <param name="left">The <see cref="JsonData"/> to compare.</param>
+        /// <param name="right">The <see cref="int"/> to compare.</param>
+        /// <returns>True if the given JsonData represents the given int, and false otherwise.</returns>
+        public static bool operator ==(JsonData? left, int right)
+        {
+            if (left is null)
+            {
+                return false;
+            }
+
+            return left.Kind == JsonValueKind.Number && ((int)left) == right;
+        }
+
+        /// <summary>
+        /// Returns false if a <see cref="JsonData"/> has the same value as a given int,
+        /// and true otherwise.
+        /// </summary>
+        /// <param name="left">The <see cref="JsonData"/> to compare.</param>
+        /// <param name="right">The <see cref="int"/> to compare.</param>
+        /// <returns>False if the given JsonData represents the given string, and false otherwise</returns>
+        public static bool operator !=(JsonData? left, int right) => !(left == right);
+
+        /// <summary>
+        /// Returns true if a <see cref="JsonData"/> has the same value as a given int,
+        /// and false otherwise.
+        /// </summary>
+        /// <param name="left">The <see cref="int"/> to compare.</param>
+        /// <param name="right">The <see cref="JsonData"/> to compare.</param>
+        /// <returns>True if the given JsonData represents the given int, and false otherwise.</returns>
+        public static bool operator ==(int left, JsonData? right)
+        {
+            if (right is null)
+            {
+                return false;
+            }
+
+            return right.Kind == JsonValueKind.Number && ((int)right) == left;
+        }
+
+        /// <summary>
+        /// Returns false if a <see cref="JsonData"/> has the same value as a given int,
+        /// and true otherwise.
+        /// </summary>
+        /// <param name="left">The <see cref="int"/> to compare.</param>
+        /// <param name="right">The <see cref="JsonData"/> to compare.</param>
+        /// <returns>False if the given JsonData represents the given int, and false otherwise</returns>
+        public static bool operator !=(int left, JsonData? right) => !(left == right);
+
+        /// <summary>
+        /// Returns true if a <see cref="JsonData"/> has the same value as a given long,
+        /// and false otherwise.
+        /// </summary>
+        /// <param name="left">The <see cref="JsonData"/> to compare.</param>
+        /// <param name="right">The <see cref="long"/> to compare.</param>
+        /// <returns>True if the given JsonData represents the given long, and false otherwise.</returns>
+        public static bool operator ==(JsonData? left, long right)
+        {
+            if (left is null)
+            {
+                return false;
+            }
+
+            return left.Kind == JsonValueKind.Number && ((long)left) == right;
+        }
+
+        /// <summary>
+        /// Returns false if a <see cref="JsonData"/> has the same value as a given long,
+        /// and true otherwise.
+        /// </summary>
+        /// <param name="left">The <see cref="JsonData"/> to compare.</param>
+        /// <param name="right">The <see cref="long"/> to compare.</param>
+        /// <returns>False if the given JsonData represents the given string, and false otherwise</returns>
+        public static bool operator !=(JsonData? left, long right) => !(left == right);
+
+        /// <summary>
+        /// Returns true if a <see cref="JsonData"/> has the same value as a given long,
+        /// and false otherwise.
+        /// </summary>
+        /// <param name="left">The <see cref="long"/> to compare.</param>
+        /// <param name="right">The <see cref="JsonData"/> to compare.</param>
+        /// <returns>True if the given JsonData represents the given long, and false otherwise.</returns>
+        public static bool operator ==(long left, JsonData? right)
+        {
+            if (right is null)
+            {
+                return false;
+            }
+
+            return right.Kind == JsonValueKind.Number && ((long)right) == left;
+        }
+
+        /// <summary>
+        /// Returns false if a <see cref="JsonData"/> has the same value as a given long,
+        /// and true otherwise.
+        /// </summary>
+        /// <param name="left">The <see cref="long"/> to compare.</param>
+        /// <param name="right">The <see cref="JsonData"/> to compare.</param>
+        /// <returns>False if the given JsonData represents the given long, and false otherwise</returns>
+        public static bool operator !=(long left, JsonData? right) => !(left == right);
 
         /// <summary>
         /// Returns true if a <see cref="JsonData"/> has the same value as a given string,
@@ -141,55 +299,107 @@ namespace Azure.Core.Dynamic
         public static bool operator !=(string? left, JsonData? right) => !(left == right);
 
         /// <summary>
-        /// Returns true if a <see cref="JsonData"/> has the same value as a given int,
+        /// Returns true if a <see cref="JsonData"/> has the same value as a given float,
         /// and false otherwise.
         /// </summary>
         /// <param name="left">The <see cref="JsonData"/> to compare.</param>
-        /// <param name="right">The <see cref="int"/> to compare.</param>
-        /// <returns>True if the given JsonData represents the given int, and false otherwise.</returns>
-        public static bool operator ==(JsonData? left, int right)
+        /// <param name="right">The <see cref="float"/> to compare.</param>
+        /// <returns>True if the given JsonData represents the given float, and false otherwise.</returns>
+        public static bool operator ==(JsonData? left, float right)
         {
             if (left is null)
             {
                 return false;
             }
 
-            return left.Kind == JsonValueKind.Number && ((int)left) == right;
+            return left.Kind == JsonValueKind.Number && ((float)left) == right;
         }
 
         /// <summary>
-        /// Returns false if a <see cref="JsonData"/> has the same value as a given int,
+        /// Returns false if a <see cref="JsonData"/> has the same value as a given float,
         /// and true otherwise.
         /// </summary>
         /// <param name="left">The <see cref="JsonData"/> to compare.</param>
-        /// <param name="right">The <see cref="int"/> to compare.</param>
+        /// <param name="right">The <see cref="float"/> to compare.</param>
         /// <returns>False if the given JsonData represents the given string, and false otherwise</returns>
-        public static bool operator !=(JsonData? left, int right) => !(left == right);
+        public static bool operator !=(JsonData? left, float right) => !(left == right);
 
         /// <summary>
-        /// Returns true if a <see cref="JsonData"/> has the same value as a given int,
+        /// Returns true if a <see cref="JsonData"/> has the same value as a given float,
         /// and false otherwise.
         /// </summary>
-        /// <param name="left">The <see cref="int"/> to compare.</param>
+        /// <param name="left">The <see cref="float"/> to compare.</param>
         /// <param name="right">The <see cref="JsonData"/> to compare.</param>
-        /// <returns>True if the given JsonData represents the given int, and false otherwise.</returns>
-        public static bool operator ==(int left, JsonData? right)
+        /// <returns>True if the given JsonData represents the given float, and false otherwise.</returns>
+        public static bool operator ==(float left, JsonData? right)
         {
             if (right is null)
             {
                 return false;
             }
 
-            return right.Kind == JsonValueKind.Number && ((int)right) == left;
+            return right.Kind == JsonValueKind.Number && ((float)right) == left;
         }
 
         /// <summary>
-        /// Returns false if a <see cref="JsonData"/> has the same value as a given int,
+        /// Returns false if a <see cref="JsonData"/> has the same value as a given float,
         /// and true otherwise.
         /// </summary>
-        /// <param name="left">The <see cref="int"/> to compare.</param>
+        /// <param name="left">The <see cref="float"/> to compare.</param>
         /// <param name="right">The <see cref="JsonData"/> to compare.</param>
-        /// <returns>False if the given JsonData represents the given int, and false otherwise</returns>
-        public static bool operator !=(int left, JsonData? right) => !(left == right);
+        /// <returns>False if the given JsonData represents the given float, and false otherwise</returns>
+        public static bool operator !=(float left, JsonData? right) => !(left == right);
+
+        /// <summary>
+        /// Returns true if a <see cref="JsonData"/> has the same value as a given double,
+        /// and false otherwise.
+        /// </summary>
+        /// <param name="left">The <see cref="JsonData"/> to compare.</param>
+        /// <param name="right">The <see cref="double"/> to compare.</param>
+        /// <returns>True if the given JsonData represents the given double, and false otherwise.</returns>
+        public static bool operator ==(JsonData? left, double right)
+        {
+            if (left is null)
+            {
+                return false;
+            }
+
+            return left.Kind == JsonValueKind.Number && ((double)left) == right;
+        }
+
+        /// <summary>
+        /// Returns false if a <see cref="JsonData"/> has the same value as a given double,
+        /// and true otherwise.
+        /// </summary>
+        /// <param name="left">The <see cref="JsonData"/> to compare.</param>
+        /// <param name="right">The <see cref="double"/> to compare.</param>
+        /// <returns>False if the given JsonData represents the given string, and false otherwise</returns>
+        public static bool operator !=(JsonData? left, double right) => !(left == right);
+
+        /// <summary>
+        /// Returns true if a <see cref="JsonData"/> has the same value as a given double,
+        /// and false otherwise.
+        /// </summary>
+        /// <param name="left">The <see cref="double"/> to compare.</param>
+        /// <param name="right">The <see cref="JsonData"/> to compare.</param>
+        /// <returns>True if the given JsonData represents the given double, and false otherwise.</returns>
+        public static bool operator ==(double left, JsonData? right)
+        {
+            if (right is null)
+            {
+                return false;
+            }
+
+            return right.Kind == JsonValueKind.Number && ((double)right) == left;
+        }
+
+        /// <summary>
+        /// Returns false if a <see cref="JsonData"/> has the same value as a given double,
+        /// and true otherwise.
+        /// </summary>
+        /// <param name="left">The <see cref="double"/> to compare.</param>
+        /// <param name="right">The <see cref="JsonData"/> to compare.</param>
+        /// <returns>False if the given JsonData represents the given double, and false otherwise</returns>
+        public static bool operator !=(double left, JsonData? right) => !(left == right);
     }
 }

--- a/sdk/core/Azure.Core.Experimental/src/JsonData.cs
+++ b/sdk/core/Azure.Core.Experimental/src/JsonData.cs
@@ -23,7 +23,7 @@ namespace Azure.Core.Dynamic
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     [DebuggerTypeProxy(typeof(JsonDataDebuggerProxy))]
     [JsonConverter(typeof(JsonConverter))]
-    public partial class JsonData : IDynamicMetaObjectProvider, IEquatable<JsonData>
+    public partial class JsonData : DynamicData, IDynamicMetaObjectProvider, IEquatable<JsonData>
     {
         private readonly JsonValueKind _kind;
         private Dictionary<string, JsonData>? _objectRepresentation;
@@ -33,9 +33,9 @@ namespace Azure.Core.Dynamic
         private static readonly JsonSerializerOptions DefaultJsonSerializerOptions = new JsonSerializerOptions();
 
         /// <summary>
-        /// Parses a UTF8 encoded string representing a single JSON value into a <see cref="JsonData"/>.
+        /// Parses a UTF-8 encoded string representing a single JSON value into a <see cref="JsonData"/>.
         /// </summary>
-        /// <param name="utf8Json">A UTF8 encoded string representing a JSON value.</param>
+        /// <param name="utf8Json">A UTF-8 encoded string representing a JSON value.</param>
         /// <returns>A <see cref="JsonData"/> representation of the value.</returns>
         internal static JsonData Parse(BinaryData utf8Json)
         {
@@ -345,7 +345,7 @@ namespace Azure.Core.Dynamic
 
         private bool GetBoolean() => (bool)EnsureValue()!;
 
-        private void WriteTo(Utf8JsonWriter writer)
+        internal override void WriteTo(Utf8JsonWriter writer)
         {
             switch (_kind)
             {

--- a/sdk/core/Azure.Core.Experimental/src/Properties/AssemblyInfo.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Properties/AssemblyInfo.cs
@@ -6,6 +6,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Azure.Core.Experimental.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100d15ddcb29688295338af4b7686603fe614abd555e09efba8fb88ee09e1f7b1ccaeed2e8f823fa9eef3fdd60217fc012ea67d2479751a0b8c087a4185541b851bd8b16f8d91b840e51b1cb0ba6fe647997e57429265e85ef62d565db50a69ae1647d54d7bd855e4db3d8a91510e5bcbd0edfbbecaa20a7bd9ae74593daa7b11b4")]
 
-[assembly: SuppressMessage("Usage", "AZC0014:Avoid using banned types in public API", Justification = "Azure.Core.Experimental ships adapters for System.Text.Json", Scope = "type", Target = "~T:Azure.Core.JsonObjectSerializer")]
-[assembly: SuppressMessage("Usage", "AZC0014:Avoid using banned types in public API", Justification = "Azure.Core.Experimental ships adapters for System.Text.Json", Scope = "type", Target = "~T:Azure.Core.GeoJson.GeoJsonConverter")]
-[assembly: SuppressMessage("Usage", "AZC0014:Avoid using banned types in public API", Justification = "Azure.Core.Experimental ships adapters for System.Text.Json", Scope = "type", Target = "~T:Azure.Core.DynamicJson")]
+[assembly: SuppressMessage("Usage", "AZC0014:Avoid using banned types in public API", Justification = "Azure.Core.Experimental ships adapters for System.Text.Json", Scope = "type", Target = "~T:Azure.Core.Dynamic.DynamicData")]

--- a/sdk/core/Azure.Core.Experimental/tests/public/JsonDataPublicMutableTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/public/JsonDataPublicMutableTests.cs
@@ -34,7 +34,7 @@ namespace Azure.Core.Tests.Public
         [TestCaseSource(nameof(PrimitiveValues))]
         public void NewObjectPropertiesCanBeAssignedWithPrimitive<T>(T value, string expected)
         {
-            dynamic json = new BinaryData("{}").ToDynamic();
+            dynamic json = JsonDataTestHelpers.CreateEmpty();
             json.a = value;
 
             Assert.AreEqual(json.ToString(), "{\"a\":" + expected + "}");
@@ -51,7 +51,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void NewObjectPropertiesCanBeAssignedWithArrays()
         {
-            dynamic json = new BinaryData("{}").ToDynamic();
+            dynamic json = JsonDataTestHelpers.CreateEmpty();
             json.a = new object[] { 1, 2, null, "string" };
 
             Assert.AreEqual(json.ToString(), "{\"a\":[1,2,null,\"string\"]}");
@@ -60,7 +60,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void NewObjectPropertiesCanBeAssignedWithObject()
         {
-            var json = new BinaryData("{}").ToDynamic();
+            var json = JsonDataTestHelpers.CreateEmpty();
             json.a = new { b = 2 };
 
             Assert.AreEqual(json.ToString(), "{\"a\":{\"b\":2}}");
@@ -69,8 +69,8 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void NewObjectPropertiesCanBeAssignedWithObjectIndirectly()
         {
-            dynamic json = new BinaryData("{}").ToDynamic();
-            dynamic anotherJson = new BinaryData("{}").ToDynamic();
+            dynamic json = JsonDataTestHelpers.CreateEmpty();
+            dynamic anotherJson = JsonDataTestHelpers.CreateEmpty();
             json.a = anotherJson;
             anotherJson.b = 2;
 
@@ -80,7 +80,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void NewObjectPropertiesCanBeAssignedWithSerializedObject()
         {
-            var json = new BinaryData("{}").ToDynamic();
+            var json = JsonDataTestHelpers.CreateEmpty();
             json.a = new GeoPoint(1, 2);
 
             Assert.AreEqual("{\"a\":{\"type\":\"Point\",\"coordinates\":[1,2]}}", json.ToString());

--- a/sdk/core/Azure.Core.Experimental/tests/public/JsonDataTestHelpers.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/public/JsonDataTestHelpers.cs
@@ -8,6 +8,11 @@ namespace Azure.Core.Tests.Public
 {
     public class JsonDataTestHelpers
     {
+        public static dynamic CreateEmpty()
+        {
+            return BinaryData.FromString("{}").ToDynamic();
+        }
+
         public static dynamic CreateFromJson(string json)
         {
             return BinaryData.FromString(json).ToDynamic();


### PR DESCRIPTION
This is a follow-up to https://github.com/Azure/azure-sdk-for-net/pull/32613 that addresses:

- [x] Support for writing to a stream: https://github.com/Azure/azure-sdk-for-net/pull/32613#discussion_r1038652662
- [x] Adding equality operators to match cast operators: https://github.com/Azure/azure-sdk-for-net/pull/32613#discussion_r1047430154
- [x] Misc test clean-up and other missed PR feedback.