### PR TITLE
Update Key Vault to better support multi-targeting

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/PemReader.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/PemReader.cs
@@ -29,6 +29,7 @@ namespace Azure.Core
 
             if (s_ecCopyWithPrivateKeyMethod is null)
             {
+                // CopyWithPrivateKey was added in .NET Framework 4.7.2. We must otherwise throw without it.
                 s_ecCopyWithPrivateKeyMethod = typeof(ECDsaCertificateExtensions).GetMethod("CopyWithPrivateKey", BindingFlags.Static | BindingFlags.Public, null, new[] { typeof(X509Certificate2), typeof(ECDsa) }, null)
                     ?? throw new PlatformNotSupportedException("The current platform does not support reading an ECDsa private key from a PEM file");
             }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/Azure.Security.KeyVault.Certificates.Tests.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/Azure.Security.KeyVault.Certificates.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+    <!-- Several types and methods we need are implemented in net47 or above, so test our light-up features against at least net47 to make sure they work or fall back as expected. -->
+    <TargetFrameworks>$(RequiredTargetFrameworks);net47</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\Azure.Security.KeyVault.Shared\tests\Azure.Security.KeyVault.Shared.Tests.projitems" Label="Shared" />

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/Azure.Security.KeyVault.Certificates.Tests.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/Azure.Security.KeyVault.Certificates.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <!-- Several types and methods we need are implemented in net47 or above, so test our light-up features against at least net47 to make sure they work or fall back as expected. -->
+    <!-- If this changes, check that exclusionary preproc conditions like `!NET461 && !NET47` are updated in tests, samples. -->
     <TargetFrameworks>$(RequiredTargetFrameworks);net47</TargetFrameworks>
   </PropertyGroup>
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/PemReaderTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/PemReaderTests.cs
@@ -78,7 +78,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         [Test]
         public void LoadCertificatePemOverridesCer()
         {
-#if NET461
+#if !NET47_OR_GREATER && !NET
             Assert.Ignore("Loading X509Certificate2 with private EC key not supported on this platform");
 #endif
             using X509Certificate2 certificate = PemReader.LoadCertificate(s_ecdsaFullCertificate.AsSpan(), cer: Encoding.UTF8.GetBytes("This is not a certificate"), keyType: PemReader.KeyType.ECDsa);
@@ -89,7 +89,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         [Test]
         public void LoadRSACertificate()
         {
-#if NET461
+#if !NETCOREAPP3_0_OR_GREATER
             // Compatible with previous release. Goes through the LightweightPkcs8Decoder.DecodeECDsaPkcs8().
             Assert.Throws<InvalidDataException>(() => PemReader.LoadCertificate(RSACertificate.AsSpan(), keyType: PemReader.KeyType.ECDsa));
 #else
@@ -101,7 +101,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         [Test]
         public void LoadECDsaPrime256v1Certificate()
         {
-#if NET461
+#if !NET47_OR_GREATER && !NET
             Assert.Ignore("Loading X509Certificate2 with private EC key not supported on this platform");
 #endif
             using X509Certificate2 certificate = PemReader.LoadCertificate(s_ecdsaFullCertificate.AsSpan(), keyType: PemReader.KeyType.ECDsa);

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample4_DownloadCertificate.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample4_DownloadCertificate.cs
@@ -14,7 +14,9 @@ namespace Azure.Security.KeyVault.Certificates.Samples
 {
     public partial class DownloadCertificate
     {
-#if NET472_OR_GREATER || NET || SNIPPET
+// Need to exclude actual TFMs since SNIPPET is always passed during CIs, such that the following will fail:
+// NET472_OR_GREATER || NETSTANDARD2_1_OR_GREATER || SNIPPET
+#if !NET461 && !NET47
         [Test]
         public void DownloadCertificateSync()
         {

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample4_DownloadCertificate.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample4_DownloadCertificate.cs
@@ -14,7 +14,7 @@ namespace Azure.Security.KeyVault.Certificates.Samples
 {
     public partial class DownloadCertificate
     {
-#if !NET461
+#if NET472_OR_GREATER || NET || SNIPPET
         [Test]
         public void DownloadCertificateSync()
         {

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample4_DownloadCertificateAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample4_DownloadCertificateAsync.cs
@@ -14,7 +14,9 @@ namespace Azure.Security.KeyVault.Certificates.Samples
 {
     public partial class DownloadCertificate
     {
-#if NET472_OR_GREATER || NET || SNIPPET
+// Need to exclude actual TFMs since SNIPPET is always passed during CIs, such that the following will fail:
+// NET472_OR_GREATER || NETSTANDARD2_1_OR_GREATER || SNIPPET
+#if !NET461 && !NET47
         [Test]
         public async Task DownloadCertificateAsync()
         {

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample4_DownloadCertificateAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample4_DownloadCertificateAsync.cs
@@ -14,7 +14,7 @@ namespace Azure.Security.KeyVault.Certificates.Samples
 {
     public partial class DownloadCertificate
     {
-#if !NET461
+#if NET472_OR_GREATER || NET || SNIPPET
         [Test]
         public async Task DownloadCertificateAsync()
         {


### PR DESCRIPTION
Related to #33488. Though we decided not to take advantage of multi-targeting in KV, there may be some in the near future for all track 2 assemblies. This PR should prepare KV better, and updates some comments to better explain things w.r.t. multi-targeting.
