### PR TITLE
[AzureMonitorExporter] refactor connectionstring parsing

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/ConnectionStringParser.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/ConnectionStringParser.cs
@@ -23,7 +23,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString
         /// <exception cref="InvalidOperationException">
         /// Any exceptions that occur while parsing the connection string will be wrapped and re-thrown.
         /// </exception>
-        public static void GetValues(string connectionString, out string instrumentationKey, out string ingestionEndpoint)
+        public static ConnectionVars GetValues(string connectionString)
         {
             try
             {
@@ -37,8 +37,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString
                 }
 
                 var connString = AzureCoreConnectionString.Parse(connectionString);
-                instrumentationKey = connString.GetInstrumentationKey();
-                ingestionEndpoint = connString.GetIngestionEndpoint();
+
+                return new ConnectionVars(
+                    instrumentationKey: connString.GetInstrumentationKey(),
+                    ingestionEndpoint: connString.GetIngestionEndpoint());
             }
             catch (Exception ex)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/ConnectionVars.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/ConnectionVars.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString
+{
+    /// <summary>
+    /// Encapsulates variables from the ConnectionString.
+    /// </summary>
+    internal class ConnectionVars
+    {
+        public ConnectionVars(string instrumentationKey, string ingestionEndpoint)
+        {
+            this.InstrumentationKey = instrumentationKey;
+            this.IngestionEndpoint = ingestionEndpoint;
+        }
+
+        public string InstrumentationKey { get; }
+
+        public string IngestionEndpoint { get; }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
@@ -132,9 +132,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         {
             if (s_statsBeat_ConnectionString == null)
             {
-                ConnectionStringParser.GetValues(connectionString, out string instrumentationKey, out string ingestionEndpoint);
+                var connectionVars = ConnectionStringParser.GetValues(connectionString);
 
-                s_customer_Ikey = instrumentationKey;
+                s_customer_Ikey = connectionVars.InstrumentationKey;
 
                 // TODO: adjust based on customer's endpoint EU vs Non-EU.
                 s_statsBeat_ConnectionString = StatsBeat_ConnectionString_NonEU;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ConnectionString/ConnectionStringParserTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ConnectionString/ConnectionStringParserTests.cs
@@ -159,10 +159,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
         private void RunTest(string connectionString, string expectedIngestionEndpoint, string expectedInstrumentationKey)
         {
-            ConnectionStringParser.GetValues(connectionString, out string ikey, out string endpoint);
+            var connectionVars = ConnectionStringParser.GetValues(connectionString);
 
-            Assert.Equal(expectedIngestionEndpoint, endpoint);
-            Assert.Equal(expectedInstrumentationKey, ikey);
+            Assert.Equal(expectedIngestionEndpoint, connectionVars.IngestionEndpoint);
+            Assert.Equal(expectedInstrumentationKey, connectionVars.InstrumentationKey);
         }
     }
 }


### PR DESCRIPTION
Made a change to how ConnectionString is parsed and values are returned.
This is to support future work... both AAD and LiveMetrics will need additional variables from the ConnectionString.

## Changes
- Added a new class `ConnectionVars` to encapsulate parsed variables.
- Refactored internal class `ConnectionStringParser`
  - Old method:
    `public static void GetValues(string connectionString, out string instrumentationKey, out string ingestionEndpoint)`
  - New method:
    `public static ConnectionVars GetValues(string connectionString)`

