### PR TITLE
Add Microsoft Azure Network Management Deprecation Announcement

### DIFF
--- a/sdk/network/README.md
+++ b/sdk/network/README.md
@@ -1,0 +1,63 @@
+# Microsoft Azure Network management client library for .NET
+
+This is the Microsoft Azure Network Management Client Library.
+
+## _Disclaimer_
+
+_Versions 20.6.1-Beta, 20.6.1-Beta.1, 20.6.1-Beta.2 deprecated for azure virtual network manager operations. Please use [23.0.0](https://www.nuget.org/packages/Microsoft.Azure.Management.Network/23.0.0) instead. See release notes for suggested operation usage._
+
+## Getting started
+
+### Install the package
+
+Install the Microsoft Azure Network management library for .NET with [NuGet](https://www.nuget.org/):
+
+```dotnetcli
+dotnet add package Microsoft.Azure.Management.Network
+```
+
+### Prerequisites
+
+* You must have an [Microsoft Azure subscription](https://azure.microsoft.com/free/dotnet/).
+
+### Authenticate the Client
+
+To create an authenticated client and start interacting with Microsoft Azure resources, see the [quickstart guide here](https://github.com/Azure/azure-sdk-for-net/blob/main/doc/dev/mgmt_quickstart.md).
+
+## Key concepts
+
+Key concepts of the Microsoft Azure SDK for .NET can be found [here](https://azure.github.io/azure-sdk/dotnet_introduction.html).
+
+## Troubleshooting
+
+-   File an issue via [GitHub Issues](https://github.com/Azure/azure-sdk-for-net/issues).
+-   Check [previous questions](https://stackoverflow.com/questions/tagged/azure+.net) or ask new ones on Stack Overflow using Azure and .NET tags.
+
+## Next steps
+
+For more information about Microsoft Azure SDK, see [this website](https://azure.github.io/azure-sdk/).
+
+## Contributing
+
+For details on contributing to this repository, see the [contributing
+guide][cg].
+
+This project welcomes contributions and suggestions. Most contributions
+require you to agree to a Contributor License Agreement (CLA) declaring
+that you have the right to, and actually do, grant us the rights to use
+your contribution. For details, visit <https://cla.microsoft.com>.
+
+When you submit a pull request, a CLA-bot will automatically determine
+whether you need to provide a CLA and decorate the PR appropriately
+(for example, label, comment). Follow the instructions provided by the
+bot. You'll only need to do this action once across all repositories
+using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct][coc]. For
+more information, see the [Code of Conduct FAQ][coc_faq] or contact
+<opencode@microsoft.com> with any other questions or comments.
+
+<!-- LINKS -->
+[cg]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/resourcemanager/Azure.ResourceManager/docs/CONTRIBUTING.md
+[coc]: https://opensource.microsoft.com/codeofconduct/
+[coc_faq]: https://opensource.microsoft.com/codeofconduct/faq/


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

## Description

Azure virtual network manager team is deprecating the API version associated with 20.6.1-Beta, 20.6.1-Beta.1, 20.6.1-Beta.2 of Azure Network management client library for .NET. Therefore, we need to add the deprecation announcement for these versions. Since there was no README for this library, I have added one with a section for the announcement, as recommended by Azure API release team https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/192/Deprecation-strategy