### PR TITLE
Ignore test failing due to service regression.

### DIFF
--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/RegistryArtifactLiveTests.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/RegistryArtifactLiveTests.cs
@@ -48,6 +48,7 @@ namespace Azure.Containers.ContainerRegistry.Tests
         }
 
         [RecordedTest]
+        [Ignore("Known service regression with scheduled fix 01/12/2023.")]
         public async Task CanGetManifestProperties()
         {
             // Arrange


### PR DESCRIPTION
The service team is rolling out the fix, but with the deployment freeze, it may not be in all regions until mid-January.

Addresses https://github.com/Azure/azure-sdk-for-net/issues/32948