### PR TITLE
Allow for VisualStudioCredential on non-windows platforms

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.9.0-beta.2 (Unreleased)
 
 ### Features Added
+ - Allow `VisualStudioCredential` on non-windows platforms
 
 ### Breaking Changes
 

--- a/sdk/identity/Azure.Identity/src/Credentials/VisualStudioCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/VisualStudioCredential.cs
@@ -23,7 +23,13 @@ namespace Azure.Identity
     /// </summary>
     public class VisualStudioCredential : TokenCredential
     {
-        private static readonly string TokenProviderFilePath = Path.Combine(Environment.GetFolderPath(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? Environment.SpecialFolder.LocalApplicationData : Environment.SpecialFolder.UserProfile), ".IdentityService", "AzureServiceAuth", "tokenprovider.json");
+        private static readonly string TokenProviderFilePath = Path.Combine(
+            Environment.GetFolderPath(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 
+                Environment.SpecialFolder.LocalApplicationData :
+                Environment.SpecialFolder.UserProfile),
+            ".IdentityService",
+            "AzureServiceAuth",
+            "tokenprovider.json");
         private const string ResourceArgumentName = "--resource";
         private const string TenantArgumentName = "--tenant";
 

--- a/sdk/identity/Azure.Identity/src/Credentials/VisualStudioCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/VisualStudioCredential.cs
@@ -23,7 +23,7 @@ namespace Azure.Identity
     /// </summary>
     public class VisualStudioCredential : TokenCredential
     {
-        private const string TokenProviderFilePath = @".IdentityService\AzureServiceAuth\tokenprovider.json";
+        private static readonly string TokenProviderFilePath = Path.Combine(Environment.GetFolderPath(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? Environment.SpecialFolder.LocalApplicationData : Environment.SpecialFolder.UserProfile), ".IdentityService", "AzureServiceAuth", "tokenprovider.json");
         private const string ResourceArgumentName = "--resource";
         private const string TenantArgumentName = "--tenant";
 
@@ -81,8 +81,7 @@ namespace Azure.Identity
                     throw new CredentialUnavailableException("VisualStudioCredential authentication unavailable. ADFS tenant/authorities are not supported.");
                 }
 
-                var tokenProviderPath = GetTokenProviderPath();
-                var tokenProviders = GetTokenProviders(tokenProviderPath);
+                var tokenProviders = GetTokenProviders(TokenProviderFilePath);
 
                 var resource = ScopeUtilities.ScopesToResource(requestContext.Scopes);
                 var processStartInfos = GetProcessStartInfos(tokenProviders, resource, requestContext, cancellationToken);
@@ -106,16 +105,6 @@ namespace Azure.Identity
             {
                 throw scope.FailWrapAndThrow(e);
             }
-        }
-
-        private static string GetTokenProviderPath()
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), TokenProviderFilePath);
-            }
-
-            throw new CredentialUnavailableException($"Operating system {RuntimeInformation.OSDescription} isn't supported.");
         }
 
         private async Task<AccessToken> RunProcessesAsync(List<ProcessStartInfo> processStartInfos, bool async, CancellationToken cancellationToken)

--- a/sdk/identity/Azure.Identity/src/Credentials/VisualStudioCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/VisualStudioCredential.cs
@@ -24,7 +24,7 @@ namespace Azure.Identity
     public class VisualStudioCredential : TokenCredential
     {
         private static readonly string TokenProviderFilePath = Path.Combine(
-            Environment.GetFolderPath(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 
+            Environment.GetFolderPath(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
                 Environment.SpecialFolder.LocalApplicationData :
                 Environment.SpecialFolder.UserProfile),
             ".IdentityService",


### PR DESCRIPTION
Allow the `VisualStudioCredential` to run on non-windows platforms to unblock Container and WSL debugging scenarios.