### PR TITLE
Introduce delays to Delete tests to wait to check deletion.

### DIFF
--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/ContainerRegistryClientLiveTests.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/ContainerRegistryClientLiveTests.cs
@@ -116,6 +116,7 @@ namespace Azure.Containers.ContainerRegistry.Tests
 
                 // Act
                 await client.DeleteRepositoryAsync(repositoryId);
+                await Delay(5000);
 
                 // Assert
                 repositories = client.GetRepositoryNamesAsync();

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/ContainerRepositoryLiveTests.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/ContainerRepositoryLiveTests.cs
@@ -109,6 +109,7 @@ namespace Azure.Containers.ContainerRegistry.Tests
 
                 // Act
                 await repository.DeleteAsync();
+                await Delay(5000);
 
                 // Assert
                 Assert.ThrowsAsync<RequestFailedException>(async () => { await repository.GetPropertiesAsync(); });

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/ContainerRepositoryLiveTests.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/ContainerRepositoryLiveTests.cs
@@ -110,6 +110,8 @@ namespace Azure.Containers.ContainerRegistry.Tests
                 // Act
                 await repository.DeleteAsync();
 
+                await Delay(5000);
+
                 // Assert
                 Assert.ThrowsAsync<RequestFailedException>(async () => { await repository.GetPropertiesAsync(); });
             }

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/RegistryArtifactLiveTests.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/RegistryArtifactLiveTests.cs
@@ -152,6 +152,8 @@ namespace Azure.Containers.ContainerRegistry.Tests
                 // Act
                 await artifact.DeleteAsync();
 
+                await Delay(5000);
+
                 // Assert
                 Assert.ThrowsAsync<RequestFailedException>(async () => { await artifact.GetManifestPropertiesAsync(); });
             }

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/RegistryArtifactLiveTests.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/RegistryArtifactLiveTests.cs
@@ -151,6 +151,7 @@ namespace Azure.Containers.ContainerRegistry.Tests
 
                 // Act
                 await artifact.DeleteAsync();
+                await Delay(5000);
 
                 // Assert
                 Assert.ThrowsAsync<RequestFailedException>(async () => { await artifact.GetManifestPropertiesAsync(); });


### PR DESCRIPTION
Delete artifact and repository tests fail intermittently, possibly because we check that they are deleted before the deletion operation is complete.  This adds a delay after the delete operations to give the service a chance to complete the operation prior to our check.