### PR TITLE
[Analyze] Upgrade from Node 16 to Node 18

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -172,9 +172,8 @@ jobs:
 
       - task: NodeTool@0
         inputs:
-          # https://github.com/nodejs/node/issues/40468
-          versionSpec: '16.6.2'
-        displayName: 'Install NodeJS'
+          versionSpec: 18.x
+        displayName: 'Use Node 18.x'
 
       - template: /eng/pipelines/templates/steps/install-dotnet.yml
 


### PR DESCRIPTION
- Latest autorest requires Node 17 or higher

Verification build: https://dev.azure.com/azure-sdk/public/_build/results?buildId=2131987&view=results