### PR TITLE
Fix $base name too long

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1.md
+++ b/eng/common/TestResources/New-TestResources.ps1.md
@@ -33,7 +33,7 @@ New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-Servi
 ```
 
 ## DESCRIPTION
-Deploys live test resouces specified in test-resources.json or test-resources.bicep
+Deploys live test resources specified in test-resources.json or test-resources.bicep
 files to a new resource group.
 
 This script searches the directory specified in $ServiceDirectory recursively
@@ -560,7 +560,7 @@ Accept wildcard characters: False
 ### -SuppressVsoCommands
 By default, the -CI parameter will print out secrets to logs with Azure Pipelines log
 commands that cause them to be redacted.
-For CI environments that don't support this (like 
+For CI environments that don't support this (like
 stress test clusters), this flag can be set to $false to avoid printing out these secrets to the logs.
 
 ```yaml

--- a/eng/common/TestResources/SubConfig-Helpers.ps1
+++ b/eng/common/TestResources/SubConfig-Helpers.ps1
@@ -20,7 +20,6 @@ function GetBaseName([string]$user, [string]$serviceDirectoryName) {
     # Handle service directories in nested directories, e.g. `data/aztables`
     $serviceDirectorySafeName = $serviceDirectoryName -replace '[\./\\]', ''
     $BaseName =  "$user$serviceDirectorySafeName".ToLowerInvariant()
-    $BaseName = "loadtestingSDK"
     # Key-Vault accounts have a limit of 24 characters
     if ($BaseName.Length -gt 24) {
         Log "Truncating BaseName to 24 characters."

--- a/eng/common/TestResources/SubConfig-Helpers.ps1
+++ b/eng/common/TestResources/SubConfig-Helpers.ps1
@@ -19,7 +19,15 @@ function GetUserName() {
 function GetBaseName([string]$user, [string]$serviceDirectoryName) {
     # Handle service directories in nested directories, e.g. `data/aztables`
     $serviceDirectorySafeName = $serviceDirectoryName -replace '[\./\\]', ''
-    return "$user$serviceDirectorySafeName".ToLowerInvariant()
+    $BaseName =  "$user$serviceDirectorySafeName".ToLowerInvariant()
+    $BaseName = "loadtestingSDK"
+    # Key-Vault accounts have a limit of 24 characters
+    if ($BaseName.Length -gt 24) {
+        Log "Truncating BaseName to 24 characters."
+        $BaseName = $BaseName.Substring(0, 24)
+    }
+
+    return $BaseName
 }
 
 function ShouldMarkValueAsSecret([string]$serviceName, [string]$key, [string]$value, [array]$allowedValues = @())


### PR DESCRIPTION
Fixed the issue: https://github.com/Azure/azure-sdk-for-net/issues/33261 by truncating the $BaseName up to 24 characters if it is more than 24 characters. This fixes the problems mentioned in issue #33261