### PR TITLE
{AzureStorage} fixes Azure/azure-sdk-for-net#33071 Description of UploadAsync(BinaryData) and UploadAsync(Stream) is wrong

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
@@ -397,7 +397,7 @@ namespace Azure.Storage.Blobs
 
         /// <summary>
         /// The <see cref="UploadAsync(Stream)"/> operation creates a new block blob
-        /// or updates the content of an existing block blob.  Updating an
+        /// or throws an exception if the blob already exists.  Updating an
         /// existing block blob overwrites any existing metadata on the blob.
         ///
         /// For partial block blob updates and other advanced features, please
@@ -425,7 +425,7 @@ namespace Azure.Storage.Blobs
 
         /// <summary>
         /// The <see cref="UploadAsync(BinaryData)"/> operation creates a new block blob
-        /// or updates the content of an existing block blob.  Updating an
+        /// or throws an exception if the blob already exists.  Updating an
         /// existing block blob overwrites any existing metadata on the blob.
         ///
         /// For partial block blob updates and other advanced features, please


### PR DESCRIPTION
 fixes Azure/azure-sdk-for-net#33071
 
 Description of UploadAsync(BinaryData) and UploadAsync(Stream) is wrong
 
 The documentation for [UploadAsync(BinaryData)](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.blobs.blobclient.uploadasync?view=azure-dotnet#azure-storage-blobs-blobclient-uploadasync(system-binarydata)) states:

or updates the content of an existing block blob

but that's not true; it'll throw if the blob exists, so it should read instead:

or throws if the blob already exists

There are possibly other overloads with the same issue, like [UploadAsync(Stream)](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.blobs.blobclient.uploadasync?view=azure-dotnet#azure-storage-blobs-blobclient-uploadasync(system-io-stream)).

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
