### PR TITLE
Enhance test case to have different values of refreshProactively

### DIFF
--- a/sdk/communication/Azure.Communication.Common/tests/Identity/CommunicationTokenCredentialTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Identity/CommunicationTokenCredentialTest.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
-using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 namespace Azure.Communication.Identity

--- a/sdk/communication/Azure.Communication.Common/tests/Identity/CommunicationTokenCredentialTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Identity/CommunicationTokenCredentialTest.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 namespace Azure.Communication.Identity
@@ -46,18 +47,21 @@ namespace Azure.Communication.Identity
         }
 
         [Test]
-        public async Task CommunicationTokenCredential_CreateRefreshableWithoutInitialToken()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task CommunicationTokenCredential_CreateRefreshableWithoutInitialToken(bool refreshProactively)
         {
             #region Snippet:CommunicationTokenCredential_CreateRefreshableWithoutInitialToken
             using var tokenCredential = new CommunicationTokenCredential(
                 new CommunicationTokenRefreshOptions(
-                    refreshProactively: true, // Indicates if the token should be proactively refreshed in the background or only on-demand
+                    refreshProactively: refreshProactively, // Indicates if the token should be proactively refreshed in the background or only on-demand
                     tokenRefresher: cancellationToken => FetchTokenForUserFromMyServer("bob@contoso.com", cancellationToken))
                 {
                     AsyncTokenRefresher = cancellationToken => FetchTokenForUserFromMyServerAsync("bob@contoso.com", cancellationToken)
                 });
             #endregion
-            await tokenCredential.GetTokenAsync();
+            var accessToken = await tokenCredential.GetTokenAsync();
+            Assert.AreEqual(SampleToken, accessToken.Token);
         }
 
         [Test]

--- a/sdk/communication/Azure.Communication.Common/tests/Identity/CommunicationTokenCredentialTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Identity/CommunicationTokenCredentialTest.cs
@@ -47,19 +47,30 @@ namespace Azure.Communication.Identity
         }
 
         [Test]
-        [TestCase(true)]
-        [TestCase(false)]
-        public async Task CommunicationTokenCredential_CreateRefreshableWithoutInitialToken(bool refreshProactively)
+        public async Task CommunicationTokenCredential_CreateRefreshableWithoutInitialToken()
         {
             #region Snippet:CommunicationTokenCredential_CreateRefreshableWithoutInitialToken
             using var tokenCredential = new CommunicationTokenCredential(
                 new CommunicationTokenRefreshOptions(
-                    refreshProactively: refreshProactively, // Indicates if the token should be proactively refreshed in the background or only on-demand
+                    refreshProactively: true, // Indicates if the token should be proactively refreshed in the background or only on-demand
                     tokenRefresher: cancellationToken => FetchTokenForUserFromMyServer("bob@contoso.com", cancellationToken))
                 {
                     AsyncTokenRefresher = cancellationToken => FetchTokenForUserFromMyServerAsync("bob@contoso.com", cancellationToken)
                 });
             #endregion
+            await tokenCredential.GetTokenAsync();
+        }
+
+        [Test]
+        public async Task CommunicationTokenCredential_CreateNotRefreshableWithoutInitialToken()
+        {
+            using var tokenCredential = new CommunicationTokenCredential(
+                new CommunicationTokenRefreshOptions(
+                    refreshProactively: false,
+                    tokenRefresher: cancellationToken => FetchTokenForUserFromMyServer("bob@contoso.com", cancellationToken))
+                {
+                    AsyncTokenRefresher = cancellationToken => FetchTokenForUserFromMyServerAsync("bob@contoso.com", cancellationToken)
+                });
             var accessToken = await tokenCredential.GetTokenAsync();
             Assert.AreEqual(SampleToken, accessToken.Token);
         }


### PR DESCRIPTION
This pull requests addresses the story [User Story 3093185](https://skype.visualstudio.com/SPOOL/_workitems/edit/3093185): [SDK][Common][.NET] Capture missing key customer scenarios (Auto-Refresh) in test cases

The following scenario iscaptured:
On Demand Refresh : Refresher callback is invoked when initial token is not passed