### PR TITLE
Update `Azure.ClientSdk.Analyzers` to `0.1.1-dev.20230113.1` to fix VS breakage.

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -161,7 +161,7 @@
   -->
   <ItemGroup>
     <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20230112.4" PrivateAssets="All" />
-    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20221229.1" PrivateAssets="All" />
+    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20230113.1" PrivateAssets="All" />
     <PackageReference Update="coverlet.collector" Version="1.3.0" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.2" PrivateAssets="All" />


### PR DESCRIPTION
This PR fixes issue with faulty `Azure.ClientSdk.Analyzers` package, which broke VS build due to targeting `net6.0` instead of `netstandard2.0`. The package set in this PR uses `netstandard2.0` again.

The package was built off of this PR:

- https://github.com/Azure/azure-sdk-tools/pull/5048
    - See that PR for additional context.

The build that built the package:
- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2116003&view=results

The package itself:
- https://dev.azure.com/azure-sdk/public/_artifacts/feed/azure-sdk-for-net/NuGet/Azure.ClientSdk.Analyzers/overview/0.1.1-dev.20230113.1

This PR subsumes this PR:
- #33480