### PR TITLE
Communication Identity - added tests

### DIFF
--- a/sdk/communication/Azure.Communication.Common/tests/CommunicationIdentifierTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/CommunicationIdentifierTest.cs
@@ -123,6 +123,49 @@ namespace Azure.Communication
         }
 
         [Test]
+        public void RawIdGeneratedIdentifiersSupportedAsKeysInCollections()
+        {
+            var dictionary = new Dictionary<CommunicationIdentifier, string>
+            {
+                { new CommunicationUserIdentifier("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"), nameof(CommunicationUserIdentifier)},
+                { new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"), nameof(MicrosoftTeamsUserIdentifier) },
+                { new PhoneNumberIdentifier("+14255550123"), nameof(PhoneNumberIdentifier) },
+                { new UnknownIdentifier("28:45ab2481-1c1c-4005-be24-0ffb879b1130"), nameof(UnknownIdentifier) }
+            };
+
+            var hashSet = new HashSet<CommunicationIdentifier>
+            {
+                new CommunicationUserIdentifier("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"),
+                new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"),
+                new PhoneNumberIdentifier("+14255550123"),
+                new UnknownIdentifier("28:45ab2481-1c1c-4005-be24-0ffb879b1130")
+            };
+
+            var list = new List<CommunicationIdentifier>
+            {
+                new CommunicationUserIdentifier("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"),
+                new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"),
+                new PhoneNumberIdentifier("+14255550123"),
+                new UnknownIdentifier("28:45ab2481-1c1c-4005-be24-0ffb879b1130")
+            };
+
+            Assert.AreEqual(nameof(CommunicationUserIdentifier), dictionary[CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130")]);
+            Assert.AreEqual(nameof(MicrosoftTeamsUserIdentifier), dictionary[CommunicationIdentifier.FromRawId("8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130")]);
+            Assert.AreEqual(nameof(PhoneNumberIdentifier), dictionary[CommunicationIdentifier.FromRawId("4:+14255550123")]);
+            Assert.AreEqual(nameof(UnknownIdentifier), dictionary[CommunicationIdentifier.FromRawId("28:45ab2481-1c1c-4005-be24-0ffb879b1130")]);
+
+            Assert.IsTrue(hashSet.Contains(CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130")));
+            Assert.IsTrue(hashSet.Contains(CommunicationIdentifier.FromRawId("8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130")));
+            Assert.IsTrue(hashSet.Contains(CommunicationIdentifier.FromRawId("4:+14255550123")));
+            Assert.IsTrue(hashSet.Contains(CommunicationIdentifier.FromRawId("28:45ab2481-1c1c-4005-be24-0ffb879b1130")));
+
+            Assert.IsTrue(list.Contains(CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130")));
+            Assert.IsTrue(list.Contains(CommunicationIdentifier.FromRawId("8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130")));
+            Assert.IsTrue(list.Contains(CommunicationIdentifier.FromRawId("4:+14255550123")));
+            Assert.IsTrue(list.Contains(CommunicationIdentifier.FromRawId("28:45ab2481-1c1c-4005-be24-0ffb879b1130")));
+        }
+
+        [Test]
         public void EqualityOperatorOverrideDoesntThrow()
         {
             var identifier = new CommunicationUserIdentifier("123");

--- a/sdk/communication/Azure.Communication.Common/tests/CommunicationIdentifierTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/CommunicationIdentifierTest.cs
@@ -149,20 +149,20 @@ namespace Azure.Communication
                 new UnknownIdentifier("28:45ab2481-1c1c-4005-be24-0ffb879b1130")
             };
 
-            Assert.AreEqual(nameof(CommunicationUserIdentifier), dictionary[CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130")]);
-            Assert.AreEqual(nameof(MicrosoftTeamsUserIdentifier), dictionary[CommunicationIdentifier.FromRawId("8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130")]);
-            Assert.AreEqual(nameof(PhoneNumberIdentifier), dictionary[CommunicationIdentifier.FromRawId("4:+14255550123")]);
-            Assert.AreEqual(nameof(UnknownIdentifier), dictionary[CommunicationIdentifier.FromRawId("28:45ab2481-1c1c-4005-be24-0ffb879b1130")]);
+            Assert.That(dictionary, Does.ContainKey(CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130")).WithValue(nameof(CommunicationUserIdentifier)));
+            Assert.That(dictionary, Does.ContainKey(CommunicationIdentifier.FromRawId("8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130")).WithValue(nameof(MicrosoftTeamsUserIdentifier)));
+            Assert.That(dictionary, Does.ContainKey(CommunicationIdentifier.FromRawId("4:+14255550123")).WithValue(nameof(PhoneNumberIdentifier)));
+            Assert.That(dictionary, Does.ContainKey(CommunicationIdentifier.FromRawId("28:45ab2481-1c1c-4005-be24-0ffb879b1130")).WithValue(nameof(UnknownIdentifier)));
 
-            Assert.IsTrue(hashSet.Contains(CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130")));
-            Assert.IsTrue(hashSet.Contains(CommunicationIdentifier.FromRawId("8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130")));
-            Assert.IsTrue(hashSet.Contains(CommunicationIdentifier.FromRawId("4:+14255550123")));
-            Assert.IsTrue(hashSet.Contains(CommunicationIdentifier.FromRawId("28:45ab2481-1c1c-4005-be24-0ffb879b1130")));
+            CollectionAssert.Contains(hashSet, CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"));
+            CollectionAssert.Contains(hashSet, CommunicationIdentifier.FromRawId("8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130"));
+            CollectionAssert.Contains(hashSet, CommunicationIdentifier.FromRawId("4:+14255550123"));
+            CollectionAssert.Contains(hashSet, CommunicationIdentifier.FromRawId("28:45ab2481-1c1c-4005-be24-0ffb879b1130"));
 
-            Assert.IsTrue(list.Contains(CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130")));
-            Assert.IsTrue(list.Contains(CommunicationIdentifier.FromRawId("8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130")));
-            Assert.IsTrue(list.Contains(CommunicationIdentifier.FromRawId("4:+14255550123")));
-            Assert.IsTrue(list.Contains(CommunicationIdentifier.FromRawId("28:45ab2481-1c1c-4005-be24-0ffb879b1130")));
+            CollectionAssert.Contains(list, CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"));
+            CollectionAssert.Contains(list, CommunicationIdentifier.FromRawId("8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130"));
+            CollectionAssert.Contains(list, CommunicationIdentifier.FromRawId("4:+14255550123"));
+            CollectionAssert.Contains(list, CommunicationIdentifier.FromRawId("28:45ab2481-1c1c-4005-be24-0ffb879b1130"));
         }
 
         [Test]


### PR DESCRIPTION
- using CommunicationIdentifier as a key in collections

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
