### PR TITLE
Refactor the build method of ServiceManager to remove internal dependency

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -130,9 +130,9 @@
     <PackageReference Update="CloudNative.CloudEvents.SystemTextJson" Version="2.0.0" />
     <PackageReference Update="MessagePack" Version="1.9.11" />
     <PackageReference Update="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="1.1.5" />
-    <PackageReference Update="Microsoft.Azure.SignalR" Version="1.18.0" />
-    <PackageReference Update="Microsoft.Azure.SignalR.Management" Version="1.18.0" />
-    <PackageReference Update="Microsoft.Azure.SignalR.Protocols" Version="1.18.0" />
+    <PackageReference Update="Microsoft.Azure.SignalR" Version="1.19.2" />
+    <PackageReference Update="Microsoft.Azure.SignalR.Management" Version="1.19.2" />
+    <PackageReference Update="Microsoft.Azure.SignalR.Protocols" Version="1.19.2" />
     <PackageReference Update="Microsoft.Azure.SignalR.Serverless.Protocols" Version="1.9.0" />
     <PackageReference Update="Microsoft.Azure.WebJobs" Version="3.0.33" />
     <PackageReference Update="Microsoft.Azure.WebJobs.Sources" Version="3.0.30" />

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRInputBindings/SignalREndpointsInputBinding/SignalREndpointsAsyncConverter.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRInputBindings/SignalREndpointsInputBinding/SignalREndpointsAsyncConverter.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         {
             var hubContext = await _serviceManagerStore
                 .GetOrAddByConnectionStringKey(input.ConnectionStringSetting)
-                .GetAsync(input.HubName).ConfigureAwait(false) as IInternalServiceHubContext;
+                .GetAsync(input.HubName).ConfigureAwait(false) as ServiceHubContext;
             return hubContext.GetServiceEndpoints().ToArray();
         }
     }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRInputBindings/SignalRMultiConnectionInfoBinding/NegotiationContextAsyncConverter.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Bindings/SignalRInputBindings/SignalRMultiConnectionInfoBinding/NegotiationContextAsyncConverter.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         {
             var serviceHubContext = await _serviceManagerStore
                 .GetOrAddByConnectionStringKey(input.ConnectionStringSetting)
-                .GetAsync(input.HubName).ConfigureAwait(false) as IInternalServiceHubContext;
+                .GetAsync(input.HubName).ConfigureAwait(false) as ServiceHubContext;
             var endpoints = serviceHubContext.GetServiceEndpoints();
             var endpointConnectionInfo = await Task.WhenAll(endpoints.Select(async e =>
             {

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Client/AzureSignalRClient.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Client/AzureSignalRClient.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 
         private async Task InvokeAsync(ServiceEndpoint[] endpoints, Func<ServiceHubContext, Task> func)
         {
-            var targetHubContext = endpoints == null ? _serviceHubContext : (_serviceHubContext as IInternalServiceHubContext).WithEndpoints(endpoints);
+            var targetHubContext = endpoints == null ? _serviceHubContext : _serviceHubContext.WithEndpoints(endpoints);
             await func.Invoke(targetHubContext).ConfigureAwait(false);
         }
     }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/OptionsSetup.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/OptionsSetup.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using Microsoft.Azure.SignalR;
 using Microsoft.Azure.SignalR.Management;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
@@ -62,17 +61,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
                 }
                 //make connection more stable
                 options.ConnectionCount = 3;
-                options.ProductInfo = GetProductInfo();
             };
         }
 
         public Action<ServiceManagerOptions> Configure => _configureServiceManagerOptions;
-
-        private string GetProductInfo()
-        {
-            var workerRuntime = _configuration[Constants.FunctionsWorkerRuntime];
-            var sdkProductInfo = ProductInfo.GetProductInfo();
-            return $"{sdkProductInfo} [{Constants.FunctionsWorkerProductInfoKey}={workerRuntime}]";
-        }
     }
 }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/ServiceManagerStore.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/ServiceManagerStore.cs
@@ -50,16 +50,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         private IInternalServiceHubContextStore CreateHubContextStore(string connectionStringKey)
         {
             var serviceManagerOptionsSetup = new OptionsSetup(_configuration, _azureComponentFactory, connectionStringKey, _options);
-            var serviceManger = new ServiceManagerBuilder()
+            var serviceManagerBuilder = new ServiceManagerBuilder()
                 // Does the actual configuration
                 .WithOptions(serviceManagerOptionsSetup.Configure)
                 .WithLoggerFactory(_loggerFactory)
-                .WithRouter(_router ?? new EndpointRouterDecorator())
                 // Serves as a reload token provider only
                 .WithConfiguration(new EmptyConfiguration(_configuration))
-                .BuildServiceManager();
+                .WithCallingAssembly();
+            AddWorkingInfo(serviceManagerBuilder, _configuration);
+            if (_router != null)
+            {
+                serviceManagerBuilder.WithRouter(_router);
+            }
+            var serviceManager = serviceManagerBuilder.BuildServiceManager();
             return new ServiceCollection()
-                .AddSingleton(serviceManger)
+                .AddSingleton(serviceManager)
                 .AddOptions()
                 .AddSingleton<IConfigureOptions<SignatureValidationOptions>>(new SignatureValidationOptionsSetup(serviceManagerOptionsSetup.Configure))
                 .AddSingleton<IOptionsChangeTokenSource<SignatureValidationOptions>>(new ConfigurationChangeTokenSource<SignatureValidationOptions>(_configuration))
@@ -81,6 +86,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 #pragma warning disable AZC0102 // Do not use GetAwaiter().GetResult().
             DisposeAsync().GetAwaiter().GetResult();
 #pragma warning restore AZC0102 // Do not use GetAwaiter().GetResult().
+        }
+
+        private static void AddWorkingInfo(ServiceManagerBuilder builder, IConfiguration configuration)
+        {
+            var workerRuntime = configuration[Constants.FunctionsWorkerRuntime];
+            if (workerRuntime != null)
+            {
+                builder.AddUserAgent($" [{Constants.FunctionsWorkerProductInfoKey}={workerRuntime}]");
+            }
         }
     }
 }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/AzureSignalRClientTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/AzureSignalRClientTests.cs
@@ -53,7 +53,7 @@ namespace SignalRServiceExtension.Tests
         [Fact]
         public async Task ServiceEndpointsNotSet()
         {
-            var rootHubContextMock = new Mock<ServiceHubContext>().As<IInternalServiceHubContext>();
+            var rootHubContextMock = new Mock<ServiceHubContext>();
             var childHubContextMock = new Mock<ServiceHubContext>();
             rootHubContextMock.Setup(c => c.WithEndpoints(It.IsAny<ServiceEndpoint[]>())).Returns(childHubContextMock.Object);
             rootHubContextMock.Setup(c => c.Clients.All.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
@@ -73,7 +73,7 @@ namespace SignalRServiceExtension.Tests
         [Fact]
         public async Task ServiceEndpointsSet()
         {
-            var rootHubContextMock = new Mock<ServiceHubContext>().As<IInternalServiceHubContext>();
+            var rootHubContextMock = new Mock<ServiceHubContext>();
             var childHubContextMock = new Mock<ServiceHubContext>();
             rootHubContextMock.Setup(c => c.WithEndpoints(It.IsAny<ServiceEndpoint[]>())).Returns(childHubContextMock.Object);
             childHubContextMock.Setup(c => c.Clients.All.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

In ServiceManagerStore.cs, refactor the build method of ServiceManager to remove internal dependency. The original implementation builds the ServiceManager from a ServiceCollection directly, and inject IConfigureOptions<ServiceManagerOptions> and IOptionsChangeTokenSource<ServiceManagerOptions> to support hot reload. Without internal depdencies, we have to use the ServiceManagerBuilder to support hot-reload. The only way of ServiceManagerBuilder to support hot-reload is to inject a IConfiguration object which provides a change token. However, the SDK and function extensions have different ways to parse configuration, for example, SDK lacks the functionality to parse identity-based connection from configuration. Therefore, we have to pass the actual configuration action via ServiceManagerBuilder.WithOptions, and injects an IConfiguration object to provide change token. To avoid errors thrown by SDK when it parses the configuration, we wraps the real IConfiguration object to make it looks like empty configuration but provides the true change token.

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
