### PR TITLE
[WebPubSub]Move StringEnumConverter to explicit type converter

### DIFF
--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Bindings/WebPubSubDataTypeJsonConverter.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Bindings/WebPubSubDataTypeJsonConverter.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Azure.WebPubSub.Common;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
+{
+    internal class WebPubSubDataTypeJsonConverter : JsonConverter<WebPubSubDataType>
+    {
+        private static readonly JsonSerializer JsonSerializer = JsonSerializer.Create(new JsonSerializerSettings
+        {
+            Converters = new[]
+            {
+                new StringEnumConverter()
+            }
+        });
+
+        public override WebPubSubDataType ReadJson(JsonReader reader, Type objectType, WebPubSubDataType existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            return JsonSerializer.Deserialize<WebPubSubDataType>(reader);
+        }
+
+        public override void WriteJson(JsonWriter writer, WebPubSubDataType value, JsonSerializer serializer)
+        {
+            JsonSerializer.Serialize(writer, value);
+        }
+    }
+}

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Bindings/WebPubSubEventTypeJsonConverter.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Bindings/WebPubSubEventTypeJsonConverter.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Azure.WebPubSub.Common;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
+{
+    internal class WebPubSubEventTypeJsonConverter : JsonConverter<WebPubSubEventType>
+    {
+        private static readonly JsonSerializer JsonSerializer = JsonSerializer.Create(new JsonSerializerSettings
+        {
+            Converters = new[]
+            {
+                new StringEnumConverter()
+            }
+        });
+
+        public override WebPubSubEventType ReadJson(JsonReader reader, Type objectType, WebPubSubEventType existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            return JsonSerializer.Deserialize<WebPubSubEventType>(reader);
+        }
+
+        public override void WriteJson(JsonWriter writer, WebPubSubEventType value, JsonSerializer serializer)
+        {
+            JsonSerializer.Serialize(writer, value);
+        }
+    }
+}

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubConfigProvider.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubConfigProvider.cs
@@ -158,11 +158,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
             {
                 Converters = new List<JsonConverter>
                 {
-                    new StringEnumConverter(),
                     new BinaryDataJsonConverter(),
                     new ConnectionStatesNewtonsoftConverter(),
+                    new WebPubSubDataTypeJsonConverter(),
+                    new WebPubSubEventTypeJsonConverter(),
                 },
-                ContractResolver = new CamelCasePropertyNamesContractResolver()
             };
         }
 

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubConfigProvider.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubConfigProvider.cs
@@ -15,9 +15,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
 {

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/JObjectTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/JObjectTests.cs
@@ -183,10 +183,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
             Assert.AreEqual("aaa", message.UserId);
         }
 
-        [TestCase]
-        public async Task ParseMessageResponse()
+        [TestCase(@"""binary""", Constants.ContentTypes.BinaryContentType)]
+        [TestCase("0", Constants.ContentTypes.BinaryContentType)]
+        [TestCase(@"""Json""", Constants.ContentTypes.JsonContentType)]
+        [TestCase("1", Constants.ContentTypes.JsonContentType)]
+        [TestCase(@"""text""", Constants.ContentTypes.PlainTextContentType)]
+        [TestCase("2", Constants.ContentTypes.PlainTextContentType)]
+        public async Task ParseMessageResponse(string dataType, string expectContentType)
         {
-            var test = @"{""data"":""test"", ""dataType"":""text""}";
+            var test = @"{""data"":""test"", ""dataType"":{0}}";
+            test = test.Replace("{0}", dataType);
 
             var result = BuildResponse(test, RequestType.User);
 
@@ -195,7 +201,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
 
             var message = await result.Content.ReadAsStringAsync();
             Assert.AreEqual("test", message);
-            Assert.AreEqual(Constants.ContentTypes.PlainTextContentType, result.Content.Headers.ContentType.MediaType);
+            Assert.AreEqual(expectContentType, result.Content.Headers.ContentType.MediaType);
         }
 
         [TestCase]


### PR DESCRIPTION
Remove generic converter `StringEnumConverter` and `CamelCasePropertyNamesContractResolver` in global settings to avoid breaking others. Change to explicit type converter for the enum types that read by customer.

Fix issue: https://github.com/Azure/azure-functions-durable-extension/issues/2338
