### PR TITLE
Adapt the script to the input of docker task engine

### DIFF
--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -428,6 +428,11 @@ function New-CADLPackageFolder() {
     $ciymlFilePath =(Join-Path $sdkPath "sdk" $service $CI_YAML_FILE)
     $apifolder = (Join-Path $projectFolder "api")
     Write-Host "projectFolder:$projectFolder, apifolder:$apifolder"
+    if ((-Not $relatedCadlProjectFolder.Contains("specification")) -And $specRoot.Contains("specification"))
+    {
+        $relatedCadlProjectFolder = "specification/$relatedCadlProjectFolder"
+        $specRoot = Split-Path $specRoot
+    }
     if ((Test-Path -Path $projectFolder) -And (Test-Path -Path $apifolder)) {
         Write-Host "Path exists!"
         if (Test-Path -Path $projectFolder/src/autorest.md) {


### PR DESCRIPTION
Different from the input of spec unified pipeline, the `specFolder` and `relatedCadlProjectFolder`  of docker task engine's input looks like:
```
{
  "specFolder": "/spec-repo/specification",

  "relatedCadlProjectFolder": "contoso/Contoso"
}
```
We need to change their values before generating correct `cadl-location.yaml` file. 
The reason of specifing `relatedCadlProjectFolder`  to the relative path of specification is to adapt to shift-left pipeline, which doesn't have the `specification` folder in the spec repo. 
Add @chunyu3 for awareness.