### PR TITLE
Fix 422 in SIP Routing

### DIFF
--- a/sdk/communication/Azure.Communication.PhoneNumbers/src/SipRouting/SipRoutingClient.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/src/SipRouting/SipRoutingClient.cs
@@ -371,6 +371,11 @@ namespace Azure.Communication.PhoneNumbers.SipRouting
                     }
                 }
 
+                if (newTrunks.Count == 0)
+                {
+                    return currentConfig.GetRawResponse();
+                }
+
                 var response = _restClient.PatchSipConfiguration(new SipConfiguration(newTrunks), cancellationToken);
                 return response.GetRawResponse();
             }
@@ -405,6 +410,11 @@ namespace Azure.Communication.PhoneNumbers.SipRouting
                     {
                         newTrunks.Add(fqdn, null);
                     }
+                }
+
+                if (newTrunks.Count == 0)
+                {
+                    return currentConfig.GetRawResponse();
                 }
 
                 var response = await _restClient.PatchSipConfigurationAsync(new SipConfiguration(newTrunks), cancellationToken).ConfigureAwait(false);

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-e55f4b1768c4b2ad1aa12f7998f0e25d-41498e9cb8f9d721-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "173126526ca602f3fe59b444084944b4",
+        "traceparent": "00-f89c76254d19e170ab1292cc0c3e146e-0370897233e96b6e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8c3fb4f07222710e06d0b8c07c44f344",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:21 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:36 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,21 +22,21 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:22 GMT",
-        "MS-CV": "isGSA5etQkiZe4FQtvkwag.0",
+        "Date": "Tue, 20 Dec 2022 00:48:37 GMT",
+        "MS-CV": "k7pvPZfQXkSmuvR1TyNbCw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0lt2YYwAAAAAg9Tsjf7EQSKXNQOKWmjSaUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ZAahYwAAAADK8MwqUxO2Q6a5IWJSCz2vUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "340ms"
+        "X-Processing-Time": "313ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.577405d2-35b0-45f8-467d-57afd2ac5d12.com": {
-            "sipSignalingPort": 9999
+          "test.969deb1e232e4f9891ea63fddefd14f4.com": {
+            "sipSignalingPort": 5678
           },
-          "sbs2.577405d2-35b0-45f8-467d-57afd2ac5d12.com": {
-            "sipSignalingPort": 1123
+          "test.b50c92748e8d407eb30750778ec12387.com": {
+            "sipSignalingPort": 5678
           }
         },
         "routes": []
@@ -48,11 +48,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-632bfeed6413eec7d77847d69937b5b9-8eff1339d680112a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1941af1e87ef7de901875b2a4186746b",
+        "traceparent": "00-97b6d47efed9eccca31c24cdf4343967-91b7d578d6c450b7-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "da462f90bc750cb43a9260ff622cea75",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:22 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:37 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -60,21 +60,21 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:22 GMT",
-        "MS-CV": "j4RXPWr6BE2/3WFYxzeNzA.0",
+        "Date": "Tue, 20 Dec 2022 00:48:37 GMT",
+        "MS-CV": "vzG5FHOsvk2WKyKIauzQgw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0l92YYwAAAAA0eskBWlSORKPpgjhLggvBUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ZQahYwAAAADhWi82Ai0OSai2yNuTxvRRUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "75ms"
+        "X-Processing-Time": "98ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.577405d2-35b0-45f8-467d-57afd2ac5d12.com": {
-            "sipSignalingPort": 9999
+          "test.969deb1e232e4f9891ea63fddefd14f4.com": {
+            "sipSignalingPort": 5678
           },
-          "sbs2.577405d2-35b0-45f8-467d-57afd2ac5d12.com": {
-            "sipSignalingPort": 1123
+          "test.b50c92748e8d407eb30750778ec12387.com": {
+            "sipSignalingPort": 5678
           }
         },
         "routes": []
@@ -86,45 +86,45 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "266",
+        "Content-Length": "258",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-632bfeed6413eec7d77847d69937b5b9-1e55c31f495e02f7-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "982b4d547d21c9af297603e78d37c70f",
+        "traceparent": "00-97b6d47efed9eccca31c24cdf4343967-29b764ea0e3068f9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b0ec1fa839d297654bb0c8f7ebb8c547",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:22 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:37 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+          "sbs1.ce225909-a4c8-4178-8cc1-50a142f9a765.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+          "sbs2.ce225909-a4c8-4178-8cc1-50a142f9a765.com": {
             "sipSignalingPort": 1123
           },
-          "sbs1.577405d2-35b0-45f8-467d-57afd2ac5d12.com": null,
-          "sbs2.577405d2-35b0-45f8-467d-57afd2ac5d12.com": null
+          "test.969deb1e232e4f9891ea63fddefd14f4.com": null,
+          "test.b50c92748e8d407eb30750778ec12387.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:23 GMT",
-        "MS-CV": "et02JDDjB0SSTxyjisfKcA.0",
+        "Date": "Tue, 20 Dec 2022 00:48:38 GMT",
+        "MS-CV": "KGhKMhBKnESFPloaYqufkQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0l92YYwAAAAAXjZFhT9WyR4IzRt01/hmDUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ZQahYwAAAAAKAUxEfZDxSYFIcpaodtX4UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "514ms"
+        "X-Processing-Time": "330ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+          "sbs1.ce225909-a4c8-4178-8cc1-50a142f9a765.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+          "sbs2.ce225909-a4c8-4178-8cc1-50a142f9a765.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -139,11 +139,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d0fdfe5997755d8b6aba2b1020327921-12ec8b21f43db579-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "31a9498e2fbccb253cb3161e10c9c177",
+        "traceparent": "00-75c7858d2be3e4f21c167390c651a4da-57fc4153ad21f375-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "12100bcdcdb234ef0033528f110e0fd9",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:23 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:37 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -153,7 +153,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com"
+              "sbs1.ce225909-a4c8-4178-8cc1-50a142f9a765.com"
             ]
           }
         ]
@@ -162,20 +162,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:23 GMT",
-        "MS-CV": "v0By95XA\u002BkO6ni5W954lbA.0",
+        "Date": "Tue, 20 Dec 2022 00:48:38 GMT",
+        "MS-CV": "//XOpc5ya0iGq8UmrE8ZVA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0mN2YYwAAAAAJCBuKn/nOTImlJ6avAsfvUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ZgahYwAAAADBi9\u002BRQbs4TJTdGTgCNY\u002BIUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "106ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+          "sbs1.ce225909-a4c8-4178-8cc1-50a142f9a765.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+          "sbs2.ce225909-a4c8-4178-8cc1-50a142f9a765.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -185,7 +185,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com"
+              "sbs1.ce225909-a4c8-4178-8cc1-50a142f9a765.com"
             ]
           }
         ]
@@ -199,16 +199,16 @@
         "Authorization": "Sanitized",
         "Content-Length": "88",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-70e7570cfbeaea280b8054722e367c42-786a495673cde885-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "bbf048e5ab1da1920078f0788302efc9",
+        "traceparent": "00-adce6d7938c8a8577dbc74f6bea0e5cc-2cbb461cc20d2c17-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5d1843e643575771caaf8fc4f3bc2081",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:23 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:38 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+          "newsbs.ce225909-a4c8-4178-8cc1-50a142f9a765.com": {
             "sipSignalingPort": 3333
           }
         }
@@ -217,23 +217,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:24 GMT",
-        "MS-CV": "LG2sa3OWXEeHZCGbi4Y0jQ.0",
+        "Date": "Tue, 20 Dec 2022 00:48:38 GMT",
+        "MS-CV": "tdyJkbDHXEiMgFI6YJOi6w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0mN2YYwAAAABB0r02TL36QKz6bjgnZYHdUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ZgahYwAAAACx18h8k2GeQrF0udpHtFpeUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "450ms"
+        "X-Processing-Time": "253ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+          "sbs1.ce225909-a4c8-4178-8cc1-50a142f9a765.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+          "sbs2.ce225909-a4c8-4178-8cc1-50a142f9a765.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+          "newsbs.ce225909-a4c8-4178-8cc1-50a142f9a765.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -243,7 +243,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com"
+              "sbs1.ce225909-a4c8-4178-8cc1-50a142f9a765.com"
             ]
           }
         ]
@@ -255,11 +255,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-cf44da5e293f7f0f0a43a2ccddb8aab9-5efe5a4a663b045b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f89b4cc042dd25ae27605b6d6790b85f",
+        "traceparent": "00-7e7f54200e84c3ea71f1490a3b111bc0-bc13eb89838bc2e6-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "563218cdd71bdac230b8b09fe6d5853d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:24 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:38 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -267,23 +267,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:24 GMT",
-        "MS-CV": "4whjbdk8SEWVZOd26yHSng.0",
+        "Date": "Tue, 20 Dec 2022 00:48:38 GMT",
+        "MS-CV": "XBUiBgk7QkGs4MOqhrdTSA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0md2YYwAAAABV\u002B8iCHw/iSZYRqiRPPPpzUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ZgahYwAAAABxBm/HynwMR7DtVW/0/kuPUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "79ms"
+        "X-Processing-Time": "82ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+          "sbs1.ce225909-a4c8-4178-8cc1-50a142f9a765.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+          "sbs2.ce225909-a4c8-4178-8cc1-50a142f9a765.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+          "newsbs.ce225909-a4c8-4178-8cc1-50a142f9a765.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -293,107 +293,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-8c94ec0936c59f562f08739aad6632b5-aa0ebd510a9f993a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "45028cb50b47e3f2b60731443eac483a",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:24 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:24 GMT",
-        "MS-CV": "dQOs\u002BCjlw06MgXpliMBB9A.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0md2YYwAAAADcWzy3FGmOS6PFaUbYWdT/UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "74ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
-            "sipSignalingPort": 1123
-          },
-          "newsbs.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
-            "sipSignalingPort": 3333
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-9a456f755e516874c14e63e6129f7a90-0c2c6748948dbb95-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c45d4cc4c82da39999cb93bd4f243a6f",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:24 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:24 GMT",
-        "MS-CV": "AAt7406U/ke2xwdr2ExY7Q.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0md2YYwAAAACC\u002Br6UvTxAQLgVJLYQeuUmUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "92ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
-            "sipSignalingPort": 1123
-          },
-          "newsbs.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
-            "sipSignalingPort": 3333
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com"
+              "sbs1.ce225909-a4c8-4178-8cc1-50a142f9a765.com"
             ]
           }
         ]
@@ -407,11 +307,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-b8292a27fe83b3542f990ad8abb62d30-faf0a57f9bcc923e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f7c390bfaaffb58259b842d5106ae67b",
+        "traceparent": "00-725746fdc0ba16a9c3d66b7c0356929a-f09418b822ee10d7-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a811eea168a08aef9ab948023e2b4043",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:24 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:38 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -421,23 +321,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:25 GMT",
-        "MS-CV": "7AS\u002BaWlEXUG4ssVjpOoTeQ.0",
+        "Date": "Tue, 20 Dec 2022 00:48:39 GMT",
+        "MS-CV": "guzXpyNfLUKEFb\u002BbttIDRA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0md2YYwAAAABq5H99dSZNQbHxqhMqZzA2UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ZwahYwAAAADAKf8wcECAQarROf/uhJUzUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "105ms"
+        "X-Processing-Time": "116ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+          "sbs1.ce225909-a4c8-4178-8cc1-50a142f9a765.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+          "sbs2.ce225909-a4c8-4178-8cc1-50a142f9a765.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+          "newsbs.ce225909-a4c8-4178-8cc1-50a142f9a765.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -450,11 +350,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-aa297ff73c306050667b18ecf429f53a-f19b566eec69236b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1aa92117f432ec32f25fab7b77359391",
+        "traceparent": "00-d7d72ff1ee163e736011e4cbe914e270-3735e05282a3af88-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f8c2d012b8dc0ebe803d2c9f92d270f4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:24 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:38 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -462,23 +362,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:25 GMT",
-        "MS-CV": "Sa/RwgoDp0i8daq7rbeNNg.0",
+        "Date": "Tue, 20 Dec 2022 00:48:39 GMT",
+        "MS-CV": "dwgCuO6elEi2HaEDkKVcfw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0md2YYwAAAACC1h6SlwOfSaQBUG2RoympUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ZwahYwAAAAAn0dLJUFYARb6m9gbSKz2UUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "86ms"
+        "X-Processing-Time": "99ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+          "sbs1.ce225909-a4c8-4178-8cc1-50a142f9a765.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+          "sbs2.ce225909-a4c8-4178-8cc1-50a142f9a765.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": {
+          "newsbs.ce225909-a4c8-4178-8cc1-50a142f9a765.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -493,31 +393,31 @@
         "Authorization": "Sanitized",
         "Content-Length": "173",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-aa297ff73c306050667b18ecf429f53a-3afb60f2eaec0adc-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ad84c2cd51e9193bcaa86a7586c4922f",
+        "traceparent": "00-d7d72ff1ee163e736011e4cbe914e270-6b88f8202c6c5b64-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0422512a78ab65e128a7bc618ebf9c05",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:25 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:39 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": null,
-          "sbs2.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": null,
-          "newsbs.01791c35-4241-cf7c-58d3-fdc8e1fe4814.com": null
+          "sbs1.ce225909-a4c8-4178-8cc1-50a142f9a765.com": null,
+          "sbs2.ce225909-a4c8-4178-8cc1-50a142f9a765.com": null,
+          "newsbs.ce225909-a4c8-4178-8cc1-50a142f9a765.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:25 GMT",
-        "MS-CV": "WEbqloA7HUWfpIMITctiJg.0",
+        "Date": "Tue, 20 Dec 2022 00:48:39 GMT",
+        "MS-CV": "S5Mh1xfB0kWA9z4Pej89Wg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0mt2YYwAAAADtBo7vXEd5RJ1CK3bWcDhZUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ZwahYwAAAADm69i50LYVRIS2qCJ5jcO\u002BUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "166ms"
+        "X-Processing-Time": "126ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -527,6 +427,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1229580860"
+    "RandomSeed": "1917533732"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/AddSipTrunkForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-342c77321c0bd864454bcec0075898a1-fac30f79457e6450-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d75047619487f1bf9de23352a366f0da",
+        "traceparent": "00-c64574836a773433bbf3c0a624284254-3e3a5a37e1c24b0a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "faf4a48bc36d90a255e226c77e18da92",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:47 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:10 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:49 GMT",
-        "MS-CV": "RQLG0ZfRLEqAc0Ns5YkWiw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:10 GMT",
+        "MS-CV": "1juzGZLmBUeYTU6LcUEjvQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sN2YYwAAAAARY2rBfeNNT51gCO5bXjF3UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0hgahYwAAAADQqCk3u3RpQqLqFTMBuZ/5UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "213ms"
+        "X-Processing-Time": "156ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-86b9a3ab40c5ce7c66c62641eb23e233-77faff3ed026c710-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7643d59fd16a3e3d1072b967b343d676",
+        "traceparent": "00-80d6bc62305da60e6475a3fbcf8e924e-002a0c3c437b6042-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8abb0297ec9d933e0eb6d32a906ef5a2",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:48 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:10 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:49 GMT",
-        "MS-CV": "uafMFQaD/0aQH3bymeKEzw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:11 GMT",
+        "MS-CV": "PgQ9nVqnCUiNuxd5Mbqj4g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sd2YYwAAAACE\u002BGGaXrhOQKaRIvh4V/QSUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0hwahYwAAAADlQ4h7DPCvQYS5KYecxfHxUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
+        "X-Processing-Time": "93ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-86b9a3ab40c5ce7c66c62641eb23e233-ca255f8d2054c588-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2bb4aa8373ba2ee5774bedcd29fe4222",
+        "traceparent": "00-80d6bc62305da60e6475a3fbcf8e924e-652d6bd499fc4eaa-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bb4c09ddfc2a972e4dc548563179fabf",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:48 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:11 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+          "sbs1.9d55f05b-5739-7940-d812-55db623b507a.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+          "sbs2.9d55f05b-5739-7940-d812-55db623b507a.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:50 GMT",
-        "MS-CV": "JIBLv5f/20S1LmqL73Tcbw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:11 GMT",
+        "MS-CV": "ktmHHZCSG0S6tv5UXdGBJA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sd2YYwAAAACJR72w\u002B2SOTJdn9JkqDuVJUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0hwahYwAAAAAtSx\u002BH773gQb8VQ1eMfWewUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "569ms"
+        "X-Processing-Time": "615ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+          "sbs1.9d55f05b-5739-7940-d812-55db623b507a.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+          "sbs2.9d55f05b-5739-7940-d812-55db623b507a.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-e426e3a74dd8c549329247e476d67141-b57dc971935d6aad-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ca4b734eb48190670a12c614da573e5a",
+        "traceparent": "00-853ee27f7cf0cc9c0f91f309f900b1a9-cb27329ba51a6082-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6044c237c57f9fdc6560ebb6f078ffe7",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:49 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:11 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com"
+              "sbs1.9d55f05b-5739-7940-d812-55db623b507a.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:50 GMT",
-        "MS-CV": "mcs7GLZ2g0yN8b1pByCo9g.0",
+        "Date": "Tue, 20 Dec 2022 00:49:12 GMT",
+        "MS-CV": "ZQVoxeAgUkGAQm2C5X92Sg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0st2YYwAAAAB8cJSH84rtQpqfb0gwj8irUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0iAahYwAAAABbutwtnibQQa2Rv1/XVjddUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "188ms"
+        "X-Processing-Time": "384ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+          "sbs1.9d55f05b-5739-7940-d812-55db623b507a.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+          "sbs2.9d55f05b-5739-7940-d812-55db623b507a.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com"
+              "sbs1.9d55f05b-5739-7940-d812-55db623b507a.com"
             ]
           }
         ]
@@ -183,16 +183,16 @@
         "Authorization": "Sanitized",
         "Content-Length": "88",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d3c8a52d136f89c01511dad9226ba757-54e3191cc9b3b186-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f8cebc0cc4b22c1fef14fe1fe3701412",
+        "traceparent": "00-5e9c234afdcea521bcc15c98de02e563-1ce4d9cbc9a5097f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "75e983ed1fcc9b68d3233dd8a3e76295",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:49 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:12 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+          "newsbs.9d55f05b-5739-7940-d812-55db623b507a.com": {
             "sipSignalingPort": 3333
           }
         }
@@ -201,23 +201,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:50 GMT",
-        "MS-CV": "pQvsp9eDX0qpBD9Xi\u002Bn8Rg.0",
+        "Date": "Tue, 20 Dec 2022 00:49:12 GMT",
+        "MS-CV": "Gc6wLriOMkuYnzwEZfkn8Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0st2YYwAAAAAu12gBZd5aTY4Yz6PukkHfUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0iAahYwAAAAClTUGeQlijS5SfVV9/VdBvUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "462ms"
+        "X-Processing-Time": "616ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+          "sbs1.9d55f05b-5739-7940-d812-55db623b507a.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+          "sbs2.9d55f05b-5739-7940-d812-55db623b507a.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+          "newsbs.9d55f05b-5739-7940-d812-55db623b507a.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -227,7 +227,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com"
+              "sbs1.9d55f05b-5739-7940-d812-55db623b507a.com"
             ]
           }
         ]
@@ -239,11 +239,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-2dc2b3c26cc8504897e465f0792c7435-d416f68c91312753-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3f18972f0bf7cef5432421a8acd0541f",
+        "traceparent": "00-bb2d128dabd66385a63ef8e2edbde442-29018cb97983be59-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cef313bc942918232cac55c91078a7d4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:50 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:13 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -251,73 +251,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:51 GMT",
-        "MS-CV": "IY6olxxqoECfhkiNWOjmyQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:13 GMT",
+        "MS-CV": "BDELeXi6aUqrBoRJEEKgPQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0st2YYwAAAACHmM4rgdYGQqn7HbD/v27yUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
-            "sipSignalingPort": 1123
-          },
-          "newsbs.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
-            "sipSignalingPort": 3333
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-344fd5a61eb6543a7af7c1e10b9c6395-3447ff00c42b9172-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6dc1930d4a2f8a70541fda6cb647ac9a",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:50 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:51 GMT",
-        "MS-CV": "rF4h8\u002BGm1UiLc1nBExH8PA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0s92YYwAAAAAEYC68KVgpTLDY/0ipuJbDUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0iQahYwAAAAB6Q5ZspknlRKDrzZJgr13OUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "88ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+          "sbs1.9d55f05b-5739-7940-d812-55db623b507a.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+          "sbs2.9d55f05b-5739-7940-d812-55db623b507a.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+          "newsbs.9d55f05b-5739-7940-d812-55db623b507a.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -327,57 +277,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-902f9193b1f7285f78b41fdcf06cab4e-d6f67e0edbea1ac4-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "43e4b4fdfe3e0062c700b58da3767f1f",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:50 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:51 GMT",
-        "MS-CV": "YMlXtHD\u002BOEmiDV6zgnzizw.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0s92YYwAAAACTehzBi1/MTLVJm7afCWSOUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "90ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
-            "sipSignalingPort": 1123
-          },
-          "newsbs.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
-            "sipSignalingPort": 3333
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com"
+              "sbs1.9d55f05b-5739-7940-d812-55db623b507a.com"
             ]
           }
         ]
@@ -391,11 +291,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-4db5d47083c378d19f0e1bb3fcb72a9b-75f0ef87ad5e8662-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4f12dec0a7aee5e2278eebd7318818fb",
+        "traceparent": "00-70e788efd77018472769f3f7fdf67b0d-d40136ba59726fef-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ad6960c5858f17f359a98c5b8804fb7e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:50 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:13 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -405,23 +305,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:51 GMT",
-        "MS-CV": "A\u002Be5IpXOEkuIQGC6zW4\u002BDw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:13 GMT",
+        "MS-CV": "Qc1Tbg0tPEeJ\u002BApNz6YYRQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0s92YYwAAAACVx0GXz0deQqmpaN4tXhtzUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0iQahYwAAAADzJHTcX4eVTrjdauH1WQnaUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "165ms"
+        "X-Processing-Time": "178ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+          "sbs1.9d55f05b-5739-7940-d812-55db623b507a.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+          "sbs2.9d55f05b-5739-7940-d812-55db623b507a.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+          "newsbs.9d55f05b-5739-7940-d812-55db623b507a.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -434,11 +334,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-1af711e4107d257c2e3f690093638007-3e2ab3ae4bfa3003-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f8ab867710eb0ee131c0a62f94e2e6dd",
+        "traceparent": "00-ffc0c0bb748a376ec8155c90fa566f6e-d7d02e7d0140d6ce-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ddfa55fe318558bd60d1491fca9f8a5b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:50 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:13 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -446,23 +346,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:52 GMT",
-        "MS-CV": "4\u002Bwc1hJlY0S8AX5a9Q4dCg.0",
+        "Date": "Tue, 20 Dec 2022 00:49:13 GMT",
+        "MS-CV": "qFbMR6B9hkOuhP3byNp0zw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0s92YYwAAAAAzFhUNbCADR4u3loZSYRkMUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0iQahYwAAAADQpQjj32NLSISKsOd/NCkAUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "92ms"
+        "X-Processing-Time": "104ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+          "sbs1.9d55f05b-5739-7940-d812-55db623b507a.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+          "sbs2.9d55f05b-5739-7940-d812-55db623b507a.com": {
             "sipSignalingPort": 1123
           },
-          "newsbs.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": {
+          "newsbs.9d55f05b-5739-7940-d812-55db623b507a.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -477,31 +377,31 @@
         "Authorization": "Sanitized",
         "Content-Length": "173",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-1af711e4107d257c2e3f690093638007-8963e2f8fe44239a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d8acbba05d3456ebd1fe1cb0128bce3e",
+        "traceparent": "00-ffc0c0bb748a376ec8155c90fa566f6e-b56632a261d44191-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4312687cb47e36061fdb748007c89027",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:51 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:13 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": null,
-          "sbs2.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": null,
-          "newsbs.8b3c37c3-5db0-e650-883f-4deb9fc42ad2.com": null
+          "sbs1.9d55f05b-5739-7940-d812-55db623b507a.com": null,
+          "sbs2.9d55f05b-5739-7940-d812-55db623b507a.com": null,
+          "newsbs.9d55f05b-5739-7940-d812-55db623b507a.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:52 GMT",
-        "MS-CV": "uI7Z/a3dvkm8FT1Q9TSF6A.0",
+        "Date": "Tue, 20 Dec 2022 00:49:14 GMT",
+        "MS-CV": "XfxTGH3fDEKPC7jYtdbjYA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0tN2YYwAAAADD9omanUUERKF/ksBXMMpgUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0igahYwAAAAB02U104oOdSKPIcV1JrVJrUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "352ms"
+        "X-Processing-Time": "351ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -511,6 +411,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "2006928725"
+    "RandomSeed": "1305804913"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ClearSipRoutesForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ClearSipRoutesForResource.json
@@ -6,38 +6,112 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "86",
+        "Content-Length": "139",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-a9e5295fb3560c78a6a028174ac374c2-ca85cb19fe611447-00",
+        "traceparent": "00-0c324fc90e269035867ff6be3f846013-e588ffdf65a99c8e-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d9b05396fe9ed4b2dd2912e4568564c7",
+        "x-ms-client-request-id": "0cbfd8c27d19565975f7bfba47f9b915",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:39 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "trunks": {
-          "sbs1.d4a5abbf-09f4-80a5-1bf0-2d684635d13d.com": {
-            "sipSignalingPort": 5555
+        "routes": [
+          {
+            "description": "Handle all numbers\u0027",
+            "name": "Rule without trunks",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": []
           }
-        }
+        ]
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 20 Dec 2022 00:49:40 GMT",
-        "MS-CV": "oT6wqY1g0UqdyFPjFvJFqQ.0",
+        "Date": "Tue, 20 Dec 2022 00:48:39 GMT",
+        "MS-CV": "n0C\u002BUdppwEqSeCF6O0Xckg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pAahYwAAAADGqcwoxh6DQ6wjUxgeaM1cUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ZwahYwAAAACfafm2jhMtS6RyNTBbAfz/UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "502ms"
+        "X-Processing-Time": "112ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.d4a5abbf-09f4-80a5-1bf0-2d684635d13d.com": {
-            "sipSignalingPort": 5555
+        "trunks": {},
+        "routes": [
+          {
+            "description": "Handle all numbers\u0027",
+            "name": "Rule without trunks",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": []
           }
-        },
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-954287c66a781bba3946c9b6783a0023-e6fc980164026ab3-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0f63cd3e7eb474916ff0ceca810c998d",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:39 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:40 GMT",
+        "MS-CV": "TwUNayc1W0269HhQc1hBdA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0aAahYwAAAAD1s4SX8NTNQb/DxC\u002BsOIhSUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "101ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c146a5595e8aae80ea2fbe90ee9a216d-adef7f05aabb90d9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b45355f9b980d89b26fc4105761ab2b7",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:39 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:40 GMT",
+        "MS-CV": "bU5gydiqgkuI/kOqoFX8Sw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0aAahYwAAAADm\u002B8zecz3SRLzkQ8wZjYxYUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "89ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
         "routes": []
       }
     },
@@ -49,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-8d3085a4c457a0a30777773998159218-f2344935feae8110-00",
+        "traceparent": "00-d457a53360cf44a5373a376abf618268-49ea04210a8b40f6-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "73e4a28a6762ded4f245d876968c2dfc",
+        "x-ms-client-request-id": "28dc4adddc4b4316474a9c29af8fd468",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 20 Dec 2022 00:49:40 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:40 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -63,20 +137,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 20 Dec 2022 00:49:40 GMT",
-        "MS-CV": "H6n5VBplpUSKYbQUqOyWKA.0",
+        "Date": "Tue, 20 Dec 2022 00:48:40 GMT",
+        "MS-CV": "uwAVRRRsCECwIZVp4CbL5g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pAahYwAAAAClJIh7C1m7Sb38oILQ8ZtNUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0aAahYwAAAABsKaoI9kkzRaAGLDhD3b6YUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "158ms"
+        "X-Processing-Time": "113ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.d4a5abbf-09f4-80a5-1bf0-2d684635d13d.com": {
-            "sipSignalingPort": 5555
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -86,11 +156,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-27e66229428e663073cadf3e18ac33ec-1b56bcf51b67b521-00",
+        "traceparent": "00-52257d24ed29534f01178aec428669fe-944212fa7fa5bff3-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "651cdd37597fc12af8d1f7cbf7c02995",
+        "x-ms-client-request-id": "f2c0315e04a58495318ae8b83c8bfe55",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 20 Dec 2022 00:49:40 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:40 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -98,54 +168,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 20 Dec 2022 00:49:40 GMT",
-        "MS-CV": "fP0IG\u002BylnUujMKDiyYT6HQ.0",
+        "Date": "Tue, 20 Dec 2022 00:48:40 GMT",
+        "MS-CV": "QTw5NlgeVEmZC8bX0R8s5g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pAahYwAAAACQ36ADkAZbTaTXRN001z5EUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0aAahYwAAAACuZVm8C/j6Q5kctu\u002BbXcziUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.d4a5abbf-09f4-80a5-1bf0-2d684635d13d.com": {
-            "sipSignalingPort": 5555
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "PATCH",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "65",
-        "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-27e66229428e663073cadf3e18ac33ec-e93aef134218d28f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a4de658c5e502fda7ed2e758253b3e51",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 20 Dec 2022 00:49:40 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "trunks": {
-          "sbs1.d4a5abbf-09f4-80a5-1bf0-2d684635d13d.com": null
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 20 Dec 2022 00:49:40 GMT",
-        "MS-CV": "TbFuAPCs7060EMx1uD1MpA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pQahYwAAAADODOFKhJOXS7dpi17EgXR/UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "272ms"
+        "X-Processing-Time": "82ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -155,6 +184,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1541974148"
+    "RandomSeed": "1985524780"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ClearSipRoutesForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ClearSipRoutesForResourceAsync.json
@@ -6,38 +6,112 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "86",
+        "Content-Length": "139",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-a9e5295fb3560c78a6a028174ac374c2-ca85cb19fe611447-00",
+        "traceparent": "00-6514e94b769b737f676cdd9b8ce22344-dd01db9df818e0f6-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d9b05396fe9ed4b2dd2912e4568564c7",
+        "x-ms-client-request-id": "a708195495146eb4b9c428e5d4227e2d",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:14 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "trunks": {
-          "sbs1.d4a5abbf-09f4-80a5-1bf0-2d684635d13d.com": {
-            "sipSignalingPort": 5555
+        "routes": [
+          {
+            "description": "Handle all numbers\u0027",
+            "name": "Rule without trunks",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": []
           }
-        }
+        ]
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 20 Dec 2022 00:49:40 GMT",
-        "MS-CV": "oT6wqY1g0UqdyFPjFvJFqQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:14 GMT",
+        "MS-CV": "8bGQ4fB4hU6InmTbtk5YSA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pAahYwAAAADGqcwoxh6DQ6wjUxgeaM1cUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0igahYwAAAAC\u002BB5/YTH6SS5y827qcp3IQUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "502ms"
+        "X-Processing-Time": "173ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.d4a5abbf-09f4-80a5-1bf0-2d684635d13d.com": {
-            "sipSignalingPort": 5555
+        "trunks": {},
+        "routes": [
+          {
+            "description": "Handle all numbers\u0027",
+            "name": "Rule without trunks",
+            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
+            "trunks": []
           }
-        },
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-fb19ac4f212ccf17a13b44a49502c1f6-874bf4eab1945cb6-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4c6ce98c77c5eb9bae84fabb256f144b",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:14 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:14 GMT",
+        "MS-CV": "9sw9XrOzlkKtoMgYk5ZLhg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0igahYwAAAAAL9MVdvae\u002BSpr6495EdlueUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "197ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-786dff5d329863932918b4d329cd863d-186a05f24997f59b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0d773b9ab9db9bae185039ac3711de8b",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:14 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:14 GMT",
+        "MS-CV": "HJdiCcASI0u1Odk3FIoZnw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0iwahYwAAAABNYUovEKhpSYg/zMekOgdQUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "96ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
         "routes": []
       }
     },
@@ -49,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-8d3085a4c457a0a30777773998159218-f2344935feae8110-00",
+        "traceparent": "00-1553ec0f680e582b6a81e27d1efd802b-9736632b1028ad7a-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "73e4a28a6762ded4f245d876968c2dfc",
+        "x-ms-client-request-id": "4450a2be2b9bdcca7d1cf98f9af84949",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 20 Dec 2022 00:49:40 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:15 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -63,20 +137,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 20 Dec 2022 00:49:40 GMT",
-        "MS-CV": "H6n5VBplpUSKYbQUqOyWKA.0",
+        "Date": "Tue, 20 Dec 2022 00:49:15 GMT",
+        "MS-CV": "s3k60ZG5gkef1axirkVZlg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pAahYwAAAAClJIh7C1m7Sb38oILQ8ZtNUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0iwahYwAAAACpA0fQaWzFTJObRcQNE1vsUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "158ms"
+        "X-Processing-Time": "161ms"
       },
       "ResponseBody": {
-        "trunks": {
-          "sbs1.d4a5abbf-09f4-80a5-1bf0-2d684635d13d.com": {
-            "sipSignalingPort": 5555
-          }
-        },
+        "trunks": {},
         "routes": []
       }
     },
@@ -86,11 +156,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-27e66229428e663073cadf3e18ac33ec-1b56bcf51b67b521-00",
+        "traceparent": "00-8ca0e62b817f35fcf2380a3df5076136-48810984a77416bf-00",
         "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "651cdd37597fc12af8d1f7cbf7c02995",
+        "x-ms-client-request-id": "984adcb071abd3513bd033743eefb39d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 20 Dec 2022 00:49:40 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:15 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -98,54 +168,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 20 Dec 2022 00:49:40 GMT",
-        "MS-CV": "fP0IG\u002BylnUujMKDiyYT6HQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:15 GMT",
+        "MS-CV": "8BkjVly3PU68tNMScX6zUw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pAahYwAAAACQ36ADkAZbTaTXRN001z5EUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0iwahYwAAAAD3ae7xhVEkRpz3SWtVGbWpUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "89ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.d4a5abbf-09f4-80a5-1bf0-2d684635d13d.com": {
-            "sipSignalingPort": 5555
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "PATCH",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "65",
-        "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-27e66229428e663073cadf3e18ac33ec-e93aef134218d28f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a4de658c5e502fda7ed2e758253b3e51",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 20 Dec 2022 00:49:40 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "trunks": {
-          "sbs1.d4a5abbf-09f4-80a5-1bf0-2d684635d13d.com": null
-        }
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 20 Dec 2022 00:49:40 GMT",
-        "MS-CV": "TbFuAPCs7060EMx1uD1MpA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pQahYwAAAADODOFKhJOXS7dpi17EgXR/UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "272ms"
+        "X-Processing-Time": "181ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -155,6 +184,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1541974148"
+    "RandomSeed": "1088010620"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ClearSipRoutesForResourceWhenAlreadyEmpty.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ClearSipRoutesForResourceWhenAlreadyEmpty.json
@@ -1,0 +1,206 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-834dad16cdb22a0b2397d7e9515062f5-e724f1c9fa2010fa-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d39d89b1557f8b2cd0822fcb002ca51c",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:40 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:41 GMT",
+        "MS-CV": "GvvPHOk3RkeBVrgT\u002BfwirQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0aAahYwAAAAB6jbp/WmJvQ4EOg\u002BTPIhSKUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "207ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4f131e0b93d3360f819f26bdb80fc2b6-b5e84260adfa77fd-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d20bd5b1d2e6676eed27dd900cb5b8d3",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:40 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:41 GMT",
+        "MS-CV": "WMigFbM4DESrEoHvDjmowQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0aQahYwAAAABXPmRe3\u002BIvQI1I1DzEQj4FUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "235ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-efc6e8036ac4e0e8b856b62989b88c5a-6ef9ef9d85c66d6c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ad321e57af4bd825ed11b73b6644324a",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:41 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:41 GMT",
+        "MS-CV": "E9M\u002BEaQ/yU62a0mM7P2OwA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0aQahYwAAAADmHrmsZx1gQ6/\u002B6PrQ\u002Bd93UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "312ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-387b224e48e5ffbda694b837d93f47b2-d13297a65cfa0272-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8af62798f7a2deea1b36e657789b7f1b",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:41 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:42 GMT",
+        "MS-CV": "IVOWxHX30UiLbA0p8zla3g.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0agahYwAAAAC82PhatSClSpBpI056Jd/XUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "102ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-9729acb54010521b5a62cbc56f577c23-6a33a61ec93e773e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e2735bc9f8f901d0af33e4d51b3301a8",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:41 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:42 GMT",
+        "MS-CV": "OcAkeNgxFkO5btSi5K9U0A.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0agahYwAAAABCirSmheySQ4qZ6b94NCNqUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "104ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a284a4d82d84062391cc35c31729ecd1-d21c97ccac718fbb-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e5f792f42dbe5f3033539215c9cd6051",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:42 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:42 GMT",
+        "MS-CV": "CRTH1zu59U\u002BvoNcAnz6H6w.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0agahYwAAAAC8HBc7j8nDQ6Cp47TGRi/7UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "80ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    }
+  ],
+  "Variables": {
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "1745544547"
+  }
+}

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ClearSipRoutesForResourceWhenAlreadyEmptyAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ClearSipRoutesForResourceWhenAlreadyEmptyAsync.json
@@ -1,0 +1,206 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-1cfa1a94f529f399c24ee2216a67615a-7bbdc8640526947e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "57e898882192ddadae2cc0e6c336fc16",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:15 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:15 GMT",
+        "MS-CV": "sWQZ\u002ByZ\u002BRkqdgU65/3hHfQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0iwahYwAAAACRHU4q/HjaT4VCQTVX4pYTUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "157ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-65e0e9f9e4fd67062356be4556190ae2-54fd55c77183db8e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b9432190a03c0b64c9a7c6a46e4f8bc2",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:15 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:16 GMT",
+        "MS-CV": "g/aeSs/HPkCoQzxyonFuRg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0jAahYwAAAADk3Hz2Uq6DTa5mrTeJqrYYUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "220ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-232fb2a0b92a407cb7e6aa08ef0ccf90-cd1d15250265b342-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "59dcba853f13796b5e309fff1a714336",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:16 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:16 GMT",
+        "MS-CV": "UzVeXTuc9E6XknncQpI7zQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0jAahYwAAAABS9MO9NWuAQbUmElSB5hQrUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "185ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ea37f39d275c8ca403025e904b7cb7e4-2f1542597cce9204-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "76fdd72f1449e74f34dc8eea5b086e5e",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:16 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:16 GMT",
+        "MS-CV": "uijSBnf4DU6Eo3LYq45JdA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0jQahYwAAAAByPXk\u002BSGf0RYnKsgA9xQbfUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "92ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-355c0be507b9ca28943775826fd9f5fc-2bb9ec44bfff8fe1-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0960fda0a25a5003b6ca5a0c0064f057",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:17 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:17 GMT",
+        "MS-CV": "K40xiMAizkqr7WsnsahdoQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0jQahYwAAAABrG33VZB/lR7nEIAWDxa\u002BLUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "165ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-50b4d08ae19738ed220ca42f4ead3798-a1813961d81d7b4f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "96758f63155270796af42537b0801d55",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:17 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:17 GMT",
+        "MS-CV": "iebdbJ1GEUK\u002BbcUc1X1xmA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0jQahYwAAAADGRMklq\u002BzdRZhJwRALTaX6UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "88ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    }
+  ],
+  "Variables": {
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "328102130"
+  }
+}

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ClearSipTrunksForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ClearSipTrunksForResource.json
@@ -1,0 +1,261 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-83fc53d1dc41a89dab4d0f777938b7d8-16c11cd2924e3a5d-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c91c76a4c66c6b8dd33a5622088757d5",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:42 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:42 GMT",
+        "MS-CV": "kmUhtpOEMkKogVLWCrZSgA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0agahYwAAAABlgiH\u002Bi8ecRI2ipWuCasM9UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "87ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "160",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-83fc53d1dc41a89dab4d0f777938b7d8-949c206ef131e635-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f908501b28adda01b08d0843f6b7cfff",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:42 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.4ca58795-1b4c-facb-c953-7e48d3468211.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.4ca58795-1b4c-facb-c953-7e48d3468211.com": {
+            "sipSignalingPort": 1123
+          }
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:43 GMT",
+        "MS-CV": "DCwKZR306kmcf1A4ESFpAw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0agahYwAAAAAImyyohe/3SYVA4YHtddgaUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "404ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.4ca58795-1b4c-facb-c953-7e48d3468211.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.4ca58795-1b4c-facb-c953-7e48d3468211.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8cf0f00a8dae6b77f497e35d5df84332-6921702e72d55e29-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "619af7e9834dcf96f93a7911c5a8f242",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:43 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:43 GMT",
+        "MS-CV": "YPMitJa4dUOoWONohVr\u002B5Q.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0awahYwAAAACBSGyi7a9/SKiFZFPFuWHHUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "85ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.4ca58795-1b4c-facb-c953-7e48d3468211.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.4ca58795-1b4c-facb-c953-7e48d3468211.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "118",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-8cf0f00a8dae6b77f497e35d5df84332-41e0e06cfa5c32b5-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "832ca8fc893d7b64744219dfbd4a741b",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:43 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.4ca58795-1b4c-facb-c953-7e48d3468211.com": null,
+          "sbs2.4ca58795-1b4c-facb-c953-7e48d3468211.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:43 GMT",
+        "MS-CV": "vFb54D5MBkKFlYFH4H1r6Q.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0awahYwAAAACl8mraAeydRIrkyJqo/RnoUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "124ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-42acc7e295dfbeefb6df2171e1b35bec-c173cc350ff3b68f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1039566af5ed9787ba38ff72aeef1507",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:43 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:43 GMT",
+        "MS-CV": "Z5C8Siy2L0e\u002BXGJg45GF4w.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0awahYwAAAAAS3ng0NktZRZV83BZgztN9UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "80ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-8afa629dc8496e8a6a0004935ab72c65-b3fd95a3adeb54c9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4d47c69b4c8a5fc2931eec0b6ab612af",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:43 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:44 GMT",
+        "MS-CV": "KUSlA9HY70SWjx/\u002B0cKshw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0bAahYwAAAABx0\u002BHM5TdTTKcYTFDFfHSjUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "161ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e4bfeb501aef422bc9adedd2a35bcb45-a81df409251e8ab8-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6ea65dc5e16f06542095c8048af1cd85",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:44 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:44 GMT",
+        "MS-CV": "UwZkvOshNkS2BPm3wS3Ogg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0bAahYwAAAADvpHnKDvkMRILYYp5F7lBmUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "101ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    }
+  ],
+  "Variables": {
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "653537782"
+  }
+}

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ClearSipTrunksForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ClearSipTrunksForResourceAsync.json
@@ -1,0 +1,261 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-bde39ffe4a74cf57be0296b2c3662a45-0e1c10469e7d58d4-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e660fe322a567242bdfdfa5c6d85c47e",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:17 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:17 GMT",
+        "MS-CV": "/QdPgwhOgkmZ2B/eQkpa1w.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0jQahYwAAAABs7ah3FG9OSqWSbrZjTYxJUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "89ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "160",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-bde39ffe4a74cf57be0296b2c3662a45-750d28118200f1b1-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dff0b60759700736d983c5e8b45c1c5d",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:17 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.4a9b76f4-e07a-0467-3b65-f1645bc41fe6.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.4a9b76f4-e07a-0467-3b65-f1645bc41fe6.com": {
+            "sipSignalingPort": 1123
+          }
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:18 GMT",
+        "MS-CV": "8aO0P\u002BK/j0eXt62AwSImqw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0jgahYwAAAAD\u002BlJx88m8BTJW5FrDmVlpmUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "632ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.4a9b76f4-e07a-0467-3b65-f1645bc41fe6.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.4a9b76f4-e07a-0467-3b65-f1645bc41fe6.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b27d1fa741c333b476f2d89f283f53b5-e8177644307b9690-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5663ffa05bddca3c34288c7de50a96b5",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:18 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:18 GMT",
+        "MS-CV": "ENt8FckYpUiDG6Ipd6ai9w.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0jgahYwAAAAA1z1423zrqQbNGk2y3FoWuUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "100ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.4a9b76f4-e07a-0467-3b65-f1645bc41fe6.com": {
+            "sipSignalingPort": 1122
+          },
+          "sbs2.4a9b76f4-e07a-0467-3b65-f1645bc41fe6.com": {
+            "sipSignalingPort": 1123
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "118",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-b27d1fa741c333b476f2d89f283f53b5-3a3690ee5317b4fc-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a45d73a040d3d875c7590cd2645abe61",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:18 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "trunks": {
+          "sbs1.4a9b76f4-e07a-0467-3b65-f1645bc41fe6.com": null,
+          "sbs2.4a9b76f4-e07a-0467-3b65-f1645bc41fe6.com": null
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:19 GMT",
+        "MS-CV": "naxy2sVO/0C5Kqw8Q08qwA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0jwahYwAAAAD1gdyt7A0fQa5ZiYwEM/xDUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "408ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ad0224cdf18eba66ef2bb612a63a5e47-fdae1a4f6660b712-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6dbc9de06e21aca17a26ab48ccb921cf",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:19 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:19 GMT",
+        "MS-CV": "18HaS7Aqekm4HrJvtFAkqQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0jwahYwAAAAAkW0PlmNa0RIvpt34Buk6uUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "99ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-ee4675129ed346f6c028c4931a85c53c-40dc8f7065e55b0a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "414710ec77ff60898a8b8e844e6966d9",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:19 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:19 GMT",
+        "MS-CV": "fRBIDbrG2EeTp1yzOhxFIg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0jwahYwAAAAC4RDUSGsjhS5wZYRCoqe/nUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "165ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-83b52a5bc88953d6d4243ce3655d9159-edd7892f47c2fd59-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "479d2b69284e3293d1b129ad942d0c0e",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:19 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:19 GMT",
+        "MS-CV": "duSps5PhHU6XYr8lblTtRw.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0kAahYwAAAABZDnDduJp5TqxC36C8mAwWUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "113ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    }
+  ],
+  "Variables": {
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "1501715981"
+  }
+}

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ClearSipTrunksForResourceWhenAlreadyEmpty.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ClearSipTrunksForResourceWhenAlreadyEmpty.json
@@ -1,0 +1,202 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-617a581a859fb7f7e611d4ff14bfe888-5f408b141640da29-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ee80122b420563410f301a19d3606b62",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:44 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:44 GMT",
+        "MS-CV": "6X72lRTe10CVI\u002BV00WUB0A.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0bAahYwAAAAAbN2c6R4jhTbzDHhpoPu8kUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "115ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-075df4d4288f9a3e93cb4ddbec249114-fb40fba92c8fede1-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "31a595413494317d81379038e25343d5",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:44 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:44 GMT",
+        "MS-CV": "f2MsvH32e0ST4\u002BDR6QjcoA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0bAahYwAAAABUAsXJKOcSR5s7rjCbFUVnUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "101ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-bdbfac6f2abfe542e63d70ed10abb63c-fd05809c21255582-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ee5b4cdb38bf9f3471a7cb3619d580c0",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:44 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:45 GMT",
+        "MS-CV": "vqQWlVnTaUSUpmAyazfWHg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0bAahYwAAAACHFMRj0rLfRK2aCMB4r30IUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "134ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d9ffb038c7eec2a53304996894f79dfd-5f57c2fc3534c5dd-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "71f3b9cd1416f617954f6cceb20880bc",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:44 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:45 GMT",
+        "MS-CV": "GG3\u002BUT\u002B1Gke0upFGoo9/1w.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0bQahYwAAAAAxOVyWXwj3TJE492/GOewsUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "93ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-c591bb8bbfe6bf6b628b3bcdce0f8da8-4a804ff307a4bd0b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "873e44ed7c0508a26105bfec684617ab",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:45 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:45 GMT",
+        "MS-CV": "ThFdOeGgjE299ANf6SqgrQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0bQahYwAAAAAU0QLgI7mPQp\u002BnBzB2fpdsUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "106ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5e78e8521647d339f762e7cd1a7f4264-c8c95b99cde1ca11-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "296bd0b7d15fc6be34645970cb65ed68",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:45 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:45 GMT",
+        "MS-CV": "EizupPykeky6SK5YVaIjbg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0bQahYwAAAAD\u002BtRMfahw8TZzVZ5qgxwZQUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "87ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    }
+  ],
+  "Variables": {
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "961103220"
+  }
+}

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ClearSipTrunksForResourceWhenAlreadyEmptyAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ClearSipTrunksForResourceWhenAlreadyEmptyAsync.json
@@ -1,0 +1,202 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-d93995274f9d993fd1b6451da17d0bc6-7805f90fcf7dc889-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c4032f1fc43a963e00ccf487b4532c47",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:20 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:20 GMT",
+        "MS-CV": "8T6BNi7wc02E1UcXXbRnhQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0kAahYwAAAACOfdwJ0tQ/Q7b3h2zgrPcOUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "161ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d693f49e44a43281f0a8fa6d56c6ca2e-30c5fa9b70e25d8e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7d6119806df7f936de3534884114cb32",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:20 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:20 GMT",
+        "MS-CV": "AB7GWziOTkObTYv2K4O8dA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0kAahYwAAAADOVxRZmEPURIQfzdDYne3IUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "93ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ba18a6c201886944a2128bc0e2414587-04545dd23b42f68e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f8ae89de80433a067d92a4983bc51fdd",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:20 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:20 GMT",
+        "MS-CV": "lERjytRd6U6yO1IGoFrqGg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0kAahYwAAAADxW/UjE9b\u002BS5cWTEkfvnIgUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "114ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fae2c0d6b6fd56d22f25415da00129e3-a92ea237cc24d74b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e713a70af520b281f90ae6048fb655eb",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:20 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:20 GMT",
+        "MS-CV": "87HKqGzDgUScSwPZEIqc\u002Bg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0kAahYwAAAADfgvKceQw0RqI/N1i1cCqaUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "81ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-513376a793f0fd5395b7f20b3569c2dd-05d89efc0d5eae6c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2aa9c20034a400031327ff64c89ebd18",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:20 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:21 GMT",
+        "MS-CV": "kHDDhbXb4UGJCR1NUXWxsg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0kQahYwAAAABNoOFIDwQYSqx0K0UZhrTyUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "177ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-920d624cd5725f644f92b662d26177df-cf3c9120ac78d113-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9a7e5616e401e91207fcfe399a01aac7",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:21 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:21 GMT",
+        "MS-CV": "Bu5Bt9EcTEG1\u002BJFZzhxXgQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0kQahYwAAAAA4KF7PBphHRqscxkzqKijiUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "119ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    }
+  ],
+  "Variables": {
+    "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
+    "RandomSeed": "1901315565"
+  }
+}

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-ecd8676b0cf68fc461d1ee5abdff9d49-453ac2c9dfe0467e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ca27c411177a91b2218721d2e1013651",
+        "traceparent": "00-75adf08e81c0eb785fa79b4c4a8cf276-3dba9df50a0e3728-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "94152f714a42f302c1963eeab5b7f904",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:25 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:45 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:25 GMT",
-        "MS-CV": "Q59HWB1CCEmtvfjonLdLLg.0",
+        "Date": "Tue, 20 Dec 2022 00:48:46 GMT",
+        "MS-CV": "SKTrm1thEkKgyK4eRXb9gA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0mt2YYwAAAAB0u\u002B1AJtyMTLVTmut0gAL8UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0bQahYwAAAADi08CpKBAvQpwjjlsoLCQ\u002BUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "110ms"
+        "X-Processing-Time": "273ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-439fc691748828f70f99e98103872c95-62723fe1dd1a84e0-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "aeda3a196ef692099133d8e40a92d393",
+        "traceparent": "00-eeec4b6a450d0ec8bda4d1ee8c9b393f-7b8718a192da62b3-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1cb08c124ea509f18110f7c981dd608e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:25 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:45 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,11 +53,11 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:26 GMT",
-        "MS-CV": "a/TYlGhR0EuX0Z8BmaY1Bw.0",
+        "Date": "Tue, 20 Dec 2022 00:48:46 GMT",
+        "MS-CV": "73940WTkXkC8fxedq25LqA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0mt2YYwAAAAAwR5yyZPkXTZEt\u002BePz0R6jUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0bgahYwAAAADKCXt7yMjcTpmVrFrPdaxKUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "84ms"
       },
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-439fc691748828f70f99e98103872c95-2679cca04d94ba97-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7efe5a53d977ca15a748fdbd0b7f371a",
+        "traceparent": "00-eeec4b6a450d0ec8bda4d1ee8c9b393f-d14df124d5613a4b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b334ed8b2235c4635449df2267e32afb",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:26 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:46 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
+          "sbs1.a03c570f-a6b8-dfcd-b211-90514940b9d4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
+          "sbs2.a03c570f-a6b8-dfcd-b211-90514940b9d4.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:26 GMT",
-        "MS-CV": "OOsNc7GyJEiQhBT60ydvnA.0",
+        "Date": "Tue, 20 Dec 2022 00:48:46 GMT",
+        "MS-CV": "os6T0elfc0O9O77rOj6gaA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0mt2YYwAAAAACstsjel78TquKCWTj1TXuUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0bgahYwAAAAB2FPI6UwH8RJoiVH1lif2dUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "372ms"
+        "X-Processing-Time": "384ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
+          "sbs1.a03c570f-a6b8-dfcd-b211-90514940b9d4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
+          "sbs2.a03c570f-a6b8-dfcd-b211-90514940b9d4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-2709b252063f399ef48465143c63d306-31e50c63d69d0629-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5aabbde0ae56a3dbbb9438473fce868f",
+        "traceparent": "00-9447ef1459a90745de33b0bfbac2a5c9-fd4d38ebec8847e9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bd3e8c179c90222f3d0b1231523972e3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:26 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:46 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com"
+              "sbs1.a03c570f-a6b8-dfcd-b211-90514940b9d4.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:26 GMT",
-        "MS-CV": "HKIRQLsDSk2m1qi25pf\u002BWA.0",
+        "Date": "Tue, 20 Dec 2022 00:48:46 GMT",
+        "MS-CV": "VqT81WNQhEyAdldHGNLB0w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0m92YYwAAAAB7zECJRuYGQpjYkn/oAhEQUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0bgahYwAAAAAFJvJbovNbRZUdXNFJIXT/UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "112ms"
+        "X-Processing-Time": "132ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
+          "sbs1.a03c570f-a6b8-dfcd-b211-90514940b9d4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
+          "sbs2.a03c570f-a6b8-dfcd-b211-90514940b9d4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com"
+              "sbs1.a03c570f-a6b8-dfcd-b211-90514940b9d4.com"
             ]
           }
         ]
@@ -181,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-247755a54a9c02e95e92fd8d6c4ff087-bf55b252c63c54a5-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "867f8db4b70340d9250f07ae704c8711",
+        "traceparent": "00-fbd55e0e44a8afe6b47ab8e9108c7c0e-fbded8bc712e13d5-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c75eb0354683f0ce28ebc85b6fcfa19e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:26 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:46 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -193,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:26 GMT",
-        "MS-CV": "3nKMQcU/NE6dRCTV19ExGg.0",
+        "Date": "Tue, 20 Dec 2022 00:48:47 GMT",
+        "MS-CV": "tWfvMk7RXUqOLtksjkeItg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0m92YYwAAAABep0nKwE62QZmsASD1GOZGUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0bwahYwAAAACTnopsqsgIQZ6MuUdl6IaiUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
+        "X-Processing-Time": "267ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
+          "sbs1.a03c570f-a6b8-dfcd-b211-90514940b9d4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
+          "sbs2.a03c570f-a6b8-dfcd-b211-90514940b9d4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -216,7 +216,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com"
+              "sbs1.a03c570f-a6b8-dfcd-b211-90514940b9d4.com"
             ]
           }
         ]
@@ -230,33 +230,33 @@
         "Authorization": "Sanitized",
         "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-a2dea3d009bdba86da6422123dc3e923-7cb70561b964b35d-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4c03befc79e7a43c7f5ac3e2a0cd8bd8",
+        "traceparent": "00-cc72fca7e50bc4ee5c5056feea1faff2-66c5d67b5d8659ec-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f5b1fce6a39eeefdbe1175290f32721b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:26 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:47 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs2.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": null
+          "sbs2.a03c570f-a6b8-dfcd-b211-90514940b9d4.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:27 GMT",
-        "MS-CV": "/KefxJDSO0\u002B3YJV90oB03A.0",
+        "Date": "Tue, 20 Dec 2022 00:48:47 GMT",
+        "MS-CV": "oIuh8hHTxEuDW8/oAU6bUg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0m92YYwAAAAAS118LBEecToOT2\u002Bz4\u002Bh7LUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0bwahYwAAAAC\u002BHxmN8xUXQISY1CsZ1gGFUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "111ms"
+        "X-Processing-Time": "115ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
+          "sbs1.a03c570f-a6b8-dfcd-b211-90514940b9d4.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -266,7 +266,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com"
+              "sbs1.a03c570f-a6b8-dfcd-b211-90514940b9d4.com"
             ]
           }
         ]
@@ -278,11 +278,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-0c479b98e73a36b2c8eb6aa3fc3b01b6-32bea5beff12658a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7d086ec2b1002816e36b3546a72d326f",
+        "traceparent": "00-c07b2fcf68d17778bdce2cfddbdaf473-b40776e3702488f4-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b7ecfbd76384d177bd4e94a5d4d3b26e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:27 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:47 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -290,17 +290,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:27 GMT",
-        "MS-CV": "Byq0Pqyga02A1n0kEwGiwQ.0",
+        "Date": "Tue, 20 Dec 2022 00:48:47 GMT",
+        "MS-CV": "8aGQfoA3WEavqR17Z6KLNQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0nN2YYwAAAACeYscGS\u002BRhT7N0j1db0X19UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0bwahYwAAAAAi8FKYr6BpT7ueKeeyJlctUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "82ms"
+        "X-Processing-Time": "81ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
+          "sbs1.a03c570f-a6b8-dfcd-b211-90514940b9d4.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -310,95 +310,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-336412d2b77212f8739edc63c664c28a-9ddf14492884a359-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "814b270d39ca3aa851da06a8f4f79f57",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:27 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:27 GMT",
-        "MS-CV": "Bt/DWqQLBk64V1v8IUAAMQ.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0nN2YYwAAAAAgFVU3PykqSrm/K7OkvMTAUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "85ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
-            "sipSignalingPort": 1122
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-a44fc93a0438a332b8b76e77c861990f-caac85baf9fb992e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "02eb2f8409434a10a7db697b44f6fd52",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:27 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:27 GMT",
-        "MS-CV": "tdZDmT75/Uy0PmHlEbb4mw.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0nN2YYwAAAABU3CU6RsCeTaCDg/3AkV/xUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "80ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
-            "sipSignalingPort": 1122
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com"
+              "sbs1.a03c570f-a6b8-dfcd-b211-90514940b9d4.com"
             ]
           }
         ]
@@ -412,11 +324,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-3dfc0b9b6496c9c979ce882155daa1f8-d54d565d22de696e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "79d553280a82890dc6ce2c26aa6d33ec",
+        "traceparent": "00-a80938e3fe6847cc95c48443b91a31b5-6b472d256adfeb72-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "564a74697d879245b36f0871d1a4e0f6",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:27 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:47 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -426,17 +338,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:27 GMT",
-        "MS-CV": "7cS/NTKzWUCC1VydB/BO8A.0",
+        "Date": "Tue, 20 Dec 2022 00:48:48 GMT",
+        "MS-CV": "4zdFT40J7kCMHtg3AUAAKg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0nN2YYwAAAAB8bJlM0peGQIUZgxfmeV5xUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0bwahYwAAAABSK0/EIveDS4Do7xWPZgkPUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "96ms"
+        "X-Processing-Time": "126ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
+          "sbs1.a03c570f-a6b8-dfcd-b211-90514940b9d4.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -449,11 +361,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f9948e91bc602d29acd83ae543819fd4-604c40d4af16bcf1-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "77c2ddcc3041032c1600d9efd02cf65b",
+        "traceparent": "00-6cd450569553609a778d6b686d227e3f-6ff880beed03eac9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7484ad79eae2831984e037500f571aea",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:27 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:47 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -461,17 +373,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:28 GMT",
-        "MS-CV": "MTpfvsSK4EWKxiPhiyb5Vg.0",
+        "Date": "Tue, 20 Dec 2022 00:48:48 GMT",
+        "MS-CV": "Bw00YCc9tk2KUeYUT99\u002Bsw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0nN2YYwAAAAC3hAnS46zUSaxymrVSswgxUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0cAahYwAAAAC01S6/kw/bQITStR24MWf0UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "85ms"
+        "X-Processing-Time": "88ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": {
+          "sbs1.a03c570f-a6b8-dfcd-b211-90514940b9d4.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -486,29 +398,29 @@
         "Authorization": "Sanitized",
         "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-f9948e91bc602d29acd83ae543819fd4-a4b7b06c2ac691a1-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a080b3dd25227ad421623b75ddeaa039",
+        "traceparent": "00-6cd450569553609a778d6b686d227e3f-79ce6519654c2d71-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9ac0075f1be75a93b55a03145a06ff18",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:28 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:48 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.1fd959e2-2d44-1852-1b16-0fc494315dd2.com": null
+          "sbs1.a03c570f-a6b8-dfcd-b211-90514940b9d4.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:28 GMT",
-        "MS-CV": "RPNkgwdpfk\u002BEPfvKuuH5HQ.0",
+        "Date": "Tue, 20 Dec 2022 00:48:48 GMT",
+        "MS-CV": "QP\u002B7T7LrfUO1S/NO\u002B3HQmA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0nd2YYwAAAADL6nSW/rK8TocOBbHIICglUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0cAahYwAAAADUkCXMgke3SrICPMVYllpSUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "179ms"
+        "X-Processing-Time": "121ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -518,6 +430,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1873022794"
+    "RandomSeed": "756469625"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/DeleteSipTrunkForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-56651d5fc8818a0e26367187609d8e3f-eecee1c666cc3543-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "13f4929dc77d7d502f1328e6fec5eab5",
+        "traceparent": "00-4ea645dbffb0720f89d149be4f4fd874-9e893ecc79473f6f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ba24fa1c44b66b1dd1d0dabaaa1d9d83",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:51 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:21 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:52 GMT",
-        "MS-CV": "Jmbl1BpOBkG4i8KzFM1ZKw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:21 GMT",
+        "MS-CV": "v3CdFeZIZEudmbpLwBTU6w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0tN2YYwAAAACQ2bREFksJRI4KYiONW5/AUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0kQahYwAAAAATgialvaAETIhmkZcxslGJUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "162ms"
+        "X-Processing-Time": "193ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-5d9c1e809d52f06e9ed27bef89dea084-72b636e0fb0e78b5-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ab4faa39e82ea884767446d90388cd43",
+        "traceparent": "00-62ca5c79a4dad3bfbacdd14a7a975881-1889cb2062829961-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "eeb12ab7ec241177a1c9c3ff9fb668cf",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:51 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:21 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:52 GMT",
-        "MS-CV": "wsmCY\u002BWue0m/ZCUJ4l5/QA.0",
+        "Date": "Tue, 20 Dec 2022 00:49:21 GMT",
+        "MS-CV": "kd7N\u002BJJ9ckuxlPMvCeKzxA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0tN2YYwAAAAC0zV9qaxxYSJJKvNlzj/wHUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0kQahYwAAAAAF9R3tezLjQIzyO6OqZZ6WUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
+        "X-Processing-Time": "86ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-5d9c1e809d52f06e9ed27bef89dea084-0cb90039f04039d6-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "16bd5918d033d64815923eb96d4206fc",
+        "traceparent": "00-62ca5c79a4dad3bfbacdd14a7a975881-ce293ecbe24807bf-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "24ec8b87a8f20741e374283c0ebf11eb",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:52 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:21 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
+          "sbs1.fadf004b-e90d-bc79-085e-f8a7d645dd1f.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
+          "sbs2.fadf004b-e90d-bc79-085e-f8a7d645dd1f.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:53 GMT",
-        "MS-CV": "bNewb5vMh0C\u002BunEfNO/wHg.0",
+        "Date": "Tue, 20 Dec 2022 00:49:22 GMT",
+        "MS-CV": "zAlF\u002B3A3AE29xLBV/t4TUw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0tN2YYwAAAAC5GEgDA\u002BYpR5tA4CG56Ae4UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0kgahYwAAAAAY5RarCwXPRKou76jyTdIEUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "527ms"
+        "X-Processing-Time": "531ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
+          "sbs1.fadf004b-e90d-bc79-085e-f8a7d645dd1f.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
+          "sbs2.fadf004b-e90d-bc79-085e-f8a7d645dd1f.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-7531417a329f3cf0970408e4b6f60813-c0d57ad78d92d8fb-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c9d36f10f701b4db0d4c9d09817679a6",
+        "traceparent": "00-59ee533f4ed73bd9517cc03147a8a2a9-56751ebe7dbcbe06-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "acf074c1ee9330fb831319ec801ecc1b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:52 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:22 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com"
+              "sbs1.fadf004b-e90d-bc79-085e-f8a7d645dd1f.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:53 GMT",
-        "MS-CV": "zQLeJQwy1EG2Q18uz/ysiw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:22 GMT",
+        "MS-CV": "6dP\u002BThUM20iyr8\u002BY\u002BxFQzw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0td2YYwAAAACIKzPn/5e8SpKkvZxz4TuGUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0kgahYwAAAADRo4N4GekVTbQLc0ea4nLBUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "167ms"
+        "X-Processing-Time": "180ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
+          "sbs1.fadf004b-e90d-bc79-085e-f8a7d645dd1f.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
+          "sbs2.fadf004b-e90d-bc79-085e-f8a7d645dd1f.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com"
+              "sbs1.fadf004b-e90d-bc79-085e-f8a7d645dd1f.com"
             ]
           }
         ]
@@ -181,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-84b59651436f79a4afb993786e39ed8e-7cc98d7454fccdac-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a4cee545d40868816279959baaca3a33",
+        "traceparent": "00-f3eba6a1755624b631c908cb97922f20-ae3a5b6cc9714a45-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1f320a6778310f90e8a90bafc33b02e1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:52 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:22 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -193,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:54 GMT",
-        "MS-CV": "/N/1R8wGIU2iqkTryMSIUw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:22 GMT",
+        "MS-CV": "shgNFJ8FfUSgUOYYUVAIpQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0td2YYwAAAABYDybfKXt/T71ljTh7rzzfUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0kwahYwAAAACBLftx7Jc3S4/\u002B4mNFHZheUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "211ms"
+        "X-Processing-Time": "79ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
+          "sbs1.fadf004b-e90d-bc79-085e-f8a7d645dd1f.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
+          "sbs2.fadf004b-e90d-bc79-085e-f8a7d645dd1f.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -216,7 +216,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com"
+              "sbs1.fadf004b-e90d-bc79-085e-f8a7d645dd1f.com"
             ]
           }
         ]
@@ -230,33 +230,33 @@
         "Authorization": "Sanitized",
         "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-68e808dbe39c6c0ce4433245ae280c75-1b0fedc8845bb5a0-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "93c9496d04b521417e0808e7333e549f",
+        "traceparent": "00-31f7ec2f9401f457457636f2c19fa2e8-88e5cb5f5dbfa503-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2a3dd7b7bcc5993b90bba1df8f5586c5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:53 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:23 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs2.6e0f659d-96cc-0429-c2fb-250c7351a209.com": null
+          "sbs2.fadf004b-e90d-bc79-085e-f8a7d645dd1f.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:54 GMT",
-        "MS-CV": "jncZo58ySkGb6QrolAnnYA.0",
+        "Date": "Tue, 20 Dec 2022 00:49:23 GMT",
+        "MS-CV": "82Zwmdua8UKT9a8wW26bVA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0tt2YYwAAAAC8sBJoAONvQK/gQ9q90hJ0UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0kwahYwAAAADclNAU69JsSogeUAGa8\u002Bc6UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "261ms"
+        "X-Processing-Time": "406ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
+          "sbs1.fadf004b-e90d-bc79-085e-f8a7d645dd1f.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -266,7 +266,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com"
+              "sbs1.fadf004b-e90d-bc79-085e-f8a7d645dd1f.com"
             ]
           }
         ]
@@ -278,11 +278,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-636fc5a9c310e5dd6b0fd76b08439566-a3f90dfc2a85ca64-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8874971861743bf4ed6a6688613f0a42",
+        "traceparent": "00-3d44cf6e8e5815a21a87b19742a1687d-76abee4c82d49d2e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "04d40ca8f28d48bae4e0c4eae34b6d48",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:53 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:23 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -290,17 +290,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:54 GMT",
-        "MS-CV": "4PP2zdntYUmVWnQTaQ1NWw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:23 GMT",
+        "MS-CV": "Geggo9h0TEG0UiWRSvot3g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0tt2YYwAAAABSFFcf19F6TL9Y1/FusFT6UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0kwahYwAAAAAUxznYmo8LRamupjRzA0jpUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "161ms"
+        "X-Processing-Time": "90ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
+          "sbs1.fadf004b-e90d-bc79-085e-f8a7d645dd1f.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -310,95 +310,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-53d3d2ba6906bde53f2567f3a1e143cb-fb1e574648d16ee3-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "389c6a11e5ac40f1a3ac26ffcb9a3523",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:53 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:55 GMT",
-        "MS-CV": "6VxkoghTH0KCk/\u002BHG25QdQ.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0tt2YYwAAAAAyPnwznLIRSLVK1HWYlU/rUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "88ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
-            "sipSignalingPort": 1122
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-a73fd8fc12eb35cdce3aa5e769044f20-4a755aac93053b9e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1283f625b2560bbf548ea64a9eb9bf3e",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:54 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:55 GMT",
-        "MS-CV": "mcv7IfYoeE\u002BjZzgQDhjEyA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0t92YYwAAAAAI/2I3xX3FQ75uRv5Vrn33UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "86ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
-            "sipSignalingPort": 1122
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com"
+              "sbs1.fadf004b-e90d-bc79-085e-f8a7d645dd1f.com"
             ]
           }
         ]
@@ -412,11 +324,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-4474e4b18bf0efe83d80c26a70bd4f05-3207f5b91f8f9d93-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c9d5c5fe1ba232f2a634e4c73bf57053",
+        "traceparent": "00-bec09016f0200b6ae3d406e0bb38491a-31604ac633ece83c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a9353710a2e0ab55ce998f75d7b18093",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:54 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:23 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -426,17 +338,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:55 GMT",
-        "MS-CV": "8P9SwEdg2k6L2z0t/FxKVA.0",
+        "Date": "Tue, 20 Dec 2022 00:49:23 GMT",
+        "MS-CV": "C7H6UtB/CUeqDl56Hlf2Jg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0t92YYwAAAABwwSzeLnj0QIoncwDpghGSUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0lAahYwAAAADCKx6vbMtaSbIN3FKE0Be5UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "176ms"
+        "X-Processing-Time": "166ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
+          "sbs1.fadf004b-e90d-bc79-085e-f8a7d645dd1f.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -449,11 +361,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-fc04adbb81316ccd9caadfa570f308d8-c60f5fc4aee6bf73-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6a634235f7bc5fecaa90e31e3fa6a2ea",
+        "traceparent": "00-4a62c70a6732a0184263ddeaea1c1b96-3767031aff33c8f9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b6074622fe66c5541df445e5f851b545",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:54 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:24 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -461,17 +373,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:55 GMT",
-        "MS-CV": "exxBUVtqtUiJfAX\u002B6pNjJg.0",
+        "Date": "Tue, 20 Dec 2022 00:49:24 GMT",
+        "MS-CV": "Swx1SdUZQECEg0ODizBMSA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0t92YYwAAAACmsVcA3dyFQ6abKwWbif\u002BEUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0lAahYwAAAAAwPphcbYvDS7r0haoFz\u002Bt6UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
+        "X-Processing-Time": "94ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": {
+          "sbs1.fadf004b-e90d-bc79-085e-f8a7d645dd1f.com": {
             "sipSignalingPort": 1122
           }
         },
@@ -486,29 +398,29 @@
         "Authorization": "Sanitized",
         "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-fc04adbb81316ccd9caadfa570f308d8-45ceefff4135397f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0500e8ec6cc4098104506c22cdf8d05f",
+        "traceparent": "00-4a62c70a6732a0184263ddeaea1c1b96-8961455f0df575c8-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "57ce584edd1f06e4b62835f463457132",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:54 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:24 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.6e0f659d-96cc-0429-c2fb-250c7351a209.com": null
+          "sbs1.fadf004b-e90d-bc79-085e-f8a7d645dd1f.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:56 GMT",
-        "MS-CV": "2oJrekzXsEyOUgiS\u002BMTA\u002Bg.0",
+        "Date": "Tue, 20 Dec 2022 00:49:24 GMT",
+        "MS-CV": "8RwommMyK0ufo9aaeKmOew.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0t92YYwAAAADp1KY8i0NdRYaI5oNni7lHUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0lAahYwAAAAAgRBUQUEWgTbYFAUW7FsjsUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "246ms"
+        "X-Processing-Time": "258ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -518,6 +430,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "464633339"
+    "RandomSeed": "158800969"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthentication.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthentication.json
@@ -6,9 +6,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-046124f47e00f063d81f382c40e50cb3-755a05a8912b712e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "812b44d4418f87e2df72d1be7c59bc95",
+        "traceparent": "00-8fa88dacc9fc5e56af4b45092c50403f-fdf909aa1469bad1-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c8d12963441562da885b2f29e7a48949",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -16,13 +16,48 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:29 GMT",
-        "MS-CV": "R0nQn5Qk70WKXhIij4KCIA.0",
+        "Date": "Tue, 20 Dec 2022 00:48:49 GMT",
+        "MS-CV": "2NgRRTT0AU2O2lwIBWd93w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0nd2YYwAAAAABGIgtY9JPSLvt3BoZoCkHUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0cQahYwAAAADZ6/mGjvhsSJKBJ08bGEKMUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "140ms"
+        "X-Processing-Time": "273ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-e6efd63ee4a99cb7cabd6bf63fc16444-8f2dc51205027daf-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "550a208b67a22af9d1022c078d69dc24",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:49 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:48:49 GMT",
+        "MS-CV": "fcinpU5IBUmsW9iUZxwgMQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0cQahYwAAAADExqoGasX5SLRVaPI0kodWUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "121ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -35,11 +70,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-e06676e4ef686d83c5ef2bdf080867cd-81f8182d57c53621-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b31b67e0fc45938318542a8a37ed75eb",
+        "traceparent": "00-4986a39d4d33cdc4498568a6c3f912b4-866a6b1bbd2b4271-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8a24cd3d32604c249b90401cecf65ce4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:29 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:49 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -47,44 +82,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:29 GMT",
-        "MS-CV": "sQluWkTP2kq78lmXrsWKsA.0",
+        "Date": "Tue, 20 Dec 2022 00:48:49 GMT",
+        "MS-CV": "sVKwiz00TkC9g3t2ZqGcZQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0nt2YYwAAAADqmWvYBWSzRaLgjvVARGRhUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0cQahYwAAAACYPo9pIBWwR40MLfzVTAc1UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "82ms"
-      },
-      "ResponseBody": {
-        "trunks": {},
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-032e30d90fc94812c4911fdfb4aa6496-80d336f7ce0fe21d-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5b8f2781d720b925c5f6dca02c74b295",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:29 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:29 GMT",
-        "MS-CV": "QJWvbAZk1E\u002BBTKQthsDBwA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0nt2YYwAAAADamdnJ1e60RJv5Teg/2hKCUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "73ms"
+        "X-Processing-Time": "89ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -94,6 +98,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "856007548"
+    "RandomSeed": "547822885"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthenticationAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetFunctionUsingTokenAuthenticationAsync.json
@@ -6,9 +6,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-6e294a10ab2e31200426c003fd4ee806-5b2486979a1b9e6a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "dbd749fb7c07c78ebe6a27a0d36cbc60",
+        "traceparent": "00-ad43f906b8e39017a0935df0e950345c-3cba1c04707826b3-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "246eaa137ce7a5c45700add23fbd45fa",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -16,13 +16,48 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:56 GMT",
-        "MS-CV": "EWXvTtbjdUan2He0MLKIGw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:24 GMT",
+        "MS-CV": "YIsKsFEHs0CD/iTvzZJIFA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0uN2YYwAAAAAleNMYAzc7QLTndTcZKiaiUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0lAahYwAAAABS3Jj5aeaxQZ92lJpCucolUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "126ms"
+        "X-Processing-Time": "118ms"
+      },
+      "ResponseBody": {
+        "trunks": {},
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-0607ab256d3c088b47dbb2fe27a9380c-bd74ade1a706f038-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d59573651c33da99135bb27caba8b828",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:24 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:24 GMT",
+        "MS-CV": "zGbjqAY\u002BCE2OK1N8B2QtlA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0lQahYwAAAAArLWxS4QMWRb/49zJSMB/lUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "156ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -35,11 +70,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-718a0e5198122621a9d5bc9d27b81e86-4cf64108460ead17-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7d9e8ebbcd4309dde0c759d97a2ecaa4",
+        "traceparent": "00-699ad8ca59c34cda5e8e7e883768d824-81d2070e9d6d84c8-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7d3ef7be0b5ab2f56270208f7948a77e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:55 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:25 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -47,44 +82,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:56 GMT",
-        "MS-CV": "ycCHUdio50aJvsNEtDhkPw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:25 GMT",
+        "MS-CV": "4YDLHOSUaUCu70MRhM1Wng.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0uN2YYwAAAAD5yPzM7WfdRp\u002BAIMMXGfDKUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0lQahYwAAAABnfAM6jz4ZR7Bb11ETzO/HUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
-      },
-      "ResponseBody": {
-        "trunks": {},
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-5ad605e629a69c2d0fdf25594c9b5c3f-fd8e8924b25577a3-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0564900ace94af8dad4e1904f224d931",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:55 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:56 GMT",
-        "MS-CV": "lN/Kxuw0ZUaxavJwtf0dlA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0uN2YYwAAAAD07PrFiHOVRb35fJPV2fGCUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "81ms"
+        "X-Processing-Time": "85ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -94,6 +98,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "375446389"
+    "RandomSeed": "772863518"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d978086615c24303484f5cef18778b50-1c4e97b06964db21-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "52a1abbd1078c30e9ed252391e40080f",
+        "traceparent": "00-d25e95bc408be93a8620645070a3f443-18853e1fe13eabf0-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "03a4bc4f4fc5de3c34c079c39a65e8e9",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:29 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:49 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:29 GMT",
-        "MS-CV": "2zCwmcHUs0izC3/FUPs09A.0",
+        "Date": "Tue, 20 Dec 2022 00:48:50 GMT",
+        "MS-CV": "qkNXayOv/EiB0Md0PFeT4Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0nt2YYwAAAAD\u002BOvHzUqqrT7A2EZB4PV3IUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0cgahYwAAAAAKNl92mRmTQbohK4zmlBqUUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "118ms"
+        "X-Processing-Time": "117ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-dc529d0316d39b1f7137e77c3c42caeb-c6c3bc2768cd0f60-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "902b6340b00ef7b7cc328e3360d8511d",
+        "traceparent": "00-963915558e0aa5bf8b72e29de0fb6ef6-98f9e7895a5df9c8-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3b6784a097fd0a0f8ca4766fd77f93da",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:29 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:50 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:30 GMT",
-        "MS-CV": "ul6rof2Ua0Cy8X5VARRPcA.0",
+        "Date": "Tue, 20 Dec 2022 00:48:50 GMT",
+        "MS-CV": "VFcCrtJZwEGkHN0VXjFTsQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0nt2YYwAAAADDAvEjniYcRZejih6kz3ZoUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0cgahYwAAAABnzqRkpnynQayhZV\u002BPIohkUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "91ms"
+        "X-Processing-Time": "103ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-dc529d0316d39b1f7137e77c3c42caeb-1e6b3dc18054ccf0-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6198d92660b3bb4406021f738b46e114",
+        "traceparent": "00-963915558e0aa5bf8b72e29de0fb6ef6-9bece0a780790f09-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ce310fa01f3b3e25564f39b1a9546158",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:30 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:50 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
+          "sbs1.6d2d928e-2272-fc18-bd39-b883df0c0972.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
+          "sbs2.6d2d928e-2272-fc18-bd39-b883df0c0972.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:30 GMT",
-        "MS-CV": "tkjd9dIbtkynYywDGVL22g.0",
+        "Date": "Tue, 20 Dec 2022 00:48:50 GMT",
+        "MS-CV": "pfWnCmujhke0vXcvgNnKVw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0n92YYwAAAAC18kfheGIuSJtafMYgQa4vUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0cgahYwAAAACMqSORpcznQoBKB6AEuDDiUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "290ms"
+        "X-Processing-Time": "386ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
+          "sbs1.6d2d928e-2272-fc18-bd39-b883df0c0972.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
+          "sbs2.6d2d928e-2272-fc18-bd39-b883df0c0972.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-3f04ed82a725b3c37358264cfc4c0dfd-f5a761f144f84477-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "97ecef25e36f0daaf4a9864681da62c5",
+        "traceparent": "00-b7f5f18f7c0f98581653ae2a881e38d5-85e05d6e379e0394-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5ae3cf51cda5b775ac997621d8cd06b4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:30 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:50 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com"
+              "sbs1.6d2d928e-2272-fc18-bd39-b883df0c0972.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:30 GMT",
-        "MS-CV": "\u002BD7XFqsQ\u002B0\u002BGuWFCapQkqg.0",
+        "Date": "Tue, 20 Dec 2022 00:48:51 GMT",
+        "MS-CV": "2Hf0\u002BW\u002Bg0k\u002BRZBrm9OUEaA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0n92YYwAAAABivlLjF8CuSLJ4Tp\u002BhohXoUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0cwahYwAAAAAOOuV/DcQIQKMxYvoxOLn1UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "187ms"
+        "X-Processing-Time": "271ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
+          "sbs1.6d2d928e-2272-fc18-bd39-b883df0c0972.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
+          "sbs2.6d2d928e-2272-fc18-bd39-b883df0c0972.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,54 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-a72daec108003331706baf54002f1f9f-0ea09a027cbd546f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "44123480a7a8df5b1f6f8a0b91436c85",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:30 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:30 GMT",
-        "MS-CV": "PoHi5f9Q7UeVwijgN9vaWA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0n92YYwAAAAAXusmdlp7rSovDxn7K11PKUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "95ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com"
+              "sbs1.6d2d928e-2272-fc18-bd39-b883df0c0972.com"
             ]
           }
         ]
@@ -228,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-90067549e08f75c9f88aa1fcd4fe0e70-b92d3dded36b0f96-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "700e7a50b9ec43ae2f8b6d0ad9fe3a2b",
+        "traceparent": "00-7c400cea1521546087f74b91c0292032-4c7dea4739f6b9f9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8b239e2d193380ae5f28e5ae5e5e6038",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:30 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:51 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -240,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:31 GMT",
-        "MS-CV": "fI8LCMABVEuZl5Zi4ADhQQ.0",
+        "Date": "Tue, 20 Dec 2022 00:48:51 GMT",
+        "MS-CV": "Skq3\u002B8dZvEuYVcuEzHHEmg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0n92YYwAAAADRRdHHwX6jTqg00GPrIpnTUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0cwahYwAAAAAWYlwfEbYLRIT5ZSFsCy9OUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "125ms"
+        "X-Processing-Time": "80ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
+          "sbs1.6d2d928e-2272-fc18-bd39-b883df0c0972.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
+          "sbs2.6d2d928e-2272-fc18-bd39-b883df0c0972.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,54 +216,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-fb8a5b5509c6b9ca7617e7b2dfe7d544-e49ff7ee1baa122b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "57f359a09d337e6b930c78ff589e7bb1",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:31 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:31 GMT",
-        "MS-CV": "qu05409XCUmyZ6rJn6PDSg.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0oN2YYwAAAACmEY4aizfZS7bW09HYl0TZUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "96ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com"
+              "sbs1.6d2d928e-2272-fc18-bd39-b883df0c0972.com"
             ]
           }
         ]
@@ -324,11 +230,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-6d1ee1b3b9c518cfff0e8353157947d0-b017d06d69c93d0e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "07f5003df1ccc6d985cf141d39510621",
+        "traceparent": "00-2ccdada109810db382848e33cde0aa71-b3b2ba574cd642f6-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "081d1e42389cd2349a7922a1a8036589",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:31 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:51 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -338,20 +244,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:31 GMT",
-        "MS-CV": "28m34CBT2UmpN1LslmqChg.0",
+        "Date": "Tue, 20 Dec 2022 00:48:51 GMT",
+        "MS-CV": "CkBPBUBVokmTjY5r577VEw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0oN2YYwAAAADzC9rj2oaFQ4F9zEhgYE/vUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0cwahYwAAAACoMXCy2uX6R70BF\u002BWs2hdOUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "103ms"
+        "X-Processing-Time": "111ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
+          "sbs1.6d2d928e-2272-fc18-bd39-b883df0c0972.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
+          "sbs2.6d2d928e-2272-fc18-bd39-b883df0c0972.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -364,11 +270,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-10e5408e8f01a90ba31dde62b26bad6f-de9ffabc9cd7aabd-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "386b5e351550b3520e8fdddf41afea90",
+        "traceparent": "00-73aa29ebaa83a186e29feeb4736d36bf-2142beac5b361f46-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0a848449d53138242062fb7de8c6594e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:31 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:51 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -376,20 +282,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:31 GMT",
-        "MS-CV": "ISag6QdM3UKOxmpj\u002BIf9zw.0",
+        "Date": "Tue, 20 Dec 2022 00:48:51 GMT",
+        "MS-CV": "7BB7rm2ljUKL6HXumchtng.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0oN2YYwAAAABsfpaLilzQR6094arJ2gBCUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0cwahYwAAAACUPvIfgmTlRpnwNfeeES8XUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
+        "X-Processing-Time": "96ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
+          "sbs1.6d2d928e-2272-fc18-bd39-b883df0c0972.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": {
+          "sbs2.6d2d928e-2272-fc18-bd39-b883df0c0972.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -404,30 +310,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-10e5408e8f01a90ba31dde62b26bad6f-b38ac32337069a88-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d8cdbc0f3208ae5f7f2cd163884e4442",
+        "traceparent": "00-73aa29ebaa83a186e29feeb4736d36bf-c91a5cbef55b514f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "badf3e39fdaff5186951f1b9f60cd85b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:31 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:51 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": null,
-          "sbs2.bdc515cc-dd46-ff7f-542e-ff2cfb9a74b8.com": null
+          "sbs1.6d2d928e-2272-fc18-bd39-b883df0c0972.com": null,
+          "sbs2.6d2d928e-2272-fc18-bd39-b883df0c0972.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:32 GMT",
-        "MS-CV": "\u002BBFC\u002Bg9uV0GNFCPz1iFx2g.0",
+        "Date": "Tue, 20 Dec 2022 00:48:52 GMT",
+        "MS-CV": "CHfBWM7GX0S9qXyLmEojzQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0oN2YYwAAAADzXCUOoG0dToZmQFJ1W87IUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0dAahYwAAAACgiqDkMekIR6flU10RvEsyUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "114ms"
+        "X-Processing-Time": "133ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -437,6 +343,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "221127128"
+    "RandomSeed": "1263457680"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipRoutesForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-4bbf261ddfa39b7f33335f18584e87a8-26a27e5494b4a7b5-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "fdaa4d0d440446405fa368f0f67c0413",
+        "traceparent": "00-20dacbf12650dc2fc683af8c66381d1a-c7254ca44fce4a18-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5ac57ea4b2b72c346bca9e715f1643fa",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:55 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:25 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:56 GMT",
-        "MS-CV": "E2o3Ko25fE6fDTYui9oTvA.0",
+        "Date": "Tue, 20 Dec 2022 00:49:25 GMT",
+        "MS-CV": "FBrp59qfM0uKRfPz9toOig.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0uN2YYwAAAABqrQJ7LG0iR5flgRcYjLPvUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0lQahYwAAAADdrsBPkMZyQ5EXh42\u002BKgRBUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "156ms"
+        "X-Processing-Time": "154ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-389b5f203517f9784e31c5a2f5a552ef-54280e2c2045f77f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3b1ad4ebcfd898bbab741618d8947dd9",
+        "traceparent": "00-e7ce2315e78769004372a8547be6a4ff-eb143f03c3911149-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9019b43b72811113b40a0b7ebc554ab0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:56 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:25 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:57 GMT",
-        "MS-CV": "w03kaOmaWkSgXZXwDVH8eA.0",
+        "Date": "Tue, 20 Dec 2022 00:49:25 GMT",
+        "MS-CV": "45XpW2d8cUimiFCIX8vwHw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ud2YYwAAAAB8PmBrVid4QYz2Gbm9WNjVUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0lQahYwAAAADqxx\u002B\u002BaAPoQIL\u002BoG8P95erUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "112ms"
+        "X-Processing-Time": "104ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-389b5f203517f9784e31c5a2f5a552ef-7b9d35fdc62988cc-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "77033de64ec5668f99df45051a448490",
+        "traceparent": "00-e7ce2315e78769004372a8547be6a4ff-effbebabea1bcff0-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dcfa00397c1efd20c178e385fc87b86c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:56 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:25 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
+          "sbs1.4ea4f6b0-9b4f-18f8-83b7-911bccd22ebf.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
+          "sbs2.4ea4f6b0-9b4f-18f8-83b7-911bccd22ebf.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:57 GMT",
-        "MS-CV": "fzor/KwQ/kKkt3Fnc4oHiQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:26 GMT",
+        "MS-CV": "l7yrJVYuNEWxaTIMgUyq7g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ud2YYwAAAADftLOQZrAeSYLG3c3Xa44oUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0lgahYwAAAAAGi\u002BqYJ2FfRZmU1N1t7pEVUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "616ms"
+        "X-Processing-Time": "468ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
+          "sbs1.4ea4f6b0-9b4f-18f8-83b7-911bccd22ebf.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
+          "sbs2.4ea4f6b0-9b4f-18f8-83b7-911bccd22ebf.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-4c392b1bb2774d3d5e292d7e6db81da0-0e4c7323fa8d541e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "db6cdd25f4063e869211518f2d286dcb",
+        "traceparent": "00-a1ea0388e3302d2e5f189aa5599310ad-b475117f1ec00fcd-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "18df97739db8323e6bb3a5aca6b66f16",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:56 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:26 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com"
+              "sbs1.4ea4f6b0-9b4f-18f8-83b7-911bccd22ebf.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:58 GMT",
-        "MS-CV": "uLrbXfFXQ0yM9sTCGFyHDQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:26 GMT",
+        "MS-CV": "jhpsslgtyEGKVq8WMGfElA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ud2YYwAAAAC4bMUthQfXSbtll/Vm3ZBoUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0lgahYwAAAADU9flo2krAQo/e2sps/tokUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "157ms"
+        "X-Processing-Time": "184ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
+          "sbs1.4ea4f6b0-9b4f-18f8-83b7-911bccd22ebf.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
+          "sbs2.4ea4f6b0-9b4f-18f8-83b7-911bccd22ebf.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,54 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-c8043a3ce8db925726a7de4f93577750-4dd5f12bef1d7215-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b90a8f258c799d4e44b3a1f889b57d67",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:57 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:58 GMT",
-        "MS-CV": "ziGOQR1F2EiJnXwHl37znA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ut2YYwAAAAAxNThOao4DQLAaN94VVBbNUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "85ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com"
+              "sbs1.4ea4f6b0-9b4f-18f8-83b7-911bccd22ebf.com"
             ]
           }
         ]
@@ -228,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-da0c9f0030e9f145a1f3b5b49e4c82d1-ee4878933fb3ca3f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "fbf286efa128f1d2b7c4e5b3fcff3871",
+        "traceparent": "00-67d50f0ad1ce706ea974162ceff3c4d4-79ed8411d88a75b8-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5e37ee7f671cbfdb931cce088e8d142d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:57 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:26 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -240,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:58 GMT",
-        "MS-CV": "Gk3hp9cjwUK1\u002Brg7DsvMwA.0",
+        "Date": "Tue, 20 Dec 2022 00:49:26 GMT",
+        "MS-CV": "\u002BVGP5/9bvU\u002BUnWI9Mbu5dw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ut2YYwAAAABX\u002BtuBBDIkS7sfXTDzz/xuUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0lgahYwAAAAC7L38BJO\u002BLRYMf84mvaTKuUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "96ms"
+        "X-Processing-Time": "116ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
+          "sbs1.4ea4f6b0-9b4f-18f8-83b7-911bccd22ebf.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
+          "sbs2.4ea4f6b0-9b4f-18f8-83b7-911bccd22ebf.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,54 +216,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-eca4f3731e246c5d6f0579148fe20423-7972c5a5371bd924-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8be07a72cb3a99168fcf9752538db5dc",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:57 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:58 GMT",
-        "MS-CV": "gmnhCAFmM0yeK9YHLp/d7A.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ut2YYwAAAACSVaeXbgTnSKf7J1aEqve\u002BUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "80ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com"
+              "sbs1.4ea4f6b0-9b4f-18f8-83b7-911bccd22ebf.com"
             ]
           }
         ]
@@ -324,11 +230,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-a58b701df903675ce678263538022080-1acc68bd5e3bf4e8-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a7a0ea93723683a3bc1801b5a69aa045",
+        "traceparent": "00-e0aa26dc6271d3ebcfab0eee5505655f-8b3b3bab66810c58-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "240b9e5232759cf7c2c8706ad674560b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:57 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:26 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -338,20 +244,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:59 GMT",
-        "MS-CV": "SdLa60jLMUiQ40h95fSzpQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:26 GMT",
+        "MS-CV": "0yqsawApkk\u002BrY1gVytl1Wg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ut2YYwAAAACg9UsYsvRNSYJ7qBkSfDIkUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0lwahYwAAAAAMa9gxcSpGSJTsN3WFfRuwUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "178ms"
+        "X-Processing-Time": "174ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
+          "sbs1.4ea4f6b0-9b4f-18f8-83b7-911bccd22ebf.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
+          "sbs2.4ea4f6b0-9b4f-18f8-83b7-911bccd22ebf.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -364,11 +270,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-aa27bdf42adce76999a68ceded75f162-65eb8b959f8f04d8-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0e86307af2d5232d70596b580a809e29",
+        "traceparent": "00-0731fc11dbaf763dd71468f8983bd9f9-d5eb0dbfb02e80a3-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0e05cd08594f0b50bb1f849bce35a3de",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:58 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:27 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -376,20 +282,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:59 GMT",
-        "MS-CV": "idTiDf9E/EGdRKNUNEpZvA.0",
+        "Date": "Tue, 20 Dec 2022 00:49:27 GMT",
+        "MS-CV": "8k5f4SV/9U6v0iGLlnXFww.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0u92YYwAAAAAPSF8boeW2RIV88dOEPijVUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0lwahYwAAAADoqnzZLWMpSIVMa1N2xLSPUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "204ms"
+        "X-Processing-Time": "285ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
+          "sbs1.4ea4f6b0-9b4f-18f8-83b7-911bccd22ebf.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.a526daab-83a9-7b35-0d29-f158b0202f5e.com": {
+          "sbs2.4ea4f6b0-9b4f-18f8-83b7-911bccd22ebf.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -404,30 +310,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-aa27bdf42adce76999a68ceded75f162-e60d82eb4c229656-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "121f090f915eff3bd75cce21c961f2f5",
+        "traceparent": "00-0731fc11dbaf763dd71468f8983bd9f9-fe68d4dba8a09374-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0859789f4baa4da0f69b9c54f771e81e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:58 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:27 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.a526daab-83a9-7b35-0d29-f158b0202f5e.com": null,
-          "sbs2.a526daab-83a9-7b35-0d29-f158b0202f5e.com": null
+          "sbs1.4ea4f6b0-9b4f-18f8-83b7-911bccd22ebf.com": null,
+          "sbs2.4ea4f6b0-9b4f-18f8-83b7-911bccd22ebf.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:59 GMT",
-        "MS-CV": "yOlHIYN/JUaUAMzJY63Ixw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:27 GMT",
+        "MS-CV": "ks7qi\u002BfezkSUNC5kJiHFKA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0u92YYwAAAACvJLlAoc7AR714CN\u002BKeU0HUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0lwahYwAAAAAmELJDpdJ9Rb1sBoeCfflTUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "255ms"
+        "X-Processing-Time": "271ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -437,6 +343,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1873134163"
+    "RandomSeed": "2825993"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-bfd086659febf8eac2ebd3011a072d1b-3ea9c2de858e03e4-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8f9314266dc90d4cf1b1794e591389f8",
+        "traceparent": "00-52314d61193b8c8895c684c8c05da892-bb38c42f93148284-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "720f9305bbbdd2ad2c4de647bb0df327",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:32 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:32 GMT",
-        "MS-CV": "7UrOJbhaeUSRfdmjpMZm1g.0",
+        "Date": "Tue, 20 Dec 2022 00:48:52 GMT",
+        "MS-CV": "GM5UYCpVd0yw11AojeEFCA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0oN2YYwAAAAC3pZFD9m7cTLK/ryozkoC\u002BUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0dAahYwAAAAAsxoiQBa1ORZ9wv/Q55A7JUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "102ms"
+        "X-Processing-Time": "116ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-bc17eec21fa30c9d99c84d16cad2dda8-064208caefa09aff-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "063ea9c83fbc4261b17c7d3a2d68679c",
+        "traceparent": "00-ff0ffbc1437cf5045fa5a3d2cf94ec15-caad6c288de0ade2-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3148ec221db2fa6d5d3522dd2a37e2f7",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:32 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:32 GMT",
-        "MS-CV": "CjfEgOYe30uFlNWo\u002Brb2aQ.0",
+        "Date": "Tue, 20 Dec 2022 00:48:52 GMT",
+        "MS-CV": "kHhl8ByawEWkyoYmkM9wZA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0od2YYwAAAABtoGnxGlk0SKLM/assgh\u002B2UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0dAahYwAAAABRxrZtsShIQaxPhlx7eFr5UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "83ms"
+        "X-Processing-Time": "250ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-bc17eec21fa30c9d99c84d16cad2dda8-804518f929707f37-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "94473eeed19ecdd49330fcef08dcbfb7",
+        "traceparent": "00-ff0ffbc1437cf5045fa5a3d2cf94ec15-aa7d800896522285-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7710921c7369a3650cc24e37240e1b99",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:32 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
+          "sbs1.7b95b95e-0b84-d755-a7f8-3959dfc319a3.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
+          "sbs2.7b95b95e-0b84-d755-a7f8-3959dfc319a3.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:32 GMT",
-        "MS-CV": "yt4Ixh4pAU6HTp80ukNiVQ.0",
+        "Date": "Tue, 20 Dec 2022 00:48:53 GMT",
+        "MS-CV": "EPJse\u002B4nxkuzh4KpiWm0Tw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0od2YYwAAAADUqzWXjNICSrlNto8FZ0MfUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0dQahYwAAAADbxUg4tlRIQKDnpEVqe8UjUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "276ms"
+        "X-Processing-Time": "893ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
+          "sbs1.7b95b95e-0b84-d755-a7f8-3959dfc319a3.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
+          "sbs2.7b95b95e-0b84-d755-a7f8-3959dfc319a3.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-736a19d63496396f2e7fd1fcdc7e2ee0-e70eaf52cf2f4cf5-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b7f62182ef7ce663b351dd4cef12df89",
+        "traceparent": "00-c9acf5f52a3eabb83ea282f4898b5d37-ff82be9ebaf60734-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f3371205e77be7f12614148798cfa7f4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:32 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com"
+              "sbs1.7b95b95e-0b84-d755-a7f8-3959dfc319a3.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:33 GMT",
-        "MS-CV": "B6EuFPeQLEqOhrTWVEkRuw.0",
+        "Date": "Tue, 20 Dec 2022 00:48:54 GMT",
+        "MS-CV": "8dzhvFN\u002BSkiBXFreeQRoTQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0od2YYwAAAAAu\u002BExW2w/eR4H9O2rmD7aiUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0dgahYwAAAABePWZczEPoToHR0/Y2jzEjUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "111ms"
+        "X-Processing-Time": "229ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
+          "sbs1.7b95b95e-0b84-d755-a7f8-3959dfc319a3.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
+          "sbs2.7b95b95e-0b84-d755-a7f8-3959dfc319a3.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,54 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-09bf73ebe0deeb5d985d8bc91fcb1e6a-512904c0cfda9846-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1b60dc4af4ccf75ad570728c437139d5",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:33 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:33 GMT",
-        "MS-CV": "OvpPuRwGeEaI8jrgeto1jA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0od2YYwAAAAARX5felHGqT4GW3d8jaqFJUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "77ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com"
+              "sbs1.7b95b95e-0b84-d755-a7f8-3959dfc319a3.com"
             ]
           }
         ]
@@ -228,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-20e442c5a772f1717c3a980aae95777a-8b0f49a8b7a0799d-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0cb8c5bdb072fe20da61e14df387de81",
+        "traceparent": "00-951fa59dba37b6036577ad03b65138fb-81b25cf8bf72208a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "282aef6a7cfdaebe87a525efce36d64f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:33 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:54 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -240,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:33 GMT",
-        "MS-CV": "pmPyIBPr2k\u002B5oFgEmd1YEg.0",
+        "Date": "Tue, 20 Dec 2022 00:48:54 GMT",
+        "MS-CV": "MkPSVdE7D06myn/bX22X7A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ot2YYwAAAAA7HnF5KQ98TK\u002B8Utm/y5BgUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0dgahYwAAAAA4vSywWuHQS5or8tOF0tdqUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "74ms"
+        "X-Processing-Time": "90ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
+          "sbs1.7b95b95e-0b84-d755-a7f8-3959dfc319a3.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
+          "sbs2.7b95b95e-0b84-d755-a7f8-3959dfc319a3.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,54 +216,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-e9fe3e2867be775f82930c74cc611159-7a4838785f89414a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2ba57350a37c8eebc6fee10b7dd7a342",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:33 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:33 GMT",
-        "MS-CV": "aQ2Oz4UM1EKTmSTreSNRZg.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ot2YYwAAAAAy/HPm6H/NTbQzy7nKm8tdUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "92ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com"
+              "sbs1.7b95b95e-0b84-d755-a7f8-3959dfc319a3.com"
             ]
           }
         ]
@@ -324,11 +230,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-72ea3f39963efc74367323e7666b7926-d459a2031e7ba3c3-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "298f0817d3599a16bc61406a120d034d",
+        "traceparent": "00-4d1968ae3ebdab84ab2b80dcaca7f0a4-e7415bff8939c8aa-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "18d88819ef00357ba12851545edd0a3c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:33 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:54 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -338,20 +244,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:33 GMT",
-        "MS-CV": "RpAahZajFkSur8ffL10yGw.0",
+        "Date": "Tue, 20 Dec 2022 00:48:54 GMT",
+        "MS-CV": "aMG/5Os8pkCjnCvqK0j2AQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ot2YYwAAAAAqIZDcYpDfRY6U/NeeMpdPUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0dgahYwAAAAA6XhVNdDyqSrkooy92hwUQUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "105ms"
+        "X-Processing-Time": "176ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
+          "sbs1.7b95b95e-0b84-d755-a7f8-3959dfc319a3.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
+          "sbs2.7b95b95e-0b84-d755-a7f8-3959dfc319a3.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -364,11 +270,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-df6fea0e7c832d617fe84b3b045b2f20-9680d4ea7604b1ac-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "cf3bf0920dcb1958da294573ce148103",
+        "traceparent": "00-33d752670f83b6ed3f4710c1684c0d8b-1b05dbd25cfdcd32-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "34cc5a1bf2e4899c53886bd6c20219f0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:33 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:54 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -376,20 +282,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:33 GMT",
-        "MS-CV": "7n1HuuhrbUebGubmR5GQeA.0",
+        "Date": "Tue, 20 Dec 2022 00:48:55 GMT",
+        "MS-CV": "d1gnEcO25UWEqQ3UWP0ZXA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ot2YYwAAAAB1WMBglruLT7OPivwJZOcWUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0dwahYwAAAABslaFSyAdUTpUhkyLRgQoEUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "79ms"
+        "X-Processing-Time": "107ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
+          "sbs1.7b95b95e-0b84-d755-a7f8-3959dfc319a3.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": {
+          "sbs2.7b95b95e-0b84-d755-a7f8-3959dfc319a3.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -404,30 +310,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-df6fea0e7c832d617fe84b3b045b2f20-f646da051be7a9c1-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "eb359fbeb4f87c275d0a6f1a63807bb8",
+        "traceparent": "00-33d752670f83b6ed3f4710c1684c0d8b-9d02408cb9c153a2-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0f6dc53e8ff77af473f587d52b6950a9",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:33 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": null,
-          "sbs2.ee3de03a-81a1-192b-cb0b-1abf60baf61f.com": null
+          "sbs1.7b95b95e-0b84-d755-a7f8-3959dfc319a3.com": null,
+          "sbs2.7b95b95e-0b84-d755-a7f8-3959dfc319a3.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:34 GMT",
-        "MS-CV": "GuSdPoGehUS1dV8gN1OPZg.0",
+        "Date": "Tue, 20 Dec 2022 00:48:55 GMT",
+        "MS-CV": "Af\u002BbsMzOoUyMW2X83R7g/Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0ot2YYwAAAAAt0sFmwkEhSZ6A4KOUPLFYUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0dwahYwAAAADEDC3pX00RQJbINGakj6B5UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "122ms"
+        "X-Processing-Time": "253ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -437,6 +343,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "199239815"
+    "RandomSeed": "1831538644"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunkForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-76c5be6c1c064e391b8119b5c92c1ae6-693c559faa5e59f0-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "24fd684560194f5dc838153c486081c5",
+        "traceparent": "00-70ebdff0710744b53805fc87f34321d5-9afd7d827d28d5b8-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "336f528536197efbae096ab15565a61c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:58 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:27 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:00 GMT",
-        "MS-CV": "U/s1oK3Uj0\u002BxVLFfcfaJQg.0",
+        "Date": "Tue, 20 Dec 2022 00:49:28 GMT",
+        "MS-CV": "OGyxfqOSVkOwfN56Na/PAg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0u92YYwAAAADPJK9tiv5lRpS637MiC2RaUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mAahYwAAAADgwvULiH25SZWN4iepRitjUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "206ms"
+        "X-Processing-Time": "184ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-c0671c6d57449eb98ec1fc98a404004e-e7e2687c46f96e96-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ca5fe5daf994c4d680df54a31725288b",
+        "traceparent": "00-4a5884ebb862ea922255a1be73e408fd-d726515ebacbc54b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "db36ed0d7894f974baa13c5b6a602170",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:59 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:28 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:00 GMT",
-        "MS-CV": "5a/Y3sz8A0yU0Tv0kM2MJQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:28 GMT",
+        "MS-CV": "\u002ByKH9rjm\u002BUG1RNCV/m6m6A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vN2YYwAAAACiu4TvzKX8Q4smWB93hDhTUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mAahYwAAAAAmcgWRzdynRabIzbxc4GGfUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "82ms"
+        "X-Processing-Time": "170ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-c0671c6d57449eb98ec1fc98a404004e-be383b1731b63e9c-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "9a4940a2cca2cb76874408f75889bf01",
+        "traceparent": "00-4a5884ebb862ea922255a1be73e408fd-42cb87150a5423e8-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a9240e995fcbe7edf35eb63bc507c8ee",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:59 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:28 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
+          "sbs1.64ddee1d-2f45-1db8-531f-1244b6f5d2cb.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
+          "sbs2.64ddee1d-2f45-1db8-531f-1244b6f5d2cb.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:00 GMT",
-        "MS-CV": "i2RLadtm50me6KnSI3hV6g.0",
+        "Date": "Tue, 20 Dec 2022 00:49:29 GMT",
+        "MS-CV": "d5ss0AfrXke\u002Br1g1LNvvxQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vN2YYwAAAADw8USipPylTrkI1g\u002Bo73EnUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mAahYwAAAACaPcN/lop7R55STD1iuH1dUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "483ms"
+        "X-Processing-Time": "564ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
+          "sbs1.64ddee1d-2f45-1db8-531f-1244b6f5d2cb.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
+          "sbs2.64ddee1d-2f45-1db8-531f-1244b6f5d2cb.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-3f19f063fff7c6aabdfc6e6b550438b8-e19cf970bd366418-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "fce775470aa34c8c9239a4390bba37a3",
+        "traceparent": "00-a2c395815bdbd3fd9a31afd7b3f19f5b-42dfdda52800f72c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c836f578f7bf0d36dd767977f99f144d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:59 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:29 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com"
+              "sbs1.64ddee1d-2f45-1db8-531f-1244b6f5d2cb.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:01 GMT",
-        "MS-CV": "t/k9eflB40maLB5OIzY/lw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:29 GMT",
+        "MS-CV": "aK1x9M\u002Bhpk6eDu\u002B1OcS/kA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vN2YYwAAAADT9KJpU2nbSYzKX1eAvHrkUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mQahYwAAAABddoLUhuhfRLhLYMqBkAOiUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "156ms"
+        "X-Processing-Time": "173ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
+          "sbs1.64ddee1d-2f45-1db8-531f-1244b6f5d2cb.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
+          "sbs2.64ddee1d-2f45-1db8-531f-1244b6f5d2cb.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,54 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-5f2ee142671ec445eb436a21d18e82ae-259de12cf88fa95b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0799890fe6170e226e934350f0de6bf6",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:00 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:01 GMT",
-        "MS-CV": "19fBLRS24EiudKu7lhP2XA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vd2YYwAAAABMy\u002BoxZSV5SqeiO\u002BrBhEZBUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "85ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com"
+              "sbs1.64ddee1d-2f45-1db8-531f-1244b6f5d2cb.com"
             ]
           }
         ]
@@ -228,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-15ba14e40fab15f701a4f5682871e4cf-52661da09d28e00e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a15c531f2c3d97e8b4fc0768273cc0cc",
+        "traceparent": "00-cbad0fff4042d8aeec4810f9b5225cc1-62f4db64dd66bc61-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4617f9e8fd40ae51004fe735c23934b3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:00 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:29 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -240,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:01 GMT",
-        "MS-CV": "i/I7BYcMZk6UVssrjNslGQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:29 GMT",
+        "MS-CV": "J1bVAeXXNki5xMOXjJwySA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vd2YYwAAAACXIWVnl4ExR4fSJAD20Q9qUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mQahYwAAAADkDKvQMqi\u002BS5zylRrKufKGUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "80ms"
+        "X-Processing-Time": "109ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
+          "sbs1.64ddee1d-2f45-1db8-531f-1244b6f5d2cb.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
+          "sbs2.64ddee1d-2f45-1db8-531f-1244b6f5d2cb.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,54 +216,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-84b5a8324cba89cdc15f166cef32a4df-089858cbac7128c9-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "cfe8640cb8f060ea52d98d0fc63c5bb4",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:00 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:01 GMT",
-        "MS-CV": "9BGR5GbfWU6KR94lB3fUFA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vd2YYwAAAACmtl62Y67\u002BR45K\u002Bgy\u002BM0iBUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "90ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com"
+              "sbs1.64ddee1d-2f45-1db8-531f-1244b6f5d2cb.com"
             ]
           }
         ]
@@ -324,11 +230,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-c03a1333df4ac6e3b7c10c8091d93d93-31c1c768b0ad66f4-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b81aaece965de266a001531adebae631",
+        "traceparent": "00-063351533fb8fa7292b25a8254a6f85c-cf2ba2e834ab8036-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "74e34ed85829a2b1d817cb55e575ed54",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:00 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:29 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -338,20 +244,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:01 GMT",
-        "MS-CV": "/ow7NHeHQUuTX4f/M4ISkA.0",
+        "Date": "Tue, 20 Dec 2022 00:49:29 GMT",
+        "MS-CV": "s9LsYo1yW0WTrEic7AImuA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vd2YYwAAAAAxI9YAiovkRbkfBrScNPECUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mgahYwAAAAC8yFTy\u002BevmR4myeEZQ\u002B8YmUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "167ms"
+        "X-Processing-Time": "181ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
+          "sbs1.64ddee1d-2f45-1db8-531f-1244b6f5d2cb.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
+          "sbs2.64ddee1d-2f45-1db8-531f-1244b6f5d2cb.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -364,11 +270,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-46a4ca0b5dcb1ef9f52c33af300315b4-d8309b28029aadd8-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8b4376d39cf6670568fb4e639ed9d178",
+        "traceparent": "00-92e043447f0c2e9c87d9e9a0eebcede2-3c3d59594e4b65ad-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cb52684a82ef7bada488c86f0f004ba4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:01 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:30 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -376,20 +282,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:02 GMT",
-        "MS-CV": "E9SPVD2bTkiclxtQ\u002B39Tuw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:29 GMT",
+        "MS-CV": "2q8MgHXGwkip4NUxMnWvAA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vt2YYwAAAAA1qOP\u002BfM/hSLRqTy5I3Xd/UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mgahYwAAAABwoep54iBCR4lX//PygARiUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "82ms"
+        "X-Processing-Time": "83ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
+          "sbs1.64ddee1d-2f45-1db8-531f-1244b6f5d2cb.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": {
+          "sbs2.64ddee1d-2f45-1db8-531f-1244b6f5d2cb.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -404,30 +310,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-46a4ca0b5dcb1ef9f52c33af300315b4-143078c37a9791c2-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "799953a10822766ffe052eee64d08198",
+        "traceparent": "00-92e043447f0c2e9c87d9e9a0eebcede2-843d22fc4c4a80f7-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ab9fc5419fbc8f2448756e2832fbc88b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:01 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:30 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": null,
-          "sbs2.d193e52b-6e2f-08c6-62c8-3bc2e102d520.com": null
+          "sbs1.64ddee1d-2f45-1db8-531f-1244b6f5d2cb.com": null,
+          "sbs2.64ddee1d-2f45-1db8-531f-1244b6f5d2cb.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:02 GMT",
-        "MS-CV": "kBHXYS/keESYjK4BDA/Tvw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:30 GMT",
+        "MS-CV": "prbZCsvNs0ikISNVH2iN0g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vt2YYwAAAAC2wfWPRm0US5H5p\u002BPZFrATUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mgahYwAAAABUTwhuiB/QT4vqHKvu7v06UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "304ms"
+        "X-Processing-Time": "256ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -437,6 +343,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1967763910"
+    "RandomSeed": "873337783"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-5a7b8e3107f61d8d6f23d8dc091dbc7e-bd4169a2bc96c60d-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5d246a9749565a4dedd2ff91a944258f",
+        "traceparent": "00-2481d38f068ae9771aa2116e04389fb0-cb5cba72d2454b26-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7bd1d572b88526f75ffe513566b7ef7f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:34 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:34 GMT",
-        "MS-CV": "tlnqKQGyCkGLCfijgh83pA.0",
+        "Date": "Tue, 20 Dec 2022 00:48:55 GMT",
+        "MS-CV": "kg8BRdHGVUiqB71Z8xU\u002B9w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0o92YYwAAAAABPx3qywmvQ5krBoKtj0haUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0dwahYwAAAACSy6XUyW7MTJuMOf55sOuhUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "92ms"
+        "X-Processing-Time": "193ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-2158723de8464cc4eef801889353daf7-efa974e1a66705a7-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e363dbdd0a8ff270b3c396bb1a360c50",
+        "traceparent": "00-2fcfe75e64a9924b36042fcd42328438-79a1e8e1e848cc37-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e9a1b6878275aeb66673704defc40d6b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:34 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:34 GMT",
-        "MS-CV": "8Er91BZ3CkWcaI7/slPN6w.0",
+        "Date": "Tue, 20 Dec 2022 00:48:55 GMT",
+        "MS-CV": "zY8n0617fkist0A2Djnk9A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0o92YYwAAAADKEo/K6E0AR7ZHnQLwcpMmUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0dwahYwAAAAB4KIaRU0NCSb3WlVK8/vaiUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "80ms"
+        "X-Processing-Time": "147ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-2158723de8464cc4eef801889353daf7-a68627462cf12d10-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "983eee4118e14731a3acc8f02bee265f",
+        "traceparent": "00-2fcfe75e64a9924b36042fcd42328438-8d43a0df8e6fd04b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "25c9942443ed63dce53a8c3ca523ca1c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:34 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com": {
+          "sbs1.eb60dd1b-f63a-3159-d326-5da7e380f240.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.b507f190-2bc2-d07f-a482-576bd627436c.com": {
+          "sbs2.eb60dd1b-f63a-3159-d326-5da7e380f240.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:35 GMT",
-        "MS-CV": "tQ/jJbIkskK2V9UgDamSGw.0",
+        "Date": "Tue, 20 Dec 2022 00:48:56 GMT",
+        "MS-CV": "ONu0R5oOb0y15/6efkg0xA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0o92YYwAAAAAof6QfT3SLRrNrp9sDi2UUUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0eAahYwAAAAAZgnPZipcRRbHelfBz/bigUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "459ms"
+        "X-Processing-Time": "665ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com": {
+          "sbs1.eb60dd1b-f63a-3159-d326-5da7e380f240.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.b507f190-2bc2-d07f-a482-576bd627436c.com": {
+          "sbs2.eb60dd1b-f63a-3159-d326-5da7e380f240.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-39c2db3f298d77c8f44109d02c4b2fd3-da43123cba12557d-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "fa8ec85d60c48cdcfa31a993b29140b6",
+        "traceparent": "00-497adff2b2b6b5ea7c77c2f3ee70cf54-e7903c47d5e45775-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2c20de3609dfefcb1e22141248aa369a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:35 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:56 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com"
+              "sbs1.eb60dd1b-f63a-3159-d326-5da7e380f240.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:35 GMT",
-        "MS-CV": "tVk7tkm3NE\u002BHH0s0Sqlipg.0",
+        "Date": "Tue, 20 Dec 2022 00:48:57 GMT",
+        "MS-CV": "r\u002BkjMeFHvEyfbbjMJYRc0w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pN2YYwAAAAAaC9lJUBTNR4Y1exEWtAi7UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0eQahYwAAAACwXK7H8A1tTZ\u002BMQERxF1etUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "101ms"
+        "X-Processing-Time": "175ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com": {
+          "sbs1.eb60dd1b-f63a-3159-d326-5da7e380f240.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.b507f190-2bc2-d07f-a482-576bd627436c.com": {
+          "sbs2.eb60dd1b-f63a-3159-d326-5da7e380f240.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,54 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-f8b78c8d6999d9fcfb423d39b8dd55fa-a408ef1e784d8fd3-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "bb50aec58d06c5adaa1b3fe3427fc7c5",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:35 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:35 GMT",
-        "MS-CV": "o2lzcR31qEubRFab3j3TmA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pN2YYwAAAABFDQb8QQuJT4ukBAArpyBTUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "78ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.b507f190-2bc2-d07f-a482-576bd627436c.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com"
+              "sbs1.eb60dd1b-f63a-3159-d326-5da7e380f240.com"
             ]
           }
         ]
@@ -228,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-0c71d876a383098fe4d08b1736b43681-030aeb9a2cec6adc-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "515e379c12a8e08c12b19eb06e9e9511",
+        "traceparent": "00-7f6866f21a6e348e676793d18c7004b8-a5c05cf48b8a5269-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d111e5f0caed4392d93d033bf5790942",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:35 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -240,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:35 GMT",
-        "MS-CV": "8G6tAiWYR0CwHCwtR4EJzw.0",
+        "Date": "Tue, 20 Dec 2022 00:48:57 GMT",
+        "MS-CV": "PlHB6qaaU0adRZJSPVdYQw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pN2YYwAAAABAFw3U4xWcSIbPvoz9zqzNUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0eQahYwAAAAC6l7jAm/F5Q7cbavXxNggcUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "79ms"
+        "X-Processing-Time": "82ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com": {
+          "sbs1.eb60dd1b-f63a-3159-d326-5da7e380f240.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.b507f190-2bc2-d07f-a482-576bd627436c.com": {
+          "sbs2.eb60dd1b-f63a-3159-d326-5da7e380f240.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,54 +216,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-d6a143bdee932d3472a74d8a4cb2ae3a-09d410d1d515a007-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7c2b116c6b9ecf581ac850a820f9497a",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:35 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:35 GMT",
-        "MS-CV": "5Axeo8CrPEK1Zh0cWtKK4A.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pN2YYwAAAAA34i5wz6R4S5ng\u002BUiL4zz\u002BUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "81ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.b507f190-2bc2-d07f-a482-576bd627436c.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com"
+              "sbs1.eb60dd1b-f63a-3159-d326-5da7e380f240.com"
             ]
           }
         ]
@@ -324,11 +230,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-4a6f5d86bf8af99f217e19543e1da08e-4d2f523cb197ffd8-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7af6e469ee33b20e226fa855effd570c",
+        "traceparent": "00-cc4feae4ac664559768e551a128c5257-aa6a132f56eabc99-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "111653a8e0a41a8bc9d906ca2ec91b3a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:35 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -338,20 +244,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:36 GMT",
-        "MS-CV": "oAEEQfXbEUKQV8w3LapPHg.0",
+        "Date": "Tue, 20 Dec 2022 00:48:57 GMT",
+        "MS-CV": "hwpLIq9NjEWoJMMlqPkE2g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pN2YYwAAAAAeFYfgs5drRq9fgc4vCnHDUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0eQahYwAAAAAOr9V9oN6ESppXH64EFB7uUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "129ms"
+        "X-Processing-Time": "169ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com": {
+          "sbs1.eb60dd1b-f63a-3159-d326-5da7e380f240.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.b507f190-2bc2-d07f-a482-576bd627436c.com": {
+          "sbs2.eb60dd1b-f63a-3159-d326-5da7e380f240.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -364,11 +270,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-0db28931bc4636c12820281d35a3ec69-a545908e90cd3406-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "30762d864b543026de8e37dfc2e3bf18",
+        "traceparent": "00-8ec68926c3b696c1809a252e81e3e688-7cd3b4c6ac78e62d-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bf4bf203f9126c2e4bdc52a20590f9a5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:36 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -376,20 +282,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:36 GMT",
-        "MS-CV": "8Q56Ccu5w0SD4okW6tvJVg.0",
+        "Date": "Tue, 20 Dec 2022 00:48:57 GMT",
+        "MS-CV": "0H09NVV8N0a48y9L9dUaig.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pd2YYwAAAAAUTw4BE13PQZ5tl9kv\u002Bd3BUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0eQahYwAAAADr4tGIRgazR6iFaG4qDjkLUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "79ms"
+        "X-Processing-Time": "95ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com": {
+          "sbs1.eb60dd1b-f63a-3159-d326-5da7e380f240.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.b507f190-2bc2-d07f-a482-576bd627436c.com": {
+          "sbs2.eb60dd1b-f63a-3159-d326-5da7e380f240.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -404,30 +310,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-0db28931bc4636c12820281d35a3ec69-cbb5fb70c10cfc65-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8a4623671aa77ede0278592fc203e01c",
+        "traceparent": "00-8ec68926c3b696c1809a252e81e3e688-17bf611bf45aa20d-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f469d218259410f55af60713c3c71510",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:36 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.b507f190-2bc2-d07f-a482-576bd627436c.com": null,
-          "sbs2.b507f190-2bc2-d07f-a482-576bd627436c.com": null
+          "sbs1.eb60dd1b-f63a-3159-d326-5da7e380f240.com": null,
+          "sbs2.eb60dd1b-f63a-3159-d326-5da7e380f240.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:36 GMT",
-        "MS-CV": "SLUwasqJnE2ICPKLGiIr2g.0",
+        "Date": "Tue, 20 Dec 2022 00:48:58 GMT",
+        "MS-CV": "XIOc1UL9j0S7QkPi4KmRoQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pd2YYwAAAAArf9ZfWT4cTZOax5LkAvisUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0eQahYwAAAACViR39NA0sQY1k0djPbaREUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "115ms"
+        "X-Processing-Time": "279ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -437,6 +343,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1095461107"
+    "RandomSeed": "1703294507"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/GetSipTrunksForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-330865feebdb52a0d12769f8de4152b0-8ee032486f66664a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7b72351405bb3fcbafb1ac785c450d98",
+        "traceparent": "00-dda658f5c5c6d83ed4b32d195b013711-617ff6274490318f-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bac4973adc734e35573d00c8e2367731",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:01 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:30 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:02 GMT",
-        "MS-CV": "0nJihXzLkUW5MvjjXPbR/g.0",
+        "Date": "Tue, 20 Dec 2022 00:49:30 GMT",
+        "MS-CV": "Gs0r\u002BmU68kSjJkJSj/TWnw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vt2YYwAAAADZMse5LSyOQoePRMxqT7usUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mgahYwAAAAB5kNBmGrQZSLPlhcETQqOHUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "159ms"
+        "X-Processing-Time": "170ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-e49fc70688aca8d36c94d2e302d87f9b-07de034a81c2a639-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "27fcaa1986a6890453c23fd7659a5bab",
+        "traceparent": "00-213e465ea2d56ea0101001222c048312-a83fa7f41dcecbee-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "730b470e16add68f3dbd6112edc72ef9",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:01 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:30 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:03 GMT",
-        "MS-CV": "5ip/yD0je02qMsQwS\u002Bh4/Q.0",
+        "Date": "Tue, 20 Dec 2022 00:49:30 GMT",
+        "MS-CV": "1dgalzQ0lUKhmjIZcQL7\u002BA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0vt2YYwAAAABAc8qKRPx1RZaJDCML9axVUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mwahYwAAAAALy2\u002BGUJGqQK/vAInAPbNjUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "104ms"
+        "X-Processing-Time": "82ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-e49fc70688aca8d36c94d2e302d87f9b-44b2fc9717be4c9f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "057c5b4e05524d0272e24480805af2a4",
+        "traceparent": "00-213e465ea2d56ea0101001222c048312-6a50c8a74169a3fd-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a8fd2da981f6e12749cd2a787da96850",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:02 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:31 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
+          "sbs1.821b7ebe-7eb5-4b71-8632-74ba9eeaa2c4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
+          "sbs2.821b7ebe-7eb5-4b71-8632-74ba9eeaa2c4.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:03 GMT",
-        "MS-CV": "DqtT8w6FJkKsZzEKL2tg9Q.0",
+        "Date": "Tue, 20 Dec 2022 00:49:31 GMT",
+        "MS-CV": "q4abqGELR0OWgzb2v2OWpQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0v92YYwAAAABKTvuAcavYQoywZfGMQB2iUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mwahYwAAAADq0w/aKie8RrkzblgRPnxzUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "560ms"
+        "X-Processing-Time": "620ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
+          "sbs1.821b7ebe-7eb5-4b71-8632-74ba9eeaa2c4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
+          "sbs2.821b7ebe-7eb5-4b71-8632-74ba9eeaa2c4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-55392bc0eea6adaedd711437b82b90e9-00a2973490837f1b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6547f8a104c68ea631e828f8c5f4d914",
+        "traceparent": "00-761d2664c89624e69eec3486134b366c-972044b55afd4c1b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "57ab42bb2fdf241607ee7cb57b22608f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:02 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:31 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com"
+              "sbs1.821b7ebe-7eb5-4b71-8632-74ba9eeaa2c4.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:03 GMT",
-        "MS-CV": "YzpRD/GUF0CY6KMl\u002BsnK\u002BQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:31 GMT",
+        "MS-CV": "S\u002BlMIDxpQkmLAzYyOZgKqg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0v92YYwAAAABaOvWfQCbwRIkVm1CS2FGIUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nAahYwAAAACoW7\u002BKyGNAT4pcjQoSaP9DUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "170ms"
+        "X-Processing-Time": "189ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
+          "sbs1.821b7ebe-7eb5-4b71-8632-74ba9eeaa2c4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
+          "sbs2.821b7ebe-7eb5-4b71-8632-74ba9eeaa2c4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,54 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-336987b9d988510d68967e555ac70a21-9bc07e42f9950f07-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0129015508c91346a8afb4c4418308f8",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:03 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:04 GMT",
-        "MS-CV": "2mgkxhfevkaueYzdW1gDkQ.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wN2YYwAAAAB06Ri9Zfn\u002BR6aOzsCZgnWcUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "80ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com"
+              "sbs1.821b7ebe-7eb5-4b71-8632-74ba9eeaa2c4.com"
             ]
           }
         ]
@@ -228,11 +181,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-d56daf21d1290cb0ddeca5e5d6b6d737-4acb553a72c2b0ae-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6d369ad0f65349e4b5eed369dd09887d",
+        "traceparent": "00-e161485dad97a81a6642a9703bdc37da-5e812be538cb385a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b41f070ece388c3b1f292ae0eb175894",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:03 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:32 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -240,20 +193,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:04 GMT",
-        "MS-CV": "UyM595UEQUCfjwW3q3CDxQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:32 GMT",
+        "MS-CV": "LDooe/R08UOG5k4ftE8/Xw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wN2YYwAAAABUvfXwmc1SQqamaTCKRO52UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nAahYwAAAADQ9jFcHGl9SLHgHyJu8FPRUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "79ms"
+        "X-Processing-Time": "88ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
+          "sbs1.821b7ebe-7eb5-4b71-8632-74ba9eeaa2c4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
+          "sbs2.821b7ebe-7eb5-4b71-8632-74ba9eeaa2c4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,54 +216,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-9432d3a6afc0fb70fbc7c45dd748603c-89601f52aa5dc4f7-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7f2b3008f13098dbb233bd174fe14cae",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:03 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:04 GMT",
-        "MS-CV": "XwxNH14Zl0a3iEkl4tEsCA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wN2YYwAAAABlq4AuLmPGToFbrBgDLnhPUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "97ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com"
+              "sbs1.821b7ebe-7eb5-4b71-8632-74ba9eeaa2c4.com"
             ]
           }
         ]
@@ -324,11 +230,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-471e1f15676a25f50cf3519ce5fa371d-845f3c9c774979c7-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2a282fe06cbe5fc01de04cda35dd369e",
+        "traceparent": "00-259c4f2555a6d544b759f62eb5221683-3c4b5875d1e9e856-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ab571155d71c791917d9a10705726626",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:03 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:32 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -338,20 +244,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:04 GMT",
-        "MS-CV": "PQaQ/EX62ka2mUv31Kb/IA.0",
+        "Date": "Tue, 20 Dec 2022 00:49:32 GMT",
+        "MS-CV": "a24h/KKm7Ua6CACKAJnF8g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wN2YYwAAAABscdx73JvIRL5/euh3DuFkUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nAahYwAAAACu3lJcyeh6TJ/OT\u002BHYoMGZUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "162ms"
+        "X-Processing-Time": "165ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
+          "sbs1.821b7ebe-7eb5-4b71-8632-74ba9eeaa2c4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
+          "sbs2.821b7ebe-7eb5-4b71-8632-74ba9eeaa2c4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -364,11 +270,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-680799fa55072920609d3f390d4d8c0c-fa65eadb76420b26-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "11bb36268957dec8be9dba2038ccf9d3",
+        "traceparent": "00-6505464041273ba69819713a1304cffc-51644e4186c764eb-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "76699a6cb389ec17061f38b5053638ef",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:03 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:32 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -376,20 +282,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:04 GMT",
-        "MS-CV": "IryLkFyKr0aIExis7KtnkA.0",
+        "Date": "Tue, 20 Dec 2022 00:49:32 GMT",
+        "MS-CV": "8TS/30tXPkyWOPxI0vORQw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wN2YYwAAAAADhp7WSv/cR5yfeSNz\u002B2LjUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nAahYwAAAAAUg0EB35tsQ4vUt4WOqXNiUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "86ms"
+        "X-Processing-Time": "90ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
+          "sbs1.821b7ebe-7eb5-4b71-8632-74ba9eeaa2c4.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": {
+          "sbs2.821b7ebe-7eb5-4b71-8632-74ba9eeaa2c4.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -404,30 +310,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-680799fa55072920609d3f390d4d8c0c-af910aab6e208053-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ad8924a25ee19cbf6fcc6150a50163d5",
+        "traceparent": "00-6505464041273ba69819713a1304cffc-92ec9d3808e788ff-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6a60e896b5cb3673eda69d5f2d3487ad",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:04 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:32 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": null,
-          "sbs2.f4213d52-2d32-4ed2-eaae-906010c32b4c.com": null
+          "sbs1.821b7ebe-7eb5-4b71-8632-74ba9eeaa2c4.com": null,
+          "sbs2.821b7ebe-7eb5-4b71-8632-74ba9eeaa2c4.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:05 GMT",
-        "MS-CV": "zps0s94nn0KsarsmxWEfww.0",
+        "Date": "Tue, 20 Dec 2022 00:49:32 GMT",
+        "MS-CV": "hLVQ052p702BVoPQYWw2Vg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wd2YYwAAAABKxnzAqonlS7\u002BpF4UOAE2iUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nQahYwAAAACIqXSy1FFRSqf8lxU1CbUyUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "261ms"
+        "X-Processing-Time": "269ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -437,6 +343,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1762340353"
+    "RandomSeed": "275711774"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-871673ac6f079d336eb83a254bd9cb01-cdbf7639ecbe56b9-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5d94e9aa566e59801a05e4e8bbe95aa2",
+        "traceparent": "00-f7f3730ec6fa4deecc8d31bea0daa244-e41c70cf2f093a32-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "400cd29f0a6c06a499bbf28140464c7d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:36 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:36 GMT",
-        "MS-CV": "Nw9DLtXA1katc33lFl8GHw.0",
+        "Date": "Tue, 20 Dec 2022 00:48:58 GMT",
+        "MS-CV": "Tfi4696nlUiRWDXyObQWlg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pd2YYwAAAABtEaipf0YNQpffp9reN1C8UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0egahYwAAAAC53rG2/R4sSIam2eXc9CLDUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "107ms"
+        "X-Processing-Time": "173ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-d478ebf21f40731252f003a733aebf29-10721e0a921e1b38-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b24697f535645ef8ac7412f17a7c6b86",
+        "traceparent": "00-f91ecacfd6c434a1588a3f0e9ae05996-d70835d9453c4a74-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c9b430a9a3a4fc0959bd70079eb4194d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:36 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:37 GMT",
-        "MS-CV": "8xeYOPlGk0GKlN2ZvcilQg.0",
+        "Date": "Tue, 20 Dec 2022 00:48:58 GMT",
+        "MS-CV": "ImFCkGTJFkC\u002Bmfdep0OZIw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pd2YYwAAAADLNK1VlZFWRbtEBT2kwwDQUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0egahYwAAAADDqsr\u002B9T7IQbhXjyvvol3zUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "78ms"
+        "X-Processing-Time": "96ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d478ebf21f40731252f003a733aebf29-df5ec4d99357a8e3-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "185633093834bcbaae248d5a17722e04",
+        "traceparent": "00-f91ecacfd6c434a1588a3f0e9ae05996-4afcbada86602686-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4ff8fb56902438b336e42200c20b932a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:37 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
+          "sbs1.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
+          "sbs2.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:37 GMT",
-        "MS-CV": "2bNrPAEEDUavZ\u002Bu70q4HPA.0",
+        "Date": "Tue, 20 Dec 2022 00:48:59 GMT",
+        "MS-CV": "YThXNrPtrk221HJK8nXJtw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pd2YYwAAAAAu9Uh09ySfSZFy4Da9RUciUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0egahYwAAAAC\u002BO4x3IodiSZVOSSBfABazUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "257ms"
+        "X-Processing-Time": "804ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
+          "sbs1.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
+          "sbs2.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d48f68530bb52bffdfe64155d7b3663a-a4aaadf101ac8a4b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "bc816cf656b97409f135b1fa448fdf9d",
+        "traceparent": "00-e27b405f2040e3ab3f7cb1ab2ac8da77-b547c30ce56615be-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0af32f8c4047fb4dc910e7af999c67e5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:37 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:59 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com"
+              "sbs1.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:37 GMT",
-        "MS-CV": "DCgmA5iQ7EaW/DNPSSWv9w.0",
+        "Date": "Tue, 20 Dec 2022 00:48:59 GMT",
+        "MS-CV": "Bq/T\u002B0xthUKNC0b5Z5xpSg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pt2YYwAAAACj0xcom1xDSaAgACUVfIJ5UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ewahYwAAAACgQn8V6osrSJSNyJIn3KscUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "98ms"
+        "X-Processing-Time": "156ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
+          "sbs1.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
+          "sbs2.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com"
+              "sbs1.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com"
             ]
           }
         ]
@@ -183,11 +183,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "230",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-b122e2c0395f8bb83ec1426554fc6c50-7d75500049dee2f1-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "88de5d9a4192bd6ddc89043fa79e4639",
+        "traceparent": "00-8f9af426e26a8d486e251eb7d157ee51-e0c262601922c7ed-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "452aa5a2fd4d18597d7c92c081093a4d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:37 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:48:59 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -197,8 +197,8 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com",
-              "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com"
+              "sbs1.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com",
+              "sbs2.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com"
             ]
           }
         ]
@@ -207,20 +207,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:37 GMT",
-        "MS-CV": "pgBj3XdTqkaxcRkXBaU6pw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:00 GMT",
+        "MS-CV": "3AU7\u002BEIe2EOhMcFPfAK3xg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pt2YYwAAAABg/6I1Xi18TIkqI0kszF6ZUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0fAahYwAAAACm7RX2ayljRYREZE4Ta3wIUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "110ms"
+        "X-Processing-Time": "180ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
+          "sbs1.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
+          "sbs2.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -230,8 +230,8 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com",
-              "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com"
+              "sbs1.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com",
+              "sbs2.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com"
             ]
           }
         ]
@@ -243,11 +243,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-c5bdb2298fc1a7c74f4c397e5660628a-e83d7526daf9b6c0-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0dfa0d45aefab3cc2ae126fe87c0781e",
+        "traceparent": "00-d777acb7f18f207af6b5edea96571a2b-7c74103e7a3c80f4-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6f7b46290fc01605adfd8514a9049e99",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:37 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:00 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -255,68 +255,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:37 GMT",
-        "MS-CV": "7wam7uqVVEOmEdYGntsMiw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:00 GMT",
+        "MS-CV": "09CbyoDNY0\u002BG2MDWBRBmaA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pt2YYwAAAABySQ6By1AHRb79IJhbNhHjUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "76ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle all other numbers\u0027",
-            "name": "Last rule",
-            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
-            "trunks": [
-              "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com",
-              "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-b1108597faa2db3ab9e45cfde0bb2634-a399294af3fb0e3f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b9bff045a694b471fec4e02f52c9cd53",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:38 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:38 GMT",
-        "MS-CV": "3MIbhDH/bEuxpz67MyRhMQ.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0pt2YYwAAAABVXueM47rLSIVlyWzkDLBKUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0fAahYwAAAABRjpeTHnkGSLMdSpxyn1JHUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "91ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
+          "sbs1.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
+          "sbs2.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -326,56 +278,8 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com",
-              "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-2661ca95e73e263c9a2bb96531fc653f-95935387899d9ba7-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "36b477eed295eca3912a5eb01b6f361b",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:38 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:38 GMT",
-        "MS-CV": "xOS5OaHErE6AXr0uCsRwrg.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0p92YYwAAAACrH6D\u002BHJJWRrRcsMqmXnnIUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "96ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle all other numbers\u0027",
-            "name": "Last rule",
-            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
-            "trunks": [
-              "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com",
-              "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com"
+              "sbs1.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com",
+              "sbs2.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com"
             ]
           }
         ]
@@ -389,11 +293,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-a5c44124a093724a57636088cb95a832-f4e3f3f1e4cbf1f6-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b7fae5118dde9fa59c450e35cd9d6160",
+        "traceparent": "00-e8f9173f4b45f8a03ebf8c3507cf5c58-7885610afb9eea32-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1d5e3d7c4ee18edcd6db8dcbad8c79c0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:38 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:00 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -403,20 +307,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:38 GMT",
-        "MS-CV": "sib0JFLhhkWrWfA/0Ui1wA.0",
+        "Date": "Tue, 20 Dec 2022 00:49:00 GMT",
+        "MS-CV": "wNAVilwSy0mhxDq1y/Po4Q.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0p92YYwAAAADEigkpd0y7TrbMUZF8/OlhUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0fAahYwAAAAAdFjzDvGFMRpguj8lqfbd1UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "99ms"
+        "X-Processing-Time": "175ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
+          "sbs1.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
+          "sbs2.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -429,11 +333,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-ffa9612045368ef7bcf869fd54c41b1f-73cf0fe0d51bbded-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0f0fd314410c73894cd2286948c0998f",
+        "traceparent": "00-5b02b5fbdd3532f931e05bec4b37836b-880061225f10bc36-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "538699d5f82192249f14975077456e79",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:38 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:00 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -441,20 +345,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:38 GMT",
-        "MS-CV": "UQrj91gbmkGLMMIJfeBkIw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:00 GMT",
+        "MS-CV": "O8f/RzvkeE6nVgipIfek5A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0p92YYwAAAADB1jncHVxIQKxz\u002Bs67pbp5UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0fAahYwAAAAC630eblS4rQIxCdGLCMmElUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "75ms"
+        "X-Processing-Time": "147ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
+          "sbs1.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": {
+          "sbs2.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -469,30 +373,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-ffa9612045368ef7bcf869fd54c41b1f-acb92f83e7e3891f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6d1dc58e16cf6174d2149a4fc36d1ef3",
+        "traceparent": "00-5b02b5fbdd3532f931e05bec4b37836b-1273a21dd9fcb35d-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4444f9dd1daada6b69ec99e5813a6820",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:38 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:00 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": null,
-          "sbs2.a87e2f13-fb60-e95b-ee51-0e7753ff086d.com": null
+          "sbs1.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com": null,
+          "sbs2.bbeada43-b4bc-d38d-70d8-ad9d3bfc09f1.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:38 GMT",
-        "MS-CV": "m/WO8Qoos0GTmWMHoyJ87Q.0",
+        "Date": "Tue, 20 Dec 2022 00:49:01 GMT",
+        "MS-CV": "dHWtLM5R4ESRnfSL2TAM0A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0p92YYwAAAADAb1NCVfvTRJrANiy9mq7KUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0fQahYwAAAAAOvv0OsFmSSa2mlXQYwmYFUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "115ms"
+        "X-Processing-Time": "251ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -502,6 +406,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "689531479"
+    "RandomSeed": "1291301256"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipRoutesForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-ff78de55ce17df1d19dc01487ba79b5b-d60c465d48c24851-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1d73fc752d0358338349386642d8ab26",
+        "traceparent": "00-0a7c169520123ca3b775bbaf1573439a-14c6a5a84fa1fb49-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d4ecba845021e2ef0ee16c0f67e332b6",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:04 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:33 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:05 GMT",
-        "MS-CV": "CmJ1PYU2eEeK5OzB66RiUQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:33 GMT",
+        "MS-CV": "iAaTxn1C3Uaz8mqyeXv3lA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wd2YYwAAAAAxvzP50xZHS5GqZw/3WqW3UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nQahYwAAAAAT\u002BfvI4tapRYWfGZVzJQgEUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "160ms"
+        "X-Processing-Time": "170ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f9133a04baa32e788b219f88484383bc-ae9bfe1c51b9d0a1-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "73b736eb01756ce9659a88770c73722d",
+        "traceparent": "00-6ecb0938d7a66ae0cb9d3fd15431edaf-dcc5814717d21e15-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4bdf8e0ab2155b4f35da352f471b3fef",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:04 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:33 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:05 GMT",
-        "MS-CV": "qwt18yOaekCSsNMCXM/igw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:33 GMT",
+        "MS-CV": "bmbhFKhZEUSzogb99tlVTg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wd2YYwAAAACb1jT//UlSQIMMAIy\u002BjQJsUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nQahYwAAAAB0S7H\u002BepihSJAy9z0phY2WUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "79ms"
+        "X-Processing-Time": "90ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-f9133a04baa32e788b219f88484383bc-752677e2d07c1a87-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a9f6500b39138bdb9a9408c2ecc03c04",
+        "traceparent": "00-6ecb0938d7a66ae0cb9d3fd15431edaf-22ad5c076e38e5e2-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "14db90e73fd4f8aafc971fab3994e1e1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:04 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:33 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
+          "sbs1.2e79ec49-a58d-48a4-c554-1b802d31bb28.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
+          "sbs2.2e79ec49-a58d-48a4-c554-1b802d31bb28.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:06 GMT",
-        "MS-CV": "OgU4YDxQbk\u002BvKCaZxEalCA.0",
+        "Date": "Tue, 20 Dec 2022 00:49:34 GMT",
+        "MS-CV": "TZcczDN//EuwkPndcx8MjQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wd2YYwAAAACfsFUkVWnUSrjm\u002BL68NDC2UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nQahYwAAAAASJdbBX0jMQrNdDA1oUpH1UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "683ms"
+        "X-Processing-Time": "595ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
+          "sbs1.2e79ec49-a58d-48a4-c554-1b802d31bb28.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
+          "sbs2.2e79ec49-a58d-48a4-c554-1b802d31bb28.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-bfaeba0a059a93796a8bcba2520af320-7be17fd5c7932225-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ddec415ab24474a81206b768a5bb4c10",
+        "traceparent": "00-7cf518186aca21a772d58371aaee3481-d96ce11c9ce74e51-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9f7665217052d2136b919f471ac09bf2",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:05 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:34 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com"
+              "sbs1.2e79ec49-a58d-48a4-c554-1b802d31bb28.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:06 GMT",
-        "MS-CV": "mUlJVT2bKUS21xNNYy6ubQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:34 GMT",
+        "MS-CV": "kYOtIg0ebUycviuS30AViQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0wt2YYwAAAAC5e2IGsHKGQ4x4bErIT7dsUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ngahYwAAAAD2Q3k/CE6gRLWvyylLKUlGUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "185ms"
+        "X-Processing-Time": "171ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
+          "sbs1.2e79ec49-a58d-48a4-c554-1b802d31bb28.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
+          "sbs2.2e79ec49-a58d-48a4-c554-1b802d31bb28.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com"
+              "sbs1.2e79ec49-a58d-48a4-c554-1b802d31bb28.com"
             ]
           }
         ]
@@ -183,11 +183,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "230",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-2d3cfc197d317b126c4293f0aa69a19c-712e007843dc0f77-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f25a0bd601e1b2125a2bd9e0f82780a5",
+        "traceparent": "00-5e0e29cd3311c4ff170c274904529f71-510e51c34e5e805a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d6287da21e08cae1e3e64e7e92a421a1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:06 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:34 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -197,8 +197,8 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com",
-              "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com"
+              "sbs1.2e79ec49-a58d-48a4-c554-1b802d31bb28.com",
+              "sbs2.2e79ec49-a58d-48a4-c554-1b802d31bb28.com"
             ]
           }
         ]
@@ -207,20 +207,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:07 GMT",
-        "MS-CV": "A1wvLTY3nkeMUAmqBTlszw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:34 GMT",
+        "MS-CV": "XLDdFfS3bUKcX2yAjLXCuw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0w92YYwAAAABppN0yK/V/RZFPcqNy2JvDUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ngahYwAAAADOTgEoSWKjS7gwIgpDrYIFUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "185ms"
+        "X-Processing-Time": "170ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
+          "sbs1.2e79ec49-a58d-48a4-c554-1b802d31bb28.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
+          "sbs2.2e79ec49-a58d-48a4-c554-1b802d31bb28.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -230,8 +230,8 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com",
-              "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com"
+              "sbs1.2e79ec49-a58d-48a4-c554-1b802d31bb28.com",
+              "sbs2.2e79ec49-a58d-48a4-c554-1b802d31bb28.com"
             ]
           }
         ]
@@ -243,11 +243,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-bc0bcbe4c92b2b3bcd194d469d87ff79-e9463f3d8be94d87-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "cb1d835e948659e8a882960d8272e6df",
+        "traceparent": "00-ecbd2f5a64a4e0a2711d4a3acf7f99d6-d5b9ba08de00b0bb-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e10d53f99fa5769c7d08a942a063de3c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:06 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:34 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -255,20 +255,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:07 GMT",
-        "MS-CV": "lVe5Itae\u002BUW5DmkVKiZ4SA.0",
+        "Date": "Tue, 20 Dec 2022 00:49:34 GMT",
+        "MS-CV": "TmAz8jtDJ06I65A6iyRBUA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0w92YYwAAAABJZairHq8JSLZ7AiYd1yvDUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nwahYwAAAADlQftg05UET51rhnyDF5b2UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
         "X-Processing-Time": "95ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
+          "sbs1.2e79ec49-a58d-48a4-c554-1b802d31bb28.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
+          "sbs2.2e79ec49-a58d-48a4-c554-1b802d31bb28.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -278,104 +278,8 @@
             "name": "Last rule",
             "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
             "trunks": [
-              "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com",
-              "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-dbe9e3c11f2a2bc740ddafc8a85b917c-30429613d3c28252-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "e1ebf8484a6558232e3a8219d8c77ceb",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:06 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:07 GMT",
-        "MS-CV": "RAxLUbdew0OcRYPVJc4\u002BGg.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0w92YYwAAAADSGtPJJDqxS7s6Ov1rGC5nUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "93ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle all other numbers\u0027",
-            "name": "Last rule",
-            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
-            "trunks": [
-              "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com",
-              "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-8c7f56ff8d827f49495efef6d8aa4aa0-090713ca9c80687f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "210a1285819d41892200495f6a0430e7",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:06 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:07 GMT",
-        "MS-CV": "dkiiy\u002BALXEuKIO/zrtRyeg.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0w92YYwAAAAA3mXll8S70T5ywJUnR43RIUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "101ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
-            "sipSignalingPort": 1122
-          },
-          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle all other numbers\u0027",
-            "name": "Last rule",
-            "numberPattern": "\\\u002B[1-9][0-9]{3,23}",
-            "trunks": [
-              "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com",
-              "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com"
+              "sbs1.2e79ec49-a58d-48a4-c554-1b802d31bb28.com",
+              "sbs2.2e79ec49-a58d-48a4-c554-1b802d31bb28.com"
             ]
           }
         ]
@@ -389,11 +293,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-67c2963f2ac5277e7ba2889ae0575ae9-36fabdcd6902e43f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ff98fa459e3b143f60c49c4c12cf81e0",
+        "traceparent": "00-9dada2289248cfdd405d8fed50c1c191-1fb54592d595eb4c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bb082cfb0b6c03d983abbb6b229440c7",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:06 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:35 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -403,20 +307,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:08 GMT",
-        "MS-CV": "56POyr9Bj02IPuyJ6oPDMQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:35 GMT",
+        "MS-CV": "nFwWNtuF8UyGh6zfjnCEeg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0w92YYwAAAABB6saF3w8CSY6/fn44FESYUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nwahYwAAAAAnkHH0ehuvQZIw\u002BnSw1KGIUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "184ms"
+        "X-Processing-Time": "156ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
+          "sbs1.2e79ec49-a58d-48a4-c554-1b802d31bb28.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
+          "sbs2.2e79ec49-a58d-48a4-c554-1b802d31bb28.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -429,11 +333,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-faac09587e6e6007fb315bf28679587c-4417da87ed08110b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6f87ab05c468c6416faabe6500c4ee29",
+        "traceparent": "00-b13b58cb8a399a77a153c35c862d7fe5-9ef5d06a664193fb-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c74dfe6fb9b2034de0b158ff759e2a7f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:07 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:35 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -441,20 +345,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:08 GMT",
-        "MS-CV": "mA/aij6YTEa9Ti\u002Btjln78A.0",
+        "Date": "Tue, 20 Dec 2022 00:49:35 GMT",
+        "MS-CV": "vnQI0B3mIUyfM20QOMF5Lg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0xN2YYwAAAADi9/ncr1GRQYDq9aAER4L8UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nwahYwAAAABHlfDwxXYXQYUd8yVAtPjQUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "92ms"
+        "X-Processing-Time": "109ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
+          "sbs1.2e79ec49-a58d-48a4-c554-1b802d31bb28.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": {
+          "sbs2.2e79ec49-a58d-48a4-c554-1b802d31bb28.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -469,30 +373,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-faac09587e6e6007fb315bf28679587c-c9c2e45fcc277bc5-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ded39a0a7c2ee6b0d3f5c1d9e43d2f53",
+        "traceparent": "00-b13b58cb8a399a77a153c35c862d7fe5-8840a250b65d624b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "65821108669bee357a0a5ef9e33154e8",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:07 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:35 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": null,
-          "sbs2.8cedcdb9-250b-7f26-dd05-67d813fc251d.com": null
+          "sbs1.2e79ec49-a58d-48a4-c554-1b802d31bb28.com": null,
+          "sbs2.2e79ec49-a58d-48a4-c554-1b802d31bb28.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:08 GMT",
-        "MS-CV": "nzvb2gSLVEewGPEENZKGyw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:35 GMT",
+        "MS-CV": "kdXM01DsPUWIfLmJgYJiWw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0xN2YYwAAAADw2L\u002Btp72jQr6I55AeQvNvUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nwahYwAAAABTahvOBI8QSpcKV6sCNAkkUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "256ms"
+        "X-Processing-Time": "266ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -502,6 +406,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "609120764"
+    "RandomSeed": "1694950326"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-2aa2c5edd184375cc6e65065ae90b034-585658620be2579b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "9460e048c42ec3e8260e05c78b849804",
+        "traceparent": "00-4d6cbe52196c3991a5a0679a913f9211-06161e10c92a5ed9-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1cedbc9555592032673f566355308d04",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:39 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:01 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:39 GMT",
-        "MS-CV": "zkONfAWggkiTeQrVJqJKHg.0",
+        "Date": "Tue, 20 Dec 2022 00:49:01 GMT",
+        "MS-CV": "Xx4OZZ3rR0WSpplmWGhCOg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0qN2YYwAAAADiKxKr0cehTKC\u002BrMa/9dRCUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0fQahYwAAAADhisXp5361S4KRd0YwBmymUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "112ms"
+        "X-Processing-Time": "154ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-da6153a52b9d615acfd5e059047691b0-0be1a3e87bf9ee11-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "68382e47a402bddfd4ed4771356898d6",
+        "traceparent": "00-f06527f643c7b6f23d133108f44d0e69-92860dd9835c48ec-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4b77930c7322b69e30d483afe89d118a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:39 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:01 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:39 GMT",
-        "MS-CV": "bHs5fGqoDEGqbR5HmeqaCw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:01 GMT",
+        "MS-CV": "9PD8zAxG50G\u002BI4RSWmB49A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0qN2YYwAAAAB9CvFobIbLSImBBx5RS8TUUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0fQahYwAAAAAoItG5/T5eRJEH0kSZrLymUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
+        "X-Processing-Time": "98ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-da6153a52b9d615acfd5e059047691b0-99c28cf65cb48348-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2ebf349c411c185710a2dfdebf36a69c",
+        "traceparent": "00-f06527f643c7b6f23d133108f44d0e69-1e163d27c5994257-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4c07939277ab0356ff0bc8b5cd7205d5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:39 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:01 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
+          "sbs1.302b3158-24f5-5bd6-065e-271b197b3c54.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
+          "sbs2.302b3158-24f5-5bd6-065e-271b197b3c54.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:39 GMT",
-        "MS-CV": "Lx7LkskPMkuny2A4msh/0g.0",
+        "Date": "Tue, 20 Dec 2022 00:49:02 GMT",
+        "MS-CV": "0mMaZ6B7B0ihkVgFCJRjRg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0qN2YYwAAAAA7YD7zyqzGTLChrRc2mJ2KUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0fQahYwAAAAB2blSf2ngsSoX\u002BecaeO/C6UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "267ms"
+        "X-Processing-Time": "849ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
+          "sbs1.302b3158-24f5-5bd6-065e-271b197b3c54.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
+          "sbs2.302b3158-24f5-5bd6-065e-271b197b3c54.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-b17ae8be4f6e5a9c861bab4e12a8c1bf-68c8021569b78bc0-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8b94f7cf49f0a38501a2c0417c778dbd",
+        "traceparent": "00-7c8c7ec0af628ce312f09622a69c681c-9c12e384d76ea950-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "860f23d1f00422321e37ec84d18338ca",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:39 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:02 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com"
+              "sbs1.302b3158-24f5-5bd6-065e-271b197b3c54.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:40 GMT",
-        "MS-CV": "wTCT7IdomEO/QVrapDPr2Q.0",
+        "Date": "Tue, 20 Dec 2022 00:49:02 GMT",
+        "MS-CV": "mCp180SgiUusmX8G/tRr7g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0qN2YYwAAAACR/rCSiFBSTbNLnaPssQOUUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0fgahYwAAAAC3CtbwGTszR6eXEbIrvWqTUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "107ms"
+        "X-Processing-Time": "168ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
+          "sbs1.302b3158-24f5-5bd6-065e-271b197b3c54.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
+          "sbs2.302b3158-24f5-5bd6-065e-271b197b3c54.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com"
+              "sbs1.302b3158-24f5-5bd6-065e-271b197b3c54.com"
             ]
           }
         ]
@@ -183,11 +183,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-61cccf3231c273bca8ded9fc6f19389f-341aeac666b87021-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "572a2f766ac505e8d7205860c501fd9e",
+        "traceparent": "00-d0390a616d0568a21709c635e6904c26-e9e818e1596aacf8-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c1d1cc2e412994583c744c17aae8e8bd",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:40 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:02 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -197,20 +197,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:40 GMT",
-        "MS-CV": "qk8XXZQhxkS4XcYjSYCQmQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:03 GMT",
+        "MS-CV": "F9JHTylctEeSJFKsCwXCbQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0qd2YYwAAAADxUf3Rq/wNR73OycM99UvgUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0fwahYwAAAAATc3W0/5RLSq6Nm\u002BbexiLlUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "195ms"
+        "X-Processing-Time": "168ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
+          "sbs1.302b3158-24f5-5bd6-065e-271b197b3c54.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
+          "sbs2.302b3158-24f5-5bd6-065e-271b197b3c54.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -223,11 +223,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-15ec5b68e4a77a0b4a246ac6f280f2ae-07c80fb08b4fbc26-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3da1aa470dd453e5af1b2d7981169b99",
+        "traceparent": "00-5be491b0af9b49c6001292ee3a62d44d-e1e38e4c3d4cd74d-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c4deadcf8b8ea18661e52d748bd1317c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:40 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:03 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -235,20 +235,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:40 GMT",
-        "MS-CV": "Q9IRqw/Kl0GouGmTnH6sIg.0",
+        "Date": "Tue, 20 Dec 2022 00:49:03 GMT",
+        "MS-CV": "frQxvK6chUuD6CL/q6etTQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0qd2YYwAAAAC7pZYwq7ROR6qe6P3FtTGlUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0fwahYwAAAAByCRBoVAN0RpCa3GghQnv0UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "194ms"
+        "X-Processing-Time": "111ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
+          "sbs1.302b3158-24f5-5bd6-065e-271b197b3c54.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
+          "sbs2.302b3158-24f5-5bd6-065e-271b197b3c54.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,37 +263,37 @@
         "Authorization": "Sanitized",
         "Content-Length": "194",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-15ec5b68e4a77a0b4a246ac6f280f2ae-eb68629b071a7319-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "906822144f0b65d70f8fb3cff125deff",
+        "traceparent": "00-5be491b0af9b49c6001292ee3a62d44d-ce6616b8fd03f921-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0187fed344a18facca7a4990a41b7735",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:40 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:03 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
+          "newsbs.302b3158-24f5-5bd6-065e-271b197b3c54.com": {
             "sipSignalingPort": 3333
           },
-          "sbs1.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": null,
-          "sbs2.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": null
+          "sbs1.302b3158-24f5-5bd6-065e-271b197b3c54.com": null,
+          "sbs2.302b3158-24f5-5bd6-065e-271b197b3c54.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:41 GMT",
-        "MS-CV": "LrZU5Ce1g06ZDRQ6TQrZuQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:04 GMT",
+        "MS-CV": "QTRU67okJUqhJv\u002BYL5PuSA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0qd2YYwAAAAB3YtK0UgUUTqk76ki2wzzwUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0fwahYwAAAADsnptOjs2wTa4gVVXchPrxUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "914ms"
+        "X-Processing-Time": "826ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
+          "newsbs.302b3158-24f5-5bd6-065e-271b197b3c54.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -306,11 +306,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-16d499dc1ee1701272957c38ca6fb2dd-ed2b81002684ab1c-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d2fa21a550d568e849d7a7a93c6e83c0",
+        "traceparent": "00-51297af0f7b5ef025aec51d94954753e-d47ab9bd19c9c528-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "24b52e4e73a5a23c452f604413e4096b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:41 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:04 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -318,17 +318,56 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:42 GMT",
-        "MS-CV": "RE78mqsEhkesIfwiooZQBw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:04 GMT",
+        "MS-CV": "w2Af0PrhA0m1oJXsPTrp6A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0qt2YYwAAAAAaxwhkRIYSQLVekat\u002BQOn2UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0gAahYwAAAAAFboJ4GrExQISdg4Fr1BI7UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "82ms"
+        "X-Processing-Time": "89ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
+          "newsbs.302b3158-24f5-5bd6-065e-271b197b3c54.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-f1a6ef3b56ca46f2dc7082459538f122-663592ff7974d399-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ab43cf42e7618b1c014ef91342f6fd46",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:04 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:04 GMT",
+        "MS-CV": "x1VnhI4rDkyc22lYO7pAYA.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0gAahYwAAAAAnNK3Jip5wSbS4U1KaJCzhUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "333ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "newsbs.302b3158-24f5-5bd6-065e-271b197b3c54.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -341,11 +380,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-70de81e1a8faa0fc0f02fa852945961a-4467966dc5987a01-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "a24bbe856d99f792d33c2e455916618a",
+        "traceparent": "00-752b197122ba5fe17d7dc05c2a95de92-78559d569c8ed0ca-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5c25f76d0d1b5fd7c2e5bb72e3687ce6",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:42 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:04 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -353,87 +392,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:42 GMT",
-        "MS-CV": "KI5XOpSDlEetuwfKsQ84KQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:05 GMT",
+        "MS-CV": "SA3ghotxzESU30qHYVAAVA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0q92YYwAAAACzLSsawW24TYuuZHzRkBPPUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0gQahYwAAAABha8EdomooQp9CSxLZab39UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "80ms"
+        "X-Processing-Time": "104ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
-            "sipSignalingPort": 3333
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-6ea519292223b7fdecc4ff16df744899-aa2893f6eb0e8182-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5fd42d3dc91cc4c439ff4634a72e29a1",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:42 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:42 GMT",
-        "MS-CV": "09xr41vxFUiIkKlrdjzM8w.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0q92YYwAAAABB3DQ4gIZOQLCSkZ7GRlfAUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "newsbs.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
-            "sipSignalingPort": 3333
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-374e6815e766f57b952fedbddc2e9197-c63fe9a466924648-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "324af30b3bd937668f02fe9921a30f33",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:42 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:42 GMT",
-        "MS-CV": "F0AwmMGwr0SmwyO98wHlKQ.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0q92YYwAAAACkL7jLRoJTRp8YzAkS8RpJUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "87ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "newsbs.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": {
+          "newsbs.302b3158-24f5-5bd6-065e-271b197b3c54.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -448,29 +417,29 @@
         "Authorization": "Sanitized",
         "Content-Length": "67",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-374e6815e766f57b952fedbddc2e9197-aef30e103230240e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0e6b1d75239abba4fa866999265e50a4",
+        "traceparent": "00-752b197122ba5fe17d7dc05c2a95de92-3d45364035b2ab8a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d44ddd71cbd767d4122a22567928604f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:42 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:05 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.0565f9dc-c5ec-32fd-2168-fcdbb929b287.com": null
+          "newsbs.302b3158-24f5-5bd6-065e-271b197b3c54.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:43 GMT",
-        "MS-CV": "4dLBMO7O80Cwky9Ea3Q8Dw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:05 GMT",
+        "MS-CV": "vldW3SFIgkuoUJG\u002Bg//dlA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0q92YYwAAAAAX1MNDep9ESZMk\u002BcRywFHYUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0gQahYwAAAABY9TZ\u002BM7m\u002BS7IM1Q1sc/vmUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "283ms"
+        "X-Processing-Time": "259ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -480,6 +449,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "242078849"
+    "RandomSeed": "1755224485"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/ReplaceSipTrunksForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-664b8985742486c084855d70e83e1c7a-50e2f1dc4e48f0bf-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "59ca48c433996eb876564dc446cfcf21",
+        "traceparent": "00-fad12a593c0d98203130ede5ac92531b-567a075d89bd93e4-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "626edfcc172f99a58afd76ed05a64f64",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:07 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:35 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:09 GMT",
-        "MS-CV": "Vf3O\u002BIzFT0iedRdIVs4a2w.0",
+        "Date": "Tue, 20 Dec 2022 00:49:35 GMT",
+        "MS-CV": "tjGAA7y7UkSoMlzvuGdv5g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0xN2YYwAAAACoFLZtpQuTSpVC5ZdIqnvxUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0oAahYwAAAAAR0kf4oeetR7MMib41SFplUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "251ms"
+        "X-Processing-Time": "152ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-307fd51b261947d9247b2a800afec144-17a1c0afb0215f4a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "89f2734def770b84174683c04890c113",
+        "traceparent": "00-a4fd94da92754a8ce7bad7170faaed88-ada6c7e9de766ab6-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "af40ee55c9df26b5956bb03d0ebcf33d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:08 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:36 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:09 GMT",
-        "MS-CV": "6xeQ6OUvkEyGKDAZnHICCg.0",
+        "Date": "Tue, 20 Dec 2022 00:49:36 GMT",
+        "MS-CV": "ZrQxwenr4km\u002B\u002BW/rkH28HA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0xd2YYwAAAAC5iMdKdlo8TZ5XcJJzcb/yUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0oAahYwAAAAB6NGz/qH9VTqc0awys2FIfUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "107ms"
+        "X-Processing-Time": "89ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-307fd51b261947d9247b2a800afec144-0cae731986325632-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f387d7529ad7550dbd7ca9d0f6ecd71f",
+        "traceparent": "00-a4fd94da92754a8ce7bad7170faaed88-087c5a83f2493230-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4b6a0d2e33a200f9875fe7acd4698a56",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:08 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:36 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
+          "sbs1.71f82c17-4baa-9056-fca9-15099f8b3bd7.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
+          "sbs2.71f82c17-4baa-9056-fca9-15099f8b3bd7.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:09 GMT",
-        "MS-CV": "vbhYW0EmFkeRpKDSTtzwaw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:36 GMT",
+        "MS-CV": "XbLiQedntEKDYx97lFfw8w.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0xd2YYwAAAAD0gWyhBC/1RrniDB39ZSRtUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0oAahYwAAAAAY4XptI8s1TZUkktCArIHAUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "454ms"
+        "X-Processing-Time": "750ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
+          "sbs1.71f82c17-4baa-9056-fca9-15099f8b3bd7.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
+          "sbs2.71f82c17-4baa-9056-fca9-15099f8b3bd7.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-c3d7d2024360698719f9803a25a78b5a-e941ae60dab4ea55-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5e859807efaed445c4bf4252b0f826e6",
+        "traceparent": "00-a0fba5296f3d6cfecbba79fa50d5f32c-c14cb2cdb2f29755-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b0b3b0598c4a03f82a48cdc467678ace",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:08 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:37 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com"
+              "sbs1.71f82c17-4baa-9056-fca9-15099f8b3bd7.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:10 GMT",
-        "MS-CV": "opZPuXEUN0a/ead\u002BJttD0w.0",
+        "Date": "Tue, 20 Dec 2022 00:49:37 GMT",
+        "MS-CV": "A/44KjSryEmZ1wUGrhaAoA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0xd2YYwAAAABEoPvQGZO0TKHk9fjG1QuyUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0oQahYwAAAAAndZGVRB7ZS7ucHY8Bm7VNUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "193ms"
+        "X-Processing-Time": "173ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
+          "sbs1.71f82c17-4baa-9056-fca9-15099f8b3bd7.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
+          "sbs2.71f82c17-4baa-9056-fca9-15099f8b3bd7.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com"
+              "sbs1.71f82c17-4baa-9056-fca9-15099f8b3bd7.com"
             ]
           }
         ]
@@ -183,11 +183,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d3f66a0779789d8ae97eb64e3ebcf83a-a64a1dc2364f585e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "6f723994dc48b34a669dccfa46b3142b",
+        "traceparent": "00-0eb62aeabe3fb8da145b94da19afb1bf-48f201366f55d0f7-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f7be390a033b22c2f53f2880e208512b",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:09 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:37 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -197,20 +197,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:10 GMT",
-        "MS-CV": "wLR\u002Bwi/m9kaIMoqErZbfZQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:37 GMT",
+        "MS-CV": "D0sPkvLNyEyiZwwCRuavcw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0xt2YYwAAAACTMXvHB/8zTYuf5z77cS2TUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0oQahYwAAAADMl9JL7tnQSahMLCzvfCzOUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "156ms"
+        "X-Processing-Time": "162ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
+          "sbs1.71f82c17-4baa-9056-fca9-15099f8b3bd7.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
+          "sbs2.71f82c17-4baa-9056-fca9-15099f8b3bd7.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -223,11 +223,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-1a7a62eaf1daabdb8c8817235c3cd835-238769833e7f993c-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "b0b8636f630b626491b22e1758baa4c5",
+        "traceparent": "00-7307d9fa09876d1c7780d6f4e3cc6511-86c4d13a0e96d6e8-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5de45ae04208a2f2156721596635981f",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:09 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:37 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -235,20 +235,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:11 GMT",
-        "MS-CV": "vIC/A\u002B9KQUe/AqWYm08srQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:37 GMT",
+        "MS-CV": "w5Rzmt3JNEqpHwVzRXgTRw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0xt2YYwAAAABzpShGb/KpT7JrnQSLBHqmUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ogahYwAAAAA4jB9Ud2OxTI5wbW4rSpAMUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "321ms"
+        "X-Processing-Time": "93ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
+          "sbs1.71f82c17-4baa-9056-fca9-15099f8b3bd7.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
+          "sbs2.71f82c17-4baa-9056-fca9-15099f8b3bd7.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -263,37 +263,37 @@
         "Authorization": "Sanitized",
         "Content-Length": "194",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-1a7a62eaf1daabdb8c8817235c3cd835-21717111d1e5dabc-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "bd3bc35667792bd74dd2f811234b8e10",
+        "traceparent": "00-7307d9fa09876d1c7780d6f4e3cc6511-54e7afd8d6409389-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9ba218d492aa551aee91bb0b63772021",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:10 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:38 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
+          "newsbs.71f82c17-4baa-9056-fca9-15099f8b3bd7.com": {
             "sipSignalingPort": 3333
           },
-          "sbs1.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": null,
-          "sbs2.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": null
+          "sbs1.71f82c17-4baa-9056-fca9-15099f8b3bd7.com": null,
+          "sbs2.71f82c17-4baa-9056-fca9-15099f8b3bd7.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:11 GMT",
-        "MS-CV": "\u002BA9YsAKAskuXkTI/5qr1hQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:38 GMT",
+        "MS-CV": "rr2inkaWT06PaCOwzMutEg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0x92YYwAAAAAVktkYnEQBTKtGOBDx94FUUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0ogahYwAAAAAn9tW\u002B1XUkRLZl\u002BzWJtC9xUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "696ms"
+        "X-Processing-Time": "597ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
+          "newsbs.71f82c17-4baa-9056-fca9-15099f8b3bd7.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -306,11 +306,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-d3187af4e2385ea4f0b26d6a3c51353b-b13109b610a63007-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4de316ab763f31dad40fde95ad325aab",
+        "traceparent": "00-ccfc7abf2abaf739ac102e8c83ad3726-106f5e82585f64bf-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0de3a2f72d83c8c5461ce2d3e268bcc0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:10 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:38 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -318,17 +318,56 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:12 GMT",
-        "MS-CV": "Z7Q/Wed9B0qHFY1FlCDPNA.0",
+        "Date": "Tue, 20 Dec 2022 00:49:38 GMT",
+        "MS-CV": "nmW6\u002BLXNuE\u002BQfdY1LTLhpw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0x92YYwAAAABqokrR8FJHR7WcNsen/oXfUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0owahYwAAAAAk9yt8nfOGQI8omwppfQPHUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "118ms"
+        "X-Processing-Time": "94ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
+          "newsbs.71f82c17-4baa-9056-fca9-15099f8b3bd7.com": {
+            "sipSignalingPort": 3333
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-ae8eed933771e0da3f73398b7b65127b-4d54bea3fcc57fe8-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c9ac08a7b5664d803f8f6f7787e73e9d",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:38 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:38 GMT",
+        "MS-CV": "Y6/r10SJNEWXnptourlUGg.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0owahYwAAAADcD8WodjvFS5ubgvb0gaHeUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "156ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "newsbs.71f82c17-4baa-9056-fca9-15099f8b3bd7.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -341,11 +380,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-cafc44f5969cf3a070630d2ab68ddd7e-428c67a9b672330a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "83a406f9577707b18c8d62396a533f46",
+        "traceparent": "00-2b152654a52acb250357af43c59d66e9-2d00e8e9aa111af5-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c46200468b51a79c52d9548db0467286",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:11 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:39 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -353,87 +392,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:12 GMT",
-        "MS-CV": "s6i1Esn6zEanoLILRONayQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:39 GMT",
+        "MS-CV": "XHhostaDk0macn2EAYaW7g.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0yN2YYwAAAABPajeTpEemTbZN\u002BOkB91\u002BXUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0owahYwAAAAAVf7gcgPV7Qqz6MxWxbSaNUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "101ms"
+        "X-Processing-Time": "85ms"
       },
       "ResponseBody": {
         "trunks": {
-          "newsbs.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
-            "sipSignalingPort": 3333
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-ee914af936026121a252a4b5aae96cc5-245a7adf580bd26e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "416c1e2357d7e085e80ae86a89427d1b",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:11 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:12 GMT",
-        "MS-CV": "lWiGiTMCpEuyRyNdhMQJvA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0yN2YYwAAAAAs\u002BcNMXY\u002BrSIghbaYfBkmDUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "108ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "newsbs.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
-            "sipSignalingPort": 3333
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-b873749422de74c63f0241d4748a986b-1d8909e7c0ae5109-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1c184c770ba6539965dbc0b214a1c680",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:11 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:12 GMT",
-        "MS-CV": "EnpOaWDOUEuxX6y6KLjM5Q.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0yN2YYwAAAAD33pz/7ekoRY7AJ0v6cyGhUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "90ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "newsbs.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": {
+          "newsbs.71f82c17-4baa-9056-fca9-15099f8b3bd7.com": {
             "sipSignalingPort": 3333
           }
         },
@@ -448,29 +417,29 @@
         "Authorization": "Sanitized",
         "Content-Length": "67",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-b873749422de74c63f0241d4748a986b-3380e433bd3ab1d0-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "8f7197cf18c6a1d380c49a6d6e477d4a",
+        "traceparent": "00-2b152654a52acb250357af43c59d66e9-6434041c7e8c8b5b-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5b63fbd557cb41bb2196cdf3bd4e405e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:11 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:39 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "newsbs.1feb7689-4426-1eb0-efd7-b9d3d2a179bd.com": null
+          "newsbs.71f82c17-4baa-9056-fca9-15099f8b3bd7.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:13 GMT",
-        "MS-CV": "3pNI3yylU0aes/JyvbHobg.0",
+        "Date": "Tue, 20 Dec 2022 00:49:39 GMT",
+        "MS-CV": "auO6DvYFJUu7FDuoJnjHRg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0yN2YYwAAAACQkNYJ5MiAS6O6tOxCf7hAUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0owahYwAAAAByPBRqpRqFTIuRFTezc9yvUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "262ms"
+        "X-Processing-Time": "270ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -480,6 +449,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1865169759"
+    "RandomSeed": "985489074"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthentication.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetFunctionUsingTokenAuthentication.json
@@ -8,14 +8,14 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-6e462a588a8366eaf9641e0ba269a57e-63684faf6b1822c5-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "1b35ba6bb9ef0142b524bee9a1ddf12f",
+        "traceparent": "00-2394bb3cfae26a40ea569af4ee47aea9-d95e1b6579425b34-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "30b887d04f7232403688b4394b91efe7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.f5c433d6-e4ff-2a1a-5713-e95f12d36dc7.com": {
+          "sbs1.d7b08529-690a-b6e7-1437-564a4c6980cb.com": {
             "sipSignalingPort": 5555
           }
         }
@@ -24,17 +24,56 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:43 GMT",
-        "MS-CV": "9gYBKLQQjkmh\u002BLKy4XwEWw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:06 GMT",
+        "MS-CV": "V7dFYL\u002BXdkOFFFsA4z2dMA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rN2YYwAAAAB18pSOayeIToVtJz\u002BozhWsUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0gQahYwAAAAAaq/c\u002BvNdhSoB3VQMjYIExUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "528ms"
+        "X-Processing-Time": "678ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.f5c433d6-e4ff-2a1a-5713-e95f12d36dc7.com": {
+          "sbs1.d7b08529-690a-b6e7-1437-564a4c6980cb.com": {
+            "sipSignalingPort": 5555
+          }
+        },
+        "routes": []
+      }
+    },
+    {
+      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-c67a211756c0c362bbf1d72499e2c873-8814e92dd47ef42e-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "be39b2e03209820db701ca1949cfb419",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:06 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "routes": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 20 Dec 2022 00:49:06 GMT",
+        "MS-CV": "5SeUf2ss9UGde8Dgi9xrpQ.0",
+        "Strict-Transport-Security": "max-age=2592000",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0ggahYwAAAADz\u002BoWA8goAQ5XHpuQueCYgUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Cache": "CONFIG_NOCACHE",
+        "X-Processing-Time": "345ms"
+      },
+      "ResponseBody": {
+        "trunks": {
+          "sbs1.d7b08529-690a-b6e7-1437-564a4c6980cb.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -47,11 +86,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-3bee7c949ea37f0e1d911afbe37299df-c72701741242b54d-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "91e55788d9e9ef1b28476d9857dcd8bc",
+        "traceparent": "00-27499973a019fa980cdf54456c02637a-1b64a169cd93dbdd-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "317e4dba7277d984457da181b5ad6b82",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:43 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:06 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -59,87 +98,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:43 GMT",
-        "MS-CV": "ClwhT6lFhkq2JKW\u002BOZAyOA.0",
+        "Date": "Tue, 20 Dec 2022 00:49:06 GMT",
+        "MS-CV": "lkRuzWt0PUWUxKFIlPephw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rN2YYwAAAACHCYol5Q1iRo2R6Dgu3K0qUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0gwahYwAAAAAk6OJBs8t2ToyDE9MpTyLiUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "105ms"
+        "X-Processing-Time": "90ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.f5c433d6-e4ff-2a1a-5713-e95f12d36dc7.com": {
-            "sipSignalingPort": 5555
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-35ebfe89ef3c5643ca60c072a71b86e2-61cd0585f5cb8d76-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "c6fe65f3b1791c41f0c33fdb2530897a",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:44 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:45 GMT",
-        "MS-CV": "le9\u002BqKTiQUiOO5axSwfN/Q.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rN2YYwAAAACLz76\u002BN8NQSrA/3WVYzGyqUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "84ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.f5c433d6-e4ff-2a1a-5713-e95f12d36dc7.com": {
-            "sipSignalingPort": 5555
-          }
-        },
-        "routes": []
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-b447669b3a16cba1c26629bc0cf95c27-82268d2076b43d14-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "bad7b922dbee91de9f45f3a84caaa9d8",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:44 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:45 GMT",
-        "MS-CV": "resYAyvy1EOhdYsIfIg8tw.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rd2YYwAAAABOjTMxKyGWT7PeYJIYbmqvUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "93ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.f5c433d6-e4ff-2a1a-5713-e95f12d36dc7.com": {
+          "sbs1.d7b08529-690a-b6e7-1437-564a4c6980cb.com": {
             "sipSignalingPort": 5555
           }
         },
@@ -154,29 +123,29 @@
         "Authorization": "Sanitized",
         "Content-Length": "65",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-b447669b3a16cba1c26629bc0cf95c27-772eb9f177c38394-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "3bf6024c2bded7b615c8a0269940caf7",
+        "traceparent": "00-27499973a019fa980cdf54456c02637a-12c1237c87b60987-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "996a6f47c1309ec17a3679718427e967",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:44 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:06 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.f5c433d6-e4ff-2a1a-5713-e95f12d36dc7.com": null
+          "sbs1.d7b08529-690a-b6e7-1437-564a4c6980cb.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:45 GMT",
-        "MS-CV": "VCtsW9XYvkWLV3tdqSWE6w.0",
+        "Date": "Tue, 20 Dec 2022 00:49:07 GMT",
+        "MS-CV": "eJwQojXSUECZWnQ6gl6AYg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rd2YYwAAAAAfwfbEo3L4QZOQ6y1rq4cZUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0gwahYwAAAAADzH/EN5n3R7ylYdyoPG4zUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "272ms"
+        "X-Processing-Time": "276ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -186,6 +155,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1270219646"
+    "RandomSeed": "1430354912"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResource.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResource.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-430c97640f99df03d7f20f006bcfcd75-956fe09a350ebf2c-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "22a8463e66febc50e6e7a819a9f5cf58",
+        "traceparent": "00-3f382071408d7713d48ad161f2fca021-fef1cd81af681b76-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d88c801ce1b186e243bb3c480090aed1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:44 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:07 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:46 GMT",
-        "MS-CV": "XoDr\u002B5/hJkKuZD/Ct1/exw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:07 GMT",
+        "MS-CV": "dxrKTknmoUK3PNQy6R3EGA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rd2YYwAAAACo0ZI/ObuhRZcDl0/TrdNdUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0gwahYwAAAADcynUY8o5uS6iqgCaMg15FUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "174ms"
+        "X-Processing-Time": "159ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-345bac9dbf890f8548b62d04ad010b6e-6e74dadfa87b413a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "138635d20207b166c916437a79756ff3",
+        "traceparent": "00-cebce1574b5df256cee885e75e29fd73-fb68daef13ce9c53-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3f63e28af6cbca0a0aadd8f52a51ba99",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:45 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:07 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:46 GMT",
-        "MS-CV": "i9RwpOrw0kSA8We3HroUtg.0",
+        "Date": "Tue, 20 Dec 2022 00:49:07 GMT",
+        "MS-CV": "9CGmA\u002Bmpk02eg4t6PPj4bg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rt2YYwAAAADT33LOW70iSpK4KQche/2UUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0gwahYwAAAACvrcd7abmaSI089tSXJLmLUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "86ms"
+        "X-Processing-Time": "87ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-345bac9dbf890f8548b62d04ad010b6e-26497679b74ff17f-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "649f16c5062a0c099652db14aed55c81",
+        "traceparent": "00-cebce1574b5df256cee885e75e29fd73-ae204d7775b72592-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "752e88ffd291c11d334fe034f24682bd",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:45 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:07 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
+          "sbs1.23d616a2-2ef0-828e-4da8-28326f85fc88.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
+          "sbs2.23d616a2-2ef0-828e-4da8-28326f85fc88.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:46 GMT",
-        "MS-CV": "SzWmq4O0TUSk\u002Bj7EgWm2SQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:08 GMT",
+        "MS-CV": "BPBfYbvlU023gl3S58TT\u002BA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rt2YYwAAAADHfTa0fiFmQYkJ892OW9sLUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0hAahYwAAAADa0fRnwuS9R48CUF/NKAbHUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "481ms"
+        "X-Processing-Time": "798ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
+          "sbs1.23d616a2-2ef0-828e-4da8-28326f85fc88.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
+          "sbs2.23d616a2-2ef0-828e-4da8-28326f85fc88.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-61055a5c630eaa8df31b022e69434713-1be6d1ef3e543c5c-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "cf678130dadc3bebdff659e722d64370",
+        "traceparent": "00-475719094a2f6ebc3fbc2b3378e74b24-0c8bce6fd4ddaf93-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8da856f9bd2126bd75c1ce0308ed5cf2",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:45 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:08 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com"
+              "sbs1.23d616a2-2ef0-828e-4da8-28326f85fc88.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:47 GMT",
-        "MS-CV": "Gg\u002BD1gtsdESAeUb0iwC2mg.0",
+        "Date": "Tue, 20 Dec 2022 00:49:08 GMT",
+        "MS-CV": "WKYsu1xjiEea5SyM065gRQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0rt2YYwAAAACrVCg9H\u002BYMQJ/TwidLR2QAUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0hQahYwAAAAAc1DxGpOclT7\u002B3NRhQj/r6UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "183ms"
+        "X-Processing-Time": "155ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
+          "sbs1.23d616a2-2ef0-828e-4da8-28326f85fc88.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
+          "sbs2.23d616a2-2ef0-828e-4da8-28326f85fc88.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com"
+              "sbs1.23d616a2-2ef0-828e-4da8-28326f85fc88.com"
             ]
           }
         ]
@@ -183,16 +183,16 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-64346450a3602dbb5149eedb785b886b-dcaaf21f8e23cc06-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "9254b5786a56cb2d2b797db4265103f3",
+        "traceparent": "00-147b85093edb4e33e57946382b0150fb-92cc5d7c4ba849a0-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7748a2013961b740c4a20b7b15d5d8c3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:46 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:09 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
+          "sbs1.23d616a2-2ef0-828e-4da8-28326f85fc88.com": {
             "sipSignalingPort": 9999
           }
         }
@@ -201,20 +201,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:47 GMT",
-        "MS-CV": "E\u002BTgYaMQGUmR4VbLxMMbLA.0",
+        "Date": "Tue, 20 Dec 2022 00:49:09 GMT",
+        "MS-CV": "2C5fTQbfy0OOyojI5J/psA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0r92YYwAAAAB1oS4AZWF4RZqLWnMQGF5CUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0hQahYwAAAAB38WVVw0yVQJJRWtAinA6iUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "250ms"
+        "X-Processing-Time": "288ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
+          "sbs1.23d616a2-2ef0-828e-4da8-28326f85fc88.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
+          "sbs2.23d616a2-2ef0-828e-4da8-28326f85fc88.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -224,7 +224,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com"
+              "sbs1.23d616a2-2ef0-828e-4da8-28326f85fc88.com"
             ]
           }
         ]
@@ -236,11 +236,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f2b19a91c74a4f6ed51eab3b82d50199-aac617627991b89e-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f749c2ba9f0dea162a638533ad21eabf",
+        "traceparent": "00-36d250115daeaaf18bb97b0dbf8af806-3cd73b333b51ca2c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d3fb1b2b2ca94278cb07ffcf041ab846",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:46 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:09 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -248,20 +248,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:47 GMT",
-        "MS-CV": "kJuuWwJON0amt1BSihMiZA.0",
+        "Date": "Tue, 20 Dec 2022 00:49:09 GMT",
+        "MS-CV": "L2aVhNeI4EuzJYHtU/riGg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0r92YYwAAAADSSXolGctKS5ubOdmbvbMaUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0hQahYwAAAADVDGgO7bVMSK7WN2cGj1gmUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "106ms"
+        "X-Processing-Time": "107ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
+          "sbs1.23d616a2-2ef0-828e-4da8-28326f85fc88.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
+          "sbs2.23d616a2-2ef0-828e-4da8-28326f85fc88.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -271,101 +271,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-d53d1ac059c54feeefdd3e17eed56058-27693ea7675b60f3-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f89c6a0fc981c52b549ca3635d36148d",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:46 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:47 GMT",
-        "MS-CV": "I3chCn2Fp0SvnPc086I8TQ.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0r92YYwAAAAC//Lg0DWq7RIpaw2Y55mYiUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "82ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
-            "sipSignalingPort": 9999
-          },
-          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-e3f2e2e832c732a100bb63b705b4ddaa-da6c515f672a7728-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "602d65f34b8cd8639f6a67f2e5fa1d09",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:46 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:48 GMT",
-        "MS-CV": "GEM5vIxrLEWeh47TGmzqXA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0r92YYwAAAACGhtCTUMwbR6FfVbnPmE4vUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "88ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
-            "sipSignalingPort": 9999
-          },
-          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com"
+              "sbs1.23d616a2-2ef0-828e-4da8-28326f85fc88.com"
             ]
           }
         ]
@@ -379,11 +285,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-1f4292e2692230a130261bec8a76ee16-8140f0b103fa1b81-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "bba5bd8f0ab4f1729784a371fbb38cf4",
+        "traceparent": "00-5d0df22d5c4f219ae9d92d640a2844f8-4451980bf767e4bc-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4f33eef30bfdc05b16f0c97eb14111a0",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:47 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:09 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -393,20 +299,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:48 GMT",
-        "MS-CV": "jkmnJ58oVE2wFCVh7lAvpg.0",
+        "Date": "Tue, 20 Dec 2022 00:49:09 GMT",
+        "MS-CV": "stw2lBIbvUqew2nvfFAoGw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sN2YYwAAAAAagTQkZbOeSarXsXp3ZI8jUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0hQahYwAAAABVHiWq5WM1TKm/6zxa6f8fUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "153ms"
+        "X-Processing-Time": "293ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
+          "sbs1.23d616a2-2ef0-828e-4da8-28326f85fc88.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
+          "sbs2.23d616a2-2ef0-828e-4da8-28326f85fc88.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -419,11 +325,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-24f239df6d952e31b8e249f90a5c47a6-0bd1345c05083b86-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "473ff74f89f4c43307c459176138e05a",
+        "traceparent": "00-93b5549fd0899ff478786cde75f7e578-f22b1438ee0b772a-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "edd80ae989f2d4492a06ab5a3a70b3a9",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:47 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:10 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -431,20 +337,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:48 GMT",
-        "MS-CV": "4/Iv0EiuSkqNrxST/iGByA.0",
+        "Date": "Tue, 20 Dec 2022 00:49:10 GMT",
+        "MS-CV": "6L6ZqQUJQEGNOd14CyL5GQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sN2YYwAAAADyET8D22L3TpNS/3F1\u002Bfl\u002BUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0hgahYwAAAAAFSQECBvLeRYrMU2My0xuGUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "94ms"
+        "X-Processing-Time": "135ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
+          "sbs1.23d616a2-2ef0-828e-4da8-28326f85fc88.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": {
+          "sbs2.23d616a2-2ef0-828e-4da8-28326f85fc88.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -459,30 +365,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-24f239df6d952e31b8e249f90a5c47a6-04a83c68ba1f3477-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "9fd39a7e5991e9d8f33cc808a8f1dceb",
+        "traceparent": "00-93b5549fd0899ff478786cde75f7e578-2b46eb5f68601b24-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2788c5e988a220c6c03bbcb862f9908a",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:16:47 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:10 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.c20fe673-57fc-05ee-7700-da3a0562eef3.com": null,
-          "sbs2.c20fe673-57fc-05ee-7700-da3a0562eef3.com": null
+          "sbs1.23d616a2-2ef0-828e-4da8-28326f85fc88.com": null,
+          "sbs2.23d616a2-2ef0-828e-4da8-28326f85fc88.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:16:48 GMT",
-        "MS-CV": "Bo9IvZD4HU6MsbLdLqB7ow.0",
+        "Date": "Tue, 20 Dec 2022 00:49:10 GMT",
+        "MS-CV": "81hSez7DNkqa3DWKe/HTFA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0sN2YYwAAAAA2vAGupLbMT7oEux1TqyskUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0hgahYwAAAACTTOyb0J6PSKvd9LjYU\u002BC2UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "257ms"
+        "X-Processing-Time": "261ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -492,6 +398,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1752059362"
+    "RandomSeed": "165395927"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResourceAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/SipRoutingClientLiveTests/SetSipTrunkForResourceAsync.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-d83b77c81607fb80c081e2f991ec139f-8a870d5966f92347-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "ad39c9a9cefc2fb4fce128a24e1fe083",
+        "traceparent": "00-5e9ac869ca587b913cbbe6993fbcdc6c-6e53fc920528712d-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5f256d2c135b59d38a588ab5affa83db",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:13 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:41 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,13 +22,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:14 GMT",
-        "MS-CV": "xLnN3l9pH06uJ1EMtF6kZw.0",
+        "Date": "Tue, 20 Dec 2022 00:49:41 GMT",
+        "MS-CV": "BHy\u002B\u002BcO2Cka\u002BWKAWbfOFjg.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0yt2YYwAAAAAm9icO5rk6TJ7g6FUkZE67UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pQahYwAAAACIDQDIJSh2QIxkCncsPqXIUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "158ms"
+        "X-Processing-Time": "157ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -41,11 +41,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-06a6d1de8d0a504dbc8a70805110c5c3-24d53cb544c30450-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4bcf54fa04045607d949569bdbf9215b",
+        "traceparent": "00-86841f8a63c59539a42de03c29ca2bee-b845c7e8c63d252c-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ba1d2d756726ac0f9ea12e8bfee99d94",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:14 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:41 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -53,13 +53,13 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:15 GMT",
-        "MS-CV": "UQPzHZM/00\u002BeDgDAVeo8UQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:41 GMT",
+        "MS-CV": "kWfqI\u002Bd8LUiT/ZRHsJ4T6A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0y92YYwAAAADk9l7xSoanRaGjlbDWJ4PGUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pQahYwAAAACcgDsAH3VuRbmqTlOMB3/OUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "95ms"
+        "X-Processing-Time": "88ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -74,19 +74,19 @@
         "Authorization": "Sanitized",
         "Content-Length": "160",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-06a6d1de8d0a504dbc8a70805110c5c3-3c8593b105c07687-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "438f8237250b1cacd71d5b2a0325ba54",
+        "traceparent": "00-86841f8a63c59539a42de03c29ca2bee-8757e1631cb48279-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2f23c582927adfac1664bd5610262e1c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:14 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:41 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
+          "sbs1.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
+          "sbs2.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com": {
             "sipSignalingPort": 1123
           }
         }
@@ -95,20 +95,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:15 GMT",
-        "MS-CV": "HtuTpA0YDEiK20tpYEZl9g.0",
+        "Date": "Tue, 20 Dec 2022 00:49:42 GMT",
+        "MS-CV": "WVqlISpN9EycofneRkVi3A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0y92YYwAAAADzHIeRyw8oRK2KgOd60QwEUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pgahYwAAAACQMkibXgFWQJm3m/rqs8ZPUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "597ms"
+        "X-Processing-Time": "512ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
+          "sbs1.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
+          "sbs2.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -123,11 +123,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "201",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-7e0ac1d3707b332a56e06ef2d9315c6d-6e31956663d0b9e6-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5ddc8485fc52a4cfc1e3d4b278185403",
+        "traceparent": "00-a71a2620602f52eb515979a39e9a4c2b-8bb5bdf64b3fe096-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c706ea5b0defc5dd5e78c0bae4485aa1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:14 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:42 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,7 +137,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com"
+              "sbs1.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com"
             ]
           }
         ]
@@ -146,20 +146,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:16 GMT",
-        "MS-CV": "bCKDYXaG\u002BESfPljko76WRQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:42 GMT",
+        "MS-CV": "N\u002BJaGOF4TkS8a83W1TSYgw.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0y92YYwAAAADSXW4eZf4RQatjuH5xbQzAUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pgahYwAAAAADs791s0kIRLppFCQHTTefUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "264ms"
+        "X-Processing-Time": "179ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
+          "sbs1.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com": {
             "sipSignalingPort": 1122
           },
-          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
+          "sbs2.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -169,7 +169,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com"
+              "sbs1.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com"
             ]
           }
         ]
@@ -183,16 +183,16 @@
         "Authorization": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-0915d21cc63d7e66b14552fd2c549bea-913f48686a31b5c3-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "cc6bccbf9c8fd578a8b273e6a8dc52b3",
+        "traceparent": "00-7b69aa5cbff858cdf3a0239e31f9bb4f-48c12c37393b2c6d-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e932f6bb53d6e361813ea3c1aab99c78",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:15 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:42 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
+          "sbs1.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com": {
             "sipSignalingPort": 9999
           }
         }
@@ -201,20 +201,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:16 GMT",
-        "MS-CV": "ZMP/Ugw850Gk9RWJAPr/1A.0",
+        "Date": "Tue, 20 Dec 2022 00:49:42 GMT",
+        "MS-CV": "f9iUDysbpEeGLtkdlEFMyQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0zN2YYwAAAACEJb2GKGiORaGL/GDYPWVHUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pgahYwAAAAC8S2OhwBvNRJHqM3nIO2/3UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "265ms"
+        "X-Processing-Time": "260ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
+          "sbs1.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
+          "sbs2.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -224,7 +224,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com"
+              "sbs1.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com"
             ]
           }
         ]
@@ -236,11 +236,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f11c7bf64ba5eb33fd903956d4b0718c-831f22ea92ca157a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "5616018fc31c3a09b2eb812850f9a4be",
+        "traceparent": "00-615fa6484d32ade1a02153b2b24610df-d39afeaa827d0e4d-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "14301273d5e275a4e85dd101d1f2face",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:15 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:43 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -248,20 +248,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:16 GMT",
-        "MS-CV": "BXQOXIKLBUSPVdxOCoX\u002Blg.0",
+        "Date": "Tue, 20 Dec 2022 00:49:42 GMT",
+        "MS-CV": "arR2AJkU9EKceCYrPMUoZA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0zN2YYwAAAACttPlwY1p2Qbb2SmfudKn\u002BUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pwahYwAAAADX5iK9yo4ZQ5feqicj\u002B8b9UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "94ms"
+        "X-Processing-Time": "85ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
+          "sbs1.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
+          "sbs2.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -271,101 +271,7 @@
             "name": "First rule",
             "numberPattern": "\\\u002B123[0-9]\u002B",
             "trunks": [
-              "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-98c812e8c845b07a759685e52f0326a3-cffa4f3155659f3b-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "376b58c9eebae9c50c06b49f88e9fce4",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:15 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:16 GMT",
-        "MS-CV": "071NGSUaikeF3fcab5ZPBA.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0zN2YYwAAAACICgQPoACoQ5fsG2aGfUL8UFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "92ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
-            "sipSignalingPort": 9999
-          },
-          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://jb-sdk-e2e-test.communication.azure.com/sip?api-version=2021-05-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "traceparent": "00-8ae1a1a47cffe30cc24f5471543f1adb-b91f5adc6799fb62-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "76232090fe02fce6c33019a41b5084af",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:16 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:17 GMT",
-        "MS-CV": "UD1LEqr8z0CN\u002BbOKa8FkSg.0",
-        "Strict-Transport-Security": "max-age=2592000",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0zd2YYwAAAABwixhw7mhsT58SzQXzWuctUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "80ms"
-      },
-      "ResponseBody": {
-        "trunks": {
-          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
-            "sipSignalingPort": 9999
-          },
-          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
-            "sipSignalingPort": 1123
-          }
-        },
-        "routes": [
-          {
-            "description": "Handle numbers starting with \u0027\u002B123\u0027",
-            "name": "First rule",
-            "numberPattern": "\\\u002B123[0-9]\u002B",
-            "trunks": [
-              "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com"
+              "sbs1.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com"
             ]
           }
         ]
@@ -379,11 +285,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "13",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-63bc23d7631c8cf32dd6d6c315bf7509-e8543968c3e7a55a-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "501db40e1b71a0f83b2d4a160f6ab2c9",
+        "traceparent": "00-c0baf51565dd8a973fc5d4aacb046d69-70c4fb9728f9044d-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "199a1c0944f30745882346b16a1b1aa5",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:16 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:43 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -393,20 +299,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:17 GMT",
-        "MS-CV": "wAVmR8qwwEWXto4o48\u002BuVQ.0",
+        "Date": "Tue, 20 Dec 2022 00:49:43 GMT",
+        "MS-CV": "w55FBMaGBEyAUiaL\u002BwdF0A.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0zd2YYwAAAACdaKHFfeWwTZleU78OhDIsUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pwahYwAAAAC\u002BOMl3kDUnQLoIlyN6CFN7UFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "236ms"
+        "X-Processing-Time": "166ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
+          "sbs1.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
+          "sbs2.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -419,11 +325,11 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-67aa75f25f56f74f1ec3c317e7e00585-c78b6a3ed50cb6ff-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2f979dee2dd6cabc726e748ad420cdbb",
+        "traceparent": "00-1a0c3b1ae13347ecdf7086d5b02758fa-6028764b79d18b09-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d24648db4617e5be51bd0079825f118e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:16 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:43 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -431,20 +337,20 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:17 GMT",
-        "MS-CV": "mKvBTAxoVEyGobHuPcv\u002B6g.0",
+        "Date": "Tue, 20 Dec 2022 00:49:43 GMT",
+        "MS-CV": "GdTZAiLjJkm/aI7IsY\u002BueA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0zd2YYwAAAABC8Yr1mVfWS5WZovnEYv4kUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pwahYwAAAABoLr6W1FhERr/S5yPFVeUaUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "78ms"
+        "X-Processing-Time": "84ms"
       },
       "ResponseBody": {
         "trunks": {
-          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
+          "sbs1.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com": {
             "sipSignalingPort": 9999
           },
-          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": {
+          "sbs2.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com": {
             "sipSignalingPort": 1123
           }
         },
@@ -459,30 +365,30 @@
         "Authorization": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-67aa75f25f56f74f1ec3c317e7e00585-8a34695b45401fe2-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221213.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d4900581accc747328823ad5b3d0ed58",
+        "traceparent": "00-1a0c3b1ae13347ecdf7086d5b02758fa-013523e239d80600-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221220.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8eb8d543821e2e84cc298bbf8ff30bcd",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 13 Dec 2022 20:17:16 GMT",
+        "x-ms-date": "Tue, 20 Dec 2022 00:49:43 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "trunks": {
-          "sbs1.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": null,
-          "sbs2.584d8bea-2c0c-09c8-7466-07d7b22147d4.com": null
+          "sbs1.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com": null,
+          "sbs2.47bdeaf2-9aaf-dddb-16df-c57cf50dc703.com": null
         }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "api-supported-versions": "2021-05-01-preview, 2022-09-01-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 13 Dec 2022 20:17:18 GMT",
-        "MS-CV": "8BEqmRHchESjkEcjD80z1w.0",
+        "Date": "Tue, 20 Dec 2022 00:49:44 GMT",
+        "MS-CV": "Ww5zZ5lCJUK1LDQ0OyQkdQ.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0zd2YYwAAAADh6byDK4hlSZq5h3n1xMCnUFJHMDFFREdFMDkxOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0pwahYwAAAABUlaB5XPtFQ7\u002B51M0GBgihUFJHMDFFREdFMDkyMQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "251ms"
+        "X-Processing-Time": "556ms"
       },
       "ResponseBody": {
         "trunks": {},
@@ -492,6 +398,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://jb-sdk-e2e-test.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1950990008"
+    "RandomSeed": "449379044"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/Infrastructure/TestData.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/Infrastructure/TestData.cs
@@ -20,6 +20,7 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
         public readonly SipTrunkRoute RuleNavigateToTrunk1;
         public readonly SipTrunkRoute RuleNavigateToAllTrunks;
         public readonly SipTrunkRoute RuleNavigateToNewTrunk;
+        public readonly SipTrunkRoute RuleWithoutTrunks;
 
         public TestData(Guid random)
         {
@@ -47,6 +48,11 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
                 description: "Handle all numbers'",
                 numberPattern: @"\+[1-9][0-9]{3,23}",
                 trunks: new List<string> { NewTrunk.Fqdn });
+            RuleWithoutTrunks = new SipTrunkRoute(
+                name: "Rule without trunks",
+                description: "Handle all numbers'",
+                numberPattern: @"\+[1-9][0-9]{3,23}",
+                trunks: new List<string> ());
         }
     }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/SipRoutingClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/SipRoutingClientLiveTests.cs
@@ -33,18 +33,8 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
         public async Task ClearConfiguration()
         {
             var client = CreateClient();
-            var routes = await client.GetRoutesAsync();
-            var trunks = await client.GetTrunksAsync();
-            if (routes.Value.Count > 0)
-            {
-                var response = await client.SetRoutesAsync(new List<SipTrunkRoute>());
-                Assert.AreEqual(200, response.Status);
-            }
-            if (trunks.Value.Count > 0)
-            {
-                var response = await client.SetTrunksAsync(new List<SipTrunk>());
-                Assert.AreEqual(200, response.Status);
-            }
+            Assert.AreEqual(200, (await client.SetRoutesAsync(new List<SipTrunkRoute>())).Status);
+            Assert.AreEqual(200, (await client.SetTrunksAsync(new List<SipTrunk>())).Status);
         }
 
         [Test]
@@ -166,6 +156,62 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             Assert.IsNotNull(newTrunks);
             Assert.AreEqual(1, newTrunks.Count);
             Assert.IsTrue(TrunkAreEqual(TestData!.NewTrunk, newTrunks[0]));
+        }
+
+        [Test]
+        public async Task ClearSipTrunksForResource()
+        {
+            var client = CreateClient();
+            client.SetTrunksAsync(TestData!.TrunkList).Wait();
+
+            await client.SetTrunksAsync(new List<SipTrunk>()).ConfigureAwait(false);
+
+            var response = await client.GetTrunksAsync().ConfigureAwait(false);
+            var newTrunks = response.Value;
+            Assert.IsNotNull(newTrunks);
+            Assert.IsEmpty(newTrunks);
+        }
+
+        [Test]
+        public async Task ClearSipTrunksForResourceWhenAlreadyEmpty()
+        {
+            var client = CreateClient();
+            await ClearConfiguration();
+
+            await client.SetTrunksAsync(new List<SipTrunk>()).ConfigureAwait(false);
+
+            var response = await client.GetTrunksAsync().ConfigureAwait(false);
+            var newTrunks = response.Value;
+            Assert.IsNotNull(newTrunks);
+            Assert.IsEmpty(newTrunks);
+        }
+
+        [Test]
+        public async Task ClearSipRoutesForResource()
+        {
+            var client = CreateClient();
+            client.SetRoutesAsync(new List<SipTrunkRoute> { TestData!.RuleWithoutTrunks }).Wait();
+
+            await client.SetRoutesAsync(new List<SipTrunkRoute>()).ConfigureAwait(false);
+
+            var response = await client.GetRoutesAsync().ConfigureAwait(false);
+            var newRoutes = response.Value;
+            Assert.IsNotNull(newRoutes);
+            Assert.IsEmpty(newRoutes);
+        }
+
+        [Test]
+        public async Task ClearSipRoutesForResourceWhenAlreadyEmpty()
+        {
+            var client = CreateClient();
+            await ClearConfiguration();
+
+            await client.SetRoutesAsync(new List<SipTrunkRoute>()).ConfigureAwait(false);
+
+            var response = await client.GetRoutesAsync().ConfigureAwait(false);
+            var newRoutes = response.Value;
+            Assert.IsNotNull(newRoutes);
+            Assert.IsEmpty(newRoutes);
         }
     }
 }


### PR DESCRIPTION
SIP client in Communication/PhoneNumbers SDK was failing on 422 when clearing already empty SIP trunks.

