### PR TITLE
Remove CODEOWNERS rules `/**/ci.yml` and `/**/tests.yml`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -723,8 +723,6 @@
 # ######## Eng Sys ########
 /eng/           @hallipr @weshaggard @benbp
 /eng/mgmt/      @ArthurMa1978 @m-nash @markcowl
-/**/tests.yml   @hallipr @benbp
-/**/ci.yml      @hallipr @benbp
 
 # Add owners for notifications for specific pipelines
 /eng/pipelines/aggregate-reports.yml            @jsquire @maririos @pallavit


### PR DESCRIPTION
Per these comments:
- https://github.com/Azure/azure-sdk-tools/pull/5088#issuecomment-1397330147
- https://github.com/Azure/azure-sdk-tools/pull/5088#issuecomment-1397427097

Related work:
- #33584
- https://github.com/Azure/azure-sdk-tools/issues/4859
- https://github.com/Azure/azure-sdk-tools/pull/5088
- https://github.com/Azure/azure-sdk-tools/issues/2770