### PR TITLE
[ContainerInstance] Allow to construct ContainerGroupImageRegistryCredential only with Server

### DIFF
--- a/sdk/containerinstance/Azure.ResourceManager.ContainerInstance/CHANGELOG.md
+++ b/sdk/containerinstance/Azure.ResourceManager.ContainerInstance/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.1.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.0.1 (2023-01-11)
 
 ### Bugs Fixed
 
-### Other Changes
+- Allowed to construct `ContainerGroupImageRegistryCredential` only with Server as Username should not be required when Identity is present.
 
 ## 1.0.0 (2022-08-29)
 

--- a/sdk/containerinstance/Azure.ResourceManager.ContainerInstance/api/Azure.ResourceManager.ContainerInstance.netstandard2.0.cs
+++ b/sdk/containerinstance/Azure.ResourceManager.ContainerInstance/api/Azure.ResourceManager.ContainerInstance.netstandard2.0.cs
@@ -206,6 +206,9 @@ namespace Azure.ResourceManager.ContainerInstance.Models
     }
     public partial class ContainerGroupImageRegistryCredential
     {
+        public ContainerGroupImageRegistryCredential(string server) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("This method is obsolete and will be removed in a future release.", false)]
         public ContainerGroupImageRegistryCredential(string server, string username) { }
         public string Identity { get { throw null; } set { } }
         public System.Uri IdentityUri { get { throw null; } set { } }

--- a/sdk/containerinstance/Azure.ResourceManager.ContainerInstance/src/Azure.ResourceManager.ContainerInstance.csproj
+++ b/sdk/containerinstance/Azure.ResourceManager.ContainerInstance/src/Azure.ResourceManager.ContainerInstance.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta.1</Version>
+    <Version>1.0.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.0.0</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.ContainerInstance</PackageId>

--- a/sdk/containerinstance/Azure.ResourceManager.ContainerInstance/src/Customized/Models/ContainerGroupImageRegistryCredential.cs
+++ b/sdk/containerinstance/Azure.ResourceManager.ContainerInstance/src/Customized/Models/ContainerGroupImageRegistryCredential.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using System;
+using System.ComponentModel;
+using Azure.Core;
+
+namespace Azure.ResourceManager.ContainerInstance.Models
+{
+    /// <summary> Image registry credential. </summary>
+    public partial class ContainerGroupImageRegistryCredential
+    {
+        /// <summary> Initializes a new instance of ContainerGroupImageRegistryCredential. </summary>
+        /// <param name="server"> The Docker image registry server without a protocol such as &quot;http&quot; and &quot;https&quot;. </param>
+        /// <param name="username"> The username for the private registry. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="server"/> or <paramref name="username"/> is null. </exception>
+        [Obsolete("This method is obsolete and will be removed in a future release.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ContainerGroupImageRegistryCredential(string server, string username)
+        {
+            Argument.AssertNotNull(server, nameof(server));
+            Argument.AssertNotNull(username, nameof(username));
+
+            Server = server;
+            Username = username;
+        }
+    }
+}

--- a/sdk/containerinstance/Azure.ResourceManager.ContainerInstance/src/Generated/Models/ContainerGroupImageRegistryCredential.Serialization.cs
+++ b/sdk/containerinstance/Azure.ResourceManager.ContainerInstance/src/Generated/Models/ContainerGroupImageRegistryCredential.Serialization.cs
@@ -18,8 +18,11 @@ namespace Azure.ResourceManager.ContainerInstance.Models
             writer.WriteStartObject();
             writer.WritePropertyName("server");
             writer.WriteStringValue(Server);
-            writer.WritePropertyName("username");
-            writer.WriteStringValue(Username);
+            if (Optional.IsDefined(Username))
+            {
+                writer.WritePropertyName("username");
+                writer.WriteStringValue(Username);
+            }
             if (Optional.IsDefined(Password))
             {
                 writer.WritePropertyName("password");
@@ -41,7 +44,7 @@ namespace Azure.ResourceManager.ContainerInstance.Models
         internal static ContainerGroupImageRegistryCredential DeserializeContainerGroupImageRegistryCredential(JsonElement element)
         {
             string server = default;
-            string username = default;
+            Optional<string> username = default;
             Optional<string> password = default;
             Optional<string> identity = default;
             Optional<Uri> identityUrl = default;
@@ -78,7 +81,7 @@ namespace Azure.ResourceManager.ContainerInstance.Models
                     continue;
                 }
             }
-            return new ContainerGroupImageRegistryCredential(server, username, password.Value, identity.Value, identityUrl.Value);
+            return new ContainerGroupImageRegistryCredential(server, username.Value, password.Value, identity.Value, identityUrl.Value);
         }
     }
 }

--- a/sdk/containerinstance/Azure.ResourceManager.ContainerInstance/src/Generated/Models/ContainerGroupImageRegistryCredential.cs
+++ b/sdk/containerinstance/Azure.ResourceManager.ContainerInstance/src/Generated/Models/ContainerGroupImageRegistryCredential.cs
@@ -15,15 +15,12 @@ namespace Azure.ResourceManager.ContainerInstance.Models
     {
         /// <summary> Initializes a new instance of ContainerGroupImageRegistryCredential. </summary>
         /// <param name="server"> The Docker image registry server without a protocol such as &quot;http&quot; and &quot;https&quot;. </param>
-        /// <param name="username"> The username for the private registry. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="server"/> or <paramref name="username"/> is null. </exception>
-        public ContainerGroupImageRegistryCredential(string server, string username)
+        /// <exception cref="ArgumentNullException"> <paramref name="server"/> is null. </exception>
+        public ContainerGroupImageRegistryCredential(string server)
         {
             Argument.AssertNotNull(server, nameof(server));
-            Argument.AssertNotNull(username, nameof(username));
 
             Server = server;
-            Username = username;
         }
 
         /// <summary> Initializes a new instance of ContainerGroupImageRegistryCredential. </summary>

--- a/sdk/containerinstance/Azure.ResourceManager.ContainerInstance/src/autorest.md
+++ b/sdk/containerinstance/Azure.ResourceManager.ContainerInstance/src/autorest.md
@@ -6,7 +6,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 azure-arm: true
 library-name: ContainerInstance
 namespace: Azure.ResourceManager.ContainerInstance
-require: https://github.com/Azure/azure-rest-api-specs/blob/4716fb039c67e1bee1d5448af9ce57e4942832fe/specification/containerinstance/resource-manager/readme.md
+require: https://github.com/Azure/azure-rest-api-specs/blob/bf82b74acfa933165e8e30d3403195043d1149d5/specification/containerinstance/resource-manager/readme.md
 output-folder: $(this-folder)/Generated
 clear-output-folder: true
 skip-csproj: true


### PR DESCRIPTION
Fix: https://github.com/Azure/azure-sdk-for-net/issues/33390

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
