### PR TITLE
DOCS: Fix `TableClient.GetEntityIfExistsAsync` thrown exception description

### DIFF
--- a/sdk/tables/Azure.Data.Tables/src/TableClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableClient.cs
@@ -721,7 +721,7 @@ namespace Azure.Data.Tables
         /// <param name="select">Selects which set of entity properties to return in the result set. Pass <c>null</c> to retreive all properties.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns> The <see cref="NullableResponse{T}"/> whose <c>HasValue</c> property will return <c>true</c> if the entity existed, otherwise <c>false</c>.</returns>
-        /// <exception cref="RequestFailedException">Exception thrown if the entity doesn't exist.</exception>
+        /// <exception cref="RequestFailedException">Exception thrown if an unexpected error occurs.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="partitionKey"/> or <paramref name="rowKey"/> is null.</exception>
 #pragma warning disable AZC0015 // Unexpected client method return type.
         public virtual async Task<NullableResponse<T>> GetEntityIfExistsAsync<T>(string partitionKey, string rowKey, IEnumerable<string> select = null, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Closes #33144.
`TableClient.GetEntityIfExistsAsync` documentation states that it throws an exception if the requested entity does not exist. This statement is misleading. The non-async version of this method, `TableClient.GetEntityIfExists`, correctly notifies the user that the exception is thrown if an unexpected error occurs.

This PR corrects this statement in the documentation.

Pinging @christothes 