### PR TITLE
[Search] Update readme and samples to use the same format of search resource data as official docs

### DIFF
--- a/sdk/search/Azure.Search.Documents/README.md
+++ b/sdk/search/Azure.Search.Documents/README.md
@@ -346,8 +346,8 @@ SearchIndex index = new SearchIndex("hotels")
     Fields = new FieldBuilder().Build(typeof(Hotel)),
     Suggesters =
     {
-        // Suggest query terms from the hotelName field.
-        new SearchSuggester("sg", "hotelName")
+        // Suggest query terms from the HotelName field.
+        new SearchSuggester("sg", "HotelName")
     }
 };
 
@@ -364,26 +364,26 @@ SearchIndex index = new SearchIndex("hotels")
 {
     Fields =
     {
-        new SimpleField("hotelId", SearchFieldDataType.String) { IsKey = true, IsFilterable = true, IsSortable = true },
-        new SearchableField("hotelName") { IsFilterable = true, IsSortable = true },
-        new SearchableField("description") { AnalyzerName = LexicalAnalyzerName.EnLucene },
-        new SearchableField("tags", collection: true) { IsFilterable = true, IsFacetable = true },
-        new ComplexField("address")
+        new SimpleField("HotelId", SearchFieldDataType.String) { IsKey = true, IsFilterable = true, IsSortable = true },
+        new SearchableField("HotelName") { IsFilterable = true, IsSortable = true },
+        new SearchableField("Description") { AnalyzerName = LexicalAnalyzerName.EnLucene },
+        new SearchableField("Tags", collection: true) { IsFilterable = true, IsFacetable = true },
+        new ComplexField("Address")
         {
             Fields =
             {
-                new SearchableField("streetAddress"),
-                new SearchableField("city") { IsFilterable = true, IsSortable = true, IsFacetable = true },
-                new SearchableField("stateProvince") { IsFilterable = true, IsSortable = true, IsFacetable = true },
-                new SearchableField("country") { IsFilterable = true, IsSortable = true, IsFacetable = true },
-                new SearchableField("postalCode") { IsFilterable = true, IsSortable = true, IsFacetable = true }
+                new SearchableField("StreetAddress"),
+                new SearchableField("City") { IsFilterable = true, IsSortable = true, IsFacetable = true },
+                new SearchableField("StateProvince") { IsFilterable = true, IsSortable = true, IsFacetable = true },
+                new SearchableField("Country") { IsFilterable = true, IsSortable = true, IsFacetable = true },
+                new SearchableField("PostalCode") { IsFilterable = true, IsSortable = true, IsFacetable = true }
             }
         }
     },
     Suggesters =
     {
         // Suggest query terms from the hotelName field.
-        new SearchSuggester("sg", "hotelName")
+        new SearchSuggester("sg", "HotelName")
     }
 };
 

--- a/sdk/search/Azure.Search.Documents/samples/Sample02_Service.md
+++ b/sdk/search/Azure.Search.Documents/samples/Sample02_Service.md
@@ -88,20 +88,20 @@ SearchIndex index = new SearchIndex(indexName)
 {
     Fields =
     {
-        new SimpleField("hotelId", SearchFieldDataType.String) { IsKey = true, IsFilterable = true, IsSortable = true },
-        new SearchableField("hotelName") { IsFilterable = true, IsSortable = true },
-        new SearchableField("description") { AnalyzerName = LexicalAnalyzerName.EnLucene },
-        new SearchableField("descriptionFr") { AnalyzerName = LexicalAnalyzerName.FrLucene },
-        new SearchableField("tags", collection: true) { IsFilterable = true, IsFacetable = true },
-        new ComplexField("address")
+        new SimpleField("HotelId", SearchFieldDataType.String) { IsKey = true, IsFilterable = true, IsSortable = true },
+        new SearchableField("HotelName") { IsFilterable = true, IsSortable = true },
+        new SearchableField("Description") { AnalyzerName = LexicalAnalyzerName.EnLucene },
+        new SearchableField("DescriptionFr") { AnalyzerName = LexicalAnalyzerName.FrLucene },
+        new SearchableField("Tags", collection: true) { IsFilterable = true, IsFacetable = true },
+        new ComplexField("Address")
         {
             Fields =
             {
-                new SearchableField("streetAddress"),
-                new SearchableField("city") { IsFilterable = true, IsSortable = true, IsFacetable = true },
-                new SearchableField("stateProvince") { IsFilterable = true, IsSortable = true, IsFacetable = true },
-                new SearchableField("country") { SynonymMapNames = new[] { synonymMapName }, IsFilterable = true, IsSortable = true, IsFacetable = true },
-                new SearchableField("postalCode") { IsFilterable = true, IsSortable = true, IsFacetable = true }
+                new SearchableField("StreetAddress"),
+                new SearchableField("City") { IsFilterable = true, IsSortable = true, IsFacetable = true },
+                new SearchableField("StateProvince") { IsFilterable = true, IsSortable = true, IsFacetable = true },
+                new SearchableField("Country") { SynonymMapNames = new[] { synonymMapName }, IsFilterable = true, IsSortable = true, IsFacetable = true },
+                new SearchableField("PostalCode") { IsFilterable = true, IsSortable = true, IsFacetable = true }
             }
         }
     }
@@ -167,7 +167,7 @@ about all available skills.
 TextTranslationSkill translationSkill = new TextTranslationSkill(
     inputs: new[]
     {
-        new InputFieldMappingEntry("text") { Source = "/document/description" }
+        new InputFieldMappingEntry("text") { Source = "/document/Description" }
     },
     outputs: new[]
     {
@@ -185,9 +185,9 @@ TextTranslationSkill translationSkill = new TextTranslationSkill(
 ConditionalSkill conditionalSkill = new ConditionalSkill(
     inputs: new[]
     {
-        new InputFieldMappingEntry("condition") { Source = "= $(/document/descriptionFr) == null" },
+        new InputFieldMappingEntry("condition") { Source = "= $(/document/DescriptionFr) == null" },
         new InputFieldMappingEntry("whenTrue") { Source = "/document/descriptionFrTranslated" },
-        new InputFieldMappingEntry("whenFalse") { Source = "/document/descriptionFr" }
+        new InputFieldMappingEntry("whenFalse") { Source = "/document/DescriptionFr" }
     },
     outputs: new[]
     {
@@ -230,15 +230,15 @@ SearchIndexer indexer = new SearchIndexer(
     // We only want to index fields defined in our index, excluding descriptionFr if defined.
     FieldMappings =
     {
-        new FieldMapping("hotelId"),
-        new FieldMapping("hotelName"),
-        new FieldMapping("description"),
-        new FieldMapping("tags"),
-        new FieldMapping("address")
+        new FieldMapping("HotelId"),
+        new FieldMapping("HotelName"),
+        new FieldMapping("Description"),
+        new FieldMapping("Tags"),
+        new FieldMapping("Address")
     },
     OutputFieldMappings =
     {
-        new FieldMapping("/document/descriptionFrFinal") { TargetFieldName = "descriptionFr" }
+        new FieldMapping("/document/descriptionFrFinal") { TargetFieldName = "DescriptionFr" }
     },
     Parameters = new IndexingParameters
     {

--- a/sdk/search/Azure.Search.Documents/samples/Sample06_EncryptedIndex.md
+++ b/sdk/search/Azure.Search.Documents/samples/Sample06_EncryptedIndex.md
@@ -83,11 +83,11 @@ SearchIndexer indexer = new SearchIndexer(
     // Map the fields in our documents we want to index.
     FieldMappings =
     {
-        new FieldMapping("hotelId"),
-        new FieldMapping("hotelName"),
-        new FieldMapping("description"),
-        new FieldMapping("tags"),
-        new FieldMapping("address")
+        new FieldMapping("HotelId"),
+        new FieldMapping("HotelName"),
+        new FieldMapping("Description"),
+        new FieldMapping("Tags"),
+        new FieldMapping("Address")
     },
     Parameters = new IndexingParameters
     {

--- a/sdk/search/Azure.Search.Documents/src/Indexes/Models/SearchIndex.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/Models/SearchIndex.cs
@@ -82,8 +82,8 @@ namespace Azure.Search.Documents.Indexes.Models
         ///     Fields = new FieldBuilder().Build(typeof(Hotel)),
         ///     Suggesters =
         ///     {
-        ///         // Suggest query terms from the hotelName field.
-        ///         new SearchSuggester(&quot;sg&quot;, &quot;hotelName&quot;)
+        ///         // Suggest query terms from the HotelName field.
+        ///         new SearchSuggester(&quot;sg&quot;, &quot;HotelName&quot;)
         ///     }
         /// };
         /// </code>
@@ -94,26 +94,26 @@ namespace Azure.Search.Documents.Indexes.Models
         /// {
         ///     Fields =
         ///     {
-        ///         new SimpleField(&quot;hotelId&quot;, SearchFieldDataType.String) { IsKey = true, IsFilterable = true, IsSortable = true },
-        ///         new SearchableField(&quot;hotelName&quot;) { IsFilterable = true, IsSortable = true },
-        ///         new SearchableField(&quot;description&quot;) { AnalyzerName = LexicalAnalyzerName.EnLucene },
-        ///         new SearchableField(&quot;tags&quot;, collection: true) { IsFilterable = true, IsFacetable = true },
-        ///         new ComplexField(&quot;address&quot;)
+        ///         new SimpleField(&quot;HotelId&quot;, SearchFieldDataType.String) { IsKey = true, IsFilterable = true, IsSortable = true },
+        ///         new SearchableField(&quot;HotelName&quot;) { IsFilterable = true, IsSortable = true },
+        ///         new SearchableField(&quot;Description&quot;) { AnalyzerName = LexicalAnalyzerName.EnLucene },
+        ///         new SearchableField(&quot;Tags&quot;, collection: true) { IsFilterable = true, IsFacetable = true },
+        ///         new ComplexField(&quot;Address&quot;)
         ///         {
         ///             Fields =
         ///             {
-        ///                 new SearchableField(&quot;streetAddress&quot;),
-        ///                 new SearchableField(&quot;city&quot;) { IsFilterable = true, IsSortable = true, IsFacetable = true },
-        ///                 new SearchableField(&quot;stateProvince&quot;) { IsFilterable = true, IsSortable = true, IsFacetable = true },
-        ///                 new SearchableField(&quot;country&quot;) { IsFilterable = true, IsSortable = true, IsFacetable = true },
-        ///                 new SearchableField(&quot;postalCode&quot;) { IsFilterable = true, IsSortable = true, IsFacetable = true }
+        ///                 new SearchableField(&quot;StreetAddress&quot;),
+        ///                 new SearchableField(&quot;City&quot;) { IsFilterable = true, IsSortable = true, IsFacetable = true },
+        ///                 new SearchableField(&quot;StateProvince&quot;) { IsFilterable = true, IsSortable = true, IsFacetable = true },
+        ///                 new SearchableField(&quot;Country&quot;) { IsFilterable = true, IsSortable = true, IsFacetable = true },
+        ///                 new SearchableField(&quot;PostalCode&quot;) { IsFilterable = true, IsSortable = true, IsFacetable = true }
         ///             }
         ///         }
         ///     },
         ///     Suggesters =
         ///     {
         ///         // Suggest query terms from the hotelName field.
-        ///         new SearchSuggester(&quot;sg&quot;, &quot;hotelName&quot;)
+        ///         new SearchSuggester(&quot;sg&quot;, &quot;HotelName&quot;)
         ///     }
         /// };
         /// </code>

--- a/sdk/search/Azure.Search.Documents/tests/Samples/Readme.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Samples/Readme.cs
@@ -32,7 +32,7 @@ namespace Azure.Search.Documents.Tests.Samples
         [SyncOnly]
         public async Task Authenticate()
         {
-            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this);
+            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this, true);
             Environment.SetEnvironmentVariable("SEARCH_ENDPOINT", resources.Endpoint.ToString());
             Environment.SetEnvironmentVariable("SEARCH_API_KEY", resources.PrimaryApiKey);
 
@@ -55,7 +55,7 @@ namespace Azure.Search.Documents.Tests.Samples
         [SyncOnly]
         public async Task CreateAndQuery()
         {
-            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this);
+            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this, true);
             Environment.SetEnvironmentVariable("SEARCH_ENDPOINT", resources.Endpoint.ToString());
             Environment.SetEnvironmentVariable("SEARCH_API_KEY", resources.PrimaryApiKey);
 
@@ -81,13 +81,8 @@ namespace Azure.Search.Documents.Tests.Samples
             foreach (SearchResult<SearchDocument> result in response.GetResults())
             {
                 SearchDocument doc = result.Document;
-#if SNIPPET
                 string id = (string)doc["HotelId"];
                 string name = (string)doc["HotelName"];
-#else
-                string id = (string)doc["hotelId"];
-                string name = (string)doc["hotelName"];
-#endif
                 Console.WriteLine("{id}: {name}");
             }
             #endregion Snippet:Azure_Search_Tests_Samples_Readme_Dict
@@ -95,8 +90,8 @@ namespace Azure.Search.Documents.Tests.Samples
             foreach (SearchResult<SearchDocument> result in response.GetResults())
             {
                 dynamic doc = result.Document;
-                string id = doc.hotelId;
-                string name = doc.hotelName;
+                string id = doc.HotelId;
+                string name = doc.HotelName;
                 Console.WriteLine("{id}: {name}");
             }
         }
@@ -104,63 +99,34 @@ namespace Azure.Search.Documents.Tests.Samples
         #region Snippet:Azure_Search_Tests_Samples_Readme_StaticType
         public class Hotel
         {
-#if SNIPPET
             [JsonPropertyName("HotelId")]
-#else
-            [JsonPropertyName("hotelId")]
-#endif
             [SimpleField(IsKey = true, IsFilterable = true, IsSortable = true)]
             public string Id { get; set; }
 
-#if SNIPPET
             [JsonPropertyName("HotelName")]
-#else
-            [JsonPropertyName("hotelName")]
-#endif
             [SearchableField(IsFilterable = true, IsSortable = true)]
             public string Name { get; set; }
 
-#if !SNIPPET
-            [JsonPropertyName("geoLocation")]
-#endif
             [SimpleField(IsFilterable = true, IsSortable = true)]
             public GeoPoint GeoLocation { get; set; }
 
-#if !SNIPPET
-            [JsonPropertyName("address")]
-#endif
             // Complex fields are included automatically in an index if not ignored.
             public HotelAddress Address { get; set; }
         }
 
         public class HotelAddress
         {
-#if !SNIPPET
-            [JsonPropertyName("streetAddress")]
-#endif
             public string StreetAddress { get; set; }
 
-#if !SNIPPET
-            [JsonPropertyName("city")]
-#endif
             [SimpleField(IsFilterable = true, IsSortable = true, IsFacetable = true)]
             public string City { get; set; }
 
-#if !SNIPPET
-            [JsonPropertyName("stateProvince")]
-#endif
             [SimpleField(IsFilterable = true, IsSortable = true, IsFacetable = true)]
             public string StateProvince { get; set; }
 
-#if !SNIPPET
-            [JsonPropertyName("country")]
-#endif
             [SimpleField(IsFilterable = true, IsSortable = true, IsFacetable = true)]
             public string Country { get; set; }
 
-#if !SNIPPET
-            [JsonPropertyName("postalCode")]
-#endif
             [SimpleField(IsFilterable = true, IsSortable = true, IsFacetable = true)]
             public string PostalCode { get; set; }
         }
@@ -170,7 +136,7 @@ namespace Azure.Search.Documents.Tests.Samples
         [SyncOnly]
         public async Task QueryStatic()
         {
-            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this);
+            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this, true);
             SearchClient client = resources.GetQueryClient();
 
             #region Snippet:Azure_Search_Tests_Samples_Readme_StaticQuery
@@ -196,7 +162,7 @@ namespace Azure.Search.Documents.Tests.Samples
         [SyncOnly]
         public async Task Options()
         {
-            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this);
+            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this, true);
             SearchClient client = resources.GetQueryClient();
 
             #region Snippet:Azure_Search_Tests_Samples_Readme_Options
@@ -204,17 +170,9 @@ namespace Azure.Search.Documents.Tests.Samples
             SearchOptions options = new SearchOptions
             {
                 // Filter to only Rating greater than or equal our preference
-#if SNIPPET
                 Filter = SearchFilter.Create($"Rating ge {stars}"),
-#else
-                Filter = SearchFilter.Create($"rating ge {stars}"),
-#endif
                 Size = 5, // Take only 5 results
-#if SNIPPET
                 OrderBy = { "Rating desc" } // Sort by Rating from high to low
-#else
-                OrderBy = { "rating desc" } // Sort by rating from high to low
-#endif
             };
             SearchResults<Hotel> response = client.Search<Hotel>("luxury", options);
             // ...
@@ -251,8 +209,8 @@ namespace Azure.Search.Documents.Tests.Samples
                 Fields = new FieldBuilder().Build(typeof(Hotel)),
                 Suggesters =
                 {
-                    // Suggest query terms from the hotelName field.
-                    new SearchSuggester("sg", "hotelName")
+                    // Suggest query terms from the HotelName field.
+                    new SearchSuggester("sg", "HotelName")
                 }
             };
             #endregion Snippet:Azure_Search_Tests_Samples_Readme_CreateIndex_New_SearchIndex
@@ -281,26 +239,26 @@ namespace Azure.Search.Documents.Tests.Samples
             {
                 Fields =
                 {
-                    new SimpleField("hotelId", SearchFieldDataType.String) { IsKey = true, IsFilterable = true, IsSortable = true },
-                    new SearchableField("hotelName") { IsFilterable = true, IsSortable = true },
-                    new SearchableField("description") { AnalyzerName = LexicalAnalyzerName.EnLucene },
-                    new SearchableField("tags", collection: true) { IsFilterable = true, IsFacetable = true },
-                    new ComplexField("address")
+                    new SimpleField("HotelId", SearchFieldDataType.String) { IsKey = true, IsFilterable = true, IsSortable = true },
+                    new SearchableField("HotelName") { IsFilterable = true, IsSortable = true },
+                    new SearchableField("Description") { AnalyzerName = LexicalAnalyzerName.EnLucene },
+                    new SearchableField("Tags", collection: true) { IsFilterable = true, IsFacetable = true },
+                    new ComplexField("Address")
                     {
                         Fields =
                         {
-                            new SearchableField("streetAddress"),
-                            new SearchableField("city") { IsFilterable = true, IsSortable = true, IsFacetable = true },
-                            new SearchableField("stateProvince") { IsFilterable = true, IsSortable = true, IsFacetable = true },
-                            new SearchableField("country") { IsFilterable = true, IsSortable = true, IsFacetable = true },
-                            new SearchableField("postalCode") { IsFilterable = true, IsSortable = true, IsFacetable = true }
+                            new SearchableField("StreetAddress"),
+                            new SearchableField("City") { IsFilterable = true, IsSortable = true, IsFacetable = true },
+                            new SearchableField("StateProvince") { IsFilterable = true, IsSortable = true, IsFacetable = true },
+                            new SearchableField("Country") { IsFilterable = true, IsSortable = true, IsFacetable = true },
+                            new SearchableField("PostalCode") { IsFilterable = true, IsSortable = true, IsFacetable = true }
                         }
                     }
                 },
                 Suggesters =
                 {
                     // Suggest query terms from the hotelName field.
-                    new SearchSuggester("sg", "hotelName")
+                    new SearchSuggester("sg", "HotelName")
                 }
             };
             #endregion Snippet:Azure_Search_Tests_Samples_Readme_CreateManualIndex_New_SearchIndex
@@ -315,7 +273,7 @@ namespace Azure.Search.Documents.Tests.Samples
         [SyncOnly]
         public async Task GetDocument()
         {
-            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this);
+            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this, true);
             SearchClient client = resources.GetQueryClient();
 
             #region Snippet:Azure_Search_Tests_Samples_Readme_GetDocument
@@ -328,7 +286,7 @@ namespace Azure.Search.Documents.Tests.Samples
         [SyncOnly]
         public async Task Index()
         {
-            await using SearchResources resources = await SearchResources.CreateWithEmptyHotelsIndexAsync(this);
+            await using SearchResources resources = await SearchResources.CreateWithEmptyHotelsIndexAsync(this, true);
             SearchClient client = resources.GetQueryClient();
             try
             {
@@ -351,7 +309,7 @@ namespace Azure.Search.Documents.Tests.Samples
         [SyncOnly]
         public async Task Troubleshooting()
         {
-            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this);
+            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this, true);
             SearchClient client = resources.GetQueryClient();
             LookupHotel();
 

--- a/sdk/search/Azure.Search.Documents/tests/Samples/Sample01_HelloWorld.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Samples/Sample01_HelloWorld.cs
@@ -29,7 +29,7 @@ namespace Azure.Search.Documents.Tests.Samples
         [SyncOnly]
         public async Task CreateClient()
         {
-            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this);
+            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this, true);
             Environment.SetEnvironmentVariable("SEARCH_ENDPOINT", resources.Endpoint.ToString());
             Environment.SetEnvironmentVariable("SEARCH_API_KEY", resources.PrimaryApiKey);
 
@@ -57,7 +57,7 @@ namespace Azure.Search.Documents.Tests.Samples
         [AsyncOnly]
         public async Task CreateClientAsync()
         {
-            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this);
+            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this, true);
             Environment.SetEnvironmentVariable("SEARCH_ENDPOINT", resources.Endpoint.ToString());
             Environment.SetEnvironmentVariable("SEARCH_API_KEY", resources.PrimaryApiKey);
 
@@ -85,7 +85,7 @@ namespace Azure.Search.Documents.Tests.Samples
         [SyncOnly]
         public async Task HandleErrors()
         {
-            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this);
+            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this, true);
             Environment.SetEnvironmentVariable("SEARCH_ENDPOINT", resources.Endpoint.ToString());
             Environment.SetEnvironmentVariable("SEARCH_API_KEY", resources.PrimaryApiKey);
 
@@ -115,7 +115,7 @@ namespace Azure.Search.Documents.Tests.Samples
         [AsyncOnly]
         public async Task HandleErrorsAsync()
         {
-            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this);
+            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this, true);
             Environment.SetEnvironmentVariable("SEARCH_ENDPOINT", resources.Endpoint.ToString());
             Environment.SetEnvironmentVariable("SEARCH_API_KEY", resources.PrimaryApiKey);
 
@@ -144,7 +144,7 @@ namespace Azure.Search.Documents.Tests.Samples
         [Test]
         public async Task GetStatisticsAsync()
         {
-            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this);
+            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this, true);
             Environment.SetEnvironmentVariable("SEARCH_ENDPOINT", resources.Endpoint.ToString());
             Environment.SetEnvironmentVariable("SEARCH_API_KEY", resources.PrimaryApiKey);
 
@@ -168,7 +168,7 @@ namespace Azure.Search.Documents.Tests.Samples
         [AsyncOnly]
         public async Task CreateIndexerAsync()
         {
-            await using SearchResources resources = await SearchResources.CreateWithBlobStorageAsync(this, populate: true);
+            await using SearchResources resources = await SearchResources.CreateWithBlobStorageAsync(this, populate: true, true);
             Environment.SetEnvironmentVariable("SEARCH_ENDPOINT", resources.Endpoint.ToString());
             Environment.SetEnvironmentVariable("SEARCH_API_KEY", resources.PrimaryApiKey);
             Environment.SetEnvironmentVariable("STORAGE_CONNECTION_STRING", resources.StorageAccountConnectionString);
@@ -228,20 +228,20 @@ namespace Azure.Search.Documents.Tests.Samples
                 {
                     Fields =
                     {
-                        new SimpleField("hotelId", SearchFieldDataType.String) { IsKey = true, IsFilterable = true, IsSortable = true },
-                        new SearchableField("hotelName") { IsFilterable = true, IsSortable = true },
-                        new SearchableField("description") { AnalyzerName = LexicalAnalyzerName.EnLucene },
-                        new SearchableField("descriptionFr") { AnalyzerName = LexicalAnalyzerName.FrLucene },
-                        new SearchableField("tags", collection: true) { IsFilterable = true, IsFacetable = true },
-                        new ComplexField("address")
+                        new SimpleField("HotelId", SearchFieldDataType.String) { IsKey = true, IsFilterable = true, IsSortable = true },
+                        new SearchableField("HotelName") { IsFilterable = true, IsSortable = true },
+                        new SearchableField("Description") { AnalyzerName = LexicalAnalyzerName.EnLucene },
+                        new SearchableField("DescriptionFr") { AnalyzerName = LexicalAnalyzerName.FrLucene },
+                        new SearchableField("Tags", collection: true) { IsFilterable = true, IsFacetable = true },
+                        new ComplexField("Address")
                         {
                             Fields =
                             {
-                                new SearchableField("streetAddress"),
-                                new SearchableField("city") { IsFilterable = true, IsSortable = true, IsFacetable = true },
-                                new SearchableField("stateProvince") { IsFilterable = true, IsSortable = true, IsFacetable = true },
-                                new SearchableField("country") { SynonymMapNames = new[] { synonymMapName }, IsFilterable = true, IsSortable = true, IsFacetable = true },
-                                new SearchableField("postalCode") { IsFilterable = true, IsSortable = true, IsFacetable = true }
+                                new SearchableField("StreetAddress"),
+                                new SearchableField("City") { IsFilterable = true, IsSortable = true, IsFacetable = true },
+                                new SearchableField("StateProvince") { IsFilterable = true, IsSortable = true, IsFacetable = true },
+                                new SearchableField("Country") { SynonymMapNames = new[] { synonymMapName }, IsFilterable = true, IsSortable = true, IsFacetable = true },
+                                new SearchableField("PostalCode") { IsFilterable = true, IsSortable = true, IsFacetable = true }
                             }
                         }
                     }
@@ -304,7 +304,7 @@ namespace Azure.Search.Documents.Tests.Samples
                 TextTranslationSkill translationSkill = new TextTranslationSkill(
                     inputs: new[]
                     {
-                        new InputFieldMappingEntry("text") { Source = "/document/description" }
+                        new InputFieldMappingEntry("text") { Source = "/document/Description" }
                     },
                     outputs: new[]
                     {
@@ -322,9 +322,9 @@ namespace Azure.Search.Documents.Tests.Samples
                 ConditionalSkill conditionalSkill = new ConditionalSkill(
                     inputs: new[]
                     {
-                        new InputFieldMappingEntry("condition") { Source = "= $(/document/descriptionFr) == null" },
+                        new InputFieldMappingEntry("condition") { Source = "= $(/document/DescriptionFr) == null" },
                         new InputFieldMappingEntry("whenTrue") { Source = "/document/descriptionFrTranslated" },
-                        new InputFieldMappingEntry("whenFalse") { Source = "/document/descriptionFr" }
+                        new InputFieldMappingEntry("whenFalse") { Source = "/document/DescriptionFr" }
                     },
                     outputs: new[]
                     {
@@ -371,15 +371,15 @@ namespace Azure.Search.Documents.Tests.Samples
                     // We only want to index fields defined in our index, excluding descriptionFr if defined.
                     FieldMappings =
                     {
-                        new FieldMapping("hotelId"),
-                        new FieldMapping("hotelName"),
-                        new FieldMapping("description"),
-                        new FieldMapping("tags"),
-                        new FieldMapping("address")
+                        new FieldMapping("HotelId"),
+                        new FieldMapping("HotelName"),
+                        new FieldMapping("Description"),
+                        new FieldMapping("Tags"),
+                        new FieldMapping("Address")
                     },
                     OutputFieldMappings =
                     {
-                        new FieldMapping("/document/descriptionFrFinal") { TargetFieldName = "descriptionFr" }
+                        new FieldMapping("/document/descriptionFrFinal") { TargetFieldName = "DescriptionFr" }
                     },
                     Parameters = new IndexingParameters
                     {
@@ -444,7 +444,7 @@ namespace Azure.Search.Documents.Tests.Samples
         [Test]
         public async Task GetCountAsync()
         {
-            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this);
+            await using SearchResources resources = await SearchResources.GetSharedHotelsIndexAsync(this, true);
             Environment.SetEnvironmentVariable("SEARCH_ENDPOINT", resources.Endpoint.ToString());
             Environment.SetEnvironmentVariable("SEARCH_API_KEY", resources.PrimaryApiKey);
             Environment.SetEnvironmentVariable("SEARCH_INDEX", resources.IndexName);

--- a/sdk/search/Azure.Search.Documents/tests/Samples/Sample06_EncryptedIndex.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Samples/Sample06_EncryptedIndex.cs
@@ -44,7 +44,7 @@ namespace Azure.Search.Documents.Tests.Samples
             Environment.SetEnvironmentVariable("APPLICATION_SECRET", TestEnvironment.RecordedClientSecret);
 
             // Create the blob container and persist connection information.
-            await using SearchResources resources = await SearchResources.CreateWithBlobStorageAndIndexAsync(this, populate: true);
+            await using SearchResources resources = await SearchResources.CreateWithBlobStorageAndIndexAsync(this, populate: true, true);
             Environment.SetEnvironmentVariable("STORAGE_CONNECTION_STRING", resources.StorageAccountConnectionString);
             Environment.SetEnvironmentVariable("STORAGE_CONTAINER_NAME", resources.BlobContainerName);
             Environment.SetEnvironmentVariable("SEARCH_ENDPOINT", resources.Endpoint.ToString());
@@ -101,11 +101,11 @@ namespace Azure.Search.Documents.Tests.Samples
                     // Map the fields in our documents we want to index.
                     FieldMappings =
                     {
-                        new FieldMapping("hotelId"),
-                        new FieldMapping("hotelName"),
-                        new FieldMapping("description"),
-                        new FieldMapping("tags"),
-                        new FieldMapping("address")
+                        new FieldMapping("HotelId"),
+                        new FieldMapping("HotelName"),
+                        new FieldMapping("Description"),
+                        new FieldMapping("Tags"),
+                        new FieldMapping("Address")
                     },
                     Parameters = new IndexingParameters
                     {

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/EncryptedIndex/CreateDoubleEncryptedIndex.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/EncryptedIndex/CreateDoubleEncryptedIndex.json
@@ -1,58 +1,52 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathsrchtst2kv.vault.azure.net/keys/qdsrncrr/create?api-version=7.0",
+      "RequestUri": "https://shrejaazsearchkv.vault.azure.net/keys/vcpsxqnm/create?api-version=7.0",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Type": "application/json",
-        "traceparent": "00-520a8ac85560a84986ede0ccc6b7a5f5-a388195d87b4ce4c-00",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.0.2",
-          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "cd8213ba1b155f86b98e69896fb16f15",
+        "Content-Length": "0",
+        "traceparent": "00-9c8847a5d02687f5e7a489721cf7ce14-63ac60e579eeaf04-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.2.0 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8edd79ae0c0eb04a06dde471fd5980ab",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 401,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "87",
+        "Content-Length": "97",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 02 Nov 2020 23:59:30 GMT",
+        "Date": "Fri, 06 Jan 2023 21:24:23 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.58.0",
-        "x-ms-request-id": "62532d0b-7150-40e5-b5ae-078a241840ec",
-        "X-Powered-By": "ASP.NET"
+        "x-ms-client-request-id": "8edd79ae0c0eb04a06dde471fd5980ab",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=49.36.26.233;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.576.1",
+        "x-ms-request-id": "4d80085b-e0f3-4a96-8374-84b36865e47a"
       },
       "ResponseBody": {
         "error": {
           "code": "Unauthorized",
-          "message": "Request is missing a Bearer or PoP token."
+          "message": "AKV10000: Request is missing a Bearer or PoP token."
         }
       }
     },
     {
-      "RequestUri": "https://heathsrchtst2kv.vault.azure.net/keys/qdsrncrr/create?api-version=7.0",
+      "RequestUri": "https://shrejaazsearchkv.vault.azure.net/keys/vcpsxqnm/create?api-version=7.0",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "63",
         "Content-Type": "application/json",
-        "traceparent": "00-520a8ac85560a84986ede0ccc6b7a5f5-a388195d87b4ce4c-00",
-        "User-Agent": [
-          "azsdk-net-Security.KeyVault.Keys/4.0.2",
-          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "cd8213ba1b155f86b98e69896fb16f15",
+        "traceparent": "00-9c8847a5d02687f5e7a489721cf7ce14-63ac60e579eeaf04-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.2.0 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8edd79ae0c0eb04a06dde471fd5980ab",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -66,68 +60,65 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "622",
+        "Content-Length": "623",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 02 Nov 2020 23:59:32 GMT",
+        "Date": "Fri, 06 Jan 2023 21:24:25 GMT",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
-        "x-ms-keyvault-region": "westus2",
-        "x-ms-keyvault-service-version": "1.2.58.0",
-        "x-ms-request-id": "83b22164-64ff-46b5-9642-6ce8c0dedd23",
-        "X-Powered-By": "ASP.NET"
+        "x-ms-client-request-id": "8edd79ae0c0eb04a06dde471fd5980ab",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=49.36.26.233;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.576.1",
+        "x-ms-request-id": "20220938-6967-4c51-85a6-9622cfd4653f"
       },
       "ResponseBody": {
         "key": {
-          "kid": "https://heathsrchtst2kv.vault.azure.net/keys/qdsrncrr/a68172d0313b4afa809e8cda9922dcbd",
+          "kid": "https://shrejaazsearchkv.vault.azure.net/keys/vcpsxqnm/64789432ebb6430f8d95a861c19c166c",
           "kty": "RSA",
           "key_ops": [
             "wrapKey",
             "unwrapKey"
           ],
-          "n": "rgIzUdI4CKATDoG2DWrinWJ5bqvAWyV9s-xY4RYsPGMBTRw6sL_FHCm7bI8HNZDgyYPgvDi3TLr-bUERtXm8xrkmFx_0A_bxAR-Ms5K0pOxjfXXbwCAEPRk0RKPgMjB-PPEaLdfBcFC-ex2T2Y1bAJ2kDCZWBdhazeipOxs_Jqr3WB5j0g5APCJEo9Ls6tlihguVgLd8C1I5nDZ748wYApw4WKRBMckWZRbsq6w-kMRNxPRWZPDSdkSOi2Ud-qVnsDf4KCSFam1axYsKQ40UvZHHpxBhxobUlQP3qdychhzZnwLPlVP8QeKU_GfFy0U5bZb4mrIyLKf4YyjfpXanDQ",
+          "n": "x2rt-9tdTpy5EtZM6FOueuyN5bzqyJ2y0IDi23LpKr98Iv5KnrwGoYvgOuhTjqzc1bsNAMv1CqTT2BzouNm42IUG1by9OzV2hco66Vtdp4VgNKx9CqlEZ4IJXpFhKNaHKRlamAW5zbq_7K5fv6E7wwwY07eUp1jpJmxp6Snonoas5eHLKctERmz9urXxoYNI24q_Jb8YxjUKvTy_QpJxQDaz18B4TeeNlHUYmOZDl7XDtO9Wpv7AsYR5Lf15VPZabuD_y904qNbl2trCEn_FVyQWNICdOAWok1qIf1EoqiLU7VBEbNAL7Higfp2gm6As1mzNZ6zbYHxm044yG8pDvQ",
           "e": "AQAB"
         },
         "attributes": {
           "enabled": true,
-          "created": 1604361572,
-          "updated": 1604361572,
+          "created": 1673040266,
+          "updated": 1673040266,
           "recoveryLevel": "CustomizedRecoverable"
         }
       }
     },
     {
-      "RequestUri": "https://azs-net-heathsrchtst2.search.windows.net/datasources?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/datasources?api-version=2020-06-30",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "Content-Length": "489",
+        "Content-Length": "387",
         "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.2.0-alpha.20201102.1",
-          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "926f09401b3e2e40fe29f46067a776fb",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8347d5f627c43e38a4fd88b7a016e435",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "saxjrhml",
+        "name": "jvpxvkdt",
         "type": "azureblob",
         "credentials": {
-          "connectionString": "DefaultEndpointsProtocol=https;AccountName=heathsrchtst2stg;AccountKey=Sanitized;EndpointSuffix=core.windows.net"
+          "connectionString": "Sanitized"
         },
         "container": {
-          "name": "hfbypvrf"
+          "name": "rnhaffmg"
         },
         "encryptionKey": {
-          "keyVaultKeyName": "qdsrncrr",
-          "keyVaultKeyVersion": "a68172d0313b4afa809e8cda9922dcbd",
-          "keyVaultUri": "https://heathsrchtst2kv.vault.azure.net/",
+          "keyVaultKeyName": "vcpsxqnm",
+          "keyVaultKeyVersion": "64789432ebb6430f8d95a861c19c166c",
+          "keyVaultUri": "https://shrejaazsearchkv.vault.azure.net/",
           "accessCredentials": {
-            "applicationId": "f9ab11db-b032-44b3-af0a-44713541cc40",
+            "applicationId": "fb4cb505-3ed0-48c0-b5c0-e7b7bf139923",
             "applicationSecret": "Sanitized"
           }
         }
@@ -135,23 +126,23 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "926f0940-1b3e-2e40-fe29-f46067a776fb",
-        "Content-Length": "585",
+        "client-request-id": "8347d5f6-27c4-3e38-a4fd-88b7a016e435",
+        "Content-Length": "587",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Mon, 02 Nov 2020 23:59:56 GMT",
-        "elapsed-time": "996",
+        "Date": "Fri, 06 Jan 2023 21:24:56 GMT",
+        "elapsed-time": "2073",
         "Expires": "-1",
-        "Location": "https://azs-net-heathsrchtst2.search.windows.net/datasources(\u0027saxjrhml\u0027)?api-version=2020-06-30",
+        "Location": "https://azs-net-shrejaazsearch.search.windows.net/datasources(\u0027jvpxvkdt\u0027)?api-version=2020-06-30",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "926f0940-1b3e-2e40-fe29-f46067a776fb",
+        "request-id": "8347d5f6-27c4-3e38-a4fd-88b7a016e435",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "926f0940-1b3e-2e40-fe29-f46067a776fb"
+        "x-ms-client-request-id": "8347d5f6-27c4-3e38-a4fd-88b7a016e435"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-heathsrchtst2.search.windows.net/$metadata#datasources/$entity",
-        "name": "saxjrhml",
+        "@odata.context": "https://azs-net-shrejaazsearch.search.windows.net/$metadata#datasources/$entity",
+        "name": "jvpxvkdt",
         "description": null,
         "type": "azureblob",
         "subtype": null,
@@ -159,41 +150,38 @@
           "connectionString": null
         },
         "container": {
-          "name": "hfbypvrf",
+          "name": "rnhaffmg",
           "query": null
         },
         "dataChangeDetectionPolicy": null,
         "dataDeletionDetectionPolicy": null,
         "encryptionKey": {
-          "keyVaultKeyName": "qdsrncrr",
-          "keyVaultKeyVersion": "a68172d0313b4afa809e8cda9922dcbd",
-          "keyVaultUri": "https://heathsrchtst2kv.vault.azure.net/",
+          "keyVaultKeyName": "vcpsxqnm",
+          "keyVaultKeyVersion": "64789432ebb6430f8d95a861c19c166c",
+          "keyVaultUri": "https://shrejaazsearchkv.vault.azure.net/",
           "accessCredentials": {
-            "applicationId": "f9ab11db-b032-44b3-af0a-44713541cc40",
+            "applicationId": "fb4cb505-3ed0-48c0-b5c0-e7b7bf139923",
             "applicationSecret": null
           }
         }
       }
     },
     {
-      "RequestUri": "https://azs-net-heathsrchtst2.search.windows.net/indexers?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexers?api-version=2020-06-30",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "Content-Length": "570",
+        "Content-Length": "571",
         "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.2.0-alpha.20201102.1",
-          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "82d7ef549c91c2337a309ba9099f2465",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4aad7e035fa0d6294ae3428429b2393f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "fedemlmi",
-        "dataSourceName": "saxjrhml",
-        "targetIndexName": "prgvvpbp",
+        "name": "bnruxjws",
+        "dataSourceName": "jvpxvkdt",
+        "targetIndexName": "bwlljfdx",
         "parameters": {
           "configuration": {
             "parsingMode": "json"
@@ -201,27 +189,27 @@
         },
         "fieldMappings": [
           {
-            "sourceFieldName": "hotelId"
+            "sourceFieldName": "HotelId"
           },
           {
-            "sourceFieldName": "hotelName"
+            "sourceFieldName": "HotelName"
           },
           {
-            "sourceFieldName": "description"
+            "sourceFieldName": "Description"
           },
           {
-            "sourceFieldName": "tags"
+            "sourceFieldName": "Tags"
           },
           {
-            "sourceFieldName": "address"
+            "sourceFieldName": "Address"
           }
         ],
         "encryptionKey": {
-          "keyVaultKeyName": "qdsrncrr",
-          "keyVaultKeyVersion": "a68172d0313b4afa809e8cda9922dcbd",
-          "keyVaultUri": "https://heathsrchtst2kv.vault.azure.net/",
+          "keyVaultKeyName": "vcpsxqnm",
+          "keyVaultKeyVersion": "64789432ebb6430f8d95a861c19c166c",
+          "keyVaultUri": "https://shrejaazsearchkv.vault.azure.net/",
           "accessCredentials": {
-            "applicationId": "f9ab11db-b032-44b3-af0a-44713541cc40",
+            "applicationId": "fb4cb505-3ed0-48c0-b5c0-e7b7bf139923",
             "applicationSecret": "Sanitized"
           }
         }
@@ -229,27 +217,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "82d7ef54-9c91-c233-7a30-9ba9099f2465",
-        "Content-Length": "1105",
+        "client-request-id": "4aad7e03-5fa0-d629-4ae3-428429b2393f",
+        "Content-Length": "1107",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Mon, 02 Nov 2020 23:59:57 GMT",
-        "elapsed-time": "1455",
+        "Date": "Fri, 06 Jan 2023 21:24:58 GMT",
+        "elapsed-time": "1777",
         "Expires": "-1",
-        "Location": "https://azs-net-heathsrchtst2.search.windows.net/indexers(\u0027fedemlmi\u0027)?api-version=2020-06-30",
+        "Location": "https://azs-net-shrejaazsearch.search.windows.net/indexers(\u0027bnruxjws\u0027)?api-version=2020-06-30",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "82d7ef54-9c91-c233-7a30-9ba9099f2465",
+        "request-id": "4aad7e03-5fa0-d629-4ae3-428429b2393f",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "82d7ef54-9c91-c233-7a30-9ba9099f2465"
+        "x-ms-client-request-id": "4aad7e03-5fa0-d629-4ae3-428429b2393f"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-heathsrchtst2.search.windows.net/$metadata#indexers/$entity",
-        "name": "fedemlmi",
+        "@odata.context": "https://azs-net-shrejaazsearch.search.windows.net/$metadata#indexers/$entity",
+        "name": "bnruxjws",
         "description": null,
-        "dataSourceName": "saxjrhml",
+        "dataSourceName": "jvpxvkdt",
         "skillsetName": null,
-        "targetIndexName": "prgvvpbp",
+        "targetIndexName": "bwlljfdx",
         "disabled": null,
         "schedule": null,
         "parameters": {
@@ -263,87 +251,84 @@
         },
         "fieldMappings": [
           {
-            "sourceFieldName": "hotelId",
-            "targetFieldName": "hotelId",
+            "sourceFieldName": "HotelId",
+            "targetFieldName": "HotelId",
             "mappingFunction": null
           },
           {
-            "sourceFieldName": "hotelName",
-            "targetFieldName": "hotelName",
+            "sourceFieldName": "HotelName",
+            "targetFieldName": "HotelName",
             "mappingFunction": null
           },
           {
-            "sourceFieldName": "description",
-            "targetFieldName": "description",
+            "sourceFieldName": "Description",
+            "targetFieldName": "Description",
             "mappingFunction": null
           },
           {
-            "sourceFieldName": "tags",
-            "targetFieldName": "tags",
+            "sourceFieldName": "Tags",
+            "targetFieldName": "Tags",
             "mappingFunction": null
           },
           {
-            "sourceFieldName": "address",
-            "targetFieldName": "address",
+            "sourceFieldName": "Address",
+            "targetFieldName": "Address",
             "mappingFunction": null
           }
         ],
         "outputFieldMappings": [],
         "encryptionKey": {
-          "keyVaultKeyName": "qdsrncrr",
-          "keyVaultKeyVersion": "a68172d0313b4afa809e8cda9922dcbd",
-          "keyVaultUri": "https://heathsrchtst2kv.vault.azure.net/",
+          "keyVaultKeyName": "vcpsxqnm",
+          "keyVaultKeyVersion": "64789432ebb6430f8d95a861c19c166c",
+          "keyVaultUri": "https://shrejaazsearchkv.vault.azure.net/",
           "accessCredentials": {
-            "applicationId": "f9ab11db-b032-44b3-af0a-44713541cc40",
+            "applicationId": "fb4cb505-3ed0-48c0-b5c0-e7b7bf139923",
             "applicationSecret": null
           }
         }
       }
     },
     {
-      "RequestUri": "https://azs-net-heathsrchtst2.search.windows.net/indexers(\u0027fedemlmi\u0027)/search.status?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexers(\u0027bnruxjws\u0027)/search.status?api-version=2020-06-30",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-55c173389741784d82e6df658a600827-d22822fc565bbe41-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.2.0-alpha.20201102.1",
-          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "654841b9dc416ed76def24fc0337e98a",
+        "traceparent": "00-8d1a8c9b368f17120ecfc30e40bff534-490b1b1d9b9f094a-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "287b084afd126ee75015c8ed4e775934",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "654841b9-dc41-6ed7-6def-24fc0337e98a",
-        "Content-Length": "1511",
+        "client-request-id": "287b084a-fd12-6ee7-5015-c8ed4e775934",
+        "Content-Length": "1515",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Tue, 03 Nov 2020 00:00:07 GMT",
+        "Date": "Fri, 06 Jan 2023 21:25:09 GMT",
         "elapsed-time": "21",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "654841b9-dc41-6ed7-6def-24fc0337e98a",
+        "request-id": "287b084a-fd12-6ee7-5015-c8ed4e775934",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "654841b9-dc41-6ed7-6def-24fc0337e98a"
+        "x-ms-client-request-id": "287b084a-fd12-6ee7-5015-c8ed4e775934"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-heathsrchtst2.search.windows.net/$metadata#Microsoft.Azure.Search.V2020_06_30.IndexerExecutionInfo",
-        "name": "fedemlmi",
+        "@odata.context": "https://azs-net-shrejaazsearch.search.windows.net/$metadata#Microsoft.Azure.Search.V2020_06_30.IndexerExecutionInfo",
+        "name": "bnruxjws",
         "status": "running",
         "lastResult": {
           "status": "success",
           "errorMessage": null,
-          "startTime": "2020-11-03T00:00:01.935Z",
-          "endTime": "2020-11-03T00:00:02.357Z",
+          "startTime": "2023-01-06T21:25:02.338Z",
+          "endTime": "2023-01-06T21:25:02.83Z",
           "itemsProcessed": 10,
           "itemsFailed": 0,
-          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-11-03T00:00:01.94Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-11-02T23:59:31.9408208\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-11-02T23:59:31.9408208\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222023-01-06T21:25:02.353Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222023-01-06T21:24:32.3538738\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222023-01-06T21:24:32.3538738\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
           "errors": [],
           "warnings": [],
           "metrics": null
@@ -352,12 +337,12 @@
           {
             "status": "success",
             "errorMessage": null,
-            "startTime": "2020-11-03T00:00:01.935Z",
-            "endTime": "2020-11-03T00:00:02.357Z",
+            "startTime": "2023-01-06T21:25:02.338Z",
+            "endTime": "2023-01-06T21:25:02.83Z",
             "itemsProcessed": 10,
             "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-11-03T00:00:01.94Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-11-02T23:59:31.9408208\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-11-02T23:59:31.9408208\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222023-01-06T21:25:02.353Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222023-01-06T21:24:32.3538738\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222023-01-06T21:24:32.3538738\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
             "errors": [],
             "warnings": [],
             "metrics": null
@@ -365,24 +350,21 @@
         ],
         "limits": {
           "maxRunTime": "P1D",
-          "maxDocumentExtractionSize": 16777216,
-          "maxDocumentContentCharactersToExtract": 65536
+          "maxDocumentExtractionSize": 134217728,
+          "maxDocumentContentCharactersToExtract": 4194304
         }
       }
     },
     {
-      "RequestUri": "https://azs-net-heathsrchtst2.search.windows.net/indexes(\u0027prgvvpbp\u0027)/docs/search.post.search?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027bwlljfdx\u0027)/docs/search.post.search?api-version=2020-06-30",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "26",
         "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.2.0-alpha.20201102.1",
-          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "4a9316f5527ca496d6ad180d7f97245f",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f894ada5481a963bac7039e0e4b414f1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -391,119 +373,497 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "4a9316f5-527c-a496-d6ad-180d7f97245f",
-        "Content-Length": "5929",
+        "client-request-id": "f894ada5-481a-963b-ac70-39e0e4b414f1",
+        "Content-Length": "6904",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Tue, 03 Nov 2020 00:00:07 GMT",
-        "elapsed-time": "31",
+        "Date": "Fri, 06 Jan 2023 21:25:09 GMT",
+        "elapsed-time": "77",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "4a9316f5-527c-a496-d6ad-180d7f97245f",
+        "request-id": "f894ada5-481a-963b-ac70-39e0e4b414f1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "4a9316f5-527c-a496-d6ad-180d7f97245f"
+        "x-ms-client-request-id": "f894ada5-481a-963b-ac70-39e0e4b414f1"
       },
-      "ResponseBody": "{\u0022value\u0022:[{\u0022@search.score\u0022:1.9115671,\u0022hotelId\u0022:\u00221\u0022,\u0022hotelName\u0022:\u0022Fancy Stay\u0022,\u0022description\u0022:\u0022Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.\u0022,\u0022descriptionFr\u0022:\u0022Meilleur h\\u00f4tel en ville si vous aimez les h\\u00f4tels de luxe. Ils ont une magnifique piscine \\u00e0 d\\u00e9bordement, un spa et un concierge tr\\u00e8s utile. L\u0027emplacement est parfait \\u2013 en plein centre, \\u00e0 proximit\\u00e9 de toutes les attractions touristiques. Nous recommandons fortement cet h\\u00f4tel.\u0022,\u0022category\u0022:\u0022Luxury\u0022,\u0022tags\u0022:[\u0022pool\u0022,\u0022view\u0022,\u0022wifi\u0022,\u0022concierge\u0022],\u0022parkingIncluded\u0022:false,\u0022smokingAllowed\u0022:false,\u0022lastRenovationDate\u0022:\u00222010-06-27T00:00:00Z\u0022,\u0022rating\u0022:5,\u0022location\u0022:{\u0022type\u0022:\u0022Point\u0022,\u0022coordinates\u0022:[-122.131577,47.678581],\u0022crs\u0022:{\u0022type\u0022:\u0022name\u0022,\u0022properties\u0022:{\u0022name\u0022:\u0022EPSG:4326\u0022}}},\u0022address\u0022:null,\u0022rooms\u0022:[]},{\u0022@search.score\u0022:0.5337951,\u0022hotelId\u0022:\u00223\u0022,\u0022hotelName\u0022:\u0022EconoStay\u0022,\u0022description\u0022:\u0022Very popular hotel in town\u0022,\u0022descriptionFr\u0022:\u0022H\\u00f4tel le plus populaire en ville\u0022,\u0022category\u0022:\u0022Budget\u0022,\u0022tags\u0022:[\u0022wifi\u0022,\u0022budget\u0022],\u0022parkingIncluded\u0022:true,\u0022smokingAllowed\u0022:false,\u0022lastRenovationDate\u0022:\u00221995-07-01T00:00:00Z\u0022,\u0022rating\u0022:4,\u0022location\u0022:{\u0022type\u0022:\u0022Point\u0022,\u0022coordinates\u0022:[-122.131577,46.678581],\u0022crs\u0022:{\u0022type\u0022:\u0022name\u0022,\u0022properties\u0022:{\u0022name\u0022:\u0022EPSG:4326\u0022}}},\u0022address\u0022:null,\u0022rooms\u0022:[]},{\u0022@search.score\u0022:0.3451531,\u0022hotelId\u0022:\u002210\u0022,\u0022hotelName\u0022:\u0022Countryside Hotel\u0022,\u0022description\u0022:\u0022Save up to 50% off traditional hotels.  Free WiFi, great location near downtown, full kitchen, washer \u0026 dryer, 24/7 support, bowling alley, fitness center and more.\u0022,\u0022descriptionFr\u0022:\u0022\\u00c9conomisez jusqu\u0027\\u00e0 50% sur les h\\u00f4tels traditionnels.  WiFi gratuit, tr\\u00e8s bien situ\\u00e9 pr\\u00e8s du centre-ville, cuisine compl\\u00e8te, laveuse \u0026 s\\u00e9cheuse, support 24/7, bowling, centre de fitness et plus encore.\u0022,\u0022category\u0022:\u0022Budget\u0022,\u0022tags\u0022:[\u002224-hour front desk service\u0022,\u0022coffee in lobby\u0022,\u0022restaurant\u0022],\u0022parkingIncluded\u0022:false,\u0022smokingAllowed\u0022:true,\u0022lastRenovationDate\u0022:\u00221999-09-06T00:00:00Z\u0022,\u0022rating\u0022:3,\u0022location\u0022:{\u0022type\u0022:\u0022Point\u0022,\u0022coordinates\u0022:[-78.940483,35.90416],\u0022crs\u0022:{\u0022type\u0022:\u0022name\u0022,\u0022properties\u0022:{\u0022name\u0022:\u0022EPSG:4326\u0022}}},\u0022address\u0022:{\u0022streetAddress\u0022:\u00226910 Fayetteville Rd\u0022,\u0022city\u0022:\u0022Durham\u0022,\u0022stateProvince\u0022:\u0022NC\u0022,\u0022country\u0022:\u0022USA\u0022,\u0022postalCode\u0022:\u002227713\u0022},\u0022rooms\u0022:[{\u0022description\u0022:\u0022Suite, 1 King Bed (Amenities)\u0022,\u0022descriptionFr\u0022:\u0022Suite, 1 tr\\u00e8s grand lit (Services)\u0022,\u0022type\u0022:\u0022Suite\u0022,\u0022baseRate\u0022:2.44,\u0022bedOptions\u0022:\u00221 King Bed\u0022,\u0022sleepsCount\u0022:2,\u0022smokingAllowed\u0022:true,\u0022tags\u0022:[\u0022coffee maker\u0022]},{\u0022description\u0022:\u0022Budget Room, 1 Queen Bed (Amenities)\u0022,\u0022descriptionFr\u0022:\u0022Chambre \\u00c9conomique, 1 grand lit (Services)\u0022,\u0022type\u0022:\u0022Budget Room\u0022,\u0022baseRate\u0022:7.69,\u0022bedOptions\u0022:\u00221 Queen Bed\u0022,\u0022sleepsCount\u0022:2,\u0022smokingAllowed\u0022:false,\u0022tags\u0022:[\u0022coffee maker\u0022]}]},{\u0022@search.score\u0022:0.2622748,\u0022hotelId\u0022:\u00224\u0022,\u0022hotelName\u0022:\u0022Express Rooms\u0022,\u0022description\u0022:\u0022Pretty good hotel\u0022,\u0022descriptionFr\u0022:\u0022Assez bon h\\u00f4tel\u0022,\u0022category\u0022:\u0022Budget\u0022,\u0022tags\u0022:[\u0022wifi\u0022,\u0022budget\u0022],\u0022parkingIncluded\u0022:true,\u0022smokingAllowed\u0022:false,\u0022lastRenovationDate\u0022:\u00221995-07-01T00:00:00Z\u0022,\u0022rating\u0022:4,\u0022location\u0022:{\u0022type\u0022:\u0022Point\u0022,\u0022coordinates\u0022:[-122.131577,48.678581],\u0022crs\u0022:{\u0022type\u0022:\u0022name\u0022,\u0022properties\u0022:{\u0022name\u0022:\u0022EPSG:4326\u0022}}},\u0022address\u0022:null,\u0022rooms\u0022:[]},{\u0022@search.score\u0022:0.2622748,\u0022hotelId\u0022:\u00225\u0022,\u0022hotelName\u0022:\u0022Comfy Place\u0022,\u0022description\u0022:\u0022Another good hotel\u0022,\u0022descriptionFr\u0022:\u0022Un autre bon h\\u00f4tel\u0022,\u0022category\u0022:\u0022Budget\u0022,\u0022tags\u0022:[\u0022wifi\u0022,\u0022budget\u0022],\u0022parkingIncluded\u0022:true,\u0022smokingAllowed\u0022:false,\u0022lastRenovationDate\u0022:\u00222012-08-12T00:00:00Z\u0022,\u0022rating\u0022:4,\u0022location\u0022:{\u0022type\u0022:\u0022Point\u0022,\u0022coordinates\u0022:[-122.131577,48.678581],\u0022crs\u0022:{\u0022type\u0022:\u0022name\u0022,\u0022properties\u0022:{\u0022name\u0022:\u0022EPSG:4326\u0022}}},\u0022address\u0022:null,\u0022rooms\u0022:[]},{\u0022@search.score\u0022:0.23755229,\u0022hotelId\u0022:\u00229\u0022,\u0022hotelName\u0022:\u0022Secret Point Motel\u0022,\u0022description\u0022:\u0022The hotel is ideally located on the main commercial artery of the city in the heart of New York. A few minutes away is Time\u0027s Square and the historic centre of the city, as well as other places of interest that make New York one of America\u0027s most attractive and cosmopolitan cities.\u0022,\u0022descriptionFr\u0022:\u0022L\u0027h\\u00f4tel est id\\u00e9alement situ\\u00e9 sur la principale art\\u00e8re commerciale de la ville en plein c\\u0153ur de New York. A quelques minutes se trouve la place du temps et le centre historique de la ville, ainsi que d\u0027autres lieux d\u0027int\\u00e9r\\u00eat qui font de New York l\u0027une des villes les plus attractives et cosmopolites de l\u0027Am\\u00e9rique.\u0022,\u0022category\u0022:\u0022Boutique\u0022,\u0022tags\u0022:[\u0022pool\u0022,\u0022air conditioning\u0022,\u0022concierge\u0022],\u0022parkingIncluded\u0022:false,\u0022smokingAllowed\u0022:true,\u0022lastRenovationDate\u0022:\u00221970-01-18T05:00:00Z\u0022,\u0022rating\u0022:4,\u0022location\u0022:{\u0022type\u0022:\u0022Point\u0022,\u0022coordinates\u0022:[-73.975403,40.760586],\u0022crs\u0022:{\u0022type\u0022:\u0022name\u0022,\u0022properties\u0022:{\u0022name\u0022:\u0022EPSG:4326\u0022}}},\u0022address\u0022:{\u0022streetAddress\u0022:\u0022677 5th Ave\u0022,\u0022city\u0022:\u0022New York\u0022,\u0022stateProvince\u0022:\u0022NY\u0022,\u0022country\u0022:\u0022USA\u0022,\u0022postalCode\u0022:\u002210022\u0022},\u0022rooms\u0022:[{\u0022description\u0022:\u0022Budget Room, 1 Queen Bed (Cityside)\u0022,\u0022descriptionFr\u0022:\u0022Chambre \\u00c9conomique, 1 grand lit (c\\u00f4t\\u00e9 ville)\u0022,\u0022type\u0022:\u0022Budget Room\u0022,\u0022baseRate\u0022:9.69,\u0022bedOptions\u0022:\u00221 Queen Bed\u0022,\u0022sleepsCount\u0022:2,\u0022smokingAllowed\u0022:true,\u0022tags\u0022:[\u0022vcr/dvd\u0022]},{\u0022description\u0022:\u0022Budget Room, 1 King Bed (Mountain View)\u0022,\u0022descriptionFr\u0022:\u0022Chambre \\u00c9conomique, 1 tr\\u00e8s grand lit (Mountain View)\u0022,\u0022type\u0022:\u0022Budget Room\u0022,\u0022baseRate\u0022:8.09,\u0022bedOptions\u0022:\u00221 King Bed\u0022,\u0022sleepsCount\u0022:2,\u0022smokingAllowed\u0022:true,\u0022tags\u0022:[\u0022vcr/dvd\u0022,\u0022jacuzzi tub\u0022]}]},{\u0022@search.score\u0022:0.21505894,\u0022hotelId\u0022:\u00222\u0022,\u0022hotelName\u0022:\u0022Roach Motel\u0022,\u0022description\u0022:\u0022Cheapest hotel in town. Infact, a motel.\u0022,\u0022descriptionFr\u0022:\u0022H\\u00f4tel le moins cher en ville. Infact, un motel.\u0022,\u0022category\u0022:\u0022Budget\u0022,\u0022tags\u0022:[\u0022motel\u0022,\u0022budget\u0022],\u0022parkingIncluded\u0022:true,\u0022smokingAllowed\u0022:true,\u0022lastRenovationDate\u0022:\u00221982-04-28T00:00:00Z\u0022,\u0022rating\u0022:1,\u0022location\u0022:{\u0022type\u0022:\u0022Point\u0022,\u0022coordinates\u0022:[-122.131577,49.678581],\u0022crs\u0022:{\u0022type\u0022:\u0022name\u0022,\u0022properties\u0022:{\u0022name\u0022:\u0022EPSG:4326\u0022}}},\u0022address\u0022:null,\u0022rooms\u0022:[]}]}"
+      "ResponseBody": {
+        "value": [
+          {
+            "@search.score": 1.9115671,
+            "HotelId": "1",
+            "HotelName": "Fancy Stay",
+            "Description": "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.",
+            "DescriptionFr": "Meilleur h\u00F4tel en ville si vous aimez les h\u00F4tels de luxe. Ils ont une magnifique piscine \u00E0 d\u00E9bordement, un spa et un concierge tr\u00E8s utile. L\u0027emplacement est parfait \u2013 en plein centre, \u00E0 proximit\u00E9 de toutes les attractions touristiques. Nous recommandons fortement cet h\u00F4tel.",
+            "Category": "Luxury",
+            "Tags": [
+              "pool",
+              "view",
+              "wifi",
+              "concierge"
+            ],
+            "ParkingIncluded": false,
+            "SmokingAllowed": false,
+            "LastRenovationDate": "2010-06-27T00:00:00Z",
+            "Rating": 5,
+            "Location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                47.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "GeoLocation": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                47.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "Address": null,
+            "Rooms": []
+          },
+          {
+            "@search.score": 0.5337951,
+            "HotelId": "3",
+            "HotelName": "EconoStay",
+            "Description": "Very popular hotel in town",
+            "DescriptionFr": "H\u00F4tel le plus populaire en ville",
+            "Category": "Budget",
+            "Tags": [
+              "wifi",
+              "budget"
+            ],
+            "ParkingIncluded": true,
+            "SmokingAllowed": false,
+            "LastRenovationDate": "1995-07-01T00:00:00Z",
+            "Rating": 4,
+            "Location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                46.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "GeoLocation": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                46.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "Address": null,
+            "Rooms": []
+          },
+          {
+            "@search.score": 0.3451531,
+            "HotelId": "10",
+            "HotelName": "Countryside Hotel",
+            "Description": "Save up to 50% off traditional hotels.  Free WiFi, great location near downtown, full kitchen, washer \u0026 dryer, 24/7 support, bowling alley, fitness center and more.",
+            "DescriptionFr": "\u00C9conomisez jusqu\u0027\u00E0 50% sur les h\u00F4tels traditionnels.  WiFi gratuit, tr\u00E8s bien situ\u00E9 pr\u00E8s du centre-ville, cuisine compl\u00E8te, laveuse \u0026 s\u00E9cheuse, support 24/7, bowling, centre de fitness et plus encore.",
+            "Category": "Budget",
+            "Tags": [
+              "24-hour front desk service",
+              "coffee in lobby",
+              "restaurant"
+            ],
+            "ParkingIncluded": false,
+            "SmokingAllowed": true,
+            "LastRenovationDate": "1999-09-06T00:00:00Z",
+            "Rating": 3,
+            "Location": {
+              "type": "Point",
+              "coordinates": [
+                -78.940483,
+                35.90416
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "GeoLocation": {
+              "type": "Point",
+              "coordinates": [
+                -78.940483,
+                35.90416
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "Address": {
+              "StreetAddress": "6910 Fayetteville Rd",
+              "City": "Durham",
+              "StateProvince": "NC",
+              "Country": "USA",
+              "PostalCode": "27713"
+            },
+            "Rooms": [
+              {
+                "Description": "Suite, 1 King Bed (Amenities)",
+                "DescriptionFr": "Suite, 1 tr\u00E8s grand lit (Services)",
+                "Type": "Suite",
+                "BaseRate": 2.44,
+                "BedOptions": "1 King Bed",
+                "SleepsCount": 2,
+                "SmokingAllowed": true,
+                "Tags": [
+                  "coffee maker"
+                ]
+              },
+              {
+                "Description": "Budget Room, 1 Queen Bed (Amenities)",
+                "DescriptionFr": "Chambre \u00C9conomique, 1 grand lit (Services)",
+                "Type": "Budget Room",
+                "BaseRate": 7.69,
+                "BedOptions": "1 Queen Bed",
+                "SleepsCount": 2,
+                "SmokingAllowed": false,
+                "Tags": [
+                  "coffee maker"
+                ]
+              }
+            ]
+          },
+          {
+            "@search.score": 0.2622748,
+            "HotelId": "4",
+            "HotelName": "Express Rooms",
+            "Description": "Pretty good hotel",
+            "DescriptionFr": "Assez bon h\u00F4tel",
+            "Category": "Budget",
+            "Tags": [
+              "wifi",
+              "budget"
+            ],
+            "ParkingIncluded": true,
+            "SmokingAllowed": false,
+            "LastRenovationDate": "1995-07-01T00:00:00Z",
+            "Rating": 4,
+            "Location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                48.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "GeoLocation": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                48.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "Address": null,
+            "Rooms": []
+          },
+          {
+            "@search.score": 0.2622748,
+            "HotelId": "5",
+            "HotelName": "Comfy Place",
+            "Description": "Another good hotel",
+            "DescriptionFr": "Un autre bon h\u00F4tel",
+            "Category": "Budget",
+            "Tags": [
+              "wifi",
+              "budget"
+            ],
+            "ParkingIncluded": true,
+            "SmokingAllowed": false,
+            "LastRenovationDate": "2012-08-12T00:00:00Z",
+            "Rating": 4,
+            "Location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                48.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "GeoLocation": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                48.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "Address": {
+              "StreetAddress": "677 5th Ave",
+              "City": "NEW YORK",
+              "StateProvince": "NY",
+              "Country": "USA",
+              "PostalCode": "10022"
+            },
+            "Rooms": []
+          },
+          {
+            "@search.score": 0.23755229,
+            "HotelId": "9",
+            "HotelName": "Secret Point Motel",
+            "Description": "The hotel is ideally located on the main commercial artery of the city in the heart of New York. A few minutes away is Time\u0027s Square and the historic centre of the city, as well as other places of interest that make New York one of America\u0027s most attractive and cosmopolitan cities.",
+            "DescriptionFr": "L\u0027h\u00F4tel est id\u00E9alement situ\u00E9 sur la principale art\u00E8re commerciale de la ville en plein c\u0153ur de New York. A quelques minutes se trouve la place du temps et le centre historique de la ville, ainsi que d\u0027autres lieux d\u0027int\u00E9r\u00EAt qui font de New York l\u0027une des villes les plus attractives et cosmopolites de l\u0027Am\u00E9rique.",
+            "Category": "Boutique",
+            "Tags": [
+              "pool",
+              "air conditioning",
+              "concierge"
+            ],
+            "ParkingIncluded": false,
+            "SmokingAllowed": true,
+            "LastRenovationDate": "1970-01-18T05:00:00Z",
+            "Rating": 4,
+            "Location": {
+              "type": "Point",
+              "coordinates": [
+                -73.975403,
+                40.760586
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "GeoLocation": {
+              "type": "Point",
+              "coordinates": [
+                -73.975403,
+                40.760586
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "Address": {
+              "StreetAddress": "677 5th Ave",
+              "City": "New York",
+              "StateProvince": "NY",
+              "Country": "USA",
+              "PostalCode": "10022"
+            },
+            "Rooms": [
+              {
+                "Description": "Budget Room, 1 Queen Bed (Cityside)",
+                "DescriptionFr": "Chambre \u00C9conomique, 1 grand lit (c\u00F4t\u00E9 ville)",
+                "Type": "Budget Room",
+                "BaseRate": 9.69,
+                "BedOptions": "1 Queen Bed",
+                "SleepsCount": 2,
+                "SmokingAllowed": true,
+                "Tags": [
+                  "vcr/dvd"
+                ]
+              },
+              {
+                "Description": "Budget Room, 1 King Bed (Mountain View)",
+                "DescriptionFr": "Chambre \u00C9conomique, 1 tr\u00E8s grand lit (Mountain View)",
+                "Type": "Budget Room",
+                "BaseRate": 8.09,
+                "BedOptions": "1 King Bed",
+                "SleepsCount": 2,
+                "SmokingAllowed": true,
+                "Tags": [
+                  "vcr/dvd",
+                  "jacuzzi tub"
+                ]
+              }
+            ]
+          },
+          {
+            "@search.score": 0.21505894,
+            "HotelId": "2",
+            "HotelName": "Roach Motel",
+            "Description": "Cheapest hotel in town. Infact, a motel.",
+            "DescriptionFr": "H\u00F4tel le moins cher en ville. Infact, un motel.",
+            "Category": "Budget",
+            "Tags": [
+              "motel",
+              "budget"
+            ],
+            "ParkingIncluded": true,
+            "SmokingAllowed": true,
+            "LastRenovationDate": "1982-04-28T00:00:00Z",
+            "Rating": 1,
+            "Location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                49.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "GeoLocation": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                49.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "Address": null,
+            "Rooms": []
+          }
+        ]
+      }
     },
     {
-      "RequestUri": "https://azs-net-heathsrchtst2.search.windows.net/indexers(\u0027fedemlmi\u0027)?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexers(\u0027bnruxjws\u0027)?api-version=2020-06-30",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-2a4e6745e126434d812ae1e6a2da1e51-ba8976d998677746-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.2.0-alpha.20201102.1",
-          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "26a78f04105e77ba186915a17736be42",
+        "traceparent": "00-ca4514714110855d4bf6c3bc26b6c833-0f5d7f374472361b-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "986c49c4bc9b0623963ef98a963c88d2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "26a78f04-105e-77ba-1869-15a17736be42",
-        "Date": "Tue, 03 Nov 2020 00:00:07 GMT",
-        "elapsed-time": "89",
+        "client-request-id": "986c49c4-bc9b-0623-963e-f98a963c88d2",
+        "Date": "Fri, 06 Jan 2023 21:25:11 GMT",
+        "elapsed-time": "115",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "26a78f04-105e-77ba-1869-15a17736be42",
+        "request-id": "986c49c4-bc9b-0623-963e-f98a963c88d2",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "26a78f04-105e-77ba-1869-15a17736be42"
+        "x-ms-client-request-id": "986c49c4-bc9b-0623-963e-f98a963c88d2"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://azs-net-heathsrchtst2.search.windows.net/datasources(\u0027saxjrhml\u0027)?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/datasources(\u0027jvpxvkdt\u0027)?api-version=2020-06-30",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-1b9758027812a24cbd31dfe54af19050-7989f336ee9a9f40-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.2.0-alpha.20201102.1",
-          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "f3b31047da0b66e8aba48e93c4caeed6",
+        "traceparent": "00-d2c2ddda9068d250c09cfb4b19dcbce6-29ef0c3135164e88-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7cde0e8a401e0124cce47ba1c306899b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "f3b31047-da0b-66e8-aba4-8e93c4caeed6",
-        "Date": "Tue, 03 Nov 2020 00:00:07 GMT",
-        "elapsed-time": "33",
+        "client-request-id": "7cde0e8a-401e-0124-cce4-7ba1c306899b",
+        "Date": "Fri, 06 Jan 2023 21:25:11 GMT",
+        "elapsed-time": "22",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "f3b31047-da0b-66e8-aba4-8e93c4caeed6",
+        "request-id": "7cde0e8a-401e-0124-cce4-7ba1c306899b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "f3b31047-da0b-66e8-aba4-8e93c4caeed6"
+        "x-ms-client-request-id": "7cde0e8a-401e-0124-cce4-7ba1c306899b"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://azs-net-heathsrchtst2.search.windows.net/indexes(\u0027prgvvpbp\u0027)?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027bwlljfdx\u0027)?api-version=2020-06-30",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-c60ba7669bc5534c9135bad364ff7f46-820b2168e4dc8e4e-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.2.0-alpha.20201102.1",
-          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "73f7c5cac390e52c5b1b32123df42da0",
+        "traceparent": "00-edbcfe85fab98744d8822ce034c0cc64-bd8d44e2f75c43f5-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0529d700c00be9988a8e61db4fb1ff6f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "73f7c5ca-c390-e52c-5b1b-32123df42da0",
-        "Date": "Tue, 03 Nov 2020 00:00:07 GMT",
-        "elapsed-time": "187",
+        "client-request-id": "0529d700-c00b-e998-8a8e-61db4fb1ff6f",
+        "Date": "Fri, 06 Jan 2023 21:25:12 GMT",
+        "elapsed-time": "262",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "73f7c5ca-c390-e52c-5b1b-32123df42da0",
+        "request-id": "0529d700-c00b-e998-8a8e-61db4fb1ff6f",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "73f7c5ca-c390-e52c-5b1b-32123df42da0"
+        "x-ms-client-request-id": "0529d700-c00b-e998-8a8e-61db4fb1ff6f"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     }
   ],
   "Variables": {
-    "BlobContainerName": "hfbypvrf",
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "BlobContainerName": "rnhaffmg",
+    "CLIENT_ID": "fb4cb505-3ed0-48c0-b5c0-e7b7bf139923",
     "CLIENT_SECRET": "Sanitized",
-    "RandomSeed": "1203123296",
-    "SearchIndexName": "prgvvpbp",
+    "RandomSeed": "1593268853",
+    "SearchIndexName": "bwlljfdx",
     "SEARCH_ADMIN_API_KEY": "Sanitized",
-    "SEARCH_KEYVAULT_URL": "https://heathsrchtst2kv.vault.azure.net/",
-    "SEARCH_SERVICE_NAME": "azs-net-heathsrchtst2",
+    "SEARCH_ENDPOINT_SUFFIX": "search.windows.net",
+    "SEARCH_KEYVAULT_URL": "https://shrejaazsearchkv.vault.azure.net/",
+    "SEARCH_SERVICE_NAME": "azs-net-shrejaazsearch",
     "SEARCH_STORAGE_KEY": "Sanitized",
-    "SEARCH_STORAGE_NAME": "heathsrchtst2stg"
+    "SEARCH_STORAGE_NAME": "shrejaazsearchstg",
+    "STORAGE_ENDPOINT_SUFFIX": "core.windows.net"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/FieldBuilderIgnore/CreateIndex.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/FieldBuilderIgnore/CreateIndex.json
@@ -1,20 +1,19 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://shreja-search-service.search.windows.net/indexes?api-version=2021-04-30-Preview",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes?api-version=2021-04-30-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "Connection": "keep-alive",
         "Content-Length": "880",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-Search.Documents/11.4.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.22000 )",
-        "x-ms-client-request-id": "dfab75e8dc5a803ce35043645208feaa",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "95d163af73b3faa1d09079e4c06671da",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "uunjwncb",
+        "name": "vgvemcrc",
         "fields": [
           {
             "name": "id",
@@ -83,25 +82,25 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "dfab75e8-dc5a-803c-e350-43645208feaa",
-        "Content-Length": "1710",
+        "client-request-id": "95d163af-73b3-faa1-d090-79e4c06671da",
+        "Content-Length": "1711",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 30 Jun 2022 01:08:49 GMT",
-        "elapsed-time": "737",
-        "ETag": "W/\u00220x8DA5A351708823D\u0022",
+        "Date": "Fri, 06 Jan 2023 21:04:43 GMT",
+        "elapsed-time": "696",
+        "ETag": "W/\u00220x8DAF029A2ACD163\u0022",
         "Expires": "-1",
-        "Location": "https://shreja-search-service.search.windows.net/indexes(\u0027uunjwncb\u0027)?api-version=2021-04-30-Preview",
+        "Location": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027vgvemcrc\u0027)?api-version=2021-04-30-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "dfab75e8-dc5a-803c-e350-43645208feaa",
+        "request-id": "95d163af-73b3-faa1-d090-79e4c06671da",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "dfab75e8-dc5a-803c-e350-43645208feaa"
+        "x-ms-client-request-id": "95d163af-73b3-faa1-d090-79e4c06671da"
       },
       "ResponseBody": {
-        "@odata.context": "https://shreja-search-service.search.windows.net/$metadata#indexes/$entity",
-        "@odata.etag": "\u00220x8DA5A351708823D\u0022",
-        "name": "uunjwncb",
+        "@odata.context": "https://azs-net-shrejaazsearch.search.windows.net/$metadata#indexes/$entity",
+        "@odata.etag": "\u00220x8DAF029A2ACD163\u0022",
+        "name": "vgvemcrc",
         "defaultScoringProfile": null,
         "fields": [
           {
@@ -206,49 +205,49 @@
       }
     },
     {
-      "RequestUri": "https://shreja-search-service.search.windows.net/indexes(\u0027uunjwncb\u0027)/docs/search.index?api-version=2021-04-30-Preview",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027vgvemcrc\u0027)/docs/search.index?api-version=2021-04-30-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "Content-Length": "192",
+        "Content-Length": "177",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-Search.Documents/11.4.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.22000 )",
-        "x-ms-client-request-id": "249541fd6396f53ee318d2a1995fdaac",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2d7261a75e236fcad703e002502f9648",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "value": [
           {
             "@search.action": "upload",
-            "id": "28ee4977599645f5abf37fa07dbae228",
+            "id": "1cd576f819b748aca2b5456544011313",
             "name": "The Lord of the Rings: The Return of the King",
             "genre": "Fantasy",
             "year": 2003,
-            "rating": 9.0999999999999996
+            "rating": 9.1
           }
         ]
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "249541fd-6396-f53e-e318-d2a1995fdaac",
+        "client-request-id": "2d7261a7-5e23-6fca-d703-e002502f9648",
         "Content-Length": "105",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Thu, 30 Jun 2022 01:08:49 GMT",
-        "elapsed-time": "79",
+        "Date": "Fri, 06 Jan 2023 21:04:44 GMT",
+        "elapsed-time": "90",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "249541fd-6396-f53e-e318-d2a1995fdaac",
+        "request-id": "2d7261a7-5e23-6fca-d703-e002502f9648",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "249541fd-6396-f53e-e318-d2a1995fdaac"
+        "x-ms-client-request-id": "2d7261a7-5e23-6fca-d703-e002502f9648"
       },
       "ResponseBody": {
         "value": [
           {
-            "key": "28ee4977599645f5abf37fa07dbae228",
+            "key": "1cd576f819b748aca2b5456544011313",
             "status": true,
             "errorMessage": null,
             "statusCode": 201
@@ -257,38 +256,37 @@
       }
     },
     {
-      "RequestUri": "https://shreja-search-service.search.windows.net/indexes(\u0027uunjwncb\u0027)?api-version=2021-04-30-Preview",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027vgvemcrc\u0027)?api-version=2021-04-30-Preview",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "Content-Length": "0",
-        "traceparent": "00-8e0b8c8ab5be4f42850e9acf51fcfca6-41edd0d695c2d443-00",
-        "User-Agent": "azsdk-net-Search.Documents/11.4.0-alpha.20220629.1 (.NET Framework 4.8.4510.0; Microsoft Windows 10.0.22000 )",
-        "x-ms-client-request-id": "2e600c823969b3f647b4f8fe6684415c",
+        "traceparent": "00-7680fce688d1edf3da39e58789953dfe-3781df7a7c4a1ded-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ede29331530ce6d4b46a34467ca77623",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "2e600c82-3969-b3f6-47b4-f8fe6684415c",
-        "Date": "Thu, 30 Jun 2022 01:08:50 GMT",
-        "elapsed-time": "159",
+        "client-request-id": "ede29331-530c-e6d4-b46a-34467ca77623",
+        "Date": "Fri, 06 Jan 2023 21:04:44 GMT",
+        "elapsed-time": "182",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "2e600c82-3969-b3f6-47b4-f8fe6684415c",
+        "request-id": "ede29331-530c-e6d4-b46a-34467ca77623",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "2e600c82-3969-b3f6-47b4-f8fe6684415c"
+        "x-ms-client-request-id": "ede29331-530c-e6d4-b46a-34467ca77623"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "RandomSeed": "908058385",
-    "SearchIndexName": "uunjwncb",
+    "RandomSeed": "1565912648",
+    "SearchIndexName": "vgvemcrc",
     "SEARCH_ADMIN_API_KEY": "Sanitized",
-    "SEARCH_ENDPOINT_SUFFIX": null,
-    "SEARCH_SERVICE_NAME": "shreja-search-service"
+    "SEARCH_ENDPOINT_SUFFIX": "search.windows.net",
+    "SEARCH_SERVICE_NAME": "azs-net-shrejaazsearch"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/CreateClient.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/CreateClient.json
@@ -1,65 +1,66 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-heathsrchtst.search.windows.net/servicestats?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/servicestats?api-version=2020-06-30",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.0.0-dev.20200625.1",
-          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
-        ],
-        "x-ms-client-request-id": "4b6405bb4fdcb9544c0fdf174384b8eb",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9c5d9b42dc56d1738bfeecb712e0c4a4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "4b6405bb-4fdc-b954-4c0f-df174384b8eb",
-        "Content-Length": "544",
+        "client-request-id": "9c5d9b42-dc56-d173-8bfe-ecb712e0c4a4",
+        "Content-Length": "586",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Fri, 26 Jun 2020 06:20:13 GMT",
-        "elapsed-time": "226",
+        "Date": "Fri, 06 Jan 2023 20:58:53 GMT",
+        "elapsed-time": "32",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "4b6405bb-4fdc-b954-4c0f-df174384b8eb",
+        "request-id": "9c5d9b42-dc56-d173-8bfe-ecb712e0c4a4",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "4b6405bb-4fdc-b954-4c0f-df174384b8eb"
+        "x-ms-client-request-id": "9c5d9b42-dc56-d173-8bfe-ecb712e0c4a4"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-heathsrchtst.search.windows.net/$metadata#Microsoft.Azure.Search.V2020_06_30.ServiceStatistics",
+        "@odata.context": "https://azs-net-shrejaazsearch.search.windows.net/$metadata#Microsoft.Azure.Search.V2020_06_30.ServiceStatistics",
         "counters": {
           "documentCount": {
-            "usage": 10,
+            "usage": 0,
             "quota": null
           },
           "indexesCount": {
             "usage": 1,
-            "quota": 3
+            "quota": 50
           },
           "indexersCount": {
             "usage": 0,
-            "quota": 3
+            "quota": 50
           },
           "dataSourcesCount": {
             "usage": 0,
-            "quota": 3
+            "quota": 50
           },
           "storageSize": {
-            "usage": 37093,
-            "quota": 52428800
+            "usage": 0,
+            "quota": 26843545600
           },
           "synonymMaps": {
             "usage": 0,
-            "quota": 3
+            "quota": 5
+          },
+          "skillsetCount": {
+            "usage": 0,
+            "quota": 50
           }
         },
         "limits": {
-          "maxFieldsPerIndex": 1000,
+          "maxFieldsPerIndex": 3000,
           "maxFieldNestingDepthPerIndex": 10,
           "maxComplexCollectionFieldsPerIndex": 40,
           "maxComplexObjectsInCollectionsPerDocument": 3000
@@ -68,9 +69,10 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "2134332413",
-    "SearchIndexName": "josgoidr",
+    "RandomSeed": "2004806705",
+    "SearchIndexName": "sdroirrc",
     "SEARCH_ADMIN_API_KEY": "Sanitized",
-    "SEARCH_SERVICE_NAME": "azs-net-heathsrchtst"
+    "SEARCH_ENDPOINT_SUFFIX": "search.windows.net",
+    "SEARCH_SERVICE_NAME": "azs-net-shrejaazsearch"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/CreateClientAsyncAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/CreateClientAsyncAsync.json
@@ -1,66 +1,67 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-heathsrchtst.search.windows.net/servicestats?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/servicestats?api-version=2020-06-30",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-6a8e74eed65acb419bf748d28cd18bd2-5249d3cdc1148242-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.0.0-dev.20200625.1",
-          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
-        ],
-        "x-ms-client-request-id": "a029684f073e794ac0638ad34807c434",
+        "traceparent": "00-042258db100ca8d775658a3f0cf3b9b0-662308da3f941800-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "309127ef7aaea6c82d88099b51f915d6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "a029684f-073e-794a-c063-8ad34807c434",
-        "Content-Length": "544",
+        "client-request-id": "309127ef-7aae-a6c8-2d88-099b51f915d6",
+        "Content-Length": "586",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Fri, 26 Jun 2020 06:20:13 GMT",
-        "elapsed-time": "190",
+        "Date": "Fri, 06 Jan 2023 21:00:46 GMT",
+        "elapsed-time": "15",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "a029684f-073e-794a-c063-8ad34807c434",
+        "request-id": "309127ef-7aae-a6c8-2d88-099b51f915d6",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "a029684f-073e-794a-c063-8ad34807c434"
+        "x-ms-client-request-id": "309127ef-7aae-a6c8-2d88-099b51f915d6"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-heathsrchtst.search.windows.net/$metadata#Microsoft.Azure.Search.V2020_06_30.ServiceStatistics",
+        "@odata.context": "https://azs-net-shrejaazsearch.search.windows.net/$metadata#Microsoft.Azure.Search.V2020_06_30.ServiceStatistics",
         "counters": {
           "documentCount": {
-            "usage": 10,
+            "usage": 0,
             "quota": null
           },
           "indexesCount": {
             "usage": 1,
-            "quota": 3
+            "quota": 50
           },
           "indexersCount": {
             "usage": 0,
-            "quota": 3
+            "quota": 50
           },
           "dataSourcesCount": {
             "usage": 0,
-            "quota": 3
+            "quota": 50
           },
           "storageSize": {
-            "usage": 37093,
-            "quota": 52428800
+            "usage": 0,
+            "quota": 26843545600
           },
           "synonymMaps": {
             "usage": 0,
-            "quota": 3
+            "quota": 5
+          },
+          "skillsetCount": {
+            "usage": 0,
+            "quota": 50
           }
         },
         "limits": {
-          "maxFieldsPerIndex": 1000,
+          "maxFieldsPerIndex": 3000,
           "maxFieldNestingDepthPerIndex": 10,
           "maxComplexCollectionFieldsPerIndex": 40,
           "maxComplexObjectsInCollectionsPerDocument": 3000
@@ -69,9 +70,10 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "525186745",
-    "SearchIndexName": "josgoidr",
+    "RandomSeed": "723367569",
+    "SearchIndexName": "ypjsfjyb",
     "SEARCH_ADMIN_API_KEY": "Sanitized",
-    "SEARCH_SERVICE_NAME": "azs-net-heathsrchtst"
+    "SEARCH_ENDPOINT_SUFFIX": "search.windows.net",
+    "SEARCH_SERVICE_NAME": "azs-net-shrejaazsearch"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/CreateIndexerAsyncAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/CreateIndexerAsyncAsync.json
@@ -1,67 +1,68 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/synonymmaps?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/synonymmaps?api-version=2020-06-30",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "Content-Length": "5201",
         "Content-Type": "application/json",
-        "traceparent": "00-b0f1b5cb1d3f5d4594e924e9b302f0a2-f25d96b1d012284f-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210514.1",
-          "(.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "736a681f3427c94a05ac6bd1d810826b",
+        "traceparent": "00-da794f9f8322ed8548bb31b5ef72ec1e-79ca804296e99951-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "72b4e7e3aea4158487f9bac324d3604c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "yjlkevvv",
+        "name": "tmolvpnv",
         "format": "solr",
         "synonyms": "Afghanistan,AF,AFG\n\u00C5land Islands,AX,ALA\nAlbania,AL,ALB\nAlgeria,DZ,DZA\nAmerican Samoa,AS,ASM\nAndorra,AD,AND\nAngola,AO,AGO\nAnguilla,AI,AIA\nAntarctica,AQ,ATA\nAntigua and Barbuda,AG,ATG\nArgentina,AR,ARG\nArmenia,AM,ARM\nAruba,AW,ABW\nAustralia,AU,AUS\nAustria,AT,AUT\nAzerbaijan,AZ,AZE\nBahamas,BS,BHS\nBahrain,BH,BHR\nBangladesh,BD,BGD\nBarbados,BB,BRB\nBelarus,BY,BLR\nBelgium,BE,BEL\nBelize,BZ,BLZ\nBenin,BJ,BEN\nBermuda,BM,BMU\nBhutan,BT,BTN\nBolivia,Plurinational State of Bolivia,BO,BOL\nBonaire,Sint Eustatius and Saba,BQ,BES\nBosnia and Herzegovina,BA,BIH\nBotswana,BW,BWA\nBouvet Island,BV,BVT\nBrazil,BR,BRA\nBritish Indian Ocean Territory,IO,IOT\nBrunei Darussalam,BN,BRN\nBulgaria,BG,BGR\nBurkina Faso,BF,BFA\nBurundi,BI,BDI\nCabo Verde,CV,CPV\nCambodia,KH,KHM\nCameroon,CM,CMR\nCanada,CA,CAN\nCayman Islands,KY,CYM\nCentral African Republic,CF,CAF\nChad,TD,TCD\nChile,CL,CHL\nChina,CN,CHN\nChristmas Island,CX,CXR\nCocos (Keeling) Islands,CC,CCK\nColombia,CO,COL\nComoros,KM,COM\nCongo,CG,COG\nDemocratic Republic of the Congo,CD,COD\nCook Islands,CK,COK\nCosta Rica,CR,CRI\nC\u00F4te d\u0027Ivoire,CI,CIV\nCroatia,HR,HRV\nCuba,CU,CUB\nCura\u00E7ao,CW,CUW\nCyprus,CY,CYP\nCzechia,CZ,CZE\nDenmark,DK,DNK\nDjibouti,DJ,DJI\nDominica,DM,DMA\nDominican Republic,DO,DOM\nEcuador,EC,ECU\nEgypt,EG,EGY\nEl Salvador,SV,SLV\nEquatorial Guinea,GQ,GNQ\nEritrea,ER,ERI\nEstonia,EE,EST\nEswatini,SZ,SWZ\nEthiopia,ET,ETH\nFalkland Islands (Malvinas),FK,FLK\nFaroe Islands,FO,FRO\nFiji,FJ,FJI\nFinland,FI,FIN\nFrance,FR,FRA\nFrench Guiana,GF,GUF\nFrench Polynesia,PF,PYF\nFrench Southern Territories,TF,ATF\nGabon,GA,GAB\nGambia,GM,GMB\nGeorgia,GE,GEO\nGermany,DE,DEU\nGhana,GH,GHA\nGibraltar,GI,GIB\nGreece,GR,GRC\nGreenland,GL,GRL\nGrenada,GD,GRD\nGuadeloupe,GP,GLP\nGuam,GU,GUM\nGuatemala,GT,GTM\nGuernsey,GG,GGY\nGuinea,GN,GIN\nGuinea-Bissau,GW,GNB\nGuyana,GY,GUY\nHaiti,HT,HTI\nHeard Island and McDonald Islands,HM,HMD\nHoly See,VA,VAT\nHonduras,HN,HND\nHong Kong,HK,HKG\nHungary,HU,HUN\nIceland,IS,ISL\nIndia,IN,IND\nIndonesia,ID,IDN\nIran,Islamic Republic of Iran,IR,IRN\nIraq,IQ,IRQ\nIreland,IE,IRL\nIsle of Man,IM,IMN\nIsrael,IL,ISR\nItaly,IT,ITA\nJamaica,JM,JAM\nJapan,JP,JPN\nJersey,JE,JEY\nJordan,JO,JOR\nKazakhstan,KZ,KAZ\nKenya,KE,KEN\nKiribati,KI,KIR\nDemocratic People\u0027s Republic of Korea,KP,PRK\nKorea,Republic of Korea,KR,KOR\nKuwait,KW,KWT\nKyrgyzstan,KG,KGZ\nLao People\u0027s Democratic Republic,LA,LAO\nLatvia,LV,LVA\nLebanon,LB,LBN\nLesotho,LS,LSO\nLiberia,LR,LBR\nLibya,LY,LBY\nLiechtenstein,LI,LIE\nLithuania,LT,LTU\nLuxembourg,LU,LUX\nMacao,MO,MAC\nMadagascar,MG,MDG\nMalawi,MW,MWI\nMalaysia,MY,MYS\nMaldives,MV,MDV\nMali,ML,MLI\nMalta,MT,MLT\nMarshall Islands,MH,MHL\nMartinique,MQ,MTQ\nMauritania,MR,MRT\nMauritius,MU,MUS\nMayotte,YT,MYT\nMexico,MX,MEX\nMicronesia,Federated States of Micronesia,FM,FSM\nMoldova,Republic of Moldova,MD,MDA\nMonaco,MC,MCO\nMongolia,MN,MNG\nMontenegro,ME,MNE\nMontserrat,MS,MSR\nMorocco,MA,MAR\nMozambique,MZ,MOZ\nMyanmar,MM,MMR\nNamibia,NA,NAM\nNauru,NR,NRU\nNepal,NP,NPL\nNetherlands,NL,NLD\nNew Caledonia,NC,NCL\nNew Zealand,NZ,NZL\nNicaragua,NI,NIC\nNiger,NE,NER\nNigeria,NG,NGA\nNiue,NU,NIU\nNorfolk Island,NF,NFK\nNorth Macedonia,MK,MKD\nNorthern Mariana Islands,MP,MNP\nNorway,NO,NOR\nOman,OM,OMN\nPakistan,PK,PAK\nPalau,PW,PLW\nPalestine,State of Palestine,PS,PSE\nPanama,PA,PAN\nPapua New Guinea,PG,PNG\nParaguay,PY,PRY\nPeru,PE,PER\nPhilippines,PH,PHL\nPitcairn,PN,PCN\nPoland,PL,POL\nPortugal,PT,PRT\nPuerto Rico,PR,PRI\nQatar,QA,QAT\nR\u00E9union,RE,REU\nRomania,RO,ROU\nRussia,Russian Federation,RU,RUS\nRwanda,RW,RWA\nSaint Barth\u00E9lemy,BL,BLM\nSaint Helena,Ascension and Tristan da Cunha,SH,SHN\nSaint Kitts and Nevis,KN,KNA\nSaint Lucia,LC,LCA\nSaint Martin (French part),MF,MAF\nSaint Pierre and Miquelon,PM,SPM\nSaint Vincent and the Grenadines,VC,VCT\nSamoa,WS,WSM\nSan Marino,SM,SMR\nSao Tome and Principe,ST,STP\nSaudi Arabia,SA,SAU\nSenegal,SN,SEN\nSerbia,RS,SRB\nSeychelles,SC,SYC\nSierra Leone,SL,SLE\nSingapore,SG,SGP\nSint Maarten (Dutch part),SX,SXM\nSlovakia,SK,SVK\nSlovenia,SI,SVN\nSolomon Islands,SB,SLB\nSomalia,SO,SOM\nSouth Africa,ZA,ZAF\nSouth Georgia and the South Sandwich Islands,GS,SGS\nSouth Sudan,SS,SSD\nSpain,ES,ESP\nSri Lanka,LK,LKA\nSudan,SD,SDN\nSuriname,SR,SUR\nSvalbard and Jan Mayen,SJ,SJM\nSweden,SE,SWE\nSwitzerland,CH,CHE\nSyrian Arab Republic,SY,SYR\nTaiwan,Province of China,TW,TWN\nTajikistan,TJ,TJK\nTanzania,United Republic of Tanzania,TZ,TZA\nThailand,TH,THA\nTimor-Leste,TL,TLS\nTogo,TG,TGO\nTokelau,TK,TKL\nTonga,TO,TON\nTrinidad and Tobago,TT,TTO\nTunisia,TN,TUN\nTurkey,TR,TUR\nTurkmenistan,TM,TKM\nTurks and Caicos Islands,TC,TCA\nTuvalu,TV,TUV\nUganda,UG,UGA\nUkraine,UA,UKR\nUnited Arab Emirates,AE,ARE\nUnited Kingdom of Great Britain and Northern Ireland,GB,GBR\nUnited States of America,US,USA\nUnited States Minor Outlying Islands,UM,UMI\nUruguay,UY,URY\nUzbekistan,UZ,UZB\nVanuatu,VU,VUT\nVenezuela (Bolivarian Republic of),VE,VEN\nViet Nam,VN,VNM\nVirgin Islands (British),VG,VGB\nVirgin Islands (U.S.),VI,VIR\nWallis and Futuna,WF,WLF\nWestern Sahara,EH,ESH\nYemen,YE,YEM\nZambia,ZM,ZMB\nZimbabwe,ZW,ZWE\n"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "736a681f-3427-c94a-05ac-6bd1d810826b",
-        "Content-Length": "5332",
+        "client-request-id": "72b4e7e3-aea4-1584-87f9-bac324d3604c",
+        "Content-Length": "5344",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Fri, 14 May 2021 20:51:08 GMT",
-        "elapsed-time": "93",
-        "ETag": "W/\u00220x8D9171A000D8571\u0022",
+        "Date": "Fri, 06 Jan 2023 20:48:09 GMT",
+        "elapsed-time": "100",
+        "ETag": "W/\u00220x8DAF02751DB2992\u0022",
         "Expires": "-1",
-        "Location": "https://mohitc-acs.search.windows.net/synonymmaps(\u0027yjlkevvv\u0027)?api-version=2020-06-30",
+        "Location": "https://azs-net-shrejaazsearch.search.windows.net/synonymmaps(\u0027tmolvpnv\u0027)?api-version=2020-06-30",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "736a681f-3427-c94a-05ac-6bd1d810826b",
+        "request-id": "72b4e7e3-aea4-1584-87f9-bac324d3604c",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "736a681f-3427-c94a-05ac-6bd1d810826b"
+        "x-ms-client-request-id": "72b4e7e3-aea4-1584-87f9-bac324d3604c"
       },
-      "ResponseBody": "{\u0022@odata.context\u0022:\u0022https://mohitc-acs.search.windows.net/$metadata#synonymmaps/$entity\u0022,\u0022@odata.etag\u0022:\u0022\\\u00220x8D9171A000D8571\\\u0022\u0022,\u0022name\u0022:\u0022yjlkevvv\u0022,\u0022format\u0022:\u0022solr\u0022,\u0022synonyms\u0022:\u0022Afghanistan,AF,AFG\\n\\u00c5land Islands,AX,ALA\\nAlbania,AL,ALB\\nAlgeria,DZ,DZA\\nAmerican Samoa,AS,ASM\\nAndorra,AD,AND\\nAngola,AO,AGO\\nAnguilla,AI,AIA\\nAntarctica,AQ,ATA\\nAntigua and Barbuda,AG,ATG\\nArgentina,AR,ARG\\nArmenia,AM,ARM\\nAruba,AW,ABW\\nAustralia,AU,AUS\\nAustria,AT,AUT\\nAzerbaijan,AZ,AZE\\nBahamas,BS,BHS\\nBahrain,BH,BHR\\nBangladesh,BD,BGD\\nBarbados,BB,BRB\\nBelarus,BY,BLR\\nBelgium,BE,BEL\\nBelize,BZ,BLZ\\nBenin,BJ,BEN\\nBermuda,BM,BMU\\nBhutan,BT,BTN\\nBolivia,Plurinational State of Bolivia,BO,BOL\\nBonaire,Sint Eustatius and Saba,BQ,BES\\nBosnia and Herzegovina,BA,BIH\\nBotswana,BW,BWA\\nBouvet Island,BV,BVT\\nBrazil,BR,BRA\\nBritish Indian Ocean Territory,IO,IOT\\nBrunei Darussalam,BN,BRN\\nBulgaria,BG,BGR\\nBurkina Faso,BF,BFA\\nBurundi,BI,BDI\\nCabo Verde,CV,CPV\\nCambodia,KH,KHM\\nCameroon,CM,CMR\\nCanada,CA,CAN\\nCayman Islands,KY,CYM\\nCentral African Republic,CF,CAF\\nChad,TD,TCD\\nChile,CL,CHL\\nChina,CN,CHN\\nChristmas Island,CX,CXR\\nCocos (Keeling) Islands,CC,CCK\\nColombia,CO,COL\\nComoros,KM,COM\\nCongo,CG,COG\\nDemocratic Republic of the Congo,CD,COD\\nCook Islands,CK,COK\\nCosta Rica,CR,CRI\\nC\\u00f4te d\u0027Ivoire,CI,CIV\\nCroatia,HR,HRV\\nCuba,CU,CUB\\nCura\\u00e7ao,CW,CUW\\nCyprus,CY,CYP\\nCzechia,CZ,CZE\\nDenmark,DK,DNK\\nDjibouti,DJ,DJI\\nDominica,DM,DMA\\nDominican Republic,DO,DOM\\nEcuador,EC,ECU\\nEgypt,EG,EGY\\nEl Salvador,SV,SLV\\nEquatorial Guinea,GQ,GNQ\\nEritrea,ER,ERI\\nEstonia,EE,EST\\nEswatini,SZ,SWZ\\nEthiopia,ET,ETH\\nFalkland Islands (Malvinas),FK,FLK\\nFaroe Islands,FO,FRO\\nFiji,FJ,FJI\\nFinland,FI,FIN\\nFrance,FR,FRA\\nFrench Guiana,GF,GUF\\nFrench Polynesia,PF,PYF\\nFrench Southern Territories,TF,ATF\\nGabon,GA,GAB\\nGambia,GM,GMB\\nGeorgia,GE,GEO\\nGermany,DE,DEU\\nGhana,GH,GHA\\nGibraltar,GI,GIB\\nGreece,GR,GRC\\nGreenland,GL,GRL\\nGrenada,GD,GRD\\nGuadeloupe,GP,GLP\\nGuam,GU,GUM\\nGuatemala,GT,GTM\\nGuernsey,GG,GGY\\nGuinea,GN,GIN\\nGuinea-Bissau,GW,GNB\\nGuyana,GY,GUY\\nHaiti,HT,HTI\\nHeard Island and McDonald Islands,HM,HMD\\nHoly See,VA,VAT\\nHonduras,HN,HND\\nHong Kong,HK,HKG\\nHungary,HU,HUN\\nIceland,IS,ISL\\nIndia,IN,IND\\nIndonesia,ID,IDN\\nIran,Islamic Republic of Iran,IR,IRN\\nIraq,IQ,IRQ\\nIreland,IE,IRL\\nIsle of Man,IM,IMN\\nIsrael,IL,ISR\\nItaly,IT,ITA\\nJamaica,JM,JAM\\nJapan,JP,JPN\\nJersey,JE,JEY\\nJordan,JO,JOR\\nKazakhstan,KZ,KAZ\\nKenya,KE,KEN\\nKiribati,KI,KIR\\nDemocratic People\u0027s Republic of Korea,KP,PRK\\nKorea,Republic of Korea,KR,KOR\\nKuwait,KW,KWT\\nKyrgyzstan,KG,KGZ\\nLao People\u0027s Democratic Republic,LA,LAO\\nLatvia,LV,LVA\\nLebanon,LB,LBN\\nLesotho,LS,LSO\\nLiberia,LR,LBR\\nLibya,LY,LBY\\nLiechtenstein,LI,LIE\\nLithuania,LT,LTU\\nLuxembourg,LU,LUX\\nMacao,MO,MAC\\nMadagascar,MG,MDG\\nMalawi,MW,MWI\\nMalaysia,MY,MYS\\nMaldives,MV,MDV\\nMali,ML,MLI\\nMalta,MT,MLT\\nMarshall Islands,MH,MHL\\nMartinique,MQ,MTQ\\nMauritania,MR,MRT\\nMauritius,MU,MUS\\nMayotte,YT,MYT\\nMexico,MX,MEX\\nMicronesia,Federated States of Micronesia,FM,FSM\\nMoldova,Republic of Moldova,MD,MDA\\nMonaco,MC,MCO\\nMongolia,MN,MNG\\nMontenegro,ME,MNE\\nMontserrat,MS,MSR\\nMorocco,MA,MAR\\nMozambique,MZ,MOZ\\nMyanmar,MM,MMR\\nNamibia,NA,NAM\\nNauru,NR,NRU\\nNepal,NP,NPL\\nNetherlands,NL,NLD\\nNew Caledonia,NC,NCL\\nNew Zealand,NZ,NZL\\nNicaragua,NI,NIC\\nNiger,NE,NER\\nNigeria,NG,NGA\\nNiue,NU,NIU\\nNorfolk Island,NF,NFK\\nNorth Macedonia,MK,MKD\\nNorthern Mariana Islands,MP,MNP\\nNorway,NO,NOR\\nOman,OM,OMN\\nPakistan,PK,PAK\\nPalau,PW,PLW\\nPalestine,State of Palestine,PS,PSE\\nPanama,PA,PAN\\nPapua New Guinea,PG,PNG\\nParaguay,PY,PRY\\nPeru,PE,PER\\nPhilippines,PH,PHL\\nPitcairn,PN,PCN\\nPoland,PL,POL\\nPortugal,PT,PRT\\nPuerto Rico,PR,PRI\\nQatar,QA,QAT\\nR\\u00e9union,RE,REU\\nRomania,RO,ROU\\nRussia,Russian Federation,RU,RUS\\nRwanda,RW,RWA\\nSaint Barth\\u00e9lemy,BL,BLM\\nSaint Helena,Ascension and Tristan da Cunha,SH,SHN\\nSaint Kitts and Nevis,KN,KNA\\nSaint Lucia,LC,LCA\\nSaint Martin (French part),MF,MAF\\nSaint Pierre and Miquelon,PM,SPM\\nSaint Vincent and the Grenadines,VC,VCT\\nSamoa,WS,WSM\\nSan Marino,SM,SMR\\nSao Tome and Principe,ST,STP\\nSaudi Arabia,SA,SAU\\nSenegal,SN,SEN\\nSerbia,RS,SRB\\nSeychelles,SC,SYC\\nSierra Leone,SL,SLE\\nSingapore,SG,SGP\\nSint Maarten (Dutch part),SX,SXM\\nSlovakia,SK,SVK\\nSlovenia,SI,SVN\\nSolomon Islands,SB,SLB\\nSomalia,SO,SOM\\nSouth Africa,ZA,ZAF\\nSouth Georgia and the South Sandwich Islands,GS,SGS\\nSouth Sudan,SS,SSD\\nSpain,ES,ESP\\nSri Lanka,LK,LKA\\nSudan,SD,SDN\\nSuriname,SR,SUR\\nSvalbard and Jan Mayen,SJ,SJM\\nSweden,SE,SWE\\nSwitzerland,CH,CHE\\nSyrian Arab Republic,SY,SYR\\nTaiwan,Province of China,TW,TWN\\nTajikistan,TJ,TJK\\nTanzania,United Republic of Tanzania,TZ,TZA\\nThailand,TH,THA\\nTimor-Leste,TL,TLS\\nTogo,TG,TGO\\nTokelau,TK,TKL\\nTonga,TO,TON\\nTrinidad and Tobago,TT,TTO\\nTunisia,TN,TUN\\nTurkey,TR,TUR\\nTurkmenistan,TM,TKM\\nTurks and Caicos Islands,TC,TCA\\nTuvalu,TV,TUV\\nUganda,UG,UGA\\nUkraine,UA,UKR\\nUnited Arab Emirates,AE,ARE\\nUnited Kingdom of Great Britain and Northern Ireland,GB,GBR\\nUnited States of America,US,USA\\nUnited States Minor Outlying Islands,UM,UMI\\nUruguay,UY,URY\\nUzbekistan,UZ,UZB\\nVanuatu,VU,VUT\\nVenezuela (Bolivarian Republic of),VE,VEN\\nViet Nam,VN,VNM\\nVirgin Islands (British),VG,VGB\\nVirgin Islands (U.S.),VI,VIR\\nWallis and Futuna,WF,WLF\\nWestern Sahara,EH,ESH\\nYemen,YE,YEM\\nZambia,ZM,ZMB\\nZimbabwe,ZW,ZWE\\n\u0022,\u0022encryptionKey\u0022:null}"
+      "ResponseBody": {
+        "@odata.context": "https://azs-net-shrejaazsearch.search.windows.net/$metadata#synonymmaps/$entity",
+        "@odata.etag": "\u00220x8DAF02751DB2992\u0022",
+        "name": "tmolvpnv",
+        "format": "solr",
+        "synonyms": "Afghanistan,AF,AFG\n\u00C5land Islands,AX,ALA\nAlbania,AL,ALB\nAlgeria,DZ,DZA\nAmerican Samoa,AS,ASM\nAndorra,AD,AND\nAngola,AO,AGO\nAnguilla,AI,AIA\nAntarctica,AQ,ATA\nAntigua and Barbuda,AG,ATG\nArgentina,AR,ARG\nArmenia,AM,ARM\nAruba,AW,ABW\nAustralia,AU,AUS\nAustria,AT,AUT\nAzerbaijan,AZ,AZE\nBahamas,BS,BHS\nBahrain,BH,BHR\nBangladesh,BD,BGD\nBarbados,BB,BRB\nBelarus,BY,BLR\nBelgium,BE,BEL\nBelize,BZ,BLZ\nBenin,BJ,BEN\nBermuda,BM,BMU\nBhutan,BT,BTN\nBolivia,Plurinational State of Bolivia,BO,BOL\nBonaire,Sint Eustatius and Saba,BQ,BES\nBosnia and Herzegovina,BA,BIH\nBotswana,BW,BWA\nBouvet Island,BV,BVT\nBrazil,BR,BRA\nBritish Indian Ocean Territory,IO,IOT\nBrunei Darussalam,BN,BRN\nBulgaria,BG,BGR\nBurkina Faso,BF,BFA\nBurundi,BI,BDI\nCabo Verde,CV,CPV\nCambodia,KH,KHM\nCameroon,CM,CMR\nCanada,CA,CAN\nCayman Islands,KY,CYM\nCentral African Republic,CF,CAF\nChad,TD,TCD\nChile,CL,CHL\nChina,CN,CHN\nChristmas Island,CX,CXR\nCocos (Keeling) Islands,CC,CCK\nColombia,CO,COL\nComoros,KM,COM\nCongo,CG,COG\nDemocratic Republic of the Congo,CD,COD\nCook Islands,CK,COK\nCosta Rica,CR,CRI\nC\u00F4te d\u0027Ivoire,CI,CIV\nCroatia,HR,HRV\nCuba,CU,CUB\nCura\u00E7ao,CW,CUW\nCyprus,CY,CYP\nCzechia,CZ,CZE\nDenmark,DK,DNK\nDjibouti,DJ,DJI\nDominica,DM,DMA\nDominican Republic,DO,DOM\nEcuador,EC,ECU\nEgypt,EG,EGY\nEl Salvador,SV,SLV\nEquatorial Guinea,GQ,GNQ\nEritrea,ER,ERI\nEstonia,EE,EST\nEswatini,SZ,SWZ\nEthiopia,ET,ETH\nFalkland Islands (Malvinas),FK,FLK\nFaroe Islands,FO,FRO\nFiji,FJ,FJI\nFinland,FI,FIN\nFrance,FR,FRA\nFrench Guiana,GF,GUF\nFrench Polynesia,PF,PYF\nFrench Southern Territories,TF,ATF\nGabon,GA,GAB\nGambia,GM,GMB\nGeorgia,GE,GEO\nGermany,DE,DEU\nGhana,GH,GHA\nGibraltar,GI,GIB\nGreece,GR,GRC\nGreenland,GL,GRL\nGrenada,GD,GRD\nGuadeloupe,GP,GLP\nGuam,GU,GUM\nGuatemala,GT,GTM\nGuernsey,GG,GGY\nGuinea,GN,GIN\nGuinea-Bissau,GW,GNB\nGuyana,GY,GUY\nHaiti,HT,HTI\nHeard Island and McDonald Islands,HM,HMD\nHoly See,VA,VAT\nHonduras,HN,HND\nHong Kong,HK,HKG\nHungary,HU,HUN\nIceland,IS,ISL\nIndia,IN,IND\nIndonesia,ID,IDN\nIran,Islamic Republic of Iran,IR,IRN\nIraq,IQ,IRQ\nIreland,IE,IRL\nIsle of Man,IM,IMN\nIsrael,IL,ISR\nItaly,IT,ITA\nJamaica,JM,JAM\nJapan,JP,JPN\nJersey,JE,JEY\nJordan,JO,JOR\nKazakhstan,KZ,KAZ\nKenya,KE,KEN\nKiribati,KI,KIR\nDemocratic People\u0027s Republic of Korea,KP,PRK\nKorea,Republic of Korea,KR,KOR\nKuwait,KW,KWT\nKyrgyzstan,KG,KGZ\nLao People\u0027s Democratic Republic,LA,LAO\nLatvia,LV,LVA\nLebanon,LB,LBN\nLesotho,LS,LSO\nLiberia,LR,LBR\nLibya,LY,LBY\nLiechtenstein,LI,LIE\nLithuania,LT,LTU\nLuxembourg,LU,LUX\nMacao,MO,MAC\nMadagascar,MG,MDG\nMalawi,MW,MWI\nMalaysia,MY,MYS\nMaldives,MV,MDV\nMali,ML,MLI\nMalta,MT,MLT\nMarshall Islands,MH,MHL\nMartinique,MQ,MTQ\nMauritania,MR,MRT\nMauritius,MU,MUS\nMayotte,YT,MYT\nMexico,MX,MEX\nMicronesia,Federated States of Micronesia,FM,FSM\nMoldova,Republic of Moldova,MD,MDA\nMonaco,MC,MCO\nMongolia,MN,MNG\nMontenegro,ME,MNE\nMontserrat,MS,MSR\nMorocco,MA,MAR\nMozambique,MZ,MOZ\nMyanmar,MM,MMR\nNamibia,NA,NAM\nNauru,NR,NRU\nNepal,NP,NPL\nNetherlands,NL,NLD\nNew Caledonia,NC,NCL\nNew Zealand,NZ,NZL\nNicaragua,NI,NIC\nNiger,NE,NER\nNigeria,NG,NGA\nNiue,NU,NIU\nNorfolk Island,NF,NFK\nNorth Macedonia,MK,MKD\nNorthern Mariana Islands,MP,MNP\nNorway,NO,NOR\nOman,OM,OMN\nPakistan,PK,PAK\nPalau,PW,PLW\nPalestine,State of Palestine,PS,PSE\nPanama,PA,PAN\nPapua New Guinea,PG,PNG\nParaguay,PY,PRY\nPeru,PE,PER\nPhilippines,PH,PHL\nPitcairn,PN,PCN\nPoland,PL,POL\nPortugal,PT,PRT\nPuerto Rico,PR,PRI\nQatar,QA,QAT\nR\u00E9union,RE,REU\nRomania,RO,ROU\nRussia,Russian Federation,RU,RUS\nRwanda,RW,RWA\nSaint Barth\u00E9lemy,BL,BLM\nSaint Helena,Ascension and Tristan da Cunha,SH,SHN\nSaint Kitts and Nevis,KN,KNA\nSaint Lucia,LC,LCA\nSaint Martin (French part),MF,MAF\nSaint Pierre and Miquelon,PM,SPM\nSaint Vincent and the Grenadines,VC,VCT\nSamoa,WS,WSM\nSan Marino,SM,SMR\nSao Tome and Principe,ST,STP\nSaudi Arabia,SA,SAU\nSenegal,SN,SEN\nSerbia,RS,SRB\nSeychelles,SC,SYC\nSierra Leone,SL,SLE\nSingapore,SG,SGP\nSint Maarten (Dutch part),SX,SXM\nSlovakia,SK,SVK\nSlovenia,SI,SVN\nSolomon Islands,SB,SLB\nSomalia,SO,SOM\nSouth Africa,ZA,ZAF\nSouth Georgia and the South Sandwich Islands,GS,SGS\nSouth Sudan,SS,SSD\nSpain,ES,ESP\nSri Lanka,LK,LKA\nSudan,SD,SDN\nSuriname,SR,SUR\nSvalbard and Jan Mayen,SJ,SJM\nSweden,SE,SWE\nSwitzerland,CH,CHE\nSyrian Arab Republic,SY,SYR\nTaiwan,Province of China,TW,TWN\nTajikistan,TJ,TJK\nTanzania,United Republic of Tanzania,TZ,TZA\nThailand,TH,THA\nTimor-Leste,TL,TLS\nTogo,TG,TGO\nTokelau,TK,TKL\nTonga,TO,TON\nTrinidad and Tobago,TT,TTO\nTunisia,TN,TUN\nTurkey,TR,TUR\nTurkmenistan,TM,TKM\nTurks and Caicos Islands,TC,TCA\nTuvalu,TV,TUV\nUganda,UG,UGA\nUkraine,UA,UKR\nUnited Arab Emirates,AE,ARE\nUnited Kingdom of Great Britain and Northern Ireland,GB,GBR\nUnited States of America,US,USA\nUnited States Minor Outlying Islands,UM,UMI\nUruguay,UY,URY\nUzbekistan,UZ,UZB\nVanuatu,VU,VUT\nVenezuela (Bolivarian Republic of),VE,VEN\nViet Nam,VN,VNM\nVirgin Islands (British),VG,VGB\nVirgin Islands (U.S.),VI,VIR\nWallis and Futuna,WF,WLF\nWestern Sahara,EH,ESH\nYemen,YE,YEM\nZambia,ZM,ZMB\nZimbabwe,ZW,ZWE\n",
+        "encryptionKey": null
+      }
     },
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/indexes?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes?api-version=2020-06-30",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "Content-Length": "1593",
         "Content-Type": "application/json",
-        "traceparent": "00-843c782835ab89469c8265aebf36ed14-283645f45493e547-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210514.1",
-          "(.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "29cc6bfc8a7936ff705a7e8d11c9ba9e",
+        "traceparent": "00-6a98e7c1de837bf138074a2663a4acf6-8ff9a24a6de51366-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "749b1a00eb7499d5b9b647c8c0040f49",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "fgsbkgip",
+        "name": "ymeiniso",
         "fields": [
           {
-            "name": "hotelId",
+            "name": "HotelId",
             "type": "Edm.String",
             "key": true,
             "retrievable": true,
@@ -71,7 +72,7 @@
             "facetable": false
           },
           {
-            "name": "hotelName",
+            "name": "HotelName",
             "type": "Edm.String",
             "key": false,
             "retrievable": true,
@@ -81,7 +82,7 @@
             "facetable": false
           },
           {
-            "name": "description",
+            "name": "Description",
             "type": "Edm.String",
             "key": false,
             "retrievable": true,
@@ -92,7 +93,7 @@
             "analyzer": "en.lucene"
           },
           {
-            "name": "descriptionFr",
+            "name": "DescriptionFr",
             "type": "Edm.String",
             "key": false,
             "retrievable": true,
@@ -103,7 +104,7 @@
             "analyzer": "fr.lucene"
           },
           {
-            "name": "tags",
+            "name": "Tags",
             "type": "Collection(Edm.String)",
             "key": false,
             "retrievable": true,
@@ -113,11 +114,11 @@
             "facetable": true
           },
           {
-            "name": "address",
+            "name": "Address",
             "type": "Edm.ComplexType",
             "fields": [
               {
-                "name": "streetAddress",
+                "name": "StreetAddress",
                 "type": "Edm.String",
                 "key": false,
                 "retrievable": true,
@@ -127,7 +128,7 @@
                 "facetable": false
               },
               {
-                "name": "city",
+                "name": "City",
                 "type": "Edm.String",
                 "key": false,
                 "retrievable": true,
@@ -137,7 +138,7 @@
                 "facetable": true
               },
               {
-                "name": "stateProvince",
+                "name": "StateProvince",
                 "type": "Edm.String",
                 "key": false,
                 "retrievable": true,
@@ -147,7 +148,7 @@
                 "facetable": true
               },
               {
-                "name": "country",
+                "name": "Country",
                 "type": "Edm.String",
                 "key": false,
                 "retrievable": true,
@@ -156,11 +157,11 @@
                 "sortable": true,
                 "facetable": true,
                 "synonymMaps": [
-                  "yjlkevvv"
+                  "tmolvpnv"
                 ]
               },
               {
-                "name": "postalCode",
+                "name": "PostalCode",
                 "type": "Edm.String",
                 "key": false,
                 "retrievable": true,
@@ -176,29 +177,29 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "29cc6bfc-8a79-36ff-705a-7e8d11c9ba9e",
-        "Content-Length": "2686",
+        "client-request-id": "749b1a00-eb74-99d5-b9b6-47c8c0040f49",
+        "Content-Length": "2698",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Fri, 14 May 2021 20:51:10 GMT",
-        "elapsed-time": "1289",
-        "ETag": "W/\u00220x8D9171A00DDF3B8\u0022",
+        "Date": "Fri, 06 Jan 2023 20:48:09 GMT",
+        "elapsed-time": "692",
+        "ETag": "W/\u00220x8DAF027526B949A\u0022",
         "Expires": "-1",
-        "Location": "https://mohitc-acs.search.windows.net/indexes(\u0027fgsbkgip\u0027)?api-version=2020-06-30",
+        "Location": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027ymeiniso\u0027)?api-version=2020-06-30",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "29cc6bfc-8a79-36ff-705a-7e8d11c9ba9e",
+        "request-id": "749b1a00-eb74-99d5-b9b6-47c8c0040f49",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "29cc6bfc-8a79-36ff-705a-7e8d11c9ba9e"
+        "x-ms-client-request-id": "749b1a00-eb74-99d5-b9b6-47c8c0040f49"
       },
       "ResponseBody": {
-        "@odata.context": "https://mohitc-acs.search.windows.net/$metadata#indexes/$entity",
-        "@odata.etag": "\u00220x8D9171A00DDF3B8\u0022",
-        "name": "fgsbkgip",
+        "@odata.context": "https://azs-net-shrejaazsearch.search.windows.net/$metadata#indexes/$entity",
+        "@odata.etag": "\u00220x8DAF027526B949A\u0022",
+        "name": "ymeiniso",
         "defaultScoringProfile": null,
         "fields": [
           {
-            "name": "hotelId",
+            "name": "HotelId",
             "type": "Edm.String",
             "searchable": false,
             "filterable": true,
@@ -212,7 +213,7 @@
             "synonymMaps": []
           },
           {
-            "name": "hotelName",
+            "name": "HotelName",
             "type": "Edm.String",
             "searchable": true,
             "filterable": true,
@@ -226,7 +227,7 @@
             "synonymMaps": []
           },
           {
-            "name": "description",
+            "name": "Description",
             "type": "Edm.String",
             "searchable": true,
             "filterable": false,
@@ -240,7 +241,7 @@
             "synonymMaps": []
           },
           {
-            "name": "descriptionFr",
+            "name": "DescriptionFr",
             "type": "Edm.String",
             "searchable": true,
             "filterable": false,
@@ -254,7 +255,7 @@
             "synonymMaps": []
           },
           {
-            "name": "tags",
+            "name": "Tags",
             "type": "Collection(Edm.String)",
             "searchable": true,
             "filterable": true,
@@ -268,11 +269,11 @@
             "synonymMaps": []
           },
           {
-            "name": "address",
+            "name": "Address",
             "type": "Edm.ComplexType",
             "fields": [
               {
-                "name": "streetAddress",
+                "name": "StreetAddress",
                 "type": "Edm.String",
                 "searchable": true,
                 "filterable": false,
@@ -286,7 +287,7 @@
                 "synonymMaps": []
               },
               {
-                "name": "city",
+                "name": "City",
                 "type": "Edm.String",
                 "searchable": true,
                 "filterable": true,
@@ -300,7 +301,7 @@
                 "synonymMaps": []
               },
               {
-                "name": "stateProvince",
+                "name": "StateProvince",
                 "type": "Edm.String",
                 "searchable": true,
                 "filterable": true,
@@ -314,7 +315,7 @@
                 "synonymMaps": []
               },
               {
-                "name": "country",
+                "name": "Country",
                 "type": "Edm.String",
                 "searchable": true,
                 "filterable": true,
@@ -326,11 +327,11 @@
                 "searchAnalyzer": null,
                 "analyzer": null,
                 "synonymMaps": [
-                  "yjlkevvv"
+                  "tmolvpnv"
                 ]
               },
               {
-                "name": "postalCode",
+                "name": "PostalCode",
                 "type": "Edm.String",
                 "searchable": true,
                 "filterable": true,
@@ -362,53 +363,50 @@
       }
     },
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/datasources?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/datasources?api-version=2020-06-30",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "Content-Length": "216",
+        "Content-Length": "117",
         "Content-Type": "application/json",
-        "traceparent": "00-c80e3902ad215b45b01a91e5bc2cce68-b5b1b3950b48484d-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210514.1",
-          "(.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "1e31e9c53621254d806c77bb6721507a",
+        "traceparent": "00-848426e301dc4b3a02fef9eba7f9f967-77714ce3f158f908-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e0f2ba07fea6a381dac67189130fa19b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "ofgjbglc",
+        "name": "ttmnouce",
         "type": "azureblob",
         "credentials": {
-          "connectionString": "DefaultEndpointsProtocol=https;AccountName=mohitcsablob;AccountKey=Sanitized;EndpointSuffix=core.windows.net"
+          "connectionString": "Sanitized"
         },
         "container": {
-          "name": "podjlinb"
+          "name": "elyjtapj"
         }
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "1e31e9c5-3621-254d-806c-77bb6721507a",
-        "Content-Length": "371",
+        "client-request-id": "e0f2ba07-fea6-a381-dac6-7189130fa19b",
+        "Content-Length": "383",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Fri, 14 May 2021 20:51:10 GMT",
-        "elapsed-time": "126",
-        "ETag": "W/\u00220x8D9171A0109515A\u0022",
+        "Date": "Fri, 06 Jan 2023 20:48:11 GMT",
+        "elapsed-time": "39",
+        "ETag": "W/\u00220x8DAF02752CF9EF5\u0022",
         "Expires": "-1",
-        "Location": "https://mohitc-acs.search.windows.net/datasources(\u0027ofgjbglc\u0027)?api-version=2020-06-30",
+        "Location": "https://azs-net-shrejaazsearch.search.windows.net/datasources(\u0027ttmnouce\u0027)?api-version=2020-06-30",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "1e31e9c5-3621-254d-806c-77bb6721507a",
+        "request-id": "e0f2ba07-fea6-a381-dac6-7189130fa19b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "1e31e9c5-3621-254d-806c-77bb6721507a"
+        "x-ms-client-request-id": "e0f2ba07-fea6-a381-dac6-7189130fa19b"
       },
       "ResponseBody": {
-        "@odata.context": "https://mohitc-acs.search.windows.net/$metadata#datasources/$entity",
-        "@odata.etag": "\u00220x8D9171A0109515A\u0022",
-        "name": "ofgjbglc",
+        "@odata.context": "https://azs-net-shrejaazsearch.search.windows.net/$metadata#datasources/$entity",
+        "@odata.etag": "\u00220x8DAF02752CF9EF5\u0022",
+        "name": "ttmnouce",
         "description": null,
         "type": "azureblob",
         "subtype": null,
@@ -416,7 +414,7 @@
           "connectionString": null
         },
         "container": {
-          "name": "podjlinb",
+          "name": "elyjtapj",
           "query": null
         },
         "dataChangeDetectionPolicy": null,
@@ -425,23 +423,20 @@
       }
     },
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/skillsets?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/skillsets?api-version=2020-06-30",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "Content-Length": "996",
+        "Content-Length": "1118",
         "Content-Type": "application/json",
-        "traceparent": "00-73e65024b7ed4245a742a409b284d15e-8d6ccf4ad339bc43-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210514.1",
-          "(.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "102596419a8fb2c3d682648f59e0153a",
+        "traceparent": "00-dc513a900cd0875472b50f4b9d73511f-9ecab0ede9679db3-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5749349ebc3e75210c876dbaf9f4f3bb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "tpmehipv",
+        "name": "tsucfctu",
         "skills": [
           {
             "defaultToLanguageCode": "fr",
@@ -452,7 +447,7 @@
             "inputs": [
               {
                 "name": "text",
-                "source": "/document/description"
+                "source": "/document/Description"
               }
             ],
             "outputs": [
@@ -469,7 +464,7 @@
             "inputs": [
               {
                 "name": "condition",
-                "source": "= $(/document/descriptionFr) == null"
+                "source": "= $(/document/DescriptionFr) == null"
               },
               {
                 "name": "whenTrue",
@@ -477,7 +472,7 @@
               },
               {
                 "name": "whenFalse",
-                "source": "/document/descriptionFr"
+                "source": "/document/DescriptionFr"
               }
             ],
             "outputs": [
@@ -489,36 +484,36 @@
           }
         ],
         "cognitiveServices": {
-          "key": "Sanitized",
+          "key": "4c17710874384dd682e1daa0e99ea79f",
           "@odata.type": "#Microsoft.Azure.Search.CognitiveServicesByKey"
         },
         "knowledgeStore": {
-          "storageConnectionString": "DefaultEndpointsProtocol=https;AccountName=mohitcsablob;AccountKey=Sanitized;EndpointSuffix=core.windows.net",
+          "storageConnectionString": "DefaultEndpointsProtocol=https;AccountName=shrejaazsearchstg;AccountKey=Qm9/wFNT3TWNfcQUQm67et5w\u002BkqC50FZDxLmw65rMwMPzTD5aezKQ/ERMqISTtViozjeY\u002BSIm2mG\u002BAStqbjm4A==;EndpointSuffix=core.windows.net",
           "projections": []
         }
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "10259641-9a8f-b2c3-d682-648f59e0153a",
-        "Content-Length": "1387",
+        "client-request-id": "5749349e-bc3e-7521-0c87-6dbaf9f4f3bb",
+        "Content-Length": "1506",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Fri, 14 May 2021 20:51:11 GMT",
-        "elapsed-time": "1613",
-        "ETag": "W/\u00220x8D9171A02085235\u0022",
+        "Date": "Fri, 06 Jan 2023 20:48:14 GMT",
+        "elapsed-time": "2770",
+        "ETag": "W/\u00220x8DAF02754A81162\u0022",
         "Expires": "-1",
-        "Location": "https://mohitc-acs.search.windows.net/skillsets(\u0027tpmehipv\u0027)?api-version=2020-06-30",
+        "Location": "https://azs-net-shrejaazsearch.search.windows.net/skillsets(\u0027tsucfctu\u0027)?api-version=2020-06-30",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "10259641-9a8f-b2c3-d682-648f59e0153a",
+        "request-id": "5749349e-bc3e-7521-0c87-6dbaf9f4f3bb",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "10259641-9a8f-b2c3-d682-648f59e0153a"
+        "x-ms-client-request-id": "5749349e-bc3e-7521-0c87-6dbaf9f4f3bb"
       },
       "ResponseBody": {
-        "@odata.context": "https://mohitc-acs.search.windows.net/$metadata#skillsets/$entity",
-        "@odata.etag": "\u00220x8D9171A02085235\u0022",
-        "name": "tpmehipv",
+        "@odata.context": "https://azs-net-shrejaazsearch.search.windows.net/$metadata#skillsets/$entity",
+        "@odata.etag": "\u00220x8DAF02754A81162\u0022",
+        "name": "tsucfctu",
         "description": null,
         "skills": [
           {
@@ -532,7 +527,7 @@
             "inputs": [
               {
                 "name": "text",
-                "source": "/document/description",
+                "source": "/document/Description",
                 "sourceContext": null,
                 "inputs": []
               }
@@ -552,7 +547,7 @@
             "inputs": [
               {
                 "name": "condition",
-                "source": "= $(/document/descriptionFr) == null",
+                "source": "= $(/document/DescriptionFr) == null",
                 "sourceContext": null,
                 "inputs": []
               },
@@ -564,7 +559,7 @@
               },
               {
                 "name": "whenFalse",
-                "source": "/document/descriptionFr",
+                "source": "/document/DescriptionFr",
                 "sourceContext": null,
                 "inputs": []
               }
@@ -580,10 +575,10 @@
         "cognitiveServices": {
           "@odata.type": "#Microsoft.Azure.Search.CognitiveServicesByKey",
           "description": null,
-          "key": "Sanitized"
+          "key": "4c17710874384dd682e1daa0e99ea79f"
         },
         "knowledgeStore": {
-          "storageConnectionString": "DefaultEndpointsProtocol=https;AccountName=mohitcsablob;AccountKey=Sanitized;EndpointSuffix=core.windows.net",
+          "storageConnectionString": "DefaultEndpointsProtocol=https;AccountName=shrejaazsearchstg;AccountKey=Qm9/wFNT3TWNfcQUQm67et5w\u002BkqC50FZDxLmw65rMwMPzTD5aezKQ/ERMqISTtViozjeY\u002BSIm2mG\u002BAStqbjm4A==;EndpointSuffix=core.windows.net",
           "projections": [],
           "parameters": null
         },
@@ -591,26 +586,23 @@
       }
     },
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/indexers?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexers?api-version=2020-06-30",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "Content-Length": "436",
         "Content-Type": "application/json",
-        "traceparent": "00-7d9eccb2e3ca314ca1e1f023fb3bd919-d978a972b8b20a49-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210514.1",
-          "(.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "059fef0e17e8d0b78f54dd8a113d95e5",
+        "traceparent": "00-abe22c699b42bba281ee123c1a3dec2d-046d4b80e039f9bc-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ab2b64eb9f816f862e5e4171b429651e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "caupyhfn",
-        "dataSourceName": "ofgjbglc",
-        "skillsetName": "tpmehipv",
-        "targetIndexName": "fgsbkgip",
+        "name": "blsaetlq",
+        "dataSourceName": "ttmnouce",
+        "skillsetName": "tsucfctu",
+        "targetIndexName": "ymeiniso",
         "parameters": {
           "configuration": {
             "parsingMode": "json"
@@ -618,54 +610,54 @@
         },
         "fieldMappings": [
           {
-            "sourceFieldName": "hotelId"
+            "sourceFieldName": "HotelId"
           },
           {
-            "sourceFieldName": "hotelName"
+            "sourceFieldName": "HotelName"
           },
           {
-            "sourceFieldName": "description"
+            "sourceFieldName": "Description"
           },
           {
-            "sourceFieldName": "tags"
+            "sourceFieldName": "Tags"
           },
           {
-            "sourceFieldName": "address"
+            "sourceFieldName": "Address"
           }
         ],
         "outputFieldMappings": [
           {
             "sourceFieldName": "/document/descriptionFrFinal",
-            "targetFieldName": "descriptionFr"
+            "targetFieldName": "DescriptionFr"
           }
         ]
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "059fef0e-17e8-d0b7-8f54-dd8a113d95e5",
-        "Content-Length": "1004",
+        "client-request-id": "ab2b64eb-9f81-6f86-2e5e-4171b429651e",
+        "Content-Length": "1016",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Fri, 14 May 2021 20:51:13 GMT",
-        "elapsed-time": "1685",
-        "ETag": "W/\u00220x8D9171A02E65788\u0022",
+        "Date": "Fri, 06 Jan 2023 20:48:15 GMT",
+        "elapsed-time": "575",
+        "ETag": "W/\u00220x8DAF0275534AC6D\u0022",
         "Expires": "-1",
-        "Location": "https://mohitc-acs.search.windows.net/indexers(\u0027caupyhfn\u0027)?api-version=2020-06-30",
+        "Location": "https://azs-net-shrejaazsearch.search.windows.net/indexers(\u0027blsaetlq\u0027)?api-version=2020-06-30",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "059fef0e-17e8-d0b7-8f54-dd8a113d95e5",
+        "request-id": "ab2b64eb-9f81-6f86-2e5e-4171b429651e",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "059fef0e-17e8-d0b7-8f54-dd8a113d95e5"
+        "x-ms-client-request-id": "ab2b64eb-9f81-6f86-2e5e-4171b429651e"
       },
       "ResponseBody": {
-        "@odata.context": "https://mohitc-acs.search.windows.net/$metadata#indexers/$entity",
-        "@odata.etag": "\u00220x8D9171A02E65788\u0022",
-        "name": "caupyhfn",
+        "@odata.context": "https://azs-net-shrejaazsearch.search.windows.net/$metadata#indexers/$entity",
+        "@odata.etag": "\u00220x8DAF0275534AC6D\u0022",
+        "name": "blsaetlq",
         "description": null,
-        "dataSourceName": "ofgjbglc",
-        "skillsetName": "tpmehipv",
-        "targetIndexName": "fgsbkgip",
+        "dataSourceName": "ttmnouce",
+        "skillsetName": "tsucfctu",
+        "targetIndexName": "ymeiniso",
         "disabled": null,
         "schedule": null,
         "parameters": {
@@ -679,35 +671,35 @@
         },
         "fieldMappings": [
           {
-            "sourceFieldName": "hotelId",
-            "targetFieldName": "hotelId",
+            "sourceFieldName": "HotelId",
+            "targetFieldName": "HotelId",
             "mappingFunction": null
           },
           {
-            "sourceFieldName": "hotelName",
-            "targetFieldName": "hotelName",
+            "sourceFieldName": "HotelName",
+            "targetFieldName": "HotelName",
             "mappingFunction": null
           },
           {
-            "sourceFieldName": "description",
-            "targetFieldName": "description",
+            "sourceFieldName": "Description",
+            "targetFieldName": "Description",
             "mappingFunction": null
           },
           {
-            "sourceFieldName": "tags",
-            "targetFieldName": "tags",
+            "sourceFieldName": "Tags",
+            "targetFieldName": "Tags",
             "mappingFunction": null
           },
           {
-            "sourceFieldName": "address",
-            "targetFieldName": "address",
+            "sourceFieldName": "Address",
+            "targetFieldName": "Address",
             "mappingFunction": null
           }
         ],
         "outputFieldMappings": [
           {
             "sourceFieldName": "/document/descriptionFrFinal",
-            "targetFieldName": "descriptionFr",
+            "targetFieldName": "DescriptionFr",
             "mappingFunction": null
           }
         ],
@@ -715,56 +707,53 @@
       }
     },
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/indexers(\u0027caupyhfn\u0027)/search.status?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexers(\u0027blsaetlq\u0027)/search.status?api-version=2020-06-30",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-504cc8c9e91c9841b100c4d345818edb-eada2c96f7fb0f45-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210514.1",
-          "(.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "e5e5c4a8c0bccd2120267139e6b48a42",
+        "traceparent": "00-5ded24a0bd1c95a3a56ef892910ea361-891414cc1e73cfb9-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8b7dfca4e7a12fa22d4e39e8aa910118",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "e5e5c4a8-c0bc-cd21-2026-7139e6b48a42",
-        "Content-Length": "2494",
+        "client-request-id": "8b7dfca4-e7a1-2fa2-2d4e-39e8aa910118",
+        "Content-Length": "2420",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Fri, 14 May 2021 20:51:24 GMT",
-        "elapsed-time": "110",
+        "Date": "Fri, 06 Jan 2023 20:48:25 GMT",
+        "elapsed-time": "37",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "e5e5c4a8-c0bc-cd21-2026-7139e6b48a42",
+        "request-id": "8b7dfca4-e7a1-2fa2-2d4e-39e8aa910118",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "e5e5c4a8-c0bc-cd21-2026-7139e6b48a42"
+        "x-ms-client-request-id": "8b7dfca4-e7a1-2fa2-2d4e-39e8aa910118"
       },
       "ResponseBody": {
-        "@odata.context": "https://mohitc-acs.search.windows.net/$metadata#Microsoft.Azure.Search.V2020_06_30.IndexerExecutionInfo",
-        "name": "caupyhfn",
+        "@odata.context": "https://azs-net-shrejaazsearch.search.windows.net/$metadata#Microsoft.Azure.Search.V2020_06_30.IndexerExecutionInfo",
+        "name": "blsaetlq",
         "status": "running",
         "lastResult": {
           "status": "success",
           "errorMessage": null,
-          "startTime": "2021-05-14T20:51:14.168Z",
-          "endTime": "2021-05-14T20:51:15.611Z",
+          "startTime": "2023-01-06T20:48:15.695Z",
+          "endTime": "2023-01-06T20:48:16.82Z",
           "itemsProcessed": 10,
           "itemsFailed": 0,
-          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222021-05-14T20:51:14.321Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222021-05-14T20:50:44.321583\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222021-05-14T20:50:44.321583\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222023-01-06T20:48:15.758Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222023-01-06T20:47:45.7583777\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222023-01-06T20:47:45.7583777\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
           "errors": [],
           "warnings": [
             {
               "key": "localId=6\u0026documentKey=6",
               "name": "Enrichment.ConditionalSkill.descriptionFrConditional",
               "message": "Skill executed but may have unexpected results because one or more skill input was invalid.",
-              "details": "Optional skill input is missing. Name: \u0027whenFalse\u0027, Source: \u0027$(/document/descriptionFr)\u0027.\r\nExpression language parsing issues:\nMissing value \u0027/document/descriptionFr\u0027.\r\nMissing value \u0027/document/descriptionFr\u0027.",
+              "details": "Optional skill input is missing. Name: \u0027whenFalse\u0027, Source: \u0027$(/document/DescriptionFr)\u0027.\r\nExpression language parsing issues:\nMissing value \u0027/document/DescriptionFr\u0027.",
               "documentationLink": "https://go.microsoft.com/fwlink/?linkid=2106385"
             }
           ],
@@ -774,19 +763,19 @@
           {
             "status": "success",
             "errorMessage": null,
-            "startTime": "2021-05-14T20:51:14.168Z",
-            "endTime": "2021-05-14T20:51:15.611Z",
+            "startTime": "2023-01-06T20:48:15.695Z",
+            "endTime": "2023-01-06T20:48:16.82Z",
             "itemsProcessed": 10,
             "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222021-05-14T20:51:14.321Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222021-05-14T20:50:44.321583\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222021-05-14T20:50:44.321583\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222023-01-06T20:48:15.758Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222023-01-06T20:47:45.7583777\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222023-01-06T20:47:45.7583777\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
             "errors": [],
             "warnings": [
               {
                 "key": "localId=6\u0026documentKey=6",
                 "name": "Enrichment.ConditionalSkill.descriptionFrConditional",
                 "message": "Skill executed but may have unexpected results because one or more skill input was invalid.",
-                "details": "Optional skill input is missing. Name: \u0027whenFalse\u0027, Source: \u0027$(/document/descriptionFr)\u0027.\r\nExpression language parsing issues:\nMissing value \u0027/document/descriptionFr\u0027.\r\nMissing value \u0027/document/descriptionFr\u0027.",
+                "details": "Optional skill input is missing. Name: \u0027whenFalse\u0027, Source: \u0027$(/document/DescriptionFr)\u0027.\r\nExpression language parsing issues:\nMissing value \u0027/document/DescriptionFr\u0027.",
                 "documentationLink": "https://go.microsoft.com/fwlink/?linkid=2106385"
               }
             ],
@@ -801,19 +790,16 @@
       }
     },
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/indexes(\u0027fgsbkgip\u0027)/docs/search.post.search?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027ymeiniso\u0027)/docs/search.post.search?api-version=2020-06-30",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "23",
         "Content-Type": "application/json",
-        "traceparent": "00-11628d0a1184454bb21742cb9476338f-3716ce3ac2ba0148-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210514.1",
-          "(.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "a001e65fbefbbecaca940005028a28cf",
+        "traceparent": "00-86dcac2dbd05e4531347570fde5e9cf6-3c4aee091b76891c-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d96c77ff76906cf400fd8b9ab382060b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -822,176 +808,187 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "a001e65f-befb-beca-ca94-0005028a28cf",
+        "client-request-id": "d96c77ff-7690-6cf4-00fd-8b9ab382060b",
         "Content-Length": "986",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Fri, 14 May 2021 20:51:24 GMT",
-        "elapsed-time": "397",
+        "Date": "Fri, 06 Jan 2023 20:48:25 GMT",
+        "elapsed-time": "406",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "a001e65f-befb-beca-ca94-0005028a28cf",
+        "request-id": "d96c77ff-7690-6cf4-00fd-8b9ab382060b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "a001e65f-befb-beca-ca94-0005028a28cf"
+        "x-ms-client-request-id": "d96c77ff-7690-6cf4-00fd-8b9ab382060b"
       },
-      "ResponseBody": "{\u0022value\u0022:[{\u0022@search.score\u0022:0.85747814,\u0022hotelId\u0022:\u00226\u0022,\u0022hotelName\u0022:null,\u0022description\u0022:\u0022Surprisingly expensive. Model suites have an ocean-view.\u0022,\u0022descriptionFr\u0022:\u0022\\u00c9tonnamment cher. Les suites mod\\u00e8les offrent une vue sur l\\u2019oc\\u00e9an.\u0022,\u0022tags\u0022:[],\u0022address\u0022:null},{\u0022@search.score\u0022:0.82257307,\u0022hotelId\u0022:\u00221\u0022,\u0022hotelName\u0022:\u0022Fancy Stay\u0022,\u0022description\u0022:\u0022Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.\u0022,\u0022descriptionFr\u0022:\u0022Meilleur h\\u00f4tel en ville si vous aimez les h\\u00f4tels de luxe. Ils ont une magnifique piscine \\u00e0 d\\u00e9bordement, un spa et un concierge tr\\u00e8s utile. L\u0027emplacement est parfait \\u2013 en plein centre, \\u00e0 proximit\\u00e9 de toutes les attractions touristiques. Nous recommandons fortement cet h\\u00f4tel.\u0022,\u0022tags\u0022:[\u0022pool\u0022,\u0022view\u0022,\u0022wifi\u0022,\u0022concierge\u0022],\u0022address\u0022:null}]}"
+      "ResponseBody": {
+        "value": [
+          {
+            "@search.score": 0.85747814,
+            "HotelId": "6",
+            "HotelName": null,
+            "Description": "Surprisingly expensive. Model suites have an ocean-view.",
+            "DescriptionFr": "\u00C9tonnamment cher. Les suites mod\u00E8les offrent une vue sur l\u2019oc\u00E9an.",
+            "Tags": [],
+            "Address": null
+          },
+          {
+            "@search.score": 0.82257307,
+            "HotelId": "1",
+            "HotelName": "Fancy Stay",
+            "Description": "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.",
+            "DescriptionFr": "Meilleur h\u00F4tel en ville si vous aimez les h\u00F4tels de luxe. Ils ont une magnifique piscine \u00E0 d\u00E9bordement, un spa et un concierge tr\u00E8s utile. L\u0027emplacement est parfait \u2013 en plein centre, \u00E0 proximit\u00E9 de toutes les attractions touristiques. Nous recommandons fortement cet h\u00F4tel.",
+            "Tags": [
+              "pool",
+              "view",
+              "wifi",
+              "concierge"
+            ],
+            "Address": null
+          }
+        ]
+      }
     },
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/indexers(\u0027caupyhfn\u0027)?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexers(\u0027blsaetlq\u0027)?api-version=2020-06-30",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-ea2960eed5d49d47b479c5eb3a2c0fd3-d97b907e75cb4342-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210514.1",
-          "(.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "8dfd28c352184d82cdd2e5c2a67eeadb",
+        "traceparent": "00-fa01f5f831ecb784c15289deecab55b9-50eca7433219a8c9-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9555ce3ea908042fc2fb7e32669ec59c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "8dfd28c3-5218-4d82-cdd2-e5c2a67eeadb",
-        "Date": "Fri, 14 May 2021 20:51:24 GMT",
-        "elapsed-time": "77",
+        "client-request-id": "9555ce3e-a908-042f-c2fb-7e32669ec59c",
+        "Date": "Fri, 06 Jan 2023 20:48:27 GMT",
+        "elapsed-time": "63",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "8dfd28c3-5218-4d82-cdd2-e5c2a67eeadb",
+        "request-id": "9555ce3e-a908-042f-c2fb-7e32669ec59c",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "8dfd28c3-5218-4d82-cdd2-e5c2a67eeadb"
+        "x-ms-client-request-id": "9555ce3e-a908-042f-c2fb-7e32669ec59c"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/skillsets(\u0027tpmehipv\u0027)?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/skillsets(\u0027tsucfctu\u0027)?api-version=2020-06-30",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-e96dcfb490d55c40893adfb00db27e60-6ed6b565b2efbc47-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210514.1",
-          "(.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "2a2a9bc9f43beae9fa261a28c01ccb95",
+        "traceparent": "00-3c7920c0bff112208a429244c2d7c4cb-b738b9c27409e308-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3c71285d8bbd2e8e07108ba45b087cab",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "2a2a9bc9-f43b-eae9-fa26-1a28c01ccb95",
-        "Date": "Fri, 14 May 2021 20:51:24 GMT",
-        "elapsed-time": "32",
+        "client-request-id": "3c71285d-8bbd-2e8e-0710-8ba45b087cab",
+        "Date": "Fri, 06 Jan 2023 20:48:27 GMT",
+        "elapsed-time": "44",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "2a2a9bc9-f43b-eae9-fa26-1a28c01ccb95",
+        "request-id": "3c71285d-8bbd-2e8e-0710-8ba45b087cab",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "2a2a9bc9-f43b-eae9-fa26-1a28c01ccb95"
+        "x-ms-client-request-id": "3c71285d-8bbd-2e8e-0710-8ba45b087cab"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/datasources(\u0027ofgjbglc\u0027)?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/datasources(\u0027ttmnouce\u0027)?api-version=2020-06-30",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-a04da151a7c6114f8d901a1639afc14a-11e5be45db15a14f-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210514.1",
-          "(.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "bd75a1fdfdb60d2a64b4d229d907184c",
+        "traceparent": "00-f8487e0fbd25164c7e7a0909f1ac5001-fb99527663248df9-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dbaa2d476b3c551048671794f7c20562",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "bd75a1fd-fdb6-0d2a-64b4-d229d907184c",
-        "Date": "Fri, 14 May 2021 20:51:24 GMT",
-        "elapsed-time": "21",
+        "client-request-id": "dbaa2d47-6b3c-5510-4867-1794f7c20562",
+        "Date": "Fri, 06 Jan 2023 20:48:27 GMT",
+        "elapsed-time": "26",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "bd75a1fd-fdb6-0d2a-64b4-d229d907184c",
+        "request-id": "dbaa2d47-6b3c-5510-4867-1794f7c20562",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "bd75a1fd-fdb6-0d2a-64b4-d229d907184c"
+        "x-ms-client-request-id": "dbaa2d47-6b3c-5510-4867-1794f7c20562"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/indexes(\u0027fgsbkgip\u0027)?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027ymeiniso\u0027)?api-version=2020-06-30",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-e472fc0b85deee469a749cf4e31eea64-40eedb2a682ebd46-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210514.1",
-          "(.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "673b24a9fe60ce943e1292f1375a8cb1",
+        "traceparent": "00-2ba0f522722313a5a2528f57c9cfe975-aac402e6376a5fc2-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8a3dee38ca10b34e40278ef81e8ba8ba",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "673b24a9-fe60-ce94-3e12-92f1375a8cb1",
-        "Date": "Fri, 14 May 2021 20:51:25 GMT",
-        "elapsed-time": "199",
+        "client-request-id": "8a3dee38-ca10-b34e-4027-8ef81e8ba8ba",
+        "Date": "Fri, 06 Jan 2023 20:48:28 GMT",
+        "elapsed-time": "235",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "673b24a9-fe60-ce94-3e12-92f1375a8cb1",
+        "request-id": "8a3dee38-ca10-b34e-4027-8ef81e8ba8ba",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "673b24a9-fe60-ce94-3e12-92f1375a8cb1"
+        "x-ms-client-request-id": "8a3dee38-ca10-b34e-4027-8ef81e8ba8ba"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/synonymmaps(\u0027yjlkevvv\u0027)?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/synonymmaps(\u0027tmolvpnv\u0027)?api-version=2020-06-30",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-b35b5cf2223bd44cb8ea67a28f0de159-840194eed416bc4e-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210514.1",
-          "(.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "05c44f072c08cb24701dc58621c011f2",
+        "traceparent": "00-199cf107daf1106c541550fad8ff9912-6fe812e07aff7a7e-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "39ead37ee9f3f160181bf45573f93645",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "05c44f07-2c08-cb24-701d-c58621c011f2",
-        "Date": "Fri, 14 May 2021 20:51:25 GMT",
-        "elapsed-time": "22",
+        "client-request-id": "39ead37e-e9f3-f160-181b-f45573f93645",
+        "Date": "Fri, 06 Jan 2023 20:48:28 GMT",
+        "elapsed-time": "23",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "05c44f07-2c08-cb24-701d-c58621c011f2",
+        "request-id": "39ead37e-e9f3-f160-181b-f45573f93645",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "05c44f07-2c08-cb24-701d-c58621c011f2"
+        "x-ms-client-request-id": "39ead37e-e9f3-f160-181b-f45573f93645"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     }
   ],
   "Variables": {
-    "BlobContainerName": "podjlinb",
-    "RandomSeed": "1271390025",
+    "BlobContainerName": "elyjtapj",
+    "RandomSeed": "1178905894",
     "SEARCH_ADMIN_API_KEY": "Sanitized",
     "SEARCH_COGNITIVE_KEY": "Sanitized",
-    "SEARCH_ENDPOINT_SUFFIX": null,
-    "SEARCH_SERVICE_NAME": "mohitc-acs",
+    "SEARCH_ENDPOINT_SUFFIX": "search.windows.net",
+    "SEARCH_SERVICE_NAME": "azs-net-shrejaazsearch",
     "SEARCH_STORAGE_KEY": "Sanitized",
-    "SEARCH_STORAGE_NAME": "mohitcsablob",
-    "STORAGE_ENDPOINT_SUFFIX": null
+    "SEARCH_STORAGE_NAME": "shrejaazsearchstg",
+    "STORAGE_ENDPOINT_SUFFIX": "core.windows.net"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/GetCountAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/GetCountAsync.json
@@ -1,44 +1,41 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/indexes(\u0027mbqvlxmt\u0027)/docs/$count?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027urwsditp\u0027)/docs/$count?api-version=2020-06-30",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-5dc4c4ef5d98f34798bda8f11fb9862b-61780675490fe74f-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210326.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "236582ddb742189bb152143ee3f98722",
+        "traceparent": "00-dbbdd436ee3ebe51c41a61cbfd4f1aba-eb4b7f7cc25a3f69-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c1b8eeae6ee42d3b2ef47e8d1d905609",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "236582dd-b742-189b-b152-143ee3f98722",
+        "client-request-id": "c1b8eeae-6ee4-2d3b-2ef4-7e8d1d905609",
         "Content-Length": "5",
         "Content-Type": "text/plain",
-        "Date": "Sat, 27 Mar 2021 18:39:51 GMT",
-        "elapsed-time": "59",
+        "Date": "Fri, 06 Jan 2023 20:48:04 GMT",
+        "elapsed-time": "70",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "236582dd-b742-189b-b152-143ee3f98722",
+        "request-id": "c1b8eeae-6ee4-2d3b-2ef4-7e8d1d905609",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "236582dd-b742-189b-b152-143ee3f98722"
+        "x-ms-client-request-id": "c1b8eeae-6ee4-2d3b-2ef4-7e8d1d905609"
       },
       "ResponseBody": "\uFEFF10"
     }
   ],
   "Variables": {
-    "RandomSeed": "495571034",
-    "SearchIndexName": "mbqvlxmt",
+    "RandomSeed": "220060475",
+    "SearchIndexName": "urwsditp",
     "SEARCH_ADMIN_API_KEY": "Sanitized",
-    "SEARCH_ENDPOINT_SUFFIX": null,
-    "SEARCH_SERVICE_NAME": "mohitc-acs"
+    "SEARCH_ENDPOINT_SUFFIX": "search.windows.net",
+    "SEARCH_SERVICE_NAME": "azs-net-shrejaazsearch"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/GetCountAsyncAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/GetCountAsyncAsync.json
@@ -1,44 +1,41 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/indexes(\u0027mbqvlxmt\u0027)/docs/$count?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027urwsditp\u0027)/docs/$count?api-version=2020-06-30",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-91c30a8206c6cb4ba78cc9ab776939f1-476903bf52fe2248-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210326.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "6626ad329da6fd3193b5a92b98b5b74f",
+        "traceparent": "00-0404edf43a83bbffb1deb7b1a4085358-ae82f77a632ca494-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0ac1dcccca9e32916a7e3cf2e086e86d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "6626ad32-9da6-fd31-93b5-a92b98b5b74f",
+        "client-request-id": "0ac1dccc-ca9e-3291-6a7e-3cf2e086e86d",
         "Content-Length": "5",
         "Content-Type": "text/plain",
-        "Date": "Sat, 27 Mar 2021 18:39:51 GMT",
-        "elapsed-time": "5",
+        "Date": "Fri, 06 Jan 2023 20:48:31 GMT",
+        "elapsed-time": "62",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "6626ad32-9da6-fd31-93b5-a92b98b5b74f",
+        "request-id": "0ac1dccc-ca9e-3291-6a7e-3cf2e086e86d",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "6626ad32-9da6-fd31-93b5-a92b98b5b74f"
+        "x-ms-client-request-id": "0ac1dccc-ca9e-3291-6a7e-3cf2e086e86d"
       },
       "ResponseBody": "\uFEFF10"
     }
   ],
   "Variables": {
-    "RandomSeed": "2104098183",
-    "SearchIndexName": "mbqvlxmt",
+    "RandomSeed": "1139274502",
+    "SearchIndexName": "urwsditp",
     "SEARCH_ADMIN_API_KEY": "Sanitized",
-    "SEARCH_ENDPOINT_SUFFIX": null,
-    "SEARCH_SERVICE_NAME": "mohitc-acs"
+    "SEARCH_ENDPOINT_SUFFIX": "search.windows.net",
+    "SEARCH_SERVICE_NAME": "azs-net-shrejaazsearch"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/GetStatisticsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/GetStatisticsAsync.json
@@ -1,45 +1,42 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/servicestats?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/servicestats?api-version=2020-06-30",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-e1a731da6332f645bfb54e7a5c6df871-a4ae750294df5646-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210326.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "3a08bb2910952da418397c32fedb09c4",
+        "traceparent": "00-5cb37e08c69c80e1317e4e0d9d4c90c9-c10feb1675063afd-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c7c04373cb3f6fa7e94ed5c48c5738d3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "3a08bb29-1095-2da4-1839-7c32fedb09c4",
-        "Content-Length": "584",
+        "client-request-id": "c7c04373-cb3f-6fa7-e94e-d5c48c5738d3",
+        "Content-Length": "591",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 27 Mar 2021 18:39:51 GMT",
-        "elapsed-time": "75",
+        "Date": "Fri, 06 Jan 2023 20:48:04 GMT",
+        "elapsed-time": "4",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "3a08bb29-1095-2da4-1839-7c32fedb09c4",
+        "request-id": "c7c04373-cb3f-6fa7-e94e-d5c48c5738d3",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "3a08bb29-1095-2da4-1839-7c32fedb09c4"
+        "x-ms-client-request-id": "c7c04373-cb3f-6fa7-e94e-d5c48c5738d3"
       },
       "ResponseBody": {
-        "@odata.context": "https://mohitc-acs.search.windows.net/$metadata#Microsoft.Azure.Search.V2020_06_30.ServiceStatistics",
+        "@odata.context": "https://azs-net-shrejaazsearch.search.windows.net/$metadata#Microsoft.Azure.Search.V2020_06_30.ServiceStatistics",
         "counters": {
           "documentCount": {
-            "usage": 11287,
+            "usage": 10,
             "quota": null
           },
           "indexesCount": {
-            "usage": 22,
+            "usage": 2,
             "quota": 50
           },
           "indexersCount": {
@@ -51,7 +48,7 @@
             "quota": 50
           },
           "storageSize": {
-            "usage": 884100,
+            "usage": 79406,
             "quota": 26843545600
           },
           "synonymMaps": {
@@ -73,10 +70,10 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "1977008283",
-    "SearchIndexName": "mbqvlxmt",
+    "RandomSeed": "601135478",
+    "SearchIndexName": "urwsditp",
     "SEARCH_ADMIN_API_KEY": "Sanitized",
-    "SEARCH_ENDPOINT_SUFFIX": null,
-    "SEARCH_SERVICE_NAME": "mohitc-acs"
+    "SEARCH_ENDPOINT_SUFFIX": "search.windows.net",
+    "SEARCH_SERVICE_NAME": "azs-net-shrejaazsearch"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/GetStatisticsAsyncAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/GetStatisticsAsyncAsync.json
@@ -1,45 +1,42 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/servicestats?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/servicestats?api-version=2020-06-30",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-dfb7e54cd7fbc541bc355846af253bde-89e2fa1142147b4a-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210326.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "3557d1c80476f1dec2ba685ca5c4ef71",
+        "traceparent": "00-62714bac10791a3c63fb1ec13d836d3b-90f59e6bfa724df6-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "44c04d4692d1c4f4601cfe0e549b2664",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "3557d1c8-0476-f1de-c2ba-685ca5c4ef71",
-        "Content-Length": "584",
+        "client-request-id": "44c04d46-92d1-c4f4-601c-fe0e549b2664",
+        "Content-Length": "591",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 27 Mar 2021 18:39:51 GMT",
-        "elapsed-time": "76",
+        "Date": "Fri, 06 Jan 2023 20:48:31 GMT",
+        "elapsed-time": "2",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "3557d1c8-0476-f1de-c2ba-685ca5c4ef71",
+        "request-id": "44c04d46-92d1-c4f4-601c-fe0e549b2664",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "3557d1c8-0476-f1de-c2ba-685ca5c4ef71"
+        "x-ms-client-request-id": "44c04d46-92d1-c4f4-601c-fe0e549b2664"
       },
       "ResponseBody": {
-        "@odata.context": "https://mohitc-acs.search.windows.net/$metadata#Microsoft.Azure.Search.V2020_06_30.ServiceStatistics",
+        "@odata.context": "https://azs-net-shrejaazsearch.search.windows.net/$metadata#Microsoft.Azure.Search.V2020_06_30.ServiceStatistics",
         "counters": {
           "documentCount": {
-            "usage": 11287,
+            "usage": 10,
             "quota": null
           },
           "indexesCount": {
-            "usage": 22,
+            "usage": 2,
             "quota": 50
           },
           "indexersCount": {
@@ -51,7 +48,7 @@
             "quota": 50
           },
           "storageSize": {
-            "usage": 884100,
+            "usage": 79406,
             "quota": 26843545600
           },
           "synonymMaps": {
@@ -73,10 +70,10 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "180277775",
-    "SearchIndexName": "mbqvlxmt",
+    "RandomSeed": "2090541886",
+    "SearchIndexName": "urwsditp",
     "SEARCH_ADMIN_API_KEY": "Sanitized",
-    "SEARCH_ENDPOINT_SUFFIX": null,
-    "SEARCH_SERVICE_NAME": "mohitc-acs"
+    "SEARCH_ENDPOINT_SUFFIX": "search.windows.net",
+    "SEARCH_SERVICE_NAME": "azs-net-shrejaazsearch"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/HandleErrors.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/HandleErrors.json
@@ -1,45 +1,45 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/indexes(\u0027doesnotexist\u0027)/docs/$count?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027doesnotexist\u0027)/docs/$count?api-version=2020-06-30",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210326.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "74da84cc969d91270b8cb602179371eb",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4d22cff75e8f00dcc4d6824ecd38aa7e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "74da84cc-969d-9127-0b8c-b602179371eb",
+        "client-request-id": "4d22cff7-5e8f-00dc-c4d6-824ecd38aa7e",
         "Content-Language": "en",
-        "Content-Length": "78",
+        "Content-Length": "110",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 27 Mar 2021 18:39:51 GMT",
+        "Date": "Fri, 06 Jan 2023 20:48:04 GMT",
         "elapsed-time": "8",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "74da84cc-969d-9127-0b8c-b602179371eb",
+        "request-id": "4d22cff7-5e8f-00dc-c4d6-824ecd38aa7e",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "74da84cc-969d-9127-0b8c-b602179371eb"
+        "x-ms-client-request-id": "4d22cff7-5e8f-00dc-c4d6-824ecd38aa7e"
       },
       "ResponseBody": {
-        "Message": "The index \u0027doesnotexist\u0027 for service \u0027mohitc-acs\u0027 was not found."
+        "error": {
+          "code": "",
+          "message": "The index \u0027doesnotexist\u0027 for service \u0027azs-net-shrejaazsearch\u0027 was not found."
+        }
       }
     }
   ],
   "Variables": {
-    "RandomSeed": "266578448",
-    "SearchIndexName": "mbqvlxmt",
+    "RandomSeed": "591289965",
+    "SearchIndexName": "urwsditp",
     "SEARCH_ADMIN_API_KEY": "Sanitized",
-    "SEARCH_ENDPOINT_SUFFIX": null,
-    "SEARCH_SERVICE_NAME": "mohitc-acs"
+    "SEARCH_ENDPOINT_SUFFIX": "search.windows.net",
+    "SEARCH_SERVICE_NAME": "azs-net-shrejaazsearch"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/HandleErrorsAsyncAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/HandleErrorsAsyncAsync.json
@@ -1,46 +1,46 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/indexes(\u0027doesnotexist\u0027)/docs/$count?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027doesnotexist\u0027)/docs/$count?api-version=2020-06-30",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-4a91fcdbe07e6745a821fa7718fafe39-d194ccf89bd5d647-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210326.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "9641ca3ce0e80834b37771415da659ae",
+        "traceparent": "00-c140ad14e274d6a45d41adc08cf7e152-ed1cd762e3edd9b3-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "22254b229b9fdd40bed38648cf603c8a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "9641ca3c-e0e8-0834-b377-71415da659ae",
+        "client-request-id": "22254b22-9b9f-dd40-bed3-8648cf603c8a",
         "Content-Language": "en",
-        "Content-Length": "78",
+        "Content-Length": "110",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 27 Mar 2021 18:39:51 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 06 Jan 2023 20:48:31 GMT",
+        "elapsed-time": "8",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "9641ca3c-e0e8-0834-b377-71415da659ae",
+        "request-id": "22254b22-9b9f-dd40-bed3-8648cf603c8a",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "9641ca3c-e0e8-0834-b377-71415da659ae"
+        "x-ms-client-request-id": "22254b22-9b9f-dd40-bed3-8648cf603c8a"
       },
       "ResponseBody": {
-        "Message": "The index \u0027doesnotexist\u0027 for service \u0027mohitc-acs\u0027 was not found."
+        "error": {
+          "code": "",
+          "message": "The index \u0027doesnotexist\u0027 for service \u0027azs-net-shrejaazsearch\u0027 was not found."
+        }
       }
     }
   ],
   "Variables": {
-    "RandomSeed": "2017785311",
-    "SearchIndexName": "mbqvlxmt",
+    "RandomSeed": "386709467",
+    "SearchIndexName": "urwsditp",
     "SEARCH_ADMIN_API_KEY": "Sanitized",
-    "SEARCH_ENDPOINT_SUFFIX": null,
-    "SEARCH_SERVICE_NAME": "mohitc-acs"
+    "SEARCH_ENDPOINT_SUFFIX": "search.windows.net",
+    "SEARCH_SERVICE_NAME": "azs-net-shrejaazsearch"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/Authenticate.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/Authenticate.json
@@ -1,9 +1,9 @@
 {
   "Entries": [],
   "Variables": {
-    "SearchIndexName": "mbqvlxmt",
+    "SearchIndexName": "agvwmqbx",
     "SEARCH_ADMIN_API_KEY": "Sanitized",
-    "SEARCH_ENDPOINT_SUFFIX": null,
-    "SEARCH_SERVICE_NAME": "mohitc-acs"
+    "SEARCH_ENDPOINT_SUFFIX": "search.windows.net",
+    "SEARCH_SERVICE_NAME": "azs-net-shrejaazsearch"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/CreateIndex.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/CreateIndex.json
@@ -1,25 +1,22 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-heathssearch.search.windows.net/indexes?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes?api-version=2020-06-30",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "Content-Length": "1331",
         "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.4.0-alpha.20211011.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.22000)"
-        ],
-        "x-ms-client-request-id": "ec8f1b224af8d9bff1f430bc1b15db2c",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a2b43ccc7dd61a474c17c02fc0a61b36",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "wldfvoaj",
+        "name": "cuujwfwu",
         "fields": [
           {
-            "name": "hotelId",
+            "name": "HotelId",
             "type": "Edm.String",
             "key": true,
             "retrievable": true,
@@ -29,7 +26,7 @@
             "facetable": false
           },
           {
-            "name": "hotelName",
+            "name": "HotelName",
             "type": "Edm.String",
             "key": false,
             "retrievable": true,
@@ -39,7 +36,7 @@
             "facetable": false
           },
           {
-            "name": "geoLocation",
+            "name": "GeoLocation",
             "type": "Edm.GeographyPoint",
             "key": false,
             "retrievable": true,
@@ -49,11 +46,11 @@
             "facetable": false
           },
           {
-            "name": "address",
+            "name": "Address",
             "type": "Edm.ComplexType",
             "fields": [
               {
-                "name": "streetAddress",
+                "name": "StreetAddress",
                 "type": "Edm.String",
                 "key": false,
                 "retrievable": true,
@@ -63,7 +60,7 @@
                 "facetable": false
               },
               {
-                "name": "city",
+                "name": "City",
                 "type": "Edm.String",
                 "key": false,
                 "retrievable": true,
@@ -73,7 +70,7 @@
                 "facetable": true
               },
               {
-                "name": "stateProvince",
+                "name": "StateProvince",
                 "type": "Edm.String",
                 "key": false,
                 "retrievable": true,
@@ -83,7 +80,7 @@
                 "facetable": true
               },
               {
-                "name": "country",
+                "name": "Country",
                 "type": "Edm.String",
                 "key": false,
                 "retrievable": true,
@@ -93,7 +90,7 @@
                 "facetable": true
               },
               {
-                "name": "postalCode",
+                "name": "PostalCode",
                 "type": "Edm.String",
                 "key": false,
                 "retrievable": true,
@@ -110,7 +107,7 @@
             "name": "sg",
             "searchMode": "analyzingInfixMatching",
             "sourceFields": [
-              "hotelName"
+              "HotelName"
             ]
           }
         ]
@@ -118,29 +115,29 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "ec8f1b22-4af8-d9bf-f1f4-30bc1b15db2c",
-        "Content-Length": "2315",
+        "client-request-id": "a2b43ccc-7dd6-1a47-4c17-c02fc0a61b36",
+        "Content-Length": "2317",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Mon, 11 Oct 2021 21:35:23 GMT",
-        "elapsed-time": "1583",
-        "ETag": "W/\u00220x8D98CFF0882CF84\u0022",
+        "Date": "Fri, 06 Jan 2023 20:43:29 GMT",
+        "elapsed-time": "699",
+        "ETag": "W/\u00220x8DAF026AADB762A\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-heathssearch.search.windows.net/indexes(\u0027wldfvoaj\u0027)?api-version=2020-06-30",
+        "Location": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027cuujwfwu\u0027)?api-version=2020-06-30",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "ec8f1b22-4af8-d9bf-f1f4-30bc1b15db2c",
+        "request-id": "a2b43ccc-7dd6-1a47-4c17-c02fc0a61b36",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "ec8f1b22-4af8-d9bf-f1f4-30bc1b15db2c"
+        "x-ms-client-request-id": "a2b43ccc-7dd6-1a47-4c17-c02fc0a61b36"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-heathssearch.search.windows.net/$metadata#indexes/$entity",
-        "@odata.etag": "\u00220x8D98CFF0882CF84\u0022",
-        "name": "wldfvoaj",
+        "@odata.context": "https://azs-net-shrejaazsearch.search.windows.net/$metadata#indexes/$entity",
+        "@odata.etag": "\u00220x8DAF026AADB762A\u0022",
+        "name": "cuujwfwu",
         "defaultScoringProfile": null,
         "fields": [
           {
-            "name": "hotelId",
+            "name": "HotelId",
             "type": "Edm.String",
             "searchable": false,
             "filterable": true,
@@ -154,7 +151,7 @@
             "synonymMaps": []
           },
           {
-            "name": "hotelName",
+            "name": "HotelName",
             "type": "Edm.String",
             "searchable": true,
             "filterable": true,
@@ -168,7 +165,7 @@
             "synonymMaps": []
           },
           {
-            "name": "geoLocation",
+            "name": "GeoLocation",
             "type": "Edm.GeographyPoint",
             "searchable": false,
             "filterable": true,
@@ -182,11 +179,11 @@
             "synonymMaps": []
           },
           {
-            "name": "address",
+            "name": "Address",
             "type": "Edm.ComplexType",
             "fields": [
               {
-                "name": "streetAddress",
+                "name": "StreetAddress",
                 "type": "Edm.String",
                 "searchable": false,
                 "filterable": false,
@@ -200,7 +197,7 @@
                 "synonymMaps": []
               },
               {
-                "name": "city",
+                "name": "City",
                 "type": "Edm.String",
                 "searchable": false,
                 "filterable": true,
@@ -214,7 +211,7 @@
                 "synonymMaps": []
               },
               {
-                "name": "stateProvince",
+                "name": "StateProvince",
                 "type": "Edm.String",
                 "searchable": false,
                 "filterable": true,
@@ -228,7 +225,7 @@
                 "synonymMaps": []
               },
               {
-                "name": "country",
+                "name": "Country",
                 "type": "Edm.String",
                 "searchable": false,
                 "filterable": true,
@@ -242,7 +239,7 @@
                 "synonymMaps": []
               },
               {
-                "name": "postalCode",
+                "name": "PostalCode",
                 "type": "Edm.String",
                 "searchable": false,
                 "filterable": true,
@@ -265,7 +262,7 @@
             "name": "sg",
             "searchMode": "analyzingInfixMatching",
             "sourceFields": [
-              "hotelName"
+              "HotelName"
             ]
           }
         ],
@@ -282,40 +279,37 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-heathssearch.search.windows.net/indexes(\u0027wldfvoaj\u0027)?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027cuujwfwu\u0027)?api-version=2020-06-30",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-ad1377d02ddab748a466a91b5af3ef63-57b27604cfeb5f47-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.4.0-alpha.20211011.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.22000)"
-        ],
-        "x-ms-client-request-id": "04ea96019403abe77144bfc0b4162512",
+        "traceparent": "00-514436dd83e23ed828551784d1cb9aad-b0d7649dfb3bd488-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0958dd3586bbb15492107dd54b39dc67",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "04ea9601-9403-abe7-7144-bfc0b4162512",
-        "Date": "Mon, 11 Oct 2021 21:35:23 GMT",
-        "elapsed-time": "182",
+        "client-request-id": "0958dd35-86bb-b154-9210-7dd54b39dc67",
+        "Date": "Fri, 06 Jan 2023 20:43:29 GMT",
+        "elapsed-time": "219",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "04ea9601-9403-abe7-7144-bfc0b4162512",
+        "request-id": "0958dd35-86bb-b154-9210-7dd54b39dc67",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "04ea9601-9403-abe7-7144-bfc0b4162512"
+        "x-ms-client-request-id": "0958dd35-86bb-b154-9210-7dd54b39dc67"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     }
   ],
   "Variables": {
-    "RandomSeed": "2102937546",
-    "SearchIndexName": "wldfvoaj",
+    "RandomSeed": "523236120",
+    "SearchIndexName": "cuujwfwu",
     "SEARCH_ADMIN_API_KEY": "Sanitized",
-    "SEARCH_ENDPOINT_SUFFIX": null,
-    "SEARCH_SERVICE_NAME": "azs-net-heathssearch"
+    "SEARCH_ENDPOINT_SUFFIX": "search.windows.net",
+    "SEARCH_SERVICE_NAME": "azs-net-shrejaazsearch"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/CreateManualIndex.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/CreateManualIndex.json
@@ -1,25 +1,22 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/indexes?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes?api-version=2020-06-30",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "Content-Length": "1491",
         "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210326.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "062ad9f862e213513b68f2e5dc858b77",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f78e4fc496ce9b1218e3a1e7b7fc448a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "nillbdny",
+        "name": "vpxrvivx",
         "fields": [
           {
-            "name": "hotelId",
+            "name": "HotelId",
             "type": "Edm.String",
             "key": true,
             "retrievable": true,
@@ -29,7 +26,7 @@
             "facetable": false
           },
           {
-            "name": "hotelName",
+            "name": "HotelName",
             "type": "Edm.String",
             "key": false,
             "retrievable": true,
@@ -39,7 +36,7 @@
             "facetable": false
           },
           {
-            "name": "description",
+            "name": "Description",
             "type": "Edm.String",
             "key": false,
             "retrievable": true,
@@ -50,7 +47,7 @@
             "analyzer": "en.lucene"
           },
           {
-            "name": "tags",
+            "name": "Tags",
             "type": "Collection(Edm.String)",
             "key": false,
             "retrievable": true,
@@ -60,11 +57,11 @@
             "facetable": true
           },
           {
-            "name": "address",
+            "name": "Address",
             "type": "Edm.ComplexType",
             "fields": [
               {
-                "name": "streetAddress",
+                "name": "StreetAddress",
                 "type": "Edm.String",
                 "key": false,
                 "retrievable": true,
@@ -74,7 +71,7 @@
                 "facetable": false
               },
               {
-                "name": "city",
+                "name": "City",
                 "type": "Edm.String",
                 "key": false,
                 "retrievable": true,
@@ -84,7 +81,7 @@
                 "facetable": true
               },
               {
-                "name": "stateProvince",
+                "name": "StateProvince",
                 "type": "Edm.String",
                 "key": false,
                 "retrievable": true,
@@ -94,7 +91,7 @@
                 "facetable": true
               },
               {
-                "name": "country",
+                "name": "Country",
                 "type": "Edm.String",
                 "key": false,
                 "retrievable": true,
@@ -104,7 +101,7 @@
                 "facetable": true
               },
               {
-                "name": "postalCode",
+                "name": "PostalCode",
                 "type": "Edm.String",
                 "key": false,
                 "retrievable": true,
@@ -121,7 +118,7 @@
             "name": "sg",
             "searchMode": "analyzingInfixMatching",
             "sourceFields": [
-              "hotelName"
+              "HotelName"
             ]
           }
         ]
@@ -129,29 +126,29 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "062ad9f8-62e2-1351-3b68-f2e5dc858b77",
-        "Content-Length": "2525",
+        "client-request-id": "f78e4fc4-96ce-9b12-18e3-a1e7b7fc448a",
+        "Content-Length": "2537",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 27 Mar 2021 18:42:49 GMT",
-        "elapsed-time": "654",
-        "ETag": "W/\u00220x8D8F1501F4947AB\u0022",
+        "Date": "Fri, 06 Jan 2023 20:43:33 GMT",
+        "elapsed-time": "651",
+        "ETag": "W/\u00220x8DAF026AD75203B\u0022",
         "Expires": "-1",
-        "Location": "https://mohitc-acs.search.windows.net/indexes(\u0027nillbdny\u0027)?api-version=2020-06-30",
+        "Location": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027vpxrvivx\u0027)?api-version=2020-06-30",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "062ad9f8-62e2-1351-3b68-f2e5dc858b77",
+        "request-id": "f78e4fc4-96ce-9b12-18e3-a1e7b7fc448a",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "062ad9f8-62e2-1351-3b68-f2e5dc858b77"
+        "x-ms-client-request-id": "f78e4fc4-96ce-9b12-18e3-a1e7b7fc448a"
       },
       "ResponseBody": {
-        "@odata.context": "https://mohitc-acs.search.windows.net/$metadata#indexes/$entity",
-        "@odata.etag": "\u00220x8D8F1501F4947AB\u0022",
-        "name": "nillbdny",
+        "@odata.context": "https://azs-net-shrejaazsearch.search.windows.net/$metadata#indexes/$entity",
+        "@odata.etag": "\u00220x8DAF026AD75203B\u0022",
+        "name": "vpxrvivx",
         "defaultScoringProfile": null,
         "fields": [
           {
-            "name": "hotelId",
+            "name": "HotelId",
             "type": "Edm.String",
             "searchable": false,
             "filterable": true,
@@ -165,7 +162,7 @@
             "synonymMaps": []
           },
           {
-            "name": "hotelName",
+            "name": "HotelName",
             "type": "Edm.String",
             "searchable": true,
             "filterable": true,
@@ -179,7 +176,7 @@
             "synonymMaps": []
           },
           {
-            "name": "description",
+            "name": "Description",
             "type": "Edm.String",
             "searchable": true,
             "filterable": false,
@@ -193,7 +190,7 @@
             "synonymMaps": []
           },
           {
-            "name": "tags",
+            "name": "Tags",
             "type": "Collection(Edm.String)",
             "searchable": true,
             "filterable": true,
@@ -207,11 +204,11 @@
             "synonymMaps": []
           },
           {
-            "name": "address",
+            "name": "Address",
             "type": "Edm.ComplexType",
             "fields": [
               {
-                "name": "streetAddress",
+                "name": "StreetAddress",
                 "type": "Edm.String",
                 "searchable": true,
                 "filterable": false,
@@ -225,7 +222,7 @@
                 "synonymMaps": []
               },
               {
-                "name": "city",
+                "name": "City",
                 "type": "Edm.String",
                 "searchable": true,
                 "filterable": true,
@@ -239,7 +236,7 @@
                 "synonymMaps": []
               },
               {
-                "name": "stateProvince",
+                "name": "StateProvince",
                 "type": "Edm.String",
                 "searchable": true,
                 "filterable": true,
@@ -253,7 +250,7 @@
                 "synonymMaps": []
               },
               {
-                "name": "country",
+                "name": "Country",
                 "type": "Edm.String",
                 "searchable": true,
                 "filterable": true,
@@ -267,7 +264,7 @@
                 "synonymMaps": []
               },
               {
-                "name": "postalCode",
+                "name": "PostalCode",
                 "type": "Edm.String",
                 "searchable": true,
                 "filterable": true,
@@ -290,7 +287,7 @@
             "name": "sg",
             "searchMode": "analyzingInfixMatching",
             "sourceFields": [
-              "hotelName"
+              "HotelName"
             ]
           }
         ],
@@ -307,40 +304,37 @@
       }
     },
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/indexes(\u0027nillbdny\u0027)?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027vpxrvivx\u0027)?api-version=2020-06-30",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-9e9743c78e6df64092f44897933c8c54-6d7ab5f6692b824f-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210326.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "e487c37abac16ac1ab43997c9d35868a",
+        "traceparent": "00-4d7a4f8845f17b9cc16fc4609b66fcd3-3ad3e035acf390bd-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "28428e45363a899838d4cb7c0a7f2b53",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "e487c37a-bac1-6ac1-ab43-997c9d35868a",
-        "Date": "Sat, 27 Mar 2021 18:42:49 GMT",
-        "elapsed-time": "162",
+        "client-request-id": "28428e45-363a-8998-38d4-cb7c0a7f2b53",
+        "Date": "Fri, 06 Jan 2023 20:43:33 GMT",
+        "elapsed-time": "307",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "e487c37a-bac1-6ac1-ab43-997c9d35868a",
+        "request-id": "28428e45-363a-8998-38d4-cb7c0a7f2b53",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "e487c37a-bac1-6ac1-ab43-997c9d35868a"
+        "x-ms-client-request-id": "28428e45-363a-8998-38d4-cb7c0a7f2b53"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     }
   ],
   "Variables": {
-    "RandomSeed": "1446516247",
-    "SearchIndexName": "nillbdny",
+    "RandomSeed": "392231300",
+    "SearchIndexName": "vpxrvivx",
     "SEARCH_ADMIN_API_KEY": "Sanitized",
-    "SEARCH_ENDPOINT_SUFFIX": null,
-    "SEARCH_SERVICE_NAME": "mohitc-acs"
+    "SEARCH_ENDPOINT_SUFFIX": "search.windows.net",
+    "SEARCH_SERVICE_NAME": "azs-net-shrejaazsearch"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/GetDocument.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/GetDocument.json
@@ -1,43 +1,84 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/indexes(\u0027mbqvlxmt\u0027)/docs(\u00271\u0027)?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027agvwmqbx\u0027)/docs(\u00271\u0027)?api-version=2020-06-30",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210326.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "f3ceff4513b1ace31223fc6345609397",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "107f85f3b6a26c4d93865dc4324d6938",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "f3ceff45-13b1-ace3-1223-fc6345609397",
+        "client-request-id": "107f85f3-b6a2-6c4d-9386-5dc4324d6938",
         "Content-Length": "1065",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 27 Mar 2021 18:42:52 GMT",
-        "elapsed-time": "93",
+        "Date": "Fri, 06 Jan 2023 20:43:36 GMT",
+        "elapsed-time": "98",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "f3ceff45-13b1-ace3-1223-fc6345609397",
+        "request-id": "107f85f3-b6a2-6c4d-9386-5dc4324d6938",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "f3ceff45-13b1-ace3-1223-fc6345609397"
+        "x-ms-client-request-id": "107f85f3-b6a2-6c4d-9386-5dc4324d6938"
       },
-      "ResponseBody": "{\u0022hotelId\u0022:\u00221\u0022,\u0022hotelName\u0022:\u0022Fancy Stay\u0022,\u0022description\u0022:\u0022Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.\u0022,\u0022descriptionFr\u0022:\u0022Meilleur h\\u00f4tel en ville si vous aimez les h\\u00f4tels de luxe. Ils ont une magnifique piscine \\u00e0 d\\u00e9bordement, un spa et un concierge tr\\u00e8s utile. L\u0027emplacement est parfait \\u2013 en plein centre, \\u00e0 proximit\\u00e9 de toutes les attractions touristiques. Nous recommandons fortement cet h\\u00f4tel.\u0022,\u0022category\u0022:\u0022Luxury\u0022,\u0022tags\u0022:[\u0022pool\u0022,\u0022view\u0022,\u0022wifi\u0022,\u0022concierge\u0022],\u0022parkingIncluded\u0022:false,\u0022smokingAllowed\u0022:false,\u0022lastRenovationDate\u0022:\u00222010-06-27T00:00:00Z\u0022,\u0022rating\u0022:5,\u0022location\u0022:{\u0022type\u0022:\u0022Point\u0022,\u0022coordinates\u0022:[-122.131577,47.678581],\u0022crs\u0022:{\u0022type\u0022:\u0022name\u0022,\u0022properties\u0022:{\u0022name\u0022:\u0022EPSG:4326\u0022}}},\u0022geoLocation\u0022:{\u0022type\u0022:\u0022Point\u0022,\u0022coordinates\u0022:[-122.131577,47.678581],\u0022crs\u0022:{\u0022type\u0022:\u0022name\u0022,\u0022properties\u0022:{\u0022name\u0022:\u0022EPSG:4326\u0022}}},\u0022address\u0022:null,\u0022rooms\u0022:[]}"
+      "ResponseBody": {
+        "HotelId": "1",
+        "HotelName": "Fancy Stay",
+        "Description": "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.",
+        "DescriptionFr": "Meilleur h\u00F4tel en ville si vous aimez les h\u00F4tels de luxe. Ils ont une magnifique piscine \u00E0 d\u00E9bordement, un spa et un concierge tr\u00E8s utile. L\u0027emplacement est parfait \u2013 en plein centre, \u00E0 proximit\u00E9 de toutes les attractions touristiques. Nous recommandons fortement cet h\u00F4tel.",
+        "Category": "Luxury",
+        "Tags": [
+          "pool",
+          "view",
+          "wifi",
+          "concierge"
+        ],
+        "ParkingIncluded": false,
+        "SmokingAllowed": false,
+        "LastRenovationDate": "2010-06-27T00:00:00Z",
+        "Rating": 5,
+        "Location": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            47.678581
+          ],
+          "crs": {
+            "type": "name",
+            "properties": {
+              "name": "EPSG:4326"
+            }
+          }
+        },
+        "GeoLocation": {
+          "type": "Point",
+          "coordinates": [
+            -122.131577,
+            47.678581
+          ],
+          "crs": {
+            "type": "name",
+            "properties": {
+              "name": "EPSG:4326"
+            }
+          }
+        },
+        "Address": null,
+        "Rooms": []
+      }
     }
   ],
   "Variables": {
-    "RandomSeed": "509178331",
-    "SearchIndexName": "mbqvlxmt",
-    "SEARCH_ENDPOINT_SUFFIX": null,
+    "RandomSeed": "1978895706",
+    "SearchIndexName": "agvwmqbx",
+    "SEARCH_ENDPOINT_SUFFIX": "search.windows.net",
     "SEARCH_QUERY_API_KEY": "Sanitized",
-    "SEARCH_SERVICE_NAME": "mohitc-acs"
+    "SEARCH_SERVICE_NAME": "azs-net-shrejaazsearch"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/Index.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/Index.json
@@ -1,50 +1,50 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/indexes(\u0027lwuhsdmj\u0027)/docs/search.index?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027kltikpql\u0027)/docs/search.index?api-version=2020-06-30",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "Content-Length": "152",
+        "Content-Length": "220",
         "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210326.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "024524334adee593f5ff620e2e46cb84",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3620949f1d89dd88c1b7cad58e338614",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "value": [
           {
             "@search.action": "upload",
-            "hotelId": "783",
-            "hotelName": "Upload Inn"
+            "HotelId": "783",
+            "HotelName": "Upload Inn",
+            "GeoLocation": null,
+            "Address": null
           },
           {
             "@search.action": "merge",
-            "hotelId": "12",
-            "hotelName": "Renovated Ranch"
+            "HotelId": "12",
+            "HotelName": "Renovated Ranch",
+            "GeoLocation": null,
+            "Address": null
           }
         ]
       },
       "StatusCode": 403,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "02452433-4ade-e593-f5ff-620e2e46cb84",
+        "client-request-id": "3620949f-1d89-dd88-c1b7-cad58e338614",
         "Content-Language": "en",
         "Content-Length": "55",
-        "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 27 Mar 2021 18:43:13 GMT",
-        "elapsed-time": "67",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 06 Jan 2023 20:43:58 GMT",
+        "elapsed-time": "57",
         "Expires": "-1",
-        "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "02452433-4ade-e593-f5ff-620e2e46cb84",
+        "request-id": "3620949f-1d89-dd88-c1b7-cad58e338614",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "02452433-4ade-e593-f5ff-620e2e46cb84"
+        "x-ms-client-request-id": "3620949f-1d89-dd88-c1b7-cad58e338614"
       },
       "ResponseBody": {
         "error": {
@@ -54,41 +54,38 @@
       }
     },
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/indexes(\u0027lwuhsdmj\u0027)?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027kltikpql\u0027)?api-version=2020-06-30",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-370d8174adf9b144b67738cb8c41811c-70e87ff0bc260643-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210326.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "a522fd35141b7174122ccf9c9ccbaae0",
+        "traceparent": "00-3d64dc375cfe82c81e6537d71683def3-2e6c9267a78d646a-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6bc22d7e40ec3d881a44e1c0da28e2c6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "a522fd35-141b-7174-122c-cf9c9ccbaae0",
-        "Date": "Sat, 27 Mar 2021 18:43:13 GMT",
-        "elapsed-time": "199",
+        "client-request-id": "6bc22d7e-40ec-3d88-1a44-e1c0da28e2c6",
+        "Date": "Fri, 06 Jan 2023 20:43:58 GMT",
+        "elapsed-time": "200",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "a522fd35-141b-7174-122c-cf9c9ccbaae0",
+        "request-id": "6bc22d7e-40ec-3d88-1a44-e1c0da28e2c6",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "a522fd35-141b-7174-122c-cf9c9ccbaae0"
+        "x-ms-client-request-id": "6bc22d7e-40ec-3d88-1a44-e1c0da28e2c6"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     }
   ],
   "Variables": {
-    "RandomSeed": "978400005",
-    "SearchIndexName": "lwuhsdmj",
+    "RandomSeed": "2090605161",
+    "SearchIndexName": "kltikpql",
     "SEARCH_ADMIN_API_KEY": "Sanitized",
-    "SEARCH_ENDPOINT_SUFFIX": null,
+    "SEARCH_ENDPOINT_SUFFIX": "search.windows.net",
     "SEARCH_QUERY_API_KEY": "Sanitized",
-    "SEARCH_SERVICE_NAME": "mohitc-acs"
+    "SEARCH_SERVICE_NAME": "azs-net-shrejaazsearch"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/Options.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/Options.json
@@ -1,50 +1,96 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/indexes(\u0027mbqvlxmt\u0027)/docs/search.post.search?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027agvwmqbx\u0027)/docs/search.post.search?api-version=2020-06-30",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "74",
         "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210326.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "4cbbd33490420dee971451eace00649b",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f3fcc139aea8901a8d912c4478e55104",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "filter": "rating ge 4",
-        "orderby": "rating desc",
+        "filter": "Rating ge 4",
+        "orderby": "Rating desc",
         "search": "luxury",
         "top": 5
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "4cbbd334-9042-0dee-9714-51eace00649b",
+        "client-request-id": "f3fcc139-aea8-901a-8d91-2c4478e55104",
         "Content-Length": "1102",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 27 Mar 2021 18:43:15 GMT",
-        "elapsed-time": "100",
+        "Date": "Fri, 06 Jan 2023 20:44:01 GMT",
+        "elapsed-time": "555",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "4cbbd334-9042-0dee-9714-51eace00649b",
+        "request-id": "f3fcc139-aea8-901a-8d91-2c4478e55104",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "4cbbd334-9042-0dee-9714-51eace00649b"
+        "x-ms-client-request-id": "f3fcc139-aea8-901a-8d91-2c4478e55104"
       },
-      "ResponseBody": "{\u0022value\u0022:[{\u0022@search.score\u0022:1.355029,\u0022hotelId\u0022:\u00221\u0022,\u0022hotelName\u0022:\u0022Fancy Stay\u0022,\u0022description\u0022:\u0022Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.\u0022,\u0022descriptionFr\u0022:\u0022Meilleur h\\u00f4tel en ville si vous aimez les h\\u00f4tels de luxe. Ils ont une magnifique piscine \\u00e0 d\\u00e9bordement, un spa et un concierge tr\\u00e8s utile. L\u0027emplacement est parfait \\u2013 en plein centre, \\u00e0 proximit\\u00e9 de toutes les attractions touristiques. Nous recommandons fortement cet h\\u00f4tel.\u0022,\u0022category\u0022:\u0022Luxury\u0022,\u0022tags\u0022:[\u0022pool\u0022,\u0022view\u0022,\u0022wifi\u0022,\u0022concierge\u0022],\u0022parkingIncluded\u0022:false,\u0022smokingAllowed\u0022:false,\u0022lastRenovationDate\u0022:\u00222010-06-27T00:00:00Z\u0022,\u0022rating\u0022:5,\u0022location\u0022:{\u0022type\u0022:\u0022Point\u0022,\u0022coordinates\u0022:[-122.131577,47.678581],\u0022crs\u0022:{\u0022type\u0022:\u0022name\u0022,\u0022properties\u0022:{\u0022name\u0022:\u0022EPSG:4326\u0022}}},\u0022geoLocation\u0022:{\u0022type\u0022:\u0022Point\u0022,\u0022coordinates\u0022:[-122.131577,47.678581],\u0022crs\u0022:{\u0022type\u0022:\u0022name\u0022,\u0022properties\u0022:{\u0022name\u0022:\u0022EPSG:4326\u0022}}},\u0022address\u0022:null,\u0022rooms\u0022:[]}]}"
+      "ResponseBody": {
+        "value": [
+          {
+            "@search.score": 1.355029,
+            "HotelId": "1",
+            "HotelName": "Fancy Stay",
+            "Description": "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.",
+            "DescriptionFr": "Meilleur h\u00F4tel en ville si vous aimez les h\u00F4tels de luxe. Ils ont une magnifique piscine \u00E0 d\u00E9bordement, un spa et un concierge tr\u00E8s utile. L\u0027emplacement est parfait \u2013 en plein centre, \u00E0 proximit\u00E9 de toutes les attractions touristiques. Nous recommandons fortement cet h\u00F4tel.",
+            "Category": "Luxury",
+            "Tags": [
+              "pool",
+              "view",
+              "wifi",
+              "concierge"
+            ],
+            "ParkingIncluded": false,
+            "SmokingAllowed": false,
+            "LastRenovationDate": "2010-06-27T00:00:00Z",
+            "Rating": 5,
+            "Location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                47.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "GeoLocation": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                47.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "Address": null,
+            "Rooms": []
+          }
+        ]
+      }
     }
   ],
   "Variables": {
-    "RandomSeed": "1402132638",
-    "SearchIndexName": "mbqvlxmt",
-    "SEARCH_ENDPOINT_SUFFIX": null,
+    "RandomSeed": "522976750",
+    "SearchIndexName": "agvwmqbx",
+    "SEARCH_ENDPOINT_SUFFIX": "search.windows.net",
     "SEARCH_QUERY_API_KEY": "Sanitized",
-    "SEARCH_SERVICE_NAME": "mohitc-acs"
+    "SEARCH_SERVICE_NAME": "azs-net-shrejaazsearch"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/QueryStatic.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/QueryStatic.json
@@ -1,18 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/indexes(\u0027mbqvlxmt\u0027)/docs/search.post.search?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027agvwmqbx\u0027)/docs/search.post.search?api-version=2020-06-30",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "19",
         "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210326.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "3ca72ac76a8c267bd9f5e5c0f47395a4",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a0e36c88ead7866de9bb8c24136ef9d0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -21,35 +18,81 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "3ca72ac7-6a8c-267b-d9f5-e5c0f47395a4",
+        "client-request-id": "a0e36c88-ead7-866d-e9bb-8c24136ef9d0",
         "Content-Length": "1102",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 27 Mar 2021 18:43:15 GMT",
-        "elapsed-time": "11",
+        "Date": "Fri, 06 Jan 2023 20:44:02 GMT",
+        "elapsed-time": "33",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "3ca72ac7-6a8c-267b-d9f5-e5c0f47395a4",
+        "request-id": "a0e36c88-ead7-866d-e9bb-8c24136ef9d0",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "3ca72ac7-6a8c-267b-d9f5-e5c0f47395a4"
+        "x-ms-client-request-id": "a0e36c88-ead7-866d-e9bb-8c24136ef9d0"
       },
-      "ResponseBody": "{\u0022value\u0022:[{\u0022@search.score\u0022:1.355029,\u0022hotelId\u0022:\u00221\u0022,\u0022hotelName\u0022:\u0022Fancy Stay\u0022,\u0022description\u0022:\u0022Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.\u0022,\u0022descriptionFr\u0022:\u0022Meilleur h\\u00f4tel en ville si vous aimez les h\\u00f4tels de luxe. Ils ont une magnifique piscine \\u00e0 d\\u00e9bordement, un spa et un concierge tr\\u00e8s utile. L\u0027emplacement est parfait \\u2013 en plein centre, \\u00e0 proximit\\u00e9 de toutes les attractions touristiques. Nous recommandons fortement cet h\\u00f4tel.\u0022,\u0022category\u0022:\u0022Luxury\u0022,\u0022tags\u0022:[\u0022pool\u0022,\u0022view\u0022,\u0022wifi\u0022,\u0022concierge\u0022],\u0022parkingIncluded\u0022:false,\u0022smokingAllowed\u0022:false,\u0022lastRenovationDate\u0022:\u00222010-06-27T00:00:00Z\u0022,\u0022rating\u0022:5,\u0022location\u0022:{\u0022type\u0022:\u0022Point\u0022,\u0022coordinates\u0022:[-122.131577,47.678581],\u0022crs\u0022:{\u0022type\u0022:\u0022name\u0022,\u0022properties\u0022:{\u0022name\u0022:\u0022EPSG:4326\u0022}}},\u0022geoLocation\u0022:{\u0022type\u0022:\u0022Point\u0022,\u0022coordinates\u0022:[-122.131577,47.678581],\u0022crs\u0022:{\u0022type\u0022:\u0022name\u0022,\u0022properties\u0022:{\u0022name\u0022:\u0022EPSG:4326\u0022}}},\u0022address\u0022:null,\u0022rooms\u0022:[]}]}"
+      "ResponseBody": {
+        "value": [
+          {
+            "@search.score": 1.355029,
+            "HotelId": "1",
+            "HotelName": "Fancy Stay",
+            "Description": "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.",
+            "DescriptionFr": "Meilleur h\u00F4tel en ville si vous aimez les h\u00F4tels de luxe. Ils ont une magnifique piscine \u00E0 d\u00E9bordement, un spa et un concierge tr\u00E8s utile. L\u0027emplacement est parfait \u2013 en plein centre, \u00E0 proximit\u00E9 de toutes les attractions touristiques. Nous recommandons fortement cet h\u00F4tel.",
+            "Category": "Luxury",
+            "Tags": [
+              "pool",
+              "view",
+              "wifi",
+              "concierge"
+            ],
+            "ParkingIncluded": false,
+            "SmokingAllowed": false,
+            "LastRenovationDate": "2010-06-27T00:00:00Z",
+            "Rating": 5,
+            "Location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                47.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "GeoLocation": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                47.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "Address": null,
+            "Rooms": []
+          }
+        ]
+      }
     },
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/indexes(\u0027mbqvlxmt\u0027)/docs/search.post.search?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027agvwmqbx\u0027)/docs/search.post.search?api-version=2020-06-30",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "19",
         "Content-Type": "application/json",
-        "traceparent": "00-18d0d6be554c734e9b8c3d494231268f-3001670dc3fe314b-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210326.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "c4773c05d66cb29c12ab04f8a2e9b0c8",
+        "traceparent": "00-c9c9b6ca9a7cb508e2f1aab84eaab39e-6d51091c691b2fba-00",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8f5ec171052ff8bb029ddd9d555b1940",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -58,27 +101,76 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "c4773c05-d66c-b29c-12ab-04f8a2e9b0c8",
+        "client-request-id": "8f5ec171-052f-f8bb-029d-dd9d555b1940",
         "Content-Length": "1102",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 27 Mar 2021 18:43:15 GMT",
-        "elapsed-time": "10",
+        "Date": "Fri, 06 Jan 2023 20:44:02 GMT",
+        "elapsed-time": "20",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "c4773c05-d66c-b29c-12ab-04f8a2e9b0c8",
+        "request-id": "8f5ec171-052f-f8bb-029d-dd9d555b1940",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "c4773c05-d66c-b29c-12ab-04f8a2e9b0c8"
+        "x-ms-client-request-id": "8f5ec171-052f-f8bb-029d-dd9d555b1940"
       },
-      "ResponseBody": "{\u0022value\u0022:[{\u0022@search.score\u0022:1.355029,\u0022hotelId\u0022:\u00221\u0022,\u0022hotelName\u0022:\u0022Fancy Stay\u0022,\u0022description\u0022:\u0022Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.\u0022,\u0022descriptionFr\u0022:\u0022Meilleur h\\u00f4tel en ville si vous aimez les h\\u00f4tels de luxe. Ils ont une magnifique piscine \\u00e0 d\\u00e9bordement, un spa et un concierge tr\\u00e8s utile. L\u0027emplacement est parfait \\u2013 en plein centre, \\u00e0 proximit\\u00e9 de toutes les attractions touristiques. Nous recommandons fortement cet h\\u00f4tel.\u0022,\u0022category\u0022:\u0022Luxury\u0022,\u0022tags\u0022:[\u0022pool\u0022,\u0022view\u0022,\u0022wifi\u0022,\u0022concierge\u0022],\u0022parkingIncluded\u0022:false,\u0022smokingAllowed\u0022:false,\u0022lastRenovationDate\u0022:\u00222010-06-27T00:00:00Z\u0022,\u0022rating\u0022:5,\u0022location\u0022:{\u0022type\u0022:\u0022Point\u0022,\u0022coordinates\u0022:[-122.131577,47.678581],\u0022crs\u0022:{\u0022type\u0022:\u0022name\u0022,\u0022properties\u0022:{\u0022name\u0022:\u0022EPSG:4326\u0022}}},\u0022geoLocation\u0022:{\u0022type\u0022:\u0022Point\u0022,\u0022coordinates\u0022:[-122.131577,47.678581],\u0022crs\u0022:{\u0022type\u0022:\u0022name\u0022,\u0022properties\u0022:{\u0022name\u0022:\u0022EPSG:4326\u0022}}},\u0022address\u0022:null,\u0022rooms\u0022:[]}]}"
+      "ResponseBody": {
+        "value": [
+          {
+            "@search.score": 1.355029,
+            "HotelId": "1",
+            "HotelName": "Fancy Stay",
+            "Description": "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, and a really helpful concierge. The location is perfect -- right downtown, close to all the tourist attractions. We highly recommend this hotel.",
+            "DescriptionFr": "Meilleur h\u00F4tel en ville si vous aimez les h\u00F4tels de luxe. Ils ont une magnifique piscine \u00E0 d\u00E9bordement, un spa et un concierge tr\u00E8s utile. L\u0027emplacement est parfait \u2013 en plein centre, \u00E0 proximit\u00E9 de toutes les attractions touristiques. Nous recommandons fortement cet h\u00F4tel.",
+            "Category": "Luxury",
+            "Tags": [
+              "pool",
+              "view",
+              "wifi",
+              "concierge"
+            ],
+            "ParkingIncluded": false,
+            "SmokingAllowed": false,
+            "LastRenovationDate": "2010-06-27T00:00:00Z",
+            "Rating": 5,
+            "Location": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                47.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "GeoLocation": {
+              "type": "Point",
+              "coordinates": [
+                -122.131577,
+                47.678581
+              ],
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "EPSG:4326"
+                }
+              }
+            },
+            "Address": null,
+            "Rooms": []
+          }
+        ]
+      }
     }
   ],
   "Variables": {
-    "RandomSeed": "549811099",
-    "SearchIndexName": "mbqvlxmt",
-    "SEARCH_ENDPOINT_SUFFIX": null,
+    "RandomSeed": "2010196718",
+    "SearchIndexName": "agvwmqbx",
+    "SEARCH_ENDPOINT_SUFFIX": "search.windows.net",
     "SEARCH_QUERY_API_KEY": "Sanitized",
-    "SEARCH_SERVICE_NAME": "mohitc-acs"
+    "SEARCH_SERVICE_NAME": "azs-net-shrejaazsearch"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/Troubleshooting.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/Troubleshooting.json
@@ -1,40 +1,37 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mohitc-acs.search.windows.net/indexes(\u0027mbqvlxmt\u0027)/docs(\u002712345\u0027)?api-version=2020-06-30",
+      "RequestUri": "https://azs-net-shrejaazsearch.search.windows.net/indexes(\u0027agvwmqbx\u0027)/docs(\u002712345\u0027)?api-version=2020-06-30",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/11.3.0-alpha.20210326.1",
-          "(.NET Core 4.6.29719.03; Microsoft Windows 10.0.19043 )"
-        ],
-        "x-ms-client-request-id": "7c34fbb2dd26e95ef8b150d6b9aa6381",
+        "User-Agent": "azsdk-net-Search.Documents/11.5.0-alpha.20230106.1 (.NET 6.0.12; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9d57ea4673e62ea2fc6cd94145328e41",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "client-request-id": "7c34fbb2-dd26-e95e-f8b1-50d6b9aa6381",
+        "client-request-id": "9d57ea46-73e6-2ea2-fc6c-d94145328e41",
         "Content-Length": "0",
-        "Date": "Sat, 27 Mar 2021 18:43:15 GMT",
-        "elapsed-time": "6",
+        "Date": "Fri, 06 Jan 2023 20:44:02 GMT",
+        "elapsed-time": "9",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "7c34fbb2-dd26-e95e-f8b1-50d6b9aa6381",
+        "request-id": "9d57ea46-73e6-2ea2-fc6c-d94145328e41",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "7c34fbb2-dd26-e95e-f8b1-50d6b9aa6381"
+        "x-ms-client-request-id": "9d57ea46-73e6-2ea2-fc6c-d94145328e41"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     }
   ],
   "Variables": {
-    "RandomSeed": "1565637229",
-    "SearchIndexName": "mbqvlxmt",
-    "SEARCH_ENDPOINT_SUFFIX": null,
+    "RandomSeed": "2042591370",
+    "SearchIndexName": "agvwmqbx",
+    "SEARCH_ENDPOINT_SUFFIX": "search.windows.net",
     "SEARCH_QUERY_API_KEY": "Sanitized",
-    "SEARCH_SERVICE_NAME": "mohitc-acs"
+    "SEARCH_SERVICE_NAME": "azs-net-shrejaazsearch"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/Utilities/SearchResources.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Utilities/SearchResources.cs
@@ -12,6 +12,7 @@ using Azure.Core.TestFramework;
 using Azure.Search.Documents.Indexes;
 using Azure.Search.Documents.Indexes.Models;
 using Azure.Search.Documents.Models;
+using Azure.Search.Documents.Tests.Samples;
 using Azure.Storage.Blobs;
 using NUnit.Framework;
 
@@ -171,10 +172,10 @@ namespace Azure.Search.Documents.Tests
         /// recordings, instrumentation, etc.
         /// </param>
         /// <returns>A new TestResources context.</returns>
-        public static async Task<SearchResources> CreateWithEmptyIndexAsync<T>(SearchTestBase fixture)
+        public static async Task<SearchResources> CreateWithEmptyIndexAsync<T>(SearchTestBase fixture, bool isSample = false)
         {
             var resources = new SearchResources(fixture);
-            await resources.CreateSearchServiceAndIndexAsync(name =>
+            await resources.CreateSearchServiceAndIndexAsync(isSample, name =>
                 new SearchIndex(name)
                 {
                     Fields = new FieldBuilder().Build(typeof(T))
@@ -191,10 +192,10 @@ namespace Azure.Search.Documents.Tests
         /// recordings, instrumentation, etc.
         /// </param>
         /// <returns>A new TestResources context.</returns>
-        public static async Task<SearchResources> CreateWithEmptyHotelsIndexAsync(SearchTestBase fixture)
+        public static async Task<SearchResources> CreateWithEmptyHotelsIndexAsync(SearchTestBase fixture, bool isSample = false)
         {
             var resources = new SearchResources(fixture);
-            await resources.CreateSearchServiceAndIndexAsync();
+            await resources.CreateSearchServiceAndIndexAsync(isSample);
             return resources;
         }
 
@@ -207,10 +208,10 @@ namespace Azure.Search.Documents.Tests
         /// recordings, instrumentation, etc.
         /// </param>
         /// <returns>A new TestResources context.</returns>
-        public static async Task<SearchResources> CreateWithHotelsIndexAsync(SearchTestBase fixture)
+        public static async Task<SearchResources> CreateWithHotelsIndexAsync(SearchTestBase fixture, bool isSample = false)
         {
             var resources = new SearchResources(fixture);
-            await resources.CreateSearchServiceIndexAndDocumentsAsync();
+            await resources.CreateSearchServiceIndexAndDocumentsAsync(isSample);
             return resources;
         }
 
@@ -226,10 +227,10 @@ namespace Azure.Search.Documents.Tests
         /// Whether to populate the container with Hotel documents. The default is false.
         /// </param>
         /// <returns>A new <see cref="SearchResources"/> context.</returns>
-        public static async Task<SearchResources> CreateWithBlobStorageAsync(SearchTestBase fixture, bool populate = false)
+        public static async Task<SearchResources> CreateWithBlobStorageAsync(SearchTestBase fixture, bool populate = false, bool isSample = false)
         {
             var resources = new SearchResources(fixture);
-            await resources.CreateHotelsBlobContainerAsync(populate);
+            await resources.CreateHotelsBlobContainerAsync(populate, isSample);
             return resources;
         }
 
@@ -245,13 +246,13 @@ namespace Azure.Search.Documents.Tests
         /// Whether to populate the container with Hotel documents. The default is false.
         /// </param>
         /// <returns>A new <see cref="SearchResources"/> context.</returns>
-        public static async Task<SearchResources> CreateWithBlobStorageAndIndexAsync(SearchTestBase fixture, bool populate = false)
+        public static async Task<SearchResources> CreateWithBlobStorageAndIndexAsync(SearchTestBase fixture, bool populate = false, bool isSample = false)
         {
             var resources = new SearchResources(fixture);
 
             // Keep them ordered or records may not match seeded random names.
-            await resources.CreateSearchServiceAndIndexAsync();
-            await resources.CreateHotelsBlobContainerAsync(populate);
+            await resources.CreateSearchServiceAndIndexAsync(isSample);
+            await resources.CreateHotelsBlobContainerAsync(populate, isSample);
 
             return resources;
         }
@@ -267,9 +268,9 @@ namespace Azure.Search.Documents.Tests
         /// recordings, instrumentation, etc.
         /// </param>
         /// <returns>The shared TestResources context.</returns>
-        public static async Task<SearchResources> GetSharedHotelsIndexAsync(SearchTestBase fixture)
+        public static async Task<SearchResources> GetSharedHotelsIndexAsync(SearchTestBase fixture, bool isSample = false)
         {
-            await SharedSearchResources.EnsureInitialized(async () => await CreateWithHotelsIndexAsync(fixture));
+            await SharedSearchResources.EnsureInitialized(async () => await CreateWithHotelsIndexAsync(fixture, isSample));
 
             // Clone it for the current fixture (note that setting these values
             // will create the recording ServiceName/IndexName/etc. variables)
@@ -383,9 +384,9 @@ namespace Azure.Search.Documents.Tests
         /// </param>
         /// <returns>This TestResources context.</returns>
         private async Task<SearchResources> CreateSearchServiceAndIndexAsync(
-            Func<string, SearchIndex> getIndex = null)
+            bool isSample, Func<string, SearchIndex> getIndex = null)
         {
-            getIndex ??= GetHotelIndex;
+            getIndex ??= isSample ? SearchResourcesSample.GetHotelIndexForSample : GetHotelIndex;
 
             // Create the index
             if (TestFixture.Mode != RecordedTestMode.Playback)
@@ -410,17 +411,24 @@ namespace Azure.Search.Documents.Tests
         /// test documents.
         /// </summary>
         /// <returns>This TestResources context.</returns>
-        private async Task<SearchResources> CreateSearchServiceIndexAndDocumentsAsync()
+        private async Task<SearchResources> CreateSearchServiceIndexAndDocumentsAsync(bool isSample = false)
         {
             // Create the Search Service and Index first
-            await CreateSearchServiceAndIndexAsync();
+            await CreateSearchServiceAndIndexAsync(isSample);
 
             // Upload the documents
             if (TestFixture.Mode != RecordedTestMode.Playback)
             {
                 SearchClient client = new SearchClient(Endpoint, IndexName, new AzureKeyCredential(PrimaryApiKey));
-                IndexDocumentsBatch<Hotel> batch = IndexDocumentsBatch.Upload(TestDocuments);
-                await client.IndexDocumentsAsync(batch);
+
+                if (isSample)
+                {
+                    await client.IndexDocumentsAsync(IndexDocumentsBatch.Upload(SearchResourcesSample.TestDocumentsForSample));
+                }
+                else
+                {
+                    await client.IndexDocumentsAsync(IndexDocumentsBatch.Upload(TestDocuments));
+                }
 
                 await WaitForIndexingAsync();
             }
@@ -432,7 +440,7 @@ namespace Azure.Search.Documents.Tests
         /// Upload <see cref="TestDocuments"/> to a new blob storage container identified by <see cref="BlobContainerName"/>.
         /// </summary>
         /// <returns>The current <see cref="SearchResources"/>.</returns>
-        private async Task<SearchResources> CreateHotelsBlobContainerAsync(bool populate)
+        private async Task<SearchResources> CreateHotelsBlobContainerAsync(bool populate, bool isSample)
         {
             if (TestFixture.Mode != RecordedTestMode.Playback)
             {
@@ -447,23 +455,34 @@ namespace Azure.Search.Documents.Tests
 
                 if (populate)
                 {
-                    Hotel[] hotels = TestDocuments;
+                    object[] hotels = isSample ? SearchResourcesSample.TestDocumentsForSample : TestDocuments;
                     List<Task> tasks = new List<Task>(hotels.Length);
 
-                    foreach (Hotel hotel in hotels)
+                    foreach (object obj in hotels)
                     {
                         Task task = Task.Run(async () =>
                         {
                             using MemoryStream stream = new MemoryStream();
                             await JsonSerializer
-                                .SerializeAsync(stream, hotel, JsonSerialization.SerializerOptions, cts.Token)
+                                .SerializeAsync(stream, obj, JsonSerialization.SerializerOptions, cts.Token)
                                 .ConfigureAwait(false);
 
                             stream.Seek(0, SeekOrigin.Begin);
 
-                            await client
-                                .UploadBlobAsync(hotel.HotelId, stream, cts.Token)
-                                .ConfigureAwait(false);
+                            if (isSample)
+                            {
+                                Samples.Hotel hotel = (Samples.Hotel)obj;
+                                await client
+                                    .UploadBlobAsync(hotel.HotelId, stream, cts.Token)
+                                    .ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                Hotel hotel = (Hotel)obj;
+                                await client
+                                    .UploadBlobAsync(hotel.HotelId, stream, cts.Token)
+                                    .ConfigureAwait(false);
+                            }
                         });
 
                         tasks.Add(task);

--- a/sdk/search/Azure.Search.Documents/tests/Utilities/SearchResources.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Utilities/SearchResources.cs
@@ -386,7 +386,7 @@ namespace Azure.Search.Documents.Tests
         private async Task<SearchResources> CreateSearchServiceAndIndexAsync(
             bool isSample, Func<string, SearchIndex> getIndex = null)
         {
-            getIndex ??= isSample ? SearchResourcesSample.GetHotelIndexForSample : GetHotelIndex;
+            getIndex ??= isSample ? SearchResourcesSample.GetHotelIndex : GetHotelIndex;
 
             // Create the index
             if (TestFixture.Mode != RecordedTestMode.Playback)

--- a/sdk/search/Azure.Search.Documents/tests/Utilities/SearchResourcesSample.Data.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Utilities/SearchResourcesSample.Data.cs
@@ -1,0 +1,400 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Text.Json.Serialization;
+using Azure.Core.GeoJson;
+using Azure.Core.Serialization;
+using Azure.Search.Documents.Indexes.Models;
+using Azure.Search.Documents.Models;
+using Microsoft.Spatial;
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+namespace Azure.Search.Documents.Tests.Samples
+{
+    public static class SearchResourcesSample
+    {
+        /// <summary>
+        /// <para>
+        /// Get a <see cref="SearchIndex"/> for the Hotels sample data.
+        /// </para>
+        /// <para>
+        /// This index is tuned more for exercising document serialization,
+        /// indexing, and querying operations. Also, the fields of this index
+        /// should exactly match the properties of the Hotel test model class
+        /// below.
+        /// </para>
+        /// </summary>
+        /// <param name="name">The name of the index to create.</param>
+        /// <returns>A <see cref="SearchIndex"/> for the Hotels sample data.</returns>
+        internal static SearchIndex GetHotelIndexForSample(string name) =>
+            new SearchIndex(name)
+            {
+                Fields =
+                {
+                    new SimpleField("HotelId", SearchFieldDataType.String) { IsKey = true, IsFilterable = true, IsSortable = true, IsFacetable = true },
+                    new SearchableField("HotelName") { IsFilterable = true, IsSortable = true },
+                    new SearchableField("Description") { AnalyzerName = LexicalAnalyzerName.EnLucene },
+                    new SearchableField("DescriptionFr") { AnalyzerName = LexicalAnalyzerName.FrLucene },
+                    new SearchableField("Category") { IsFilterable = true, IsSortable = true, IsFacetable = true },
+                    new SearchableField("Tags", collection: true) { IsFilterable = true, IsFacetable = true },
+                    new SimpleField("ParkingIncluded", SearchFieldDataType.Boolean) { IsFilterable = true, IsSortable = true, IsFacetable = true },
+                    new SimpleField("SmokingAllowed", SearchFieldDataType.Boolean) { IsFilterable = true, IsSortable = true, IsFacetable = true },
+                    new SimpleField("LastRenovationDate", SearchFieldDataType.DateTimeOffset) { IsFilterable = true, IsSortable = true, IsFacetable = true },
+                    new SimpleField("Rating", SearchFieldDataType.Int32) { IsFilterable = true, IsSortable = true, IsFacetable = true },
+                    new SimpleField("Location", SearchFieldDataType.GeographyPoint) { IsFilterable = true, IsSortable = true },
+                    new SimpleField("GeoLocation", SearchFieldDataType.GeographyPoint) { IsFilterable = true, IsSortable = true },
+                    new ComplexField("Address")
+                    {
+                        Fields =
+                        {
+                            new SearchableField("StreetAddress"),
+                            new SearchableField("City") { IsFilterable = true, IsSortable = true, IsFacetable = true, NormalizerName = LexicalNormalizerName.Lowercase },
+                            new SearchableField("StateProvince") { IsFilterable = true, IsSortable = true, IsFacetable = true },
+                            new SearchableField("Country") { IsFilterable = true, IsSortable = true, IsFacetable = true },
+                            new SearchableField("PostalCode") { IsFilterable = true, IsSortable = true, IsFacetable = true },
+                        },
+                    },
+                    new ComplexField("Rooms", collection: true)
+                    {
+                        Fields =
+                        {
+                            new SearchableField("Description") { AnalyzerName = LexicalAnalyzerName.EnLucene },
+                            new SearchableField("DescriptionFr") { AnalyzerName = LexicalAnalyzerName.FrLucene },
+                            new SearchableField("Type") { IsFilterable = true, IsFacetable = true },
+                            new SimpleField("BaseRate", SearchFieldDataType.Double) { IsFilterable = true, IsFacetable = true },
+                            new SearchableField("BedOptions") { IsFilterable = true, IsFacetable = true },
+                            new SimpleField("SleepsCount", SearchFieldDataType.Int32) { IsFilterable = true, IsFacetable = true },
+                            new SimpleField("SmokingAllowed", SearchFieldDataType.Boolean) { IsFilterable = true, IsFacetable = true },
+                            new SearchableField("Tags", collection: true) { IsFilterable = true, IsFacetable = true },
+                        },
+                    },
+                },
+                Suggesters =
+                {
+                    new SearchSuggester("sg", "Description", "HotelName"),
+                },
+                ScoringProfiles =
+                {
+                    new ScoringProfile("nearest")
+                    {
+                        FunctionAggregation = ScoringFunctionAggregation.Sum,
+                        Functions =
+                        {
+                            new DistanceScoringFunction("Location", 2, new DistanceScoringParameters("myloc", 100)),
+                            new DistanceScoringFunction("GeoLocation", 2, new DistanceScoringParameters("mygeoloc", 100)),
+                        },
+                    },
+                },
+            };
+
+        /// <summary>
+        /// Sample documents used by the tests.
+        /// </summary>
+        internal static readonly Hotel[] TestDocumentsForSample =
+            new[]
+            {
+                new Hotel()
+                {
+                    HotelId = "1",
+                    Description =
+                        "Best hotel in town if you like luxury hotels. They have an amazing infinity pool, a spa, " +
+                        "and a really helpful concierge. The location is perfect -- right downtown, close to all " +
+                        "the tourist attractions. We highly recommend this hotel.",
+                    DescriptionFr =
+                        "Meilleur hôtel en ville si vous aimez les hôtels de luxe. Ils ont une magnifique piscine " +
+                        "à débordement, un spa et un concierge très utile. L'emplacement est parfait – en plein " +
+                        "centre, à proximité de toutes les attractions touristiques. Nous recommandons fortement " +
+                        "cet hôtel.",
+                    HotelName = "Fancy Stay",
+                    Category = "Luxury",
+                    Tags = new[] { "pool", "view", "wifi", "concierge" },
+                    ParkingIncluded = false,
+                    SmokingAllowed = false,
+                    LastRenovationDate = new DateTimeOffset(2010, 6, 27, 0, 0, 0, TimeSpan.Zero),
+                    Rating = 5,
+                    Location = TestExtensions.CreatePoint(-122.131577, 47.678581),
+                    GeoLocation = TestExtensions.CreateGeoPoint(-122.131577, 47.678581),
+                },
+                new Hotel()
+                {
+                    HotelId = "2",
+                    Description = "Cheapest hotel in town. Infact, a motel.",
+                    DescriptionFr = "Hôtel le moins cher en ville. Infact, un motel.",
+                    HotelName = "Roach Motel",
+                    Category = "Budget",
+                    Tags = new[] { "motel", "budget" },
+                    ParkingIncluded = true,
+                    SmokingAllowed = true,
+                    LastRenovationDate = new DateTimeOffset(1982, 4, 28, 0, 0, 0, TimeSpan.Zero),   //aka.ms/sre-codescan/disable
+                    Rating = 1,
+                    Location = TestExtensions.CreatePoint(-122.131577, 49.678581),
+                    GeoLocation = TestExtensions.CreateGeoPoint(-122.131577, 49.678581),
+                },
+                new Hotel()
+                {
+                    HotelId = "3",
+                    Description = "Very popular hotel in town",
+                    DescriptionFr = "Hôtel le plus populaire en ville",
+                    HotelName = "EconoStay",
+                    Category = "Budget",
+                    Tags = new[] { "wifi", "budget" },
+                    ParkingIncluded = true,
+                    SmokingAllowed = false,
+                    LastRenovationDate = new DateTimeOffset(1995, 7, 1, 0, 0, 0, TimeSpan.Zero),
+                    Rating = 4,
+                    Location = TestExtensions.CreatePoint(-122.131577, 46.678581),
+                    GeoLocation = TestExtensions.CreateGeoPoint(-122.131577, 46.678581),
+                },
+                new Hotel()
+                {
+                    HotelId = "4",
+                    Description = "Pretty good hotel",
+                    DescriptionFr = "Assez bon hôtel",
+                    HotelName = "Express Rooms",
+                    Category = "Budget",
+                    Tags = new[] { "wifi", "budget" },
+                    ParkingIncluded = true,
+                    SmokingAllowed = false,
+                    LastRenovationDate = new DateTimeOffset(1995, 7, 1, 0, 0, 0, TimeSpan.Zero),
+                    Rating = 4,
+                    Location = TestExtensions.CreatePoint(-122.131577, 48.678581),
+                    GeoLocation = TestExtensions.CreateGeoPoint(-122.131577, 48.678581),
+                },
+                new Hotel()
+                {
+                    HotelId = "5",
+                    Description = "Another good hotel",
+                    DescriptionFr = "Un autre bon hôtel",
+                    HotelName = "Comfy Place",
+                    Category = "Budget",
+                    Tags = new[] { "wifi", "budget" },
+                    ParkingIncluded = true,
+                    SmokingAllowed = false,
+                    LastRenovationDate = new DateTimeOffset(2012, 8, 12, 0, 0, 0, TimeSpan.Zero),
+                    Rating = 4,
+                    Location = TestExtensions.CreatePoint(-122.131577, 48.678581),
+                    GeoLocation = TestExtensions.CreateGeoPoint(-122.131577, 48.678581),
+                    Address = new HotelAddress()
+                    {
+                        StreetAddress = "677 5th Ave",
+                        City = "NEW YORK",
+                        StateProvince = "NY",
+                        Country = "USA",
+                        PostalCode = "10022"
+                    },
+                },
+                new Hotel()
+                {
+                    HotelId = "6",
+                    Description = "Surprisingly expensive. Model suites have an ocean-view.",
+                    LastRenovationDate = null
+                },
+                new Hotel()
+                {
+                    HotelId = "7",
+                    Description = "Modern architecture, very polite staff and very clean. Also very affordable.",
+                    DescriptionFr = "Architecture moderne, personnel poli et très propre. Aussi très abordable.",
+                    HotelName = "Modern Stay"
+                },
+                new Hotel()
+                {
+                    HotelId = "8",
+                    Description = "Has some road noise and is next to the very police station. Bathrooms had morel coverings.",
+                    DescriptionFr = "Il y a du bruit de la route et se trouve à côté de la station de police. Les salles de bain avaient des revêtements de morilles."
+                },
+                new Hotel()
+                {
+                    HotelId = "9",
+                    HotelName = "Secret Point Motel",
+                    Description = "The hotel is ideally located on the main commercial artery of the city in the heart of New York. A few minutes away is Time's Square and the historic centre of the city, as well as other places of interest that make New York one of America's most attractive and cosmopolitan cities.",
+                    DescriptionFr = "L'hôtel est idéalement situé sur la principale artère commerciale de la ville en plein cœur de New York. A quelques minutes se trouve la place du temps et le centre historique de la ville, ainsi que d'autres lieux d'intérêt qui font de New York l'une des villes les plus attractives et cosmopolites de l'Amérique.",
+                    Category = "Boutique",
+                    Tags = new[] { "pool", "air conditioning", "concierge" },
+                    ParkingIncluded = false,
+                    SmokingAllowed = true,
+                    LastRenovationDate = new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.FromHours(-5)),
+                    Rating = 4,
+                    Location = TestExtensions.CreatePoint(-73.975403, 40.760586),
+                    GeoLocation = TestExtensions.CreateGeoPoint(-73.975403, 40.760586),
+                    Address = new HotelAddress()
+                    {
+                        StreetAddress = "677 5th Ave",
+                        City = "New York",
+                        StateProvince = "NY",
+                        Country = "USA",
+                        PostalCode = "10022"
+                    },
+                    Rooms = new[]
+                    {
+                        new HotelRoom()
+                        {
+                            Description = "Budget Room, 1 Queen Bed (Cityside)",
+                            DescriptionFr = "Chambre Économique, 1 grand lit (côté ville)",
+                            Type = "Budget Room",
+                            BaseRate = 9.69,
+                            BedOptions = "1 Queen Bed",
+                            SleepsCount = 2,
+                            SmokingAllowed = true,
+                            Tags = new[] { "vcr/dvd" }
+                        },
+                        new HotelRoom()
+                        {
+                            Description = "Budget Room, 1 King Bed (Mountain View)",
+                            DescriptionFr = "Chambre Économique, 1 très grand lit (Mountain View)",
+                            Type = "Budget Room",
+                            BaseRate = 8.09,
+                            BedOptions = "1 King Bed",
+                            SleepsCount = 2,
+                            SmokingAllowed = true,
+                            Tags = new[] { "vcr/dvd", "jacuzzi tub" }
+                        }
+                    }
+                },
+                new Hotel()
+                {
+                    HotelId = "10",
+                    HotelName = "Countryside Hotel",
+                    Description = "Save up to 50% off traditional hotels.  Free WiFi, great location near downtown, full kitchen, washer & dryer, 24/7 support, bowling alley, fitness center and more.",
+                    DescriptionFr = "Économisez jusqu'à 50% sur les hôtels traditionnels.  WiFi gratuit, très bien situé près du centre-ville, cuisine complète, laveuse & sécheuse, support 24/7, bowling, centre de fitness et plus encore.",
+                    Category = "Budget",
+                    Tags = new[] { "24-hour front desk service", "coffee in lobby", "restaurant" },
+                    ParkingIncluded = false,
+                    SmokingAllowed = true,
+                    LastRenovationDate = new DateTimeOffset(1999, 9, 6, 0, 0, 0, TimeSpan.Zero),   //aka.ms/sre-codescan/disable
+                    Rating = 3,
+                    Location = TestExtensions.CreatePoint(-78.940483, 35.904160),
+                    GeoLocation = TestExtensions.CreateGeoPoint(-78.940483, 35.904160),
+                    Address = new HotelAddress()
+                    {
+                        StreetAddress = "6910 Fayetteville Rd",
+                        City = "Durham",
+                        StateProvince = "NC",
+                        Country = "USA",
+                        PostalCode = "27713"
+                    },
+                    Rooms = new[]
+                    {
+                        new HotelRoom()
+                        {
+                            Description = "Suite, 1 King Bed (Amenities)",
+                            DescriptionFr = "Suite, 1 très grand lit (Services)",
+                            Type = "Suite",
+                            BaseRate = 2.44,
+                            BedOptions = "1 King Bed",
+                            SleepsCount = 2,
+                            SmokingAllowed = true,
+                            Tags = new[] { "coffee maker" }
+                        },
+                        new HotelRoom()
+                        {
+                            Description = "Budget Room, 1 Queen Bed (Amenities)",
+                            DescriptionFr = "Chambre Économique, 1 grand lit (Services)",
+                            Type = "Budget Room",
+                            BaseRate = 7.69,
+                            BedOptions = "1 Queen Bed",
+                            SleepsCount = 2,
+                            SmokingAllowed = false,
+                            Tags = new[] { "coffee maker" }
+                        }
+                    }
+                }
+            };
+    }
+
+    internal class Hotel
+    {
+        public string HotelId { get; set; }
+        public string HotelName { get; set; }
+        public string Description { get; set; }
+        public string DescriptionFr { get; set; }
+        public string Category { get; set; }
+        // TODO: #10596 - Investigate JsonConverter for null arrays
+        public string[] Tags { get; set; } = new string[] { };
+        public bool? ParkingIncluded { get; set; }
+        public bool? SmokingAllowed { get; set; }
+        public DateTimeOffset? LastRenovationDate { get; set; }
+        public int? Rating { get; set; }
+        public GeoPoint GeoLocation { get; set; }
+        [JsonConverter(typeof(MicrosoftSpatialGeoJsonConverter))]
+        public GeographyPoint Location { get; set; } = null;
+        public HotelAddress Address { get; set; }
+        public HotelRoom[] Rooms { get; set; } = new HotelRoom[] { };
+
+        public override bool Equals(object obj) =>
+            obj is Hotel other &&
+            HotelId == other.HotelId &&
+            HotelName == other.HotelName &&
+            Description == other.Description &&
+            DescriptionFr == other.DescriptionFr &&
+            Category == other.Category &&
+            Tags.SequenceEqualsNullSafe(other.Tags) &&
+            ParkingIncluded == other.ParkingIncluded &&
+            SmokingAllowed == other.SmokingAllowed &&
+            LastRenovationDate.EqualsDateTimeOffset(other.LastRenovationDate) &&
+            Rating == other.Rating &&
+            (GeoLocation?.Coordinates ?? default).Equals(other.GeoLocation?.Coordinates ?? default) &&
+            Location.EqualsNullSafe(other.Location) &&
+            Address.EqualsNullSafe(other.Address) &&
+            Rooms.SequenceEqualsNullSafe(other.Rooms);
+
+        public override int GetHashCode() => HotelId?.GetHashCode() ?? 0;
+    }
+
+    internal class HotelAddress
+    {
+        public string StreetAddress { get; set; }
+
+        public string City { get; set; }
+
+        public string StateProvince { get; set; }
+
+        public string Country { get; set; }
+
+        public string PostalCode { get; set; }
+
+        public override bool Equals(object obj) =>
+            obj is HotelAddress other &&
+            StreetAddress == other.StreetAddress &&
+            City == other.City &&
+            StateProvince == other.StateProvince &&
+            Country == other.Country &&
+            PostalCode == other.PostalCode;
+
+        public override int GetHashCode() => StreetAddress?.GetHashCode() ?? 0;
+    }
+
+    internal class HotelRoom
+    {
+        public string Description { get; set; }
+
+        public string DescriptionFr { get; set; }
+
+        public string Type { get; set; }
+
+        public double? BaseRate { get; set; }
+
+        public string BedOptions { get; set; }
+
+        public int? SleepsCount { get; set; }
+
+        public bool? SmokingAllowed { get; set; }
+
+        public string[] Tags { get; set; } = new string[] { };
+
+        public override bool Equals(object obj) =>
+            obj is HotelRoom other &&
+            Description == other.Description &&
+            DescriptionFr == other.DescriptionFr &&
+            Type == other.Type &&
+            BaseRate.EqualsDouble(other.BaseRate) &&
+            BedOptions == other.BedOptions &&
+            SleepsCount == other.SleepsCount &&
+            SmokingAllowed == other.SmokingAllowed &&
+            Tags.SequenceEqualsNullSafe(other.Tags);
+
+        public override int GetHashCode() => Description?.GetHashCode() ?? 0;
+    }
+}

--- a/sdk/search/Azure.Search.Documents/tests/Utilities/SearchResourcesSample.Data.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Utilities/SearchResourcesSample.Data.cs
@@ -29,7 +29,7 @@ namespace Azure.Search.Documents.Tests.Samples
         /// </summary>
         /// <param name="name">The name of the index to create.</param>
         /// <returns>A <see cref="SearchIndex"/> for the Hotels sample data.</returns>
-        internal static SearchIndex GetHotelIndexForSample(string name) =>
+        internal static SearchIndex GetHotelIndex(string name) =>
             new SearchIndex(name)
             {
                 Fields =


### PR DESCRIPTION
For "Hotel" example, Readme and Sample docs use camel case for fields but official "Hotel" example in the portal uses [pascal case](https://learn.microsoft.com/en-us/azure/search/search-get-started-portal#step-3---configure-index). In this PR, fixing the fields format of "Hotel" example in the samples and readme and removing the snippet hacks.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/13502 