### PR TITLE
[AzureMonitorExporter] fix test dependency

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
@@ -26,12 +26,12 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" VersionOverride="[2.1.1,2.2)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="3.1.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="5.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkVersion)' != '' and $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '6.0'))">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="5.0.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/BasicTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/BasicTests.cs
@@ -25,7 +25,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests
             this.factory = factory;
         }
 
-        [Theory(Skip = "https://github.com/Azure/azure-sdk-for-net/issues/33403")]
+        [Theory]
         [InlineData(HttpStatusCode.OK)]
         [InlineData(HttpStatusCode.BadRequest)]
         public async Task VerifyRequest(HttpStatusCode httpStatusCode)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/RequestTelemetryTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/RequestTelemetryTests.cs
@@ -34,7 +34,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests
         /// This test validates that when an app instrumented with the AzureMonitorExporter receives an HTTP request,
         /// A TelemetryItem is created matching that request.
         /// </summary>
-        [Fact(Skip = "https://github.com/Azure/azure-sdk-for-net/issues/33403")]
+        [Fact]
         public async Task VerifyRequestTelemetry()
         {
             string testValue = Guid.NewGuid().ToString();


### PR DESCRIPTION
Fixes #33403

## Changes
- add dependency `Microsoft.AspNetCore.Mvc.Testing` for `net7.0`
- update dependency `Microsoft.AspNetCore.Mvc.Testing` for `net6.0`
- remove dependency `Microsoft.AspNetCore.Mvc.Testing` for `netcoreapp3.1`
- enable skipped tests (disabled in #32814)