### PR TITLE
[AzureMonitorExporter] Add support for AADAudience

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+* Added support for parsing AADAudience from ConnectionString ([#33593](https://github.com/Azure/azure-sdk-for-net/pull/33593))
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -45,10 +45,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             {
                 var scope = AadHelper.GetScope(_connectionVars.AadAudience);
                 var httpPipelinePolicy = new HttpPipelinePolicy[]
-                                            {
-                                                new BearerTokenAuthenticationPolicy(credential, scope),
-                                                new IngestionRedirectPolicy()
-                                            };
+                                             {
+                                                 new BearerTokenAuthenticationPolicy(credential, scope),
+                                                 new IngestionRedirectPolicy()
+                                             };
 
                 pipeline = HttpPipelineBuilder.Build(options, httpPipelinePolicy);
                 AzureMonitorExporterEventSource.Log.WriteInformational("SetAADCredentialsToPipeline", $"HttpPipelineBuilder is built with AAD Credentials. TokenCredential: {credential.GetType().Name} Scope: {scope}");

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -38,14 +38,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             }
 
             options.Retry.MaxRetries = 0;
-            ConnectionStringParser.GetValues(options.ConnectionString, out _instrumentationKey, out string ingestionEndpoint);
+            ConnectionStringParser.GetValues(options.ConnectionString, out _instrumentationKey, out string ingestionEndpoint, out string aadAudience);
 
             HttpPipeline pipeline;
             if (credential != null)
             {
                 var httpPipelinePolicy = new HttpPipelinePolicy[]
                                              {
-                                                 new BearerTokenAuthenticationPolicy(credential, "https://monitor.azure.com//.default"),
+                                                 new BearerTokenAuthenticationPolicy(credential, aadAudience ?? Constants.DefaultAADAudience),
                                                  new IngestionRedirectPolicy()
                                              };
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -51,7 +51,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                                             };
 
                 pipeline = HttpPipelineBuilder.Build(options, httpPipelinePolicy);
-                AzureMonitorExporterEventSource.Log.WriteInformational("SetAADCredentialsToPipeline", "HttpPipelineBuilder is built with AAD Credentials"); // TODO: CONSIDER INCLUDING TYPE NAME OF TokenCredential and SCOPE value.
+                AzureMonitorExporterEventSource.Log.WriteInformational("SetAADCredentialsToPipeline", $"HttpPipelineBuilder is built with AAD Credentials. TokenCredential: {credential.GetType().Name} Scope: {scope}");
             }
             else
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -43,14 +43,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             HttpPipeline pipeline;
             if (credential != null)
             {
+                var scope = AadHelper.GetScope(aadAudience);
                 var httpPipelinePolicy = new HttpPipelinePolicy[]
-                                             {
-                                                 new BearerTokenAuthenticationPolicy(credential, aadAudience ?? Constants.DefaultAADAudience),
-                                                 new IngestionRedirectPolicy()
-                                             };
+                                            {
+                                                new BearerTokenAuthenticationPolicy(credential, scope),
+                                                new IngestionRedirectPolicy()
+                                            };
 
                 pipeline = HttpPipelineBuilder.Build(options, httpPipelinePolicy);
-                AzureMonitorExporterEventSource.Log.WriteInformational("SetAADCredentialsToPipeline", "HttpPipelineBuilder is built with AAD Credentials");
+                AzureMonitorExporterEventSource.Log.WriteInformational("SetAADCredentialsToPipeline", "HttpPipelineBuilder is built with AAD Credentials"); // TODO: CONSIDER INCLUDING TYPE NAME OF TokenCredential and SCOPE value.
             }
             else
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -43,7 +43,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             HttpPipeline pipeline;
             if (credential != null)
             {
-                var scope = AadHelper.GetScope(aadAudience);
+                var scope = AadHelper.GetScope(_connectionVars.AadAudience);
                 var httpPipelinePolicy = new HttpPipelinePolicy[]
                                             {
                                                 new BearerTokenAuthenticationPolicy(credential, scope),

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/AadHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/AadHelper.cs
@@ -3,34 +3,27 @@
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString
 {
-    /// <summary>
-    /// Helper for working with AAD (Azure Activity Directory).
-    /// </summary>
-    /// <remarks>
-    /// The AUDIENCE is a url that identifies Azure Monitor in a specific cloud (For example: "https://monitor.azure.com/").
-    /// The SCOPE is the audience + the permission (For example: "https://monitor.azure.com//.default").
-    /// </remarks>
     internal static class AadHelper
     {
         /// <summary>
-        /// Default AAD Audience for Ingestion (aka Breeze).
+        /// Default AAD Scope for Ingestion.
         /// IMPORTANT: This value only works in the Public Azure Cloud.
-        /// For Sovereign Azure Clouds, this value MUST come from the Connection String.
+        /// For Sovereign Azure Clouds, this value MUST be built from the Connection String.
         /// </summary>
-        public const string DefaultAADAudience = "https://monitor.azure.com//.default";
+        public const string DefaultAadScope = "https://monitor.azure.com//.default";
 
-        public const string DefaultPermission = ".default";
-
+        /// <summary>
+        /// Get the Scope value required for AAD authentication.
+        /// </summary>
+        /// <remarks>
+        /// The AUDIENCE is a url that identifies Azure Monitor in a specific cloud (For example: "https://monitor.azure.com/").
+        /// The SCOPE is the audience + the permission (For example: "https://monitor.azure.com//.default").
+        /// </remarks>
         public static string GetScope(string? audience = null)
         {
-            if (audience == null)
-            {
-                return DefaultAADAudience;
-            }
-            else
-            {
-                return audience + "/.default";
-            }
+            return string.IsNullOrWhiteSpace(audience)
+                ? DefaultAadScope
+                : audience + "/.default";
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/AadHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/AadHelper.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString
+{
+    /// <summary>
+    /// Helper for working with AAD (Azure Activity Directory).
+    /// </summary>
+    /// <remarks>
+    /// The AUDIENCE is a url that identifies Azure Monitor in a specific cloud (For example: "https://monitor.azure.com/").
+    /// The SCOPE is the audience + the permission (For example: "https://monitor.azure.com//.default").
+    /// </remarks>
+    internal static class AadHelper
+    {
+        /// <summary>
+        /// Default AAD Audience for Ingestion (aka Breeze).
+        /// IMPORTANT: This value only works in the Public Azure Cloud.
+        /// For Sovereign Azure Clouds, this value MUST come from the Connection String.
+        /// </summary>
+        public const string DefaultAADAudience = "https://monitor.azure.com//.default";
+
+        public const string DefaultPermission = ".default";
+
+        public static string GetScope(string? audience = null)
+        {
+            if (audience == null)
+            {
+                return DefaultAADAudience;
+            }
+            else
+            {
+                return audience + "/.default";
+            }
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/ConnectionStringParser.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/ConnectionStringParser.cs
@@ -23,7 +23,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString
         /// <exception cref="InvalidOperationException">
         /// Any exceptions that occur while parsing the connection string will be wrapped and re-thrown.
         /// </exception>
-        public static void GetValues(string connectionString, out string instrumentationKey, out string ingestionEndpoint)
+        public static void GetValues(string connectionString, out string instrumentationKey, out string ingestionEndpoint, out string aadAudience)
         {
             try
             {
@@ -39,6 +39,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString
                 var connString = AzureCoreConnectionString.Parse(connectionString);
                 instrumentationKey = connString.GetInstrumentationKey();
                 ingestionEndpoint = connString.GetIngestionEndpoint();
+                aadAudience = connString.GetAADAudience();
             }
             catch (Exception ex)
             {
@@ -46,6 +47,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString
                 throw new InvalidOperationException("Connection String Error: " + ex.Message, ex);
             }
         }
+
+        internal static string GetAADAudience(this AzureCoreConnectionString connectionString) => connectionString.GetNonRequired(Constants.AADAudienceKey);
 
         internal static string GetInstrumentationKey(this AzureCoreConnectionString connectionString) => connectionString.GetRequired(Constants.InstrumentationKeyKey);
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/ConnectionStringParser.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/ConnectionStringParser.cs
@@ -41,7 +41,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString
                 return new ConnectionVars(
                     instrumentationKey: connString.GetInstrumentationKey(),
                     ingestionEndpoint: connString.GetIngestionEndpoint(),
-                    aadAudience = connString.GetAADAudience());
+                    aadAudience: connString.GetAADAudience());
             }
             catch (Exception ex)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/ConnectionVars.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/ConnectionVars.cs
@@ -8,14 +8,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString
     /// </summary>
     internal class ConnectionVars
     {
-        public ConnectionVars(string instrumentationKey, string ingestionEndpoint)
+        public ConnectionVars(string instrumentationKey, string ingestionEndpoint, string? aadAudience)
         {
             this.InstrumentationKey = instrumentationKey;
             this.IngestionEndpoint = ingestionEndpoint;
+            this.AadAudience = aadAudience;
         }
 
         public string InstrumentationKey { get; }
 
         public string IngestionEndpoint { get; }
+
+        public string? AadAudience { get; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/Constants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/Constants.cs
@@ -11,6 +11,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString
         internal const string DefaultIngestionEndpoint = "https://dc.services.visualstudio.com/";
 
         /// <summary>
+        /// Default AAD Audience for Ingestion (aka Breeze).
+        /// IMPORTANT: This value only works in the Public Azure Cloud.
+        /// For Sovereign Azure Clouds, this value MUST come from the Connection String.
+        /// </summary>
+        internal const string DefaultAADAudience = "https://monitor.azure.com//.default";
+
+        /// <summary>
         /// Sub-domain for Ingestion endpoint (aka Breeze). (https://dc.applicationinsights.azure.com/).
         /// </summary>
         internal const string IngestionPrefix = "dc";
@@ -36,12 +43,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString
         internal const string LocationKey = "Location";
 
         /// <summary>
+        /// This is the key that a customer would use to specify an AAD Audience in the connection string.
+        /// </summary>
+        internal const string AADAudienceKey = "AADAudience";
+
+        /// <summary>
         /// Maximum allowed length for connection string.
         /// </summary>
         /// <remarks>
-        /// Currently 8 accepted keywords (~200 characters).
-        /// Assuming 200 characters per value (~1600 characters).
-        /// Total theoretical max length: (1600 + 200) = 1800.
+        /// Currently 9 accepted keywords (~200 characters).
+        /// Assuming 200 characters per value (~1800 characters).
+        /// Total theoretical max length = (1800 + 200) = 2000.
         /// Setting an over-exaggerated max length to protect against malicious injections (2^12 = 4096).
         /// </remarks>
         internal const int ConnectionStringMaxLength = 4096;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/Constants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/Constants.cs
@@ -11,13 +11,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString
         internal const string DefaultIngestionEndpoint = "https://dc.services.visualstudio.com/";
 
         /// <summary>
-        /// Default AAD Audience for Ingestion (aka Breeze).
-        /// IMPORTANT: This value only works in the Public Azure Cloud.
-        /// For Sovereign Azure Clouds, this value MUST come from the Connection String.
-        /// </summary>
-        internal const string DefaultAADAudience = "https://monitor.azure.com//.default";
-
-        /// <summary>
         /// Sub-domain for Ingestion endpoint (aka Breeze). (https://dc.applicationinsights.azure.com/).
         /// </summary>
         internal const string IngestionPrefix = "dc";

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
@@ -132,7 +132,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         {
             if (s_statsBeat_ConnectionString == null)
             {
-                ConnectionStringParser.GetValues(connectionString, out string instrumentationKey, out string ingestionEndpoint);
+                ConnectionStringParser.GetValues(connectionString, out string instrumentationKey, out _, out _);
 
                 s_customer_Ikey = instrumentationKey;
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ConnectionString/ConnectionStringParserTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ConnectionString/ConnectionStringParserTests.cs
@@ -14,12 +14,23 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
     public class ConnectionStringParserTests
     {
         [Fact]
+        public void TestConnectionString_Full()
+        {
+            RunTest(
+                connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://ingestion.azuremonitor.com/;AADAudience=https://monitor.azure.com//testing",
+                expectedIngestionEndpoint: "https://ingestion.azuremonitor.com/",
+                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000",
+                expectedAadAudience: "https://monitor.azure.com//testing");
+        }
+
+        [Fact]
         public void TestInstrumentationKey_IsRequired()
         {
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "EndpointSuffix=ingestion.azuremonitor.com",
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null));
+                expectedInstrumentationKey: null,
+                expectedAadAudience: null));
         }
 
         [Fact]
@@ -28,7 +39,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "InstrumentationKey=;EndpointSuffix=ingestion.azuremonitor.com",
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null));
+                expectedInstrumentationKey: null,
+                expectedAadAudience: null));
         }
 
         [Fact]
@@ -37,7 +49,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
                 expectedIngestionEndpoint: Constants.DefaultIngestionEndpoint,
-                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000");
+                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000",
+                expectedAadAudience: null);
         }
 
         [Fact]
@@ -46,7 +59,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;EndpointSuffix=ingestion.azuremonitor.com",
                 expectedIngestionEndpoint: "https://dc.ingestion.azuremonitor.com/",
-                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000");
+                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000",
+                expectedAadAudience: null);
         }
 
         [Fact]
@@ -55,7 +69,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;EndpointSuffix=ingestion.azuremonitor.com;IngestionEndpoint=https://custom.contoso.com:444/",
                 expectedIngestionEndpoint: "https://custom.contoso.com:444/",
-                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000");
+                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000",
+                expectedAadAudience: null);
         }
 
         [Fact]
@@ -64,7 +79,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;EndpointSuffix=ingestion.azuremonitor.com;Location=westus2",
                 expectedIngestionEndpoint: "https://westus2.dc.ingestion.azuremonitor.com/",
-                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000");
+                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000",
+                expectedAadAudience: null);
         }
 
         [Fact]
@@ -73,7 +89,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;EndpointSuffix=ingestion.azuremonitor.com;Location=westus2;IngestionEndpoint=https://custom.contoso.com:444/",
                 expectedIngestionEndpoint: "https://custom.contoso.com:444/",
-                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000");
+                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000",
+                expectedAadAudience: null);
         }
 
         [Fact]
@@ -82,7 +99,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=http://custom.contoso.com:444/",
                 expectedIngestionEndpoint: "http://custom.contoso.com:444/",
-                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000");
+                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000",
+                expectedAadAudience: null);
         }
 
         [Fact]
@@ -91,7 +109,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https:////custom.contoso.com",
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null));
+                expectedInstrumentationKey: null,
+                expectedAadAudience: null));
         }
 
         [Fact]
@@ -100,7 +119,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://www.~!@#$%&^*()_{}{}><?<?>:L\":\"_+_+_",
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null));
+                expectedInstrumentationKey: null,
+                expectedAadAudience: null));
         }
 
         [Fact]
@@ -109,7 +129,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;EndpointSuffix=~!@#$%&^*()_{}{}><?<?>:L\":\"_+_+_",
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null));
+                expectedInstrumentationKey: null,
+                expectedAadAudience: null));
         }
 
         [Fact]
@@ -118,7 +139,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;EndpointSuffix=ingestion.azuremonitor.com;Location=~!@#$%&^*()_{}{}><?<?>:L\":\"_+_+_",
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null));
+                expectedInstrumentationKey: null,
+                expectedAadAudience: null));
         }
 
         [Fact]
@@ -127,7 +149,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: new string('*', Constants.ConnectionStringMaxLength + 1),
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null));
+                expectedInstrumentationKey: null,
+                expectedAadAudience: null));
         }
 
         [Fact]
@@ -136,7 +159,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: null,
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null));
+                expectedInstrumentationKey: null,
+                expectedAadAudience: null));
         }
 
         [Fact]
@@ -145,7 +169,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "",
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null));
+                expectedInstrumentationKey: null,
+                expectedAadAudience: null));
         }
 
         [Fact]
@@ -154,15 +179,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "key1=value1;key2=value2;key3=value3",
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null));
+                expectedInstrumentationKey: null,
+                expectedAadAudience: null));
         }
 
-        private void RunTest(string connectionString, string expectedIngestionEndpoint, string expectedInstrumentationKey)
+        private void RunTest(string connectionString, string expectedIngestionEndpoint, string expectedInstrumentationKey, string expectedAadAudience)
         {
-            ConnectionStringParser.GetValues(connectionString, out string ikey, out string endpoint);
+            ConnectionStringParser.GetValues(connectionString, out string ikey, out string endpoint, out string aadAudience);
 
             Assert.Equal(expectedIngestionEndpoint, endpoint);
             Assert.Equal(expectedInstrumentationKey, ikey);
+            Assert.Equal(expectedAadAudience, aadAudience);
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ConnectionString/ConnectionStringParserTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ConnectionString/ConnectionStringParserTests.cs
@@ -29,8 +29,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "EndpointSuffix=ingestion.azuremonitor.com",
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null,
-                expectedAadAudience: null));
+                expectedInstrumentationKey: null));
         }
 
         [Fact]
@@ -39,8 +38,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "InstrumentationKey=;EndpointSuffix=ingestion.azuremonitor.com",
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null,
-                expectedAadAudience: null));
+                expectedInstrumentationKey: null));
         }
 
         [Fact]
@@ -49,8 +47,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
                 expectedIngestionEndpoint: Constants.DefaultIngestionEndpoint,
-                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000",
-                expectedAadAudience: null);
+                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000");
         }
 
         [Fact]
@@ -59,8 +56,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;EndpointSuffix=ingestion.azuremonitor.com",
                 expectedIngestionEndpoint: "https://dc.ingestion.azuremonitor.com/",
-                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000",
-                expectedAadAudience: null);
+                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000");
         }
 
         [Fact]
@@ -69,8 +65,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;EndpointSuffix=ingestion.azuremonitor.com;IngestionEndpoint=https://custom.contoso.com:444/",
                 expectedIngestionEndpoint: "https://custom.contoso.com:444/",
-                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000",
-                expectedAadAudience: null);
+                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000");
         }
 
         [Fact]
@@ -79,8 +74,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;EndpointSuffix=ingestion.azuremonitor.com;Location=westus2",
                 expectedIngestionEndpoint: "https://westus2.dc.ingestion.azuremonitor.com/",
-                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000",
-                expectedAadAudience: null);
+                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000");
         }
 
         [Fact]
@@ -89,8 +83,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;EndpointSuffix=ingestion.azuremonitor.com;Location=westus2;IngestionEndpoint=https://custom.contoso.com:444/",
                 expectedIngestionEndpoint: "https://custom.contoso.com:444/",
-                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000",
-                expectedAadAudience: null);
+                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000");
         }
 
         [Fact]
@@ -99,8 +92,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=http://custom.contoso.com:444/",
                 expectedIngestionEndpoint: "http://custom.contoso.com:444/",
-                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000",
-                expectedAadAudience: null);
+                expectedInstrumentationKey: "00000000-0000-0000-0000-000000000000");
         }
 
         [Fact]
@@ -109,8 +101,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https:////custom.contoso.com",
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null,
-                expectedAadAudience: null));
+                expectedInstrumentationKey: null));
         }
 
         [Fact]
@@ -119,8 +110,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://www.~!@#$%&^*()_{}{}><?<?>:L\":\"_+_+_",
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null,
-                expectedAadAudience: null));
+                expectedInstrumentationKey: null));
         }
 
         [Fact]
@@ -129,8 +119,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;EndpointSuffix=~!@#$%&^*()_{}{}><?<?>:L\":\"_+_+_",
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null,
-                expectedAadAudience: null));
+                expectedInstrumentationKey: null));
         }
 
         [Fact]
@@ -139,8 +128,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;EndpointSuffix=ingestion.azuremonitor.com;Location=~!@#$%&^*()_{}{}><?<?>:L\":\"_+_+_",
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null,
-                expectedAadAudience: null));
+                expectedInstrumentationKey: null));
         }
 
         [Fact]
@@ -149,8 +137,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: new string('*', Constants.ConnectionStringMaxLength + 1),
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null,
-                expectedAadAudience: null));
+                expectedInstrumentationKey: null));
         }
 
         [Fact]
@@ -159,8 +146,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: null,
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null,
-                expectedAadAudience: null));
+                expectedInstrumentationKey: null));
         }
 
         [Fact]
@@ -169,8 +155,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "",
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null,
-                expectedAadAudience: null));
+                expectedInstrumentationKey: null));
         }
 
         [Fact]
@@ -179,11 +164,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "key1=value1;key2=value2;key3=value3",
                 expectedIngestionEndpoint: null,
-                expectedInstrumentationKey: null,
-                expectedAadAudience: null));
+                expectedInstrumentationKey: null));
         }
 
-        private void RunTest(string connectionString, string expectedIngestionEndpoint, string expectedInstrumentationKey, string expectedAadAudience)
+        private void RunTest(string connectionString, string expectedIngestionEndpoint, string expectedInstrumentationKey, string expectedAadAudience = null)
         {
             var connectionVars = ConnectionStringParser.GetValues(connectionString);
 


### PR DESCRIPTION
Add support for parsing the AADAudience value from the Connection String.
This is necessary to support AAD in Sovereign clouds.

## Changes
- add static class `AadHelper` to build the scope value
- update `ConnectionStringParser.cs` to parse AADAudience

## Note
As of today, AAD is not available for Azure Monitor in Sovereign clouds.
To test this feature, I set a value in the connection string for a resource in Public Azure, and I verified that it was correctly parsed and that telemetry was successfully ingested.