### PR TITLE
Fix an edge case around calculating resourcetype from resourceid

### DIFF
--- a/sdk/core/Azure.Core/src/ResourceIdentifier.cs
+++ b/sdk/core/Azure.Core/src/ResourceIdentifier.cs
@@ -197,7 +197,8 @@ namespace Azure.Core
 
         private static ResourceType ChooseResourceType(ReadOnlySpan<char> resourceTypeName, ResourceIdentifier parent, out SpecialType specialType)
         {
-            if (resourceTypeName.Equals(ResourceGroupKey.AsSpan(), StringComparison.OrdinalIgnoreCase))
+            //resourceGroups type is Microsoft.Resources/resourceGroups only when its parent is Subscription
+            if (resourceTypeName.Equals(ResourceGroupKey.AsSpan(), StringComparison.OrdinalIgnoreCase) && parent.ResourceType == ResourceType.Subscription)
             {
                 specialType = SpecialType.ResourceGroup;
                 return ResourceType.ResourceGroup;

--- a/sdk/core/Azure.Core/src/ResourceIdentifier.cs
+++ b/sdk/core/Azure.Core/src/ResourceIdentifier.cs
@@ -197,21 +197,25 @@ namespace Azure.Core
 
         private static ResourceType ChooseResourceType(ReadOnlySpan<char> resourceTypeName, ResourceIdentifier parent, out SpecialType specialType)
         {
-            //resourceGroups type is Microsoft.Resources/resourceGroups only when its parent is Subscription
-            if (resourceTypeName.Equals(ResourceGroupKey.AsSpan(), StringComparison.OrdinalIgnoreCase) && parent.ResourceType == ResourceType.Subscription)
+            if (resourceTypeName.Equals(ResourceGroupKey.AsSpan(), StringComparison.OrdinalIgnoreCase))
             {
+                //resourceGroups type is Microsoft.Resources/resourceGroups only when its parent is Subscription
                 specialType = SpecialType.ResourceGroup;
-                return ResourceType.ResourceGroup;
+                if (parent.ResourceType == ResourceType.Subscription)
+                {
+                    return ResourceType.ResourceGroup;
+                }
             }
-
-            //subscriptions' type is Microsoft.Resources/subscriptions only when its parent is Tenant
-            if (resourceTypeName.Equals(SubscriptionsKey.AsSpan(), StringComparison.OrdinalIgnoreCase) && parent.ResourceType == ResourceType.Tenant)
+            else if (resourceTypeName.Equals(SubscriptionsKey.AsSpan(), StringComparison.OrdinalIgnoreCase) && parent.ResourceType == ResourceType.Tenant)
             {
+                //subscriptions' type is Microsoft.Resources/subscriptions only when its parent is Tenant
                 specialType = SpecialType.Subscription;
                 return ResourceType.Subscription;
             }
-
-            specialType = resourceTypeName.Equals(LocationsKey.AsSpan(), StringComparison.OrdinalIgnoreCase) ? SpecialType.Location : SpecialType.None;
+            else
+            {
+                specialType = resourceTypeName.Equals(LocationsKey.AsSpan(), StringComparison.OrdinalIgnoreCase) ? SpecialType.Location : SpecialType.None;
+            }
 
             return parent.ResourceType.AppendChild(resourceTypeName.ToString());
         }

--- a/sdk/core/Azure.Core/tests/ResourceIdentifierTests.cs
+++ b/sdk/core/Azure.Core/tests/ResourceIdentifierTests.cs
@@ -539,10 +539,18 @@ namespace Azure.Core.Tests
         [TestCase("/subscriptions/17fecd63-33d8-4e43-ac6f-0aafa111b38d/providers/Contoso.Widgets/widgets/myWidget/configuration", Description = "singleton homed in a subscription resource")]
         [TestCase("/subscriptions/17fecd63-33d8-4e43-ac6f-0aafa111b38d/providers/Contoso.Widgets/widgets/myWidget/providers/Contoso.Extensions/extensions/myExtension", Description = "Extension over a subscription resource")]
         [TestCase("/subscriptions/17fecd63-33d8-4e43-ac6f-0aafa111b38d/providers/Contoso.Widgets/widgets/myWidget/flanges/myFlange", Description = "Child of a subscription resource")]
+        [TestCase("/subscriptions/17fecd63-33d8-4e43-ac6f-0aafa111b38d/providers/Microsoft.CognitiveServices/locations/westus/resourceGroups/myResourceGroup/deletedAccounts/myDeletedAccount", Description = "Location before ResourceGroup")]
         public void CanParseValidSubscriptionResource(string resourceId)
         {
             ResourceIdentifier subscription = GetResourceIdentifier(resourceId);
             Assert.AreEqual(resourceId, subscription.ToString());
+        }
+
+        [TestCase("/subscriptions/17fecd63-33d8-4e43-ac6f-0aafa111b38d/providers/Microsoft.CognitiveServices/locations/westus/resourceGroups/myResourceGroup/deletedAccounts/myDeletedAccount", "Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts")]
+        public void CanCalculateResourceType(string id, string resourceType)
+        {
+            ResourceIdentifier subscription = GetResourceIdentifier(id);
+            Assert.AreEqual(resourceType, subscription.ResourceType.ToString());
         }
 
         [TestCase("/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/azsecpack", Description = "No provider tagname")]

--- a/sdk/core/Azure.Core/tests/ResourceIdentifierTests.cs
+++ b/sdk/core/Azure.Core/tests/ResourceIdentifierTests.cs
@@ -549,8 +549,42 @@ namespace Azure.Core.Tests
         [TestCase("/subscriptions/17fecd63-33d8-4e43-ac6f-0aafa111b38d/providers/Microsoft.CognitiveServices/locations/westus/resourceGroups/myResourceGroup/deletedAccounts/myDeletedAccount", "Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts")]
         public void CanCalculateResourceType(string id, string resourceType)
         {
-            ResourceIdentifier subscription = GetResourceIdentifier(id);
-            Assert.AreEqual(resourceType, subscription.ResourceType.ToString());
+            ResourceIdentifier resourceId = GetResourceIdentifier(id);
+            Assert.AreEqual(resourceType, resourceId.ResourceType.ToString());
+            Assert.AreEqual("myResourceGroup", resourceId.ResourceGroupName);
+            Assert.AreEqual(AzureLocation.WestUS, resourceId.Location);
+            Assert.AreEqual("17fecd63-33d8-4e43-ac6f-0aafa111b38d", resourceId.SubscriptionId);
+            Assert.AreEqual("myDeletedAccount", resourceId.Name);
+
+            resourceId = resourceId.Parent;
+            Assert.AreEqual("Microsoft.CognitiveServices/locations/resourceGroups", resourceId.ResourceType.ToString());
+            Assert.AreEqual("myResourceGroup", resourceId.ResourceGroupName);
+            Assert.AreEqual(AzureLocation.WestUS, resourceId.Location);
+            Assert.AreEqual("17fecd63-33d8-4e43-ac6f-0aafa111b38d", resourceId.SubscriptionId);
+            Assert.AreEqual("myResourceGroup", resourceId.Name);
+
+            resourceId = resourceId.Parent;
+            Assert.AreEqual("Microsoft.CognitiveServices/locations", resourceId.ResourceType.ToString());
+            Assert.IsNull(resourceId.ResourceGroupName);
+            Assert.AreEqual(AzureLocation.WestUS, resourceId.Location);
+            Assert.AreEqual("17fecd63-33d8-4e43-ac6f-0aafa111b38d", resourceId.SubscriptionId);
+            Assert.AreEqual("westus", resourceId.Name);
+
+            resourceId = resourceId.Parent;
+            Assert.AreEqual("Microsoft.Resources/subscriptions", resourceId.ResourceType.ToString());
+            Assert.IsNull(resourceId.ResourceGroupName);
+            Assert.IsNull(resourceId.Location);
+            Assert.AreEqual("17fecd63-33d8-4e43-ac6f-0aafa111b38d", resourceId.SubscriptionId);
+            Assert.AreEqual("17fecd63-33d8-4e43-ac6f-0aafa111b38d", resourceId.Name);
+
+            resourceId = resourceId.Parent;
+            Assert.AreEqual("Microsoft.Resources/tenants", resourceId.ResourceType.ToString());
+            Assert.IsNull(resourceId.ResourceGroupName);
+            Assert.IsNull(resourceId.Location);
+            Assert.IsNull(resourceId.SubscriptionId);
+            Assert.AreEqual("", resourceId.Name);
+
+            Assert.IsNull(resourceId.Parent);
         }
 
         [TestCase("/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/azsecpack", Description = "No provider tagname")]


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
