### PR TITLE
[WebPubSub] Make ackable operation cancellable in WebPubSubClient

### DIFF
--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/WebPubSubClient.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/WebPubSubClient.cs
@@ -585,7 +585,15 @@ namespace Azure.Messaging.WebPubSub.Clients
                 }
                 throw new SendMessageFailedException("Failed to send message.", id, ex);
             }
-            return await entity.Task.ConfigureAwait(false);
+
+            try
+            {
+                return await entity.Task.AwaitWithCancellation<WebPubSubResult>(token);
+            }
+            catch (OperationCanceledException ex)
+            {
+                throw new SendMessageFailedException("Cancelled by CancellationToken", id, ex);
+            }
         }
 
         private Task HandleConnectionCloseAndNoRecovery(DisconnectedMessage disconnectedMessage, CancellationToken token)


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
