### PR TITLE
Add missing `/sdk/<dir>` rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,24 @@
 #########
 
 # Catch all
-/sdk/                                           @pallavit @jsquire
+/sdk/                          @pallavit @jsquire
+
+# Rules for directories that fell under catch-all as of 1/19/2023
+/sdk/agrifood/                 @pallavit @jsquire
+# Note there are some sub-rules for this directory, defined below
+/sdk/applicationinsights/      @pallavit @jsquire
+# Note there are some sub-rules for this directory, defined below
+/sdk/cognitiveservices/        @pallavit @jsquire
+/sdk/entra/                    @pallavit @jsquire
+/sdk/graphrbac/                @pallavit @jsquire
+/sdk/machinelearningservices/  @pallavit @jsquire
+/sdk/maps/                     @pallavit @jsquire
+# Note there are some sub-rules for this directory, defined below
+/sdk/operationalinsights/      @pallavit @jsquire
+/sdk/purview/                  @pallavit @jsquire
+# Note there are some sub-rules for this directory, defined below
+/sdk/quantum/                  @pallavit @jsquire
+/sdk/remoterendering/          @pallavit @jsquire
 
 # ######## Core Libraries ########
 


### PR DESCRIPTION
This PR adds missing `/sdk/<dir>/` rules to CODEOWNERS. These dirs need assignment of appropriate owners. @pallavit  @jsquire FYI.

This change was proposed here:
- https://github.com/Azure/azure-sdk-tools/pull/5088#issuecomment-1397332193

Related work:
- #33584
- #33595
- https://github.com/Azure/azure-sdk-tools/issues/4859
- https://github.com/Azure/azure-sdk-tools/pull/5088
- https://github.com/Azure/azure-sdk-tools/issues/2770