### PR TITLE
fix(anomalydetector): broken cadl build

### DIFF
--- a/sdk/anomalydetector/Azure.AI.AnomalyDetector/src/cadl-location.yaml
+++ b/sdk/anomalydetector/Azure.AI.AnomalyDetector/src/cadl-location.yaml
@@ -1,3 +1,3 @@
 directory: specification/cognitiveservices/AnomalyDetector
-commit: ac8e06a2ed0fc1c54663c98f12c8a073f8026b90
+commit: 1c872e22df1164f12df4285cc19153057ea2145c
 repo: Azure/azure-rest-api-specs


### PR DESCRIPTION
# Contributing to the Azure SDK

The commit id of `AnomalyDetector` CADL definition is out-of-sync with latest CADL compiler.
