### PR TITLE
Fix invalid paths in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,7 +41,7 @@
 #/<NotInRepo>/            @Azure/aks-pm
 
 # ServiceLabel: %Alerts Management %Service Attention
-/sdk/alertsmanagement/Microsoft.Azure.Management.AlertsManagement            @liadtal @yairgil
+/sdk/alertsmanagement/Microsoft.Azure.Management.AlertsManagement/            @liadtal @yairgil
 
 # ServiceLabel: %ARM %Service Attention
 #/<NotInRepo>/            @armleads-azure
@@ -400,13 +400,13 @@
 /sdk/kusto/Microsoft.Azure.Management.Kusto/            @ilayrn @orhasban
 
 # ServiceLabel: %Lab Services %Service Attention
-sdk/labservices/Microsoft.Azure.Management.LabServices/           @Tanmayeekamath
+/sdk/labservices/Microsoft.Azure.Management.LabServices/           @Tanmayeekamath
 
 # ServiceLabel: %Load Test Service %Service Attention
-sdk/loadtestservice/            @abranj1219 @ninallam @NiveditJain
+/sdk/loadtestservice/            @abranj1219 @ninallam @NiveditJain
 
 # PRLabel: %Load Test Service
-sdk/loadtestservice/            @abranj1219 @ninallam @NiveditJain @christothes
+/sdk/loadtestservice/            @abranj1219 @ninallam @NiveditJain @christothes
 
 
 # ServiceLabel: %Logic App %Service Attention
@@ -446,11 +446,11 @@ sdk/loadtestservice/            @abranj1219 @ninallam @NiveditJain @christothes
 #/<NotInRepo>/            @kpiteira
 
 # ServiceLabel: %Monitor %Service Attention
-sdk/monitor/           @SameergMS @dadunl
+/sdk/monitor/           @SameergMS @dadunl
 
 # PRLabel: %Monitor - Query
-sdk/monitor/Azure.Monitor.Query            @nisha-bhatia @ShivangiReja
-sdk/monitor/ci.yml                         @nisha-bhatia @ShivangiReja
+/sdk/monitor/Azure.Monitor.Query/           @nisha-bhatia @ShivangiReja
+/sdk/monitor/ci.yml                         @nisha-bhatia @ShivangiReja
 
 # PRLabel: %Monitor - ApplicationInsights
 # ServiceLabel: %Monitor - ApplicationInsights %Service Attention
@@ -491,7 +491,7 @@ sdk/monitor/ci.yml                         @nisha-bhatia @ShivangiReja
 /sdk/mixedreality/                                 @crtreasu @rgarcia @JoshLove-msft
 
 # ServiceLabel: %Network %Service Attention
-sdk/network/           @aznetsuppgithub
+/sdk/network/           @aznetsuppgithub
 
 # ServiceLabel: %Network - Application Gateway %Service Attention
 #/<NotInRepo>/            @appgwsuppgithub
@@ -500,7 +500,7 @@ sdk/network/           @aznetsuppgithub
 #/<NotInRepo>/            @bastionsuppgithub
 
 # ServiceLabel: %Network - CDN %Service Attention
-sdk/cdn/Microsoft.Azure.Management.Cdn/         @cdnfdsuppgithub
+/sdk/cdn/Microsoft.Azure.Management.Cdn/         @cdnfdsuppgithub
 
 # ServiceLabel: %Network - DDOS Protection %Service Attention
 #/<NotInRepo>/            @ddossuppgithub
@@ -527,13 +527,13 @@ sdk/cdn/Microsoft.Azure.Management.Cdn/         @cdnfdsuppgithub
 #/<NotInRepo>/            @netwatchsuppgithub
 
 # ServiceLabel: %Network - DNS %Service Attention
-sdk/dns/            @dnssuppgithub
+/sdk/dns/            @dnssuppgithub
 
 # ServiceLabel: %Network - Network Virtual Appliance %Service Attention
 #/<NotInRepo>/            @nvasuppgithub
 
 # ServiceLabel: %Network - Traffic Manager %Service Attention
-sdk/trafficmanager/Microsoft.Azure.Management.TrafficManager/            @tmsuppgithub
+/sdk/trafficmanager/Microsoft.Azure.Management.TrafficManager/            @tmsuppgithub
 
 # ServiceLabel: %Network - Virtual WAN %Service Attention
 #/<NotInRepo>/            @vwansuppgithub


### PR DESCRIPTION
This PR fixes paths in CODEOWNERS that were violating following two rules, given [here](https://github.com/Azure/azure-sdk/blob/main/docs/policies/opensource.md#codeowners):

1. All paths must start with `/`
2. Paths to directories must end with `/`

These changes should have no effect on [owners determination by GitHub](https://github.com/Azure/azure-sdk-for-net/blob/main/.github/CODEOWNERS).

Violations of rule 2. would result in [ADO build failure notifications](https://github.com/Azure/azure-sdk/blob/main/docs/policies/opensource.md#codeowners) being set to different set of people once we enable the new regex-based CODEOWNERS matcher, per:
- https://github.com/Azure/azure-sdk-tools/pull/5165

This PR is done in preparation of following work:

- https://github.com/Azure/azure-sdk-tools/issues/4859
- https://github.com/Azure/azure-sdk-tools/pull/5088
- https://github.com/Azure/azure-sdk-tools/issues/2770