### PR TITLE
[Service Bus] Peek doc updates

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessorReceiveActions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessorReceiveActions.cs
@@ -72,7 +72,7 @@ namespace Azure.Messaging.ServiceBus
             return TrackMessagesAsReceived(messages);
         }
 
-       /// <summary>
+        /// <summary>
         /// Receives a list of deferred <see cref="ServiceBusReceivedMessage"/> identified by <paramref name="sequenceNumbers"/>.
         /// Messages received using this method are subject to the behavior defined in the <see cref="ServiceBusProcessorOptions.AutoCompleteMessages"/>
         /// and <see cref="ServiceBusProcessorOptions.MaxAutoLockRenewalDuration"/> properties.
@@ -88,7 +88,7 @@ namespace Azure.Messaging.ServiceBus
         ///   The specified sequence number does not correspond to a message that has been deferred.
         ///   The <see cref="ServiceBusException.Reason" /> will be set to <see cref="ServiceBusFailureReason.MessageNotFound"/> in this case.
         /// </exception>
-       public virtual async Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveDeferredMessagesAsync(
+        public virtual async Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveDeferredMessagesAsync(
             IEnumerable<long> sequenceNumbers,
             CancellationToken cancellationToken = default)
         {
@@ -97,22 +97,22 @@ namespace Azure.Messaging.ServiceBus
             return TrackMessagesAsReceived(messages);
         }
 
-       /// <inheritdoc cref="ServiceBusReceiver.PeekMessagesAsync"/>
-       public virtual async Task<IReadOnlyList<ServiceBusReceivedMessage>> PeekMessagesAsync(
-           int maxMessages,
-           long? fromSequenceNumber = default,
-           CancellationToken cancellationToken = default)
+        /// <inheritdoc cref="ServiceBusReceiver.PeekMessagesAsync"/>
+        public virtual async Task<IReadOnlyList<ServiceBusReceivedMessage>> PeekMessagesAsync(
+            int maxMessages,
+            long? fromSequenceNumber = default,
+            CancellationToken cancellationToken = default)
        {
-           ValidateCallbackInScope();
+            ValidateCallbackInScope();
 
-           // Peeked messages are not locked so we don't need to track them for lock renewal or autocompletion, as these options do not apply.
-           return await _receiver.PeekMessagesAsync(
-               maxMessages: maxMessages,
-               fromSequenceNumber: fromSequenceNumber,
-               cancellationToken: cancellationToken).ConfigureAwait(false);
+            // Peeked messages are not locked so we don't need to track them for lock renewal or autocompletion, as these options do not apply.
+            return await _receiver.PeekMessagesAsync(
+                maxMessages: maxMessages,
+                fromSequenceNumber: fromSequenceNumber,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
        }
 
-       private IReadOnlyList<ServiceBusReceivedMessage> TrackMessagesAsReceived(IReadOnlyList<ServiceBusReceivedMessage> messages)
+        private IReadOnlyList<ServiceBusReceivedMessage> TrackMessagesAsReceived(IReadOnlyList<ServiceBusReceivedMessage> messages)
         {
             if (_autoRenew)
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -419,6 +419,7 @@ namespace Azure.Messaging.ServiceBus
         /// </remarks>
         ///
         /// <returns>The <see cref="ServiceBusReceivedMessage" /> that represents the next message to be read. Returns null when nothing to peek.</returns>
+        /// <seealso href="https://aka.ms/azsdk/servicebus/message-browsing">Service Bus message browsing</seealso>
         public virtual async Task<ServiceBusReceivedMessage> PeekMessageAsync(
             long? fromSequenceNumber = default,
             CancellationToken cancellationToken = default)
@@ -451,6 +452,7 @@ namespace Azure.Messaging.ServiceBus
         /// </remarks>
         ///
         /// <returns>An <see cref="IReadOnlyList{ServiceBusReceivedMessage}" /> of messages that were peeked.</returns>
+        /// <seealso href="https://aka.ms/azsdk/servicebus/message-browsing">Service Bus message browsing</seealso>
         public virtual async Task<IReadOnlyList<ServiceBusReceivedMessage>> PeekMessagesAsync(
             int maxMessages,
             long? fromSequenceNumber = default,

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/ServiceBusReceiveActions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/ServiceBusReceiveActions.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         ///   The specified sequence number does not correspond to a message that has been deferred.
         ///   The <see cref="ServiceBusException.Reason" /> will be set to <see cref="ServiceBusFailureReason.MessageNotFound"/> in this case.
         /// </exception>
-       public virtual async Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveDeferredMessagesAsync(
+        public virtual async Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveDeferredMessagesAsync(
             IEnumerable<long> sequenceNumbers,
             CancellationToken cancellationToken = default)
         {


### PR DESCRIPTION
# Overview

The focus of these changes is to add a "see also" link to the peek-related methods helping developers to find the official documentation with context around browsing messages.  Also riding along are some minor formatting fixes.

# References and Related

- [Service Bus: Link to product documentation for peeking messages (#33318)](https://github.com/Azure/azure-sdk-for-net/issues/33318)