### PR TITLE
Hide deprecated German cloud option in ACR Audience extensible enum

### DIFF
--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/api/Azure.Containers.ContainerRegistry.netstandard2.0.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/api/Azure.Containers.ContainerRegistry.netstandard2.0.cs
@@ -117,6 +117,7 @@ namespace Azure.Containers.ContainerRegistry
         private readonly int _dummyPrimitive;
         public ContainerRegistryAudience(string value) { throw null; }
         public static Azure.Containers.ContainerRegistry.ContainerRegistryAudience AzureResourceManagerChina { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public static Azure.Containers.ContainerRegistry.ContainerRegistryAudience AzureResourceManagerGermany { get { throw null; } }
         public static Azure.Containers.ContainerRegistry.ContainerRegistryAudience AzureResourceManagerGovernment { get { throw null; } }
         public static Azure.Containers.ContainerRegistry.ContainerRegistryAudience AzureResourceManagerPublicCloud { get { throw null; } }

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/src/Models/ContainerRegistryAudience.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/src/Models/ContainerRegistryAudience.cs
@@ -27,6 +27,7 @@ namespace Azure.Containers.ContainerRegistry
         public static ContainerRegistryAudience AzureResourceManagerChina { get; } = new ContainerRegistryAudience(AzureResourceManagerChinaValue);
 
         /// <summary> Azure Germany. </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static ContainerRegistryAudience AzureResourceManagerGermany { get; } = new ContainerRegistryAudience(AzureResourceManagerGermanyValue);
 
         /// <summary> Azure Government. </summary>

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/ContainerRegistryRecordedTestBase.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/ContainerRegistryRecordedTestBase.cs
@@ -101,11 +101,6 @@ namespace Azure.Containers.ContainerRegistry.Tests
                 return AzureAuthorityHosts.AzureGovernment;
             }
 
-            if (endpoint.Contains(".azurecr.de"))
-            {
-                return AzureAuthorityHosts.AzureGermany;
-            }
-
             throw new NotSupportedException($"Cloud for endpoint {endpoint} is not supported.");
         }
 
@@ -205,11 +200,6 @@ namespace Azure.Containers.ContainerRegistry.Tests
             if (authorityHost == AzureAuthorityHosts.AzureGovernment)
             {
                 return ContainerRegistryAudience.AzureResourceManagerGovernment;
-            }
-
-            if (authorityHost == AzureAuthorityHosts.AzureGermany)
-            {
-                return ContainerRegistryAudience.AzureResourceManagerGermany;
             }
 
             throw new NotSupportedException($"Cloud for authority host {authorityHost} is not supported.");


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/32883

Removing support from tests as well.