### PR TITLE
Fix for AES GCM live mac tests

### DIFF
--- a/sdk/storage/tests.yml
+++ b/sdk/storage/tests.yml
@@ -24,11 +24,11 @@ extends:
           Selection: sparse
           GenerateVMJobs: true
     EnvVars:
-      DYLD_LIBRARY_PATH: /opt/homebrew/opt/openssl@3/lib
+      DYLD_LIBRARY_PATH: /usr/local/opt/openssl@1.1/lib
       ${{ if not(contains(variables['Build.DefinitionName'], 'tests-weekly')) }}:
         AZURE_ONLY_TEST_LATEST_SERVICE_VERSION: true
     TestSetupSteps:
     - template: /sdk/storage/tests-install-azurite.yml
-    - bash: brew install openssl@3
+    - bash: brew install openssl@1.1
       displayName: (MacOS) Install OpenSSL
       condition: contains(variables['OSVmImage'], 'mac')

--- a/sdk/storage/tests.yml
+++ b/sdk/storage/tests.yml
@@ -24,7 +24,7 @@ extends:
           Selection: sparse
           GenerateVMJobs: true
     EnvVars:
-      DYLD_LIBRARY_PATH: /usr/local/opt/openssl@3/lib
+      DYLD_LIBRARY_PATH: /opt/homebrew/opt/openssl@3/lib
       ${{ if not(contains(variables['Build.DefinitionName'], 'tests-weekly')) }}:
         AZURE_ONLY_TEST_LATEST_SERVICE_VERSION: true
     TestSetupSteps:


### PR DESCRIPTION
Change path to DYLD_Library_path for the OpenSSL installation to see if that would resolve the issue.
