### PR TITLE
Allow use of ServiceProvider func to create BlobClient for PersistKeysToAzureBlobStorage 

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/AzureStorageBlobDataProtectionBuilderExtensions.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/AzureStorageBlobDataProtectionBuilderExtensions.cs
@@ -98,36 +98,6 @@ namespace Microsoft.AspNetCore.DataProtection
         /// <param name="builder">The builder instance to modify.</param>
         /// <param name="sasUri">The full URI where the key file should be stored.
         /// The URI must contain the SAS token as a query string parameter.</param>
-        /// <param name="tokenCredential">The credentials to connect to the blob.</param>
-        /// <returns>The value <paramref name="builder"/>.</returns>
-        /// <remarks>
-        /// The container referenced by <paramref name="blobUri"/> must already exist.
-        /// </remarks>
-        public static IDataProtectionBuilder PersistKeysToAzureBlobStorage(this IDataProtectionBuilder builder, Uri blobUri, Func<IServiceProvider, TokenCredential> tokenCredentialFactory)
-        {
-            if (builder == null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
-            if (blobUri == null)
-            {
-                throw new ArgumentNullException(nameof(blobUri));
-            }
-            if (tokenCredentialFactory == null)
-            {
-                throw new ArgumentNullException(nameof(tokenCredentialFactory));
-            }
-
-            return builder;
-        }
-
-        /// <summary>
-        /// Configures the data protection system to persist keys to the specified path
-        /// in Azure Blob Storage.
-        /// </summary>
-        /// <param name="builder">The builder instance to modify.</param>
-        /// <param name="sasUri">The full URI where the key file should be stored.
-        /// The URI must contain the SAS token as a query string parameter.</param>
         /// <param name="sharedKeyCredential">The credentials to connect to the blob.</param>
         /// <returns>The value <paramref name="builder"/>.</returns>
         /// <remarks>

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/ConfigureKeyManagementBlobClientOptions.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/ConfigureKeyManagementBlobClientOptions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+#pragma warning disable AZC0001 //
+namespace Azure.Extensions.AspNetCore.DataProtection.Blobs
+#pragma warning restore
+{
+    internal sealed class ConfigureKeyManagementBlobClientOptions : IConfigureOptions<KeyManagementOptions>
+    {
+        private readonly IServiceScopeFactory _serviceScopeFactory;
+
+        public ConfigureKeyManagementBlobClientOptions(IServiceScopeFactory serviceScopeFactory)
+        {
+            _serviceScopeFactory = serviceScopeFactory;
+        }
+
+        public void Configure(KeyManagementOptions options)
+        {
+            using var scope = _serviceScopeFactory.CreateScope();
+
+            var provider = scope.ServiceProvider;
+
+            options.XmlRepository = provider.GetRequiredService<AzureBlobXmlRepository>();
+        }
+    }
+}

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/tests/AzureDataProtectionBuilderExtensionsTests.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/tests/AzureDataProtectionBuilderExtensionsTests.cs
@@ -29,5 +29,21 @@ namespace Azure.Extensions.AspNetCore.DataProtection.Blobs.Tests
             var options = services.GetRequiredService<IOptions<KeyManagementOptions>>();
             Assert.IsInstanceOf<AzureBlobXmlRepository>(options.Value.XmlRepository);
         }
+
+        [Test]
+        public void PersistKeysToAzureBlobStorage_WithServiceProviderFunc_UsesAzureBlobXmlRepository()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            var builder = serviceCollection.AddDataProtection();
+
+            // Act
+            builder.PersistKeysToAzureBlobStorage(sp => new BlobClient(new Uri("http://www.example.com")));
+            var services = serviceCollection.BuildServiceProvider();
+
+            // Assert
+            var options = services.GetRequiredService<IOptions<KeyManagementOptions>>();
+            Assert.IsInstanceOf<AzureBlobXmlRepository>(options.Value.XmlRepository);
+        }
     }
 }


### PR DESCRIPTION
Allow use of ServiceProvider func to create BlobClient for PersistKeysToAzureBlobStorage call (for resolving nested dependencies)

I've come across code where we want to generate our blob client using other services (CertificateTokenCredential which then relies on a KeyVaultClient, etc.) and without access to the ServiceProvider, this is dependency hell.

Being able to use the ServiceProvider to resolve your blob client allows us to retrieve registered dependencies and write cleaner setup code where needed.