### PR TITLE
Revert win2022 pool back to win2019 

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -15,14 +15,14 @@
         "Pool": "azsdk-pool-mms-ubuntu-2004-general",
         "TestTargetFramework": "net6.0"
       },
-      "windows2022_NET6.0": {
-        "OSVmImage": "MMS2022",
-        "Pool": "azsdk-pool-mms-win-2022-general",
+      "windows2019_NET6.0": {
+        "OSVmImage": "MMS2019",
+        "Pool": "azsdk-pool-mms-win-2019-general",
         "TestTargetFramework": "net6.0"
       },
-      "windows2022_NET461": {
-        "OSVmImage": "MMS2022",
-        "Pool": "azsdk-pool-mms-win-2022-general",
+      "windows2019_NET461": {
+        "OSVmImage": "MMS2019",
+        "Pool": "azsdk-pool-mms-win-2019-general",
         "TestTargetFramework": "net461"
       },
       "macos-11_NETCore3.1": {
@@ -48,9 +48,9 @@
   "include": [
     {
       "Agent": {
-        "windows2022": {
-          "OSVmImage": "MMS2022",
-          "Pool": "azsdk-pool-mms-win-2022-general",
+        "windows2019": {
+          "OSVmImage": "MMS2019",
+          "Pool": "azsdk-pool-mms-win-2019-general",
           "TestTargetFramework": "net6.0"
         }
       },


### PR DESCRIPTION
# Contributing to the Azure SDK
Fixed the failure of pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2080863&view=results

Testing pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2081441&view=results

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
