### PR TITLE
[DataProtection] Changelog Updates

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## 1.3.0-beta.1 (Unreleased)
 
+### Acknowledgments
+
+Thank you to our developer community members who helped to make the Event Hubs client libraries better with their contributions to this release:
+
+- Tom Longhurst _([GitHub](https://github.com/thomhurst))_
+
 ### Features Added
+
+- Added an overload when configuring data protection which allows token credentials to be created by a factory on-demand.  _(A community contribution, courtesy of [thomhurst](https://github.com/thomhurst))_
 
 ### Breaking Changes
 
@@ -10,7 +18,7 @@
 
 ### Other Changes
 
-- Updated dependency version of `Microsoft.AspNetCore.DataProtection` to mitigate [CVE-2021-24112](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-24112).  Note that the vulnerability only exists in a dependency referenced by the `netcoreapp3.0` target, which reach end-of-life in December, 2019.  
+- Updated dependency version of `Microsoft.AspNetCore.DataProtection` to mitigate [CVE-2021-24112](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-24112).  Note that the vulnerability only exists in a dependency referenced by the `netcoreapp3.0` target, which reach end-of-life in December, 2019.
 
 ## 1.2.3 (2022-09-12)
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## 1.2.0-beta.1 (Unreleased)
 
+### Acknowledgments
+
+Thank you to our developer community members who helped to make the Event Hubs client libraries better with their contributions to this release:
+
+- Tom Longhurst _([GitHub](https://github.com/thomhurst))_
+
 ### Features Added
+
+- Added an overload when configuring data protection which allows token credentials to be created by a factory on-demand.  _(A community contribution, courtesy of [thomhurst](https://github.com/thomhurst))_
 
 ### Breaking Changes
 
@@ -10,7 +18,7 @@
 
 ### Other Changes
 
-- Updated dependency version of `Microsoft.AspNetCore.DataProtection` to mitigate [CVE-2021-24112](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-24112).  Note that the vulnerability only exists in a dependency referenced by the `netcoreapp3.0` target, which reach end-of-life in December, 2019. 
+- Updated dependency version of `Microsoft.AspNetCore.DataProtection` to mitigate [CVE-2021-24112](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-24112).  Note that the vulnerability only exists in a dependency referenced by the `netcoreapp3.0` target, which reach end-of-life in December, 2019.
 
 ## 1.1.0 (2021-09-07)
 
@@ -43,7 +51,7 @@
 ## 1.0.0-preview.2 (2020-05-05)
 
 - Package renamed to Azure.Extensions.AspNetCore.DataProtection.Keys
-- Default overload of ProtectKeysWithAzureKeyVault now takes a Uri to be consistent with other extension methods and KeyVault clients.  
+- Default overload of ProtectKeysWithAzureKeyVault now takes a Uri to be consistent with other extension methods and KeyVault clients.
 
 ## 1.0.0-preview.1 (2020-03-02)
 


### PR DESCRIPTION
# Summary

The focus of these changes is to add the recent community contribution feature to the change log, along with attribution.

# References and Related

- [Allow use of ServiceProvider func to create BlobClient for PersistKeysToAzureBlobStorage (#33455)](https://github.com/Azure/azure-sdk-for-net/pull/33455)
- [Allow use of ServiceProvider func to create KeyResolver for ProtectKeysWithAzureKeyVault (#33454)](https://github.com/Azure/azure-sdk-for-net/pull/33454)