### PR TITLE
build(template): remove global suppression of azc0002

### DIFF
--- a/sdk/template/.content/src/GlobalSuppressions.cs
+++ b/sdk/template/.content/src/GlobalSuppressions.cs
@@ -1,7 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// add global suppression here
-// [assembly: SuppressMessage(category, checkId)]

--- a/sdk/template/.content/src/GlobalSuppressions.cs
+++ b/sdk/template/.content/src/GlobalSuppressions.cs
@@ -3,4 +3,5 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Usage", "AZC0002:DO ensure all service methods, both asynchronous and synchronous, take an optional CancellationToken parameter called cancellationToken.", Justification = "CancellationToken can be passed through RequestOptions")]
+// add global suppression here
+// [assembly: SuppressMessage(category, checkId)]


### PR DESCRIPTION
We don't need to suppress it anymore, since the rule AZC0002 has been updated to include `RequestContext` as a valid last parameter. See:
- Latest implemetation of `AZC0002`: https://github.com/Azure/azure-sdk-tools/blob/17876d209b476d853f17b093a8012bea552f8354/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs#L28-L29
- Corresponding commit: https://github.com/Azure/azure-sdk-tools/commit/17876d209b476d853f17b093a8012bea552f8354#diff-9877e11c2950c55f3d6c2af6cd8ef36fff8c17c44173a54c356b06247c016985R29

resolve https://github.com/Azure/azure-sdk-tools/issues/4715

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
